### PR TITLE
feat(scenario): 消防兵棋推演引導式想定播放模式（Phase 1 MVP）

### DIFF
--- a/public/scenarios/demo.json
+++ b/public/scenarios/demo.json
@@ -1,0 +1,140 @@
+{
+  "id": "xinyi-highrise-fire",
+  "name": "信義區商辦火警",
+  "description": "台北市信義區某商辦大樓 5 樓火警，分隊出動、雲梯佈署、救護待命之引導式想定示範。",
+  "camera": { "center": [121.5672, 25.0365], "zoom": 14.5, "pitch": 55, "bearing": 20 },
+  "startUnix": 1779861600,
+  "durationSec": 1200,
+  "defaultSpeed": 60,
+  "injects": [
+    {
+      "id": "cam-open",
+      "type": "camera",
+      "at": 0,
+      "label": "進場：信義區火場",
+      "center": [121.5672, 25.0365],
+      "zoom": 14.5,
+      "pitch": 55,
+      "bearing": 20,
+      "layers": { "fireScenario": true }
+    },
+    {
+      "id": "b-report",
+      "type": "banner",
+      "at": 0,
+      "text": "14:00 信義區某商辦大樓 5 樓傳出火警，119 受理報案",
+      "holdSec": 12,
+      "label": "受理報案"
+    },
+    {
+      "id": "fire-main",
+      "type": "fire",
+      "at": 5,
+      "label": "起火點（5 樓）",
+      "origin": [121.5672, 25.0365],
+      "growth": { "startRadiusM": 15, "maxRadiusM": 130, "rampSec": 650 },
+      "wind": { "bearingDeg": 60, "stretch": 1.6 },
+      "endAt": 1000
+    },
+    {
+      "id": "d-engine",
+      "type": "dispatch",
+      "at": 30,
+      "label": "信義分隊水箱車出動",
+      "unitKind": "engine",
+      "durationSec": 120,
+      "route": [
+        [121.5601, 25.0412],
+        [121.5625, 25.0395],
+        [121.5655, 25.0378],
+        [121.5672, 25.0365]
+      ]
+    },
+    {
+      "id": "b-engine",
+      "type": "banner",
+      "at": 40,
+      "text": "信義分隊 2 車 6 人出動，預計 3 分鐘抵達",
+      "holdSec": 10,
+      "label": "分隊出動"
+    },
+    {
+      "id": "d-ladder",
+      "type": "dispatch",
+      "at": 90,
+      "label": "雲梯車出動",
+      "unitKind": "ladder",
+      "durationSec": 150,
+      "route": [
+        [121.5752, 25.0302],
+        [121.5718, 25.033],
+        [121.569, 25.0352],
+        [121.5672, 25.0365]
+      ]
+    },
+    {
+      "id": "b-ladder",
+      "type": "banner",
+      "at": 150,
+      "text": "雲梯車抵達，佈署高空射水",
+      "holdSec": 10,
+      "label": "雲梯佈署"
+    },
+    {
+      "id": "d-ambulance",
+      "type": "dispatch",
+      "at": 200,
+      "label": "救護車待命",
+      "unitKind": "ambulance",
+      "durationSec": 130,
+      "route": [
+        [121.5548, 25.0331],
+        [121.559, 25.0345],
+        [121.564, 25.0358],
+        [121.567, 25.0364]
+      ]
+    },
+    {
+      "id": "b-rescue",
+      "type": "banner",
+      "at": 210,
+      "text": "1 名民眾受困 7 樓，救護隊待命搶救",
+      "holdSec": 10,
+      "label": "民眾受困"
+    },
+    {
+      "id": "cam-wide",
+      "type": "camera",
+      "at": 400,
+      "label": "拉遠：全局指揮",
+      "center": [121.5662, 25.037],
+      "zoom": 13.6,
+      "pitch": 50,
+      "bearing": 0
+    },
+    {
+      "id": "b-spread",
+      "type": "banner",
+      "at": 420,
+      "text": "火勢延燒至 6 樓，指揮官調派鄰近分隊支援",
+      "holdSec": 12,
+      "label": "延燒擴大"
+    },
+    {
+      "id": "b-control",
+      "type": "banner",
+      "at": 700,
+      "text": "火勢獲得控制",
+      "holdSec": 10,
+      "label": "火勢控制"
+    },
+    {
+      "id": "b-out",
+      "type": "banner",
+      "at": 1000,
+      "text": "16:40 火勢撲滅，現場進行清理與火調",
+      "holdSec": 30,
+      "label": "火勢撲滅"
+    }
+  ]
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,6 +20,9 @@ import { useMapInteraction } from "./hooks/useMapInteraction";
 import { useNewsTimeline } from "./hooks/useNewsTimeline";
 import { useEarthquakeLayer } from "./hooks/useEarthquakeLayer";
 import { useFreewayLayer } from "./hooks/useFreewayLayer";
+import { useFireScenarioLayer } from "./hooks/useFireScenarioLayer";
+import { useScenario } from "./hooks/useScenario";
+import { ScenarioPanel } from "./components/ScenarioPanel";
 import { useReservoirContextLayer } from "./hooks/useReservoirContextLayer";
 import { useReservoirStatusLayer } from "./hooks/useReservoirStatusLayer";
 import type { ReservoirScene } from "./three/ReservoirScene";
@@ -223,6 +226,28 @@ export default function App() {
   const { isMobile, isLandscape } = useIsMobile();
   const { layerVisibility, layerVisibilityRef, setLayerVisibility, toggleVisibility } = useLayerVisibility();
 
+  // ── 消防兵棋推演模式（?mode=scenario） ──
+  const appMode = useMemo<"data" | "scenario">(
+    () => (new URLSearchParams(window.location.search).get("mode") === "scenario" ? "scenario" : "data"),
+    [],
+  );
+  const isScenario = appMode === "scenario";
+  const mapRef = useRef<MapboxMap | null>(null);
+  const [mapReady, setMapReady] = useState(false);
+  const scenario = useScenario({ active: isScenario, mapReady, mapRef, setLayerVisibility });
+
+  // 進入想定模式：只留消防想定圖層，關掉預設開啟的運具圖層讓場景乾淨
+  useEffect(() => {
+    if (!isScenario) return;
+    setLayerVisibility((prev) => ({
+      ...prev,
+      fireScenario: true,
+      flights: false, ships: false, rail: false,
+      stationsTHSR: false, stationsTRA: false, stationsMetro: false,
+      ports: false, lighthouses: false, airports: false,
+    }));
+  }, [isScenario, setLayerVisibility]);
+
   // 圖層可見性變化時踢 Mapbox 一次，確保從 idle 喚醒渲染循環
   useEffect(() => {
     mapRef.current?.triggerRepaint();
@@ -255,6 +280,7 @@ export default function App() {
   const timeline = useTimeline({
     dataStartTime: dataTimeRange.start,
     dataEndTime: dataTimeRange.end,
+    overrideWindow: isScenario ? scenario.scenarioWindow : undefined,
   });
 
   // ── 活躍日追蹤：訂閱 timeStore 日期粒度（不走 React re-render） ──
@@ -289,7 +315,6 @@ export default function App() {
   const showTrails = displayMode === "trails";
 
   // Refs for Three.js render loops
-  const mapRef = useRef<MapboxMap | null>(null);
   const flightsRef = useRef<Flight[]>([]);
   const shipsRef = useRef(ships);
   const timeRef = useRef(timeline.currentTime);
@@ -510,6 +535,14 @@ export default function App() {
     isDarkTheme,
   );
 
+  // ── 消防想定動態層（火場 + 出動單位，gate on mapReady 確保 style 就緒） ──
+  useFireScenarioLayer(
+    mapRef,
+    mapReady && layerVisibility.fireScenario,
+    isDarkTheme,
+    scenario.engineRef,
+  );
+
   // ── Derived values ──
 
   const preset = useMemo(
@@ -523,6 +556,7 @@ export default function App() {
 
   const handleMapReady = (map: MapboxMap) => {
     mapRef.current = map;
+    setMapReady(true);
     addAllLayers(map);
 
     const updateCamera = () => {
@@ -841,6 +875,35 @@ export default function App() {
         onMapReady={handleMapReady}
       />
 
+      {/* ── 想定播報 Banner（消防兵棋推演模式） ── */}
+      {isScenario && scenario.banner && (
+        <div
+          style={{
+            position: "absolute",
+            top: isMobile ? 96 : 24,
+            left: "50%",
+            transform: "translateX(-50%)",
+            zIndex: 25,
+            maxWidth: "72%",
+            background: "rgba(180,40,0,0.88)",
+            backdropFilter: "blur(8px)",
+            border: "1px solid rgba(255,180,0,0.6)",
+            borderRadius: 10,
+            padding: "10px 22px",
+            color: "#fff",
+            fontFamily: "monospace",
+            fontSize: isMobile ? 14 : 17,
+            fontWeight: 700,
+            letterSpacing: 1,
+            textAlign: "center",
+            boxShadow: "0 4px 24px rgba(0,0,0,0.4)",
+            pointerEvents: "none",
+          }}
+        >
+          {scenario.banner}
+        </div>
+      )}
+
       {/* ── 拍攝模式 vignette + 標題 ── */}
       {captureMode && (
         <>
@@ -1001,29 +1064,42 @@ export default function App() {
             )}
           </div>
 
-          {/* Icon Rail + Sliding Panel Sidebar */}
-          <div style={{ position: "absolute", top: 0, left: 0, bottom: 0, zIndex: 11, pointerEvents: "none" }}>
-            <IconRailSidebar
-              visibility={layerVisibility}
-              expandedLayer={expandedLayer}
-              viewMode={viewMode}
-              displayMode={displayMode}
-              counts={sidebarCounts}
-              onLayerClick={handleLayerClick}
-              onToggleVisibility={toggleVisibility}
-              onViewModeChange={setViewMode}
-              onDisplayModeChange={handleDisplayModeChange}
-              onHideTransport={handleHideTransport}
-              onAllOff={handleAllOff}
-              getControls={transportParams.getControls}
-              currentLocationId={selectedAirport}
-              onLocationJump={handleLocationJump}
-              onWidthChange={handleSidebarWidthChange}
-              dataRegistry={dataRegistry}
-              selectedDate={timeline.selectedDate}
-              onDateSelect={timeline.setSelectedDate}
-            />
-          </div>
+          {/* Icon Rail + Sliding Panel Sidebar（一般模式） */}
+          {!isScenario && (
+            <div style={{ position: "absolute", top: 0, left: 0, bottom: 0, zIndex: 11, pointerEvents: "none" }}>
+              <IconRailSidebar
+                visibility={layerVisibility}
+                expandedLayer={expandedLayer}
+                viewMode={viewMode}
+                displayMode={displayMode}
+                counts={sidebarCounts}
+                onLayerClick={handleLayerClick}
+                onToggleVisibility={toggleVisibility}
+                onViewModeChange={setViewMode}
+                onDisplayModeChange={handleDisplayModeChange}
+                onHideTransport={handleHideTransport}
+                onAllOff={handleAllOff}
+                getControls={transportParams.getControls}
+                currentLocationId={selectedAirport}
+                onLocationJump={handleLocationJump}
+                onWidthChange={handleSidebarWidthChange}
+                dataRegistry={dataRegistry}
+                selectedDate={timeline.selectedDate}
+                onDateSelect={timeline.setSelectedDate}
+              />
+            </div>
+          )}
+
+          {/* 想定面板（消防兵棋推演模式） */}
+          {isScenario && scenario.scenario && (
+            <div style={{ position: "absolute", top: 92, left: 16, zIndex: 11, pointerEvents: "none" }}>
+              <ScenarioPanel
+                scenario={scenario.scenario}
+                currentTime={timeline.currentTime}
+                isDarkTheme={isDarkTheme}
+              />
+            </div>
+          )}
 
           {/* 時間軸 */}
           <TimelineControls

--- a/src/components/IconRailSidebar.tsx
+++ b/src/components/IconRailSidebar.tsx
@@ -8,6 +8,7 @@ import {
   GraduationCap, Store, Play, Cable, Radio, Mountain,
   Cloud, CloudRain,
   Droplets, Droplet, Waves, GitBranch, Dam, Factory, Gauge, Shield, ShieldCheck,
+  Flame,
   type LucideIcon,
 } from "lucide-react";
 import type {
@@ -62,6 +63,7 @@ const LAYER_COLORS: Record<keyof LayerVisibility, string> = {
   groundwaterWells: "#64748b",
   iotWraRiver: "#06b6d4",
   iotWraStructure: "#a855f7",
+  fireScenario: "#ff4d00",
 };
 
 const TRANSPORT_LABELS: Record<string, string> = {
@@ -124,6 +126,7 @@ const LAYER_ICONS: Record<keyof LayerVisibility, LucideIcon> = {
   groundwaterWells: Droplet,
   iotWraRiver: Waves,
   iotWraStructure: Gauge,
+  fireScenario: Flame,
 };
 
 // ── Section Config ──

--- a/src/components/LayerSidebar.tsx
+++ b/src/components/LayerSidebar.tsx
@@ -60,6 +60,7 @@ const LAYER_COLORS: Record<keyof LayerVisibility, string> = {
   groundwaterWells: "#64748b",
   iotWraRiver: "#06b6d4",
   iotWraStructure: "#a855f7",
+  fireScenario: "#ff4d00",
 };
 
 const TRANSPORT_LABELS: Record<TransportType, string> = {

--- a/src/components/ScenarioPanel.tsx
+++ b/src/components/ScenarioPanel.tsx
@@ -1,0 +1,108 @@
+import type { Scenario, Inject } from "../types/scenario";
+
+interface Props {
+  scenario: Scenario;
+  currentTime: number; // unix
+  isDarkTheme?: boolean;
+}
+
+const TYPE_LABEL: Record<Inject["type"], string> = {
+  fire: "火場",
+  dispatch: "出動",
+  banner: "播報",
+  camera: "鏡頭",
+};
+
+const TYPE_COLOR: Record<Inject["type"], string> = {
+  fire: "#ff4d00",
+  dispatch: "#ff3b30",
+  banner: "#ffb000",
+  camera: "#64aaff",
+};
+
+function fmtRel(sec: number): string {
+  const m = Math.floor(sec / 60);
+  const s = Math.floor(sec % 60);
+  return `+${m}:${String(s).padStart(2, "0")}`;
+}
+
+export function ScenarioPanel({ scenario, currentTime, isDarkTheme = true }: Props) {
+  const dark = isDarkTheme;
+  const elapsed = currentTime - scenario.startUnix;
+  const sorted = [...scenario.injects].sort((a, b) => a.at - b.at);
+  const lastTriggeredAt = sorted.reduce(
+    (acc, i) => (i.at <= elapsed ? i.at : acc),
+    -Infinity,
+  );
+
+  return (
+    <div
+      style={{
+        width: 300,
+        maxHeight: "70vh",
+        overflowY: "auto",
+        background: dark ? "rgba(10,12,20,0.82)" : "rgba(255,255,255,0.9)",
+        backdropFilter: "blur(10px)",
+        border: `1px solid ${dark ? "rgba(255,255,255,0.12)" : "rgba(0,0,0,0.1)"}`,
+        borderRadius: 10,
+        padding: "14px 16px",
+        fontFamily: "monospace",
+        pointerEvents: "auto",
+      }}
+    >
+      <div style={{ fontSize: 15, fontWeight: 700, color: dark ? "#fff" : "#222", letterSpacing: 1 }}>
+        {scenario.name}
+      </div>
+      <div style={{ fontSize: 11, color: dark ? "rgba(255,255,255,0.55)" : "rgba(0,0,0,0.5)", marginTop: 4, lineHeight: 1.5 }}>
+        {scenario.description}
+      </div>
+
+      <div style={{ height: 1, background: dark ? "rgba(255,255,255,0.1)" : "rgba(0,0,0,0.08)", margin: "12px 0" }} />
+
+      <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+        {sorted.map((inj) => {
+          const triggered = inj.at <= elapsed;
+          const isCurrent = inj.at === lastTriggeredAt;
+          return (
+            <div
+              key={inj.id}
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: 8,
+                padding: "5px 8px",
+                borderRadius: 6,
+                background: isCurrent
+                  ? (dark ? "rgba(255,176,0,0.16)" : "rgba(255,176,0,0.2)")
+                  : "transparent",
+                opacity: triggered ? 1 : 0.45,
+                transition: "opacity 0.3s, background 0.3s",
+              }}
+            >
+              <span style={{ fontSize: 11, color: dark ? "rgba(255,255,255,0.5)" : "rgba(0,0,0,0.45)", minWidth: 44 }}>
+                {fmtRel(inj.at)}
+              </span>
+              <span
+                style={{
+                  fontSize: 10,
+                  fontWeight: 700,
+                  color: TYPE_COLOR[inj.type],
+                  border: `1px solid ${TYPE_COLOR[inj.type]}66`,
+                  borderRadius: 4,
+                  padding: "1px 6px",
+                  minWidth: 36,
+                  textAlign: "center",
+                }}
+              >
+                {TYPE_LABEL[inj.type]}
+              </span>
+              <span style={{ fontSize: 12, color: dark ? "rgba(255,255,255,0.85)" : "#333", flex: 1 }}>
+                {inj.label ?? (inj.type === "banner" ? inj.text : inj.id)}
+              </span>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/engines/DispatchEngine.ts
+++ b/src/engines/DispatchEngine.ts
@@ -1,0 +1,53 @@
+/**
+ * 出動引擎 — 腳本式 A→B 沿線移動
+ *
+ * 刻意不重用 BusEngine（那是為 GPS snap / trip 分段 / 異常剔除設計，
+ * 與「照腳本從站點開到火場」無關）。只重用核心：
+ *   progress = clamp(elapsed / duration) → interpolateOnLineString(route, progress)
+ */
+
+import type { DispatchInject } from "../types/scenario";
+import { interpolateOnLineString } from "./railUtils";
+
+export interface DispatchUnit {
+  id: string;
+  unitKind: DispatchInject["unitKind"];
+  position: [number, number]; // [lng, lat]
+  progress: number; // 0..1
+  arrived: boolean;
+}
+
+const UNIT_COLOR: Record<DispatchInject["unitKind"], string> = {
+  engine: "#ff3b30", // 消防車（紅）
+  ladder: "#ff9800", // 雲梯車（橙）
+  ambulance: "#ffffff", // 救護車（白）
+};
+
+export function unitColor(kind: DispatchInject["unitKind"]): string {
+  return UNIT_COLOR[kind];
+}
+
+/**
+ * 算出某 unix 時刻所有「已出動」單位的位置。
+ * elapsedSec < 0（尚未出動）的單位不回傳。
+ */
+export function computeDispatchUnits(
+  injects: DispatchInject[],
+  startUnix: number,
+  unix: number,
+): DispatchUnit[] {
+  const units: DispatchUnit[] = [];
+  for (const inj of injects) {
+    const elapsed = unix - startUnix - inj.at;
+    if (elapsed < 0) continue;
+    const progress = inj.durationSec > 0 ? Math.min(1, elapsed / inj.durationSec) : 1;
+    units.push({
+      id: inj.id,
+      unitKind: inj.unitKind,
+      position: interpolateOnLineString(inj.route, progress),
+      progress,
+      arrived: progress >= 1,
+    });
+  }
+  return units;
+}

--- a/src/engines/ScenarioEngine.ts
+++ b/src/engines/ScenarioEngine.ts
@@ -1,0 +1,114 @@
+/**
+ * 想定引擎 — 把 inject 清單依 timeStore 的 unix 時間展開成當下狀態
+ *
+ * 純資料推導，無 React 依賴（仿 BusEngine 風格）。所有「想定相對秒」
+ * 透過 scenario.startUnix 換成 unix 比對。
+ */
+
+import type {
+  Scenario,
+  FireInject,
+  DispatchInject,
+  BannerInject,
+  CameraInject,
+} from "../types/scenario";
+import { computeDispatchUnits, type DispatchUnit } from "./DispatchEngine";
+
+const DEFAULT_BANNER_HOLD_SEC = 8;
+
+export interface FireState {
+  id: string;
+  origin: [number, number];
+  radiusM: number;
+  wind?: { bearingDeg: number; stretch: number };
+}
+
+export class ScenarioEngine {
+  readonly scenario: Scenario;
+  private fires: FireInject[];
+  private dispatches: DispatchInject[];
+  private banners: BannerInject[];
+  private cameras: CameraInject[];
+  /** camera inject 觸發水位（上次 poll 的 unix）；null = 尚未 poll */
+  private lastPolledUnix: number | null = null;
+
+  constructor(scenario: Scenario) {
+    this.scenario = scenario;
+    const sorted = [...scenario.injects].sort((a, b) => a.at - b.at);
+    this.fires = sorted.filter((i): i is FireInject => i.type === "fire");
+    this.dispatches = sorted.filter((i): i is DispatchInject => i.type === "dispatch");
+    this.banners = sorted.filter((i): i is BannerInject => i.type === "banner");
+    this.cameras = sorted.filter((i): i is CameraInject => i.type === "camera");
+  }
+
+  private injectUnix(at: number): number {
+    return this.scenario.startUnix + at;
+  }
+
+  /** 當下所有燃燒中的火場（含依 ramp 算出的半徑） */
+  getActiveFires(unix: number): FireState[] {
+    const out: FireState[] = [];
+    for (const f of this.fires) {
+      const ignite = this.injectUnix(f.at);
+      if (unix < ignite) continue;
+      if (f.endAt != null && unix > this.injectUnix(f.endAt)) continue;
+      const elapsed = unix - ignite;
+      const { startRadiusM, maxRadiusM, rampSec } = f.growth;
+      const t = rampSec > 0 ? Math.min(1, elapsed / rampSec) : 1;
+      const radiusM = startRadiusM + (maxRadiusM - startRadiusM) * t;
+      out.push({ id: f.id, origin: f.origin, radiusM, wind: f.wind });
+    }
+    return out;
+  }
+
+  /** 當下所有已出動單位的位置 */
+  getDispatchUnits(unix: number): DispatchUnit[] {
+    return computeDispatchUnits(this.dispatches, this.scenario.startUnix, unix);
+  }
+
+  /** 已出動單位的路線（供 context 顯示，單位抵達後即收起） */
+  getActiveRoutes(unix: number): [number, number][][] {
+    const out: [number, number][][] = [];
+    for (const d of this.dispatches) {
+      const elapsed = unix - this.injectUnix(d.at);
+      if (elapsed >= 0 && elapsed <= d.durationSec) out.push(d.route);
+    }
+    return out;
+  }
+
+  /** 當下應顯示的播報文字（重疊時取最新觸發者） */
+  getCurrentBanner(unix: number): string | null {
+    let active: string | null = null;
+    let activeAt = -Infinity;
+    for (const b of this.banners) {
+      const start = this.injectUnix(b.at);
+      const end = start + (b.holdSec ?? DEFAULT_BANNER_HOLD_SEC);
+      if (unix >= start && unix < end && b.at >= activeAt) {
+        active = b.text;
+        activeAt = b.at;
+      }
+    }
+    return active;
+  }
+
+  /**
+   * 取得自上次 poll 後應觸發的 camera inject。
+   * - 首次 poll 或往回 seek：回傳「當下時間點之前最近一個」以還原鏡頭/圖層狀態
+   * - 往前播放：回傳期間內新跨過的所有 camera inject
+   */
+  pollCameraInjects(unix: number): CameraInject[] {
+    let result: CameraInject[];
+    if (this.lastPolledUnix === null || unix < this.lastPolledUnix) {
+      const past = this.cameras.filter((c) => this.injectUnix(c.at) <= unix);
+      result = past.length > 0 ? [past[past.length - 1]!] : [];
+    } else {
+      const from = this.lastPolledUnix;
+      result = this.cameras.filter((c) => {
+        const u = this.injectUnix(c.at);
+        return u > from && u <= unix;
+      });
+    }
+    this.lastPolledUnix = unix;
+    return result;
+  }
+}

--- a/src/hooks/useFireScenarioLayer.ts
+++ b/src/hooks/useFireScenarioLayer.ts
@@ -1,0 +1,190 @@
+import { useEffect, useRef, useCallback } from "react";
+import type {
+  Map as MapboxMap,
+  FillLayer,
+  LineLayer,
+  CircleLayer,
+  GeoJSONSource,
+} from "mapbox-gl";
+import { timeStore } from "../state/timeStore";
+import { unitColor } from "../engines/DispatchEngine";
+import type { ScenarioEngine, FireState } from "../engines/ScenarioEngine";
+
+/**
+ * 消防想定動態圖層（火場 + 出動單位），仿 useFreewayLayer：
+ * 自管一個 GeoJSON source，訂閱 timeStore 每幀重建 features。
+ * 火場足跡用真實地理 polygon（公尺→度換算），確保各 zoom 下大小正確。
+ */
+
+const SOURCE_ID = "fire-scenario";
+const LAYER_FIRE_FILL = "fireScenario-fill";
+const LAYER_FIRE_GLOW = "fireScenario-glow";
+const LAYER_ROUTE = "fireScenario-route";
+const LAYER_UNIT = "fireScenario-unit";
+const ALL_LAYERS = [LAYER_FIRE_FILL, LAYER_FIRE_GLOW, LAYER_ROUTE, LAYER_UNIT];
+
+const M_PER_DEG_LAT = 111320;
+const ELLIPSE_SEGMENTS = 48;
+
+/** 把火場狀態轉成地理橢圓 polygon ring（風向沿 bearing 拉長 stretch 倍） */
+function fireRing(fire: FireState): [number, number][] {
+  const [lng, lat] = fire.origin;
+  const mPerDegLng = M_PER_DEG_LAT * Math.cos((lat * Math.PI) / 180);
+  const stretch = fire.wind?.stretch ?? 1;
+  const a = fire.radiusM * stretch; // 沿風向半徑
+  const b = fire.radiusM; // 側向半徑
+  const phi = ((fire.wind?.bearingDeg ?? 0) * Math.PI) / 180; // 自北順時針
+  const sinP = Math.sin(phi);
+  const cosP = Math.cos(phi);
+  const ring: [number, number][] = [];
+  for (let i = 0; i <= ELLIPSE_SEGMENTS; i++) {
+    const t = (i / ELLIPSE_SEGMENTS) * 2 * Math.PI;
+    const u = a * Math.cos(t); // 沿風向
+    const v = b * Math.sin(t); // 側向
+    const eastM = u * sinP + v * cosP;
+    const northM = u * cosP - v * sinP;
+    ring.push([lng + eastM / mPerDegLng, lat + northM / M_PER_DEG_LAT]);
+  }
+  return ring;
+}
+
+function buildGeoJSON(
+  engine: ScenarioEngine | null,
+  unix: number,
+): GeoJSON.FeatureCollection {
+  const features: GeoJSON.Feature[] = [];
+  if (engine) {
+    for (const fire of engine.getActiveFires(unix)) {
+      features.push({
+        type: "Feature",
+        properties: { kind: "fire", radiusM: Math.round(fire.radiusM) },
+        geometry: { type: "Polygon", coordinates: [fireRing(fire)] },
+      });
+    }
+    for (const route of engine.getActiveRoutes(unix)) {
+      features.push({
+        type: "Feature",
+        properties: { kind: "route" },
+        geometry: { type: "LineString", coordinates: route },
+      });
+    }
+    for (const unit of engine.getDispatchUnits(unix)) {
+      features.push({
+        type: "Feature",
+        properties: { kind: "unit", color: unitColor(unit.unitKind), arrived: unit.arrived },
+        geometry: { type: "Point", coordinates: unit.position },
+      });
+    }
+  }
+  return { type: "FeatureCollection", features };
+}
+
+function buildLayers(map: MapboxMap, isDark: boolean): boolean {
+  if (!map.getSource(SOURCE_ID)) return false;
+
+  if (!map.getLayer(LAYER_FIRE_FILL)) {
+    map.addLayer({
+      id: LAYER_FIRE_FILL,
+      type: "fill",
+      source: SOURCE_ID,
+      filter: ["==", ["get", "kind"], "fire"],
+      paint: { "fill-color": "#ff4d00", "fill-opacity": isDark ? 0.32 : 0.28 },
+    } as FillLayer);
+  }
+  if (!map.getLayer(LAYER_FIRE_GLOW)) {
+    map.addLayer({
+      id: LAYER_FIRE_GLOW,
+      type: "line",
+      source: SOURCE_ID,
+      filter: ["==", ["get", "kind"], "fire"],
+      layout: { "line-cap": "round", "line-join": "round" },
+      paint: { "line-color": "#ffb000", "line-width": 2, "line-blur": 3, "line-opacity": 0.85 },
+    } as LineLayer);
+  }
+  if (!map.getLayer(LAYER_ROUTE)) {
+    map.addLayer({
+      id: LAYER_ROUTE,
+      type: "line",
+      source: SOURCE_ID,
+      filter: ["==", ["get", "kind"], "route"],
+      layout: { "line-cap": "round", "line-join": "round" },
+      paint: {
+        "line-color": isDark ? "#8fd3ff" : "#2b6cb0",
+        "line-width": 2,
+        "line-dasharray": [2, 2],
+        "line-opacity": 0.6,
+      },
+    } as LineLayer);
+  }
+  if (!map.getLayer(LAYER_UNIT)) {
+    map.addLayer({
+      id: LAYER_UNIT,
+      type: "circle",
+      source: SOURCE_ID,
+      filter: ["==", ["get", "kind"], "unit"],
+      paint: {
+        "circle-radius": ["interpolate", ["linear"], ["zoom"], 8, 4, 13, 8, 16, 12],
+        "circle-color": ["get", "color"],
+        "circle-stroke-color": "#ffffff",
+        "circle-stroke-width": 1.5,
+        "circle-opacity": 0.95,
+      },
+    } as CircleLayer);
+  }
+  return true;
+}
+
+export function useFireScenarioLayer(
+  mapRef: React.RefObject<MapboxMap | null>,
+  visible: boolean,
+  isDark: boolean,
+  engineRef: React.RefObject<ScenarioEngine | null>,
+) {
+  const layersReadyRef = useRef(false);
+
+  const ensureLayers = useCallback(
+    (map: MapboxMap) => {
+      if (!map.getSource(SOURCE_ID)) {
+        map.addSource(SOURCE_ID, {
+          type: "geojson",
+          data: { type: "FeatureCollection", features: [] },
+        });
+      }
+      if (!layersReadyRef.current || !map.getLayer(LAYER_UNIT)) {
+        layersReadyRef.current = buildLayers(map, isDark);
+      }
+      return layersReadyRef.current;
+    },
+    [isDark],
+  );
+
+  const refresh = useCallback((map: MapboxMap, unix: number) => {
+    const src = map.getSource(SOURCE_ID) as GeoJSONSource | undefined;
+    if (!src) return;
+    src.setData(buildGeoJSON(engineRef.current, unix));
+  }, [engineRef]);
+
+  useEffect(() => {
+    const map = mapRef.current;
+    if (!map) return;
+
+    if (!visible) {
+      for (const id of ALL_LAYERS) {
+        if (map.getLayer(id)) map.setLayoutProperty(id, "visibility", "none");
+      }
+      return;
+    }
+
+    if (!ensureLayers(map)) return;
+    for (const id of ALL_LAYERS) {
+      if (map.getLayer(id)) map.setLayoutProperty(id, "visibility", "visible");
+    }
+
+    const tick = (unix: number) => {
+      const m = mapRef.current;
+      if (m) refresh(m, unix);
+    };
+    tick(timeStore.getTime()); // 初始 + seek/暫停時的單次重繪
+    return timeStore.subscribe(tick); // 每幀更新（單位數量少，成本可忽略）
+  }, [visible, ensureLayers, refresh, mapRef]);
+}

--- a/src/hooks/useLayerVisibility.ts
+++ b/src/hooks/useLayerVisibility.ts
@@ -58,6 +58,7 @@ export function useLayerVisibility() {
     groundwaterWells: false,
     iotWraRiver: false,
     iotWraStructure: false,
+    fireScenario: false,
   });
   const layerVisibilityRef = useRef(layerVisibility);
   layerVisibilityRef.current = layerVisibility;

--- a/src/hooks/useScenario.ts
+++ b/src/hooks/useScenario.ts
@@ -1,0 +1,98 @@
+import { useEffect, useRef, useState } from "react";
+import type { Map as MapboxMap } from "mapbox-gl";
+import type { LayerVisibility } from "../types";
+import type { Scenario } from "../types/scenario";
+import { ScenarioEngine } from "../engines/ScenarioEngine";
+import { timeStore } from "../state/timeStore";
+import { withLoading } from "../lib/loadingRegistry";
+
+const DEFAULT_SCENARIO_URL = "./scenarios/demo.json";
+
+interface UseScenarioArgs {
+  active: boolean;
+  mapReady: boolean;
+  mapRef: React.RefObject<MapboxMap | null>;
+  setLayerVisibility: React.Dispatch<React.SetStateAction<LayerVisibility>>;
+}
+
+interface UseScenarioReturn {
+  scenario: Scenario | null;
+  engineRef: React.RefObject<ScenarioEngine | null>;
+  banner: string | null;
+  /** 想定時間視窗（unix），餵給 useTimeline 的 overrideWindow */
+  scenarioWindow: { start: number; end: number } | undefined;
+}
+
+/**
+ * 載入想定 JSON、建立 ScenarioEngine，並驅動：
+ *  - banner 文字（throttled 250ms）
+ *  - camera inject（flyTo + setLayerVisibility，watermark cursor 由 engine 管）
+ */
+export function useScenario({
+  active,
+  mapReady,
+  mapRef,
+  setLayerVisibility,
+}: UseScenarioArgs): UseScenarioReturn {
+  const [scenario, setScenario] = useState<Scenario | null>(null);
+  const engineRef = useRef<ScenarioEngine | null>(null);
+  const [banner, setBanner] = useState<string | null>(null);
+
+  // 載入想定 JSON
+  useEffect(() => {
+    if (!active || scenario) return;
+    let cancelled = false;
+    withLoading(
+      "scenario:demo",
+      "載入想定",
+      fetch(DEFAULT_SCENARIO_URL).then((r) => {
+        if (!r.ok) throw new Error(`scenario ${r.status}`);
+        return r.json() as Promise<Scenario>;
+      }),
+    )
+      .then((data) => {
+        if (cancelled) return;
+        engineRef.current = new ScenarioEngine(data);
+        setScenario(data);
+      })
+      .catch((err) => console.warn("[Scenario] load failed:", err));
+    return () => { cancelled = true; };
+  }, [active, scenario]);
+
+  // 導播：banner + camera inject（需地圖就緒）
+  useEffect(() => {
+    if (!active || !mapReady || !scenario) return;
+    const engine = engineRef.current;
+    if (!engine) return;
+
+    // 進場先框到想定鏡頭
+    mapRef.current?.jumpTo({
+      center: scenario.camera.center,
+      zoom: scenario.camera.zoom,
+      pitch: scenario.camera.pitch,
+      bearing: scenario.camera.bearing,
+    });
+
+    const apply = (unix: number) => {
+      setBanner(engine.getCurrentBanner(unix));
+      for (const cam of engine.pollCameraInjects(unix)) {
+        mapRef.current?.flyTo({
+          center: cam.center,
+          zoom: cam.zoom,
+          pitch: cam.pitch,
+          bearing: cam.bearing,
+          duration: 1500,
+        });
+        if (cam.layers) setLayerVisibility((prev) => ({ ...prev, ...cam.layers }));
+      }
+    };
+    apply(timeStore.getTime());
+    return timeStore.subscribeThrottled(250, apply);
+  }, [active, mapReady, scenario, mapRef, setLayerVisibility]);
+
+  const scenarioWindow = scenario
+    ? { start: scenario.startUnix, end: scenario.startUnix + scenario.durationSec }
+    : undefined;
+
+  return { scenario, engineRef, banner, scenarioWindow };
+}

--- a/src/hooks/useTimeline.ts
+++ b/src/hooks/useTimeline.ts
@@ -32,6 +32,11 @@ interface UseTimelineOptions {
   dataStartTime: number;
   dataEndTime: number;
   timeMode?: TimeMode;
+  /**
+   * 想定模式：直接指定播放視窗（unix），繞過日期格邏輯。
+   * 設定時 windowStart/windowEnd 與時鐘初值都改用它。
+   */
+  overrideWindow?: { start: number; end: number };
 }
 
 interface UseTimelineReturn {
@@ -75,6 +80,7 @@ export function useTimeline({
   dataStartTime,
   dataEndTime: _dataEndTime,
   timeMode: initialTimeMode = "replay",
+  overrideWindow,
 }: UseTimelineOptions): UseTimelineReturn {
   void _dataEndTime; // 保留 interface 相容，實際用 dataStartTime 初始化
   // 預設選定日期 = 台灣時間的今天（不依賴資料範圍，避免不同資料源日期不一致）
@@ -84,17 +90,21 @@ export function useTimeline({
   });
   const [rangeDays, setRangeDays] = useState(1);
 
-  // 視窗起止
-  const windowStart = dayStartUnix(selectedDate);
-  const windowEnd = dayEndUnix(addDays(selectedDate, rangeDays - 1));
+  // 視窗起止（想定模式直接用 overrideWindow）
+  const windowStart = overrideWindow ? overrideWindow.start : dayStartUnix(selectedDate);
+  const windowEnd = overrideWindow ? overrideWindow.end : dayEndUnix(addDays(selectedDate, rangeDays - 1));
 
   // 首次渲染寫入 timeStore 初始值（從「現在 - 1 小時」開始；過去日期從午夜開始）
   const initRef = useRef(false);
   if (!initRef.current) {
-    const startUnix = Date.now() / 1000 - 3600;
-    const initial =
-      startUnix >= windowStart && startUnix <= windowEnd ? startUnix : windowStart;
-    timeStore.setTime(initial);
+    if (overrideWindow) {
+      timeStore.setTime(overrideWindow.start);
+    } else {
+      const startUnix = Date.now() / 1000 - 3600;
+      const initial =
+        startUnix >= windowStart && startUnix <= windowEnd ? startUnix : windowStart;
+      timeStore.setTime(initial);
+    }
     initRef.current = true;
   }
 
@@ -103,6 +113,13 @@ export function useTimeline({
   const [timeMode, setTimeMode] = useState<TimeMode>(initialTimeMode);
   const rafRef = useRef<number>(0);
   const lastFrameRef = useRef<number>(0);
+
+  // overrideWindow 在想定載入後才出現/變更 → 重新把時鐘 seed 到視窗起點
+  useEffect(() => {
+    if (!overrideWindow) return;
+    timeStore.setTime(overrideWindow.start);
+    setPlaying(false);
+  }, [overrideWindow?.start, overrideWindow?.end]);
 
   // UI 取用的 currentTime：節流訂閱，不隨每幀 re-render。
   // 動畫迴圈請直接 timeStore.getTime()，不要經過這個值。

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -459,6 +459,7 @@ export interface LayerVisibility {
   groundwaterWells: boolean;
   iotWraRiver: boolean;
   iotWraStructure: boolean;
+  fireScenario: boolean;
 }
 
 // ── 空氣品質 ──

--- a/src/types/scenario.ts
+++ b/src/types/scenario.ts
@@ -1,0 +1,89 @@
+/**
+ * 消防兵棋推演 — 引導式想定（scripted scenario）資料模型
+ *
+ * 想定 = 一串以「想定相對秒」(at) 為軸的 inject。引擎把 at 映射到 unix
+ * （unix = scenario.startUnix + at），再交給既有 timeStore 時鐘播放。
+ *
+ * 注意：這不是模擬引擎。火場成長走簡化規則（半徑隨時間 ramp，風向拉長橢圓），
+ * 單位移動走 LineString 線性插值，全部由 timeStore.getTime() 推導，無物理。
+ */
+
+import type { LayerVisibility } from "./index";
+
+export type InjectType = "fire" | "dispatch" | "banner" | "camera";
+
+interface BaseInject {
+  id: string;
+  /** 想定相對秒（從 t=0 起算） */
+  at: number;
+  /** 主持人 inject 清單顯示用標籤 */
+  label?: string;
+}
+
+/** 火場：在某點點燃，半徑依成長曲線擴大，風向把足跡拉成橢圓 */
+export interface FireInject extends BaseInject {
+  type: "fire";
+  origin: [number, number]; // [lng, lat]
+  growth: {
+    startRadiusM: number;
+    maxRadiusM: number;
+    /** 從 startRadius 漲到 maxRadius 所需的想定秒數 */
+    rampSec: number;
+  };
+  wind?: {
+    /** 風吹向的方位角（度，0=北、90=東） */
+    bearingDeg: number;
+    /** 沿風向的拉長倍率（1 = 正圓） */
+    stretch: number;
+  };
+  /** 撲滅時間（想定相對秒）；未指定則持續到想定結束 */
+  endAt?: number;
+}
+
+/** 出動：單位沿 route 由起點開到火場，durationSec 內走完 */
+export interface DispatchInject extends BaseInject {
+  type: "dispatch";
+  route: [number, number][]; // LineString [lng, lat][]
+  durationSec: number;
+  unitKind: "engine" | "ambulance" | "ladder";
+}
+
+/** 字幕／播報：在 at 時刻顯示一段文字 */
+export interface BannerInject extends BaseInject {
+  type: "banner";
+  text: string;
+  /** 顯示持續秒數（想定秒），預設 8 */
+  holdSec?: number;
+}
+
+/** 鏡頭 + 圖層開關：對齊 CameraPreset，複用 App 既有 flyTo + setLayerVisibility */
+export interface CameraInject extends BaseInject {
+  type: "camera";
+  center: [number, number];
+  zoom: number;
+  pitch: number;
+  bearing: number;
+  layers?: Partial<LayerVisibility>;
+}
+
+export type Inject = FireInject | DispatchInject | BannerInject | CameraInject;
+
+export interface Scenario {
+  id: string;
+  name: string;
+  description: string;
+  /** 進場鏡頭 */
+  camera: {
+    center: [number, number];
+    zoom: number;
+    pitch: number;
+    bearing: number;
+  };
+  /** 想定 t=0 對應的 unix 時間（驅動時鐘顯示與視窗起點） */
+  startUnix: number;
+  /** 想定總長（秒） */
+  durationSec: number;
+  /** 預設播放倍速 */
+  defaultSpeed?: number;
+  injects: Inject[];
+}


### PR DESCRIPTION
以 ?mode=scenario 進入。複用既有 timeStore 時鐘 + Mapbox 動態層架構， 新增火場成長（簡化規則 + 風向橢圓）、出動單位沿線插值、播報 banner、
鏡頭/圖層 inject。想定以 JSON 編寫，工作量集中在呈現層。

- types/scenario.ts: 想定 + 4 種 inject 型別
- ScenarioEngine / DispatchEngine: 純資料推導引擎（含 camera watermark）
- useScenario / useFireScenarioLayer: 載入 + 導播 + Mapbox-native 渲染
- ScenarioPanel + banner overlay: 主持人 UI
- useTimeline: 新增 overrideWindow 驅動想定時鐘（不影響資料模式）
- 7 步骨架補 fireScenario key
- public/scenarios/demo.json: 信義區商辦火警示範想定

https://claude.ai/code/session_019yHG7nfAN9nGiJDnfnDSCX