### PR TITLE
ci: add GitHub Actions (tsc + vitest)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [master]
+  push:
+    branches: [master]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - run: npm ci
+
+      - name: TypeScript build (tsc -b + vite build)
+        run: npm run build
+
+      - name: Tests (vitest)
+        run: npm test


### PR DESCRIPTION
## Summary
- Add `.github/workflows/ci.yml`：PR/push to master 自動跑 `npm ci` → `npm run build`（tsc -b + vite build）→ `npm test`（55 vitest tests）

## 動機
之前完全沒 CI，靠本地手動 tsc。這 PR 把把關移到雲端，每次推 master 之前 GitHub Actions 跑一遍乾淨環境的驗證。

## Test plan
- [ ] PR 一開，Actions 跑綠
- [ ] 故意 break TypeScript 試試紅燈是否擋下來（不在此 PR）

🤖 Generated with [Claude Code](https://claude.com/claude-code)