### PR TITLE
feat(newsEvents): 分類上色 + 圖例（階段 A）

### DIFF
--- a/src/components/LegendPanel.tsx
+++ b/src/components/LegendPanel.tsx
@@ -6,6 +6,7 @@ import { AGRI_POI_TYPES } from "../data/agriPOITypes";
 import { MEDICAL_POI_TYPES } from "../data/medicalPOITypes";
 import { AGRI_COMPANY_TYPES } from "../data/agriCompanyTypes";
 import { ALERT_GROUPS, ALERT_GROUP_KEYS } from "../data/disasterAlertTypes";
+import { NEWS_CATEGORIES } from "../data/newsEventTypes";
 import { ECO_NETWORK_ZONE_TYPES } from "../data/ecoNetworkZoneTypes";
 import { FOREST_RESERVE_TYPES } from "../data/forestReserveTypes";
 import {
@@ -95,6 +96,7 @@ export const LEGEND_REGISTRY: LegendEntry[] = [
   { keys: ["earthquakes"], render: () => <EarthquakeLegend /> },
   { keys: ["lifelineAlerts", "floodAlerts", "weatherAlerts", "transitAlerts", "safetyAlerts"], render: ({ visibility }) => <DisasterAlertLegend visibility={visibility} /> },
   { keys: ["roadEvents"], render: () => <RoadEventsLegend /> },
+  { keys: ["newsEvents"], render: () => <NewsEventsLegend /> },
   { keys: ["iotWraRiver"], render: () => <IotRiverLegend /> },
   { keys: ["iotWraStructure"], render: () => <IotStructureLegend /> },
   { keys: ["agriCropSuitability"], render: ({ overlayParams }) => <CropSuitabilityLegend cropId={overlayParams.agriCropSuitabilityCropId ?? 0} /> },
@@ -690,6 +692,38 @@ function DisasterAlertLegend({ visibility }: { visibility: LayerVisibility }) {
       ))}
       <div style={{ fontSize: 8, color: "rgba(255,255,255,0.25)", marginTop: 2 }}>
         填色深淺 = 嚴重度（Extreme→Minor）
+      </div>
+    </div>
+  );
+}
+
+// ── News Events Legend (7 類分色) ──
+
+function NewsEventsLegend() {
+  return (
+    <div>
+      <div style={{ fontSize: 9, color: "rgba(255,255,255,0.35)", letterSpacing: 1, marginBottom: 4 }}>
+        NEWS EVENTS
+      </div>
+      <div style={{ display: "flex", flexDirection: "column", gap: 2 }}>
+        {NEWS_CATEGORIES.map((cat) => (
+          <div key={cat.key} style={{ display: "flex", alignItems: "center", gap: 6 }}>
+            <div
+              style={{
+                width: 10,
+                height: 10,
+                borderRadius: "50%",
+                background: cat.color,
+                opacity: cat.key === "other" ? 0.4 : 0.9,
+                flexShrink: 0,
+              }}
+            />
+            <span style={{ fontSize: 9, color: "rgba(255,255,255,0.5)" }}>{cat.label}</span>
+          </div>
+        ))}
+      </div>
+      <div style={{ fontSize: 8, color: "rgba(255,255,255,0.25)", marginTop: 4 }}>
+        座標 = 鄉鎮代表點（非事件位置）
       </div>
     </div>
   );

--- a/src/components/featureInfo/eventPanels.tsx
+++ b/src/components/featureInfo/eventPanels.tsx
@@ -1,18 +1,20 @@
 import { Row } from "./shared";
+import { getNewsCategoryDef } from "../../data/newsEventTypes";
 
 export function NewsEventPanel({ props }: { props: Record<string, unknown> }) {
   const link = String(props.link ?? "");
+  const cat = getNewsCategoryDef(props.category as string | undefined);
   return (
     <>
       <div style={{ display: "flex", alignItems: "center", gap: 6, marginBottom: 6 }}>
-        <div style={{ width: 10, height: 10, borderRadius: "50%", background: "#ff9800", flexShrink: 0 }} />
+        <div style={{ width: 10, height: 10, borderRadius: "50%", background: cat.color, flexShrink: 0 }} />
         <div style={{ fontSize: 13, fontWeight: 700, color: "#fff", letterSpacing: 0.5, lineHeight: 1.4 }}>
           {String(props.title ?? "Unknown Event")}
         </div>
       </div>
       <Row label="摘要" value={String(props.summary ?? "")} />
       <Row label="地點" value={String(props.location_name ?? "")} />
-      <Row label="分類" value={String(props.category ?? "")} color="#ff9800" />
+      <Row label="分類" value={cat.label} color={cat.color} />
       <Row label="時間" value={String(props.published ?? "")} />
       {link && (
         <div style={{ marginTop: 6 }}>
@@ -20,9 +22,9 @@ export function NewsEventPanel({ props }: { props: Record<string, unknown> }) {
             href={link}
             target="_blank"
             rel="noopener noreferrer"
-            style={{ color: "#ff9800", fontSize: 11, fontFamily: "monospace", textDecoration: "underline" }}
+            style={{ color: cat.color, fontSize: 11, fontFamily: "monospace", textDecoration: "underline" }}
           >
-            CNA 原文
+            原文連結
           </a>
         </div>
       )}

--- a/src/components/sidebar/__tests__/layerConsistency.test.ts
+++ b/src/components/sidebar/__tests__/layerConsistency.test.ts
@@ -58,7 +58,7 @@ const BASELINE_NO_LEGEND = new Set([
   "freewayCongestion", "weatherStations", "h3Population", "popCount",
   "indicators", "socioeconomic", "spatialEconomy", "temperatureWave",
   "schools", "convenienceStores", "submarineCables", "landingStations",
-  "activeFaults", "newsEvents", "youbikeFullness", "cwaCloudImagery",
+  "activeFaults", "youbikeFullness", "cwaCloudImagery",
   "cwaRadarImagery", "aqiImagery", "aqiStations", "aqiMicroSensors",
   "busLive", "busIntercityLive", "waterBasins", "waterRivers", "waterLevees",
   "waterProtectionZones", "waterReservoirs", "waterFacilities",

--- a/src/data/newsEventTypes.ts
+++ b/src/data/newsEventTypes.ts
@@ -1,0 +1,55 @@
+/**
+ * News Events — 分類定義（單一真實來源）
+ *
+ * 對應 LLM（Gemini Flash-Lite）輸出的 7 類，collector 寫入
+ * `realtime.news_events.category`，前端用同一份表做：
+ *  - overlayRegistry circle-color match expression
+ *  - LegendPanel NewsEventLegend
+ *  - NewsEventPanel popup 中文標籤 + 對應分類色
+ *
+ * 順序 = 圖例顯示順序（重要性遞減：時序性事件 → 政策 → 兜底 other）。
+ */
+
+export type NewsCategory =
+  | "accident"
+  | "crime"
+  | "disaster"
+  | "traffic"
+  | "health"
+  | "policy"
+  | "other";
+
+export interface NewsCategoryDef {
+  key: NewsCategory;
+  label: string;
+  color: string;
+}
+
+export const NEWS_CATEGORIES: NewsCategoryDef[] = [
+  { key: "accident", label: "事故",     color: "#ef4444" },
+  { key: "crime",    label: "治安",     color: "#a855f7" },
+  { key: "disaster", label: "災害",     color: "#f97316" },
+  { key: "traffic",  label: "交通",     color: "#eab308" },
+  { key: "health",   label: "健康",     color: "#22c55e" },
+  { key: "policy",   label: "政策",     color: "#3b82f6" },
+  { key: "other",    label: "其他",     color: "#9ca3af" },
+];
+
+const OTHER_COLOR = "#9ca3af";
+
+/**
+ * Mapbox `match` expression — 給 overlayRegistry circle-color 用。
+ * 未匹配 → other 色（兜底）。
+ */
+export const NEWS_CATEGORY_COLOR_EXPR: unknown = [
+  "match",
+  ["get", "category"],
+  ...NEWS_CATEGORIES.flatMap((c) => [c.key, c.color]),
+  OTHER_COLOR,
+];
+
+const OTHER_DEF: NewsCategoryDef = { key: "other", label: "其他", color: OTHER_COLOR };
+
+export function getNewsCategoryDef(key: string | null | undefined): NewsCategoryDef {
+  return NEWS_CATEGORIES.find((c) => c.key === key) ?? OTHER_DEF;
+}

--- a/src/map/overlayRegistry.ts
+++ b/src/map/overlayRegistry.ts
@@ -1,6 +1,7 @@
 import type { OverlayConfig } from "../types";
 import { ECO_NETWORK_ZONE_MATCH } from "../data/ecoNetworkZoneTypes";
 import { FOREST_RESERVE_TYPE_MATCH } from "../data/forestReserveTypes";
+import { NEWS_CATEGORY_COLOR_EXPR } from "../data/newsEventTypes";
 
 const BASE_RADIUS = 5;
 
@@ -1617,18 +1618,19 @@ export const OVERLAY_REGISTRY: OverlayConfig[] = [
               "interpolate", ["linear"], ["zoom"],
               5, 3 * s, 10, 5 * s, 14, 8 * s,
             ],
-            "circle-color": [
-              "case",
-              ["==", ["get", "is_primary"], true],
-              isDark ? "#ff9800" : "#e65100",
-              isDark ? "#ffcc80" : "#ff9800",
-            ] as unknown as string,
+            "circle-color": NEWS_CATEGORY_COLOR_EXPR as unknown as string,
             "circle-stroke-color": isDark ? "rgba(255,255,255,0.5)" : "rgba(0,0,0,0.3)",
             "circle-stroke-width": [
               "interpolate", ["linear"], ["zoom"],
               5, 0, 10, 0.5, 14, 1,
             ],
-            "circle-opacity": isDark ? 0.85 : 0.75,
+            // other 類降透明度避免占據視覺重量
+            "circle-opacity": [
+              "case",
+              ["==", ["get", "category"], "other"],
+              isDark ? 0.4 : 0.35,
+              isDark ? 0.9 : 0.8,
+            ] as unknown as number,
           };
         },
       },


### PR DESCRIPTION
## Summary
newsEvents 圖層從單一橘色升級為 7 類分色（accident/crime/disaster/traffic/health/policy/other），並補上對應圖例與 popup 中文分類。

## 改動
- **新檔** `src/data/newsEventTypes.ts` — 單一真實來源（7 類定義 + match expression + helper）
- `src/map/overlayRegistry.ts` — circle-color 改用 category match；other 類降透明度
- `src/components/LegendPanel.tsx` — 加 NewsEventsLegend + LEGEND_REGISTRY
- `src/components/featureInfo/eventPanels.tsx` — popup 分類顯示中文 + 對應分類色
- `src/components/sidebar/__tests__/layerConsistency.test.ts` — baseline 移除 newsEvents（ratchet）

## 自我檢查
- ✅ `npx tsc -b` 通過
- ✅ `npm test` 55 tests pass（含 layerConsistency）
- ✅ 瀏覽器實測 254 features，7 類分布：other 115 / policy 55 / crime 39 / accident 33 / health 6 / traffic 3 / disaster 3
- ✅ LegendPanel NEWS EVENTS 段顯示正常
- ✅ popup「分類」欄中文 + 對應色點
- ✅ 無 console error

## 螢幕截圖
- /tmp/news_classify_test.png（多色點位）
- /tmp/news_legend_test.png（LEGEND 展開）
- /tmp/news_popup_color_test.png（accident popup）

## P0 規則檢查
- ✅ Loader 接 loadingRegistry（既有）
- ✅ 動態圖層不把 currentTime 放 useEffect deps（既有 timeStore 訂閱）
- ✅ 圖層 UX 四鐵則：透明度 slider (newsScale 既有) / 分類≥2 寫圖例 (新增) / popup (升級) / dropdown (N/A，無多選項)

🤖 Generated with [Claude Code](https://claude.com/claude-code)