### PR TITLE
feat(newsEvents): 同鄉鎮聚合 paint + popup（階段 B）

### DIFF
--- a/src/components/featureInfo/eventPanels.tsx
+++ b/src/components/featureInfo/eventPanels.tsx
@@ -1,33 +1,118 @@
 import { Row } from "./shared";
 import { getNewsCategoryDef } from "../../data/newsEventTypes";
+import type { ClusterEvent } from "../../data/newsEventsLoader";
+
+function parseEvents(raw: unknown): ClusterEvent[] {
+  if (typeof raw !== "string" || !raw) return [];
+  try {
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? (parsed as ClusterEvent[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+function formatTs(unixSec: number | undefined | null): string {
+  if (!unixSec) return "";
+  return new Date(unixSec * 1000).toLocaleString("zh-TW", {
+    timeZone: "Asia/Taipei",
+    hour12: false,
+  });
+}
 
 export function NewsEventPanel({ props }: { props: Record<string, unknown> }) {
-  const link = String(props.link ?? "");
-  const cat = getNewsCategoryDef(props.category as string | undefined);
+  const eventCount = Number(props.event_count ?? 1);
+  const location = String(props.location_name ?? props.county ?? "");
+  const events = parseEvents(props.events_json);
+
+  // 單則：維持原本簡潔版型（向後相容）
+  if (eventCount <= 1 || events.length <= 1) {
+    const link = String(props.link ?? "");
+    const cat = getNewsCategoryDef(props.category as string | undefined);
+    return (
+      <>
+        <div style={{ display: "flex", alignItems: "center", gap: 6, marginBottom: 6 }}>
+          <div style={{ width: 10, height: 10, borderRadius: "50%", background: cat.color, flexShrink: 0 }} />
+          <div style={{ fontSize: 13, fontWeight: 700, color: "#fff", letterSpacing: 0.5, lineHeight: 1.4 }}>
+            {String(props.title ?? "Unknown Event")}
+          </div>
+        </div>
+        <Row label="摘要" value={String(props.summary ?? "")} />
+        <Row label="地點" value={location} />
+        <Row label="分類" value={cat.label} color={cat.color} />
+        <Row label="時間" value={String(props.published ?? "")} />
+        {link && (
+          <div style={{ marginTop: 6 }}>
+            <a
+              href={link}
+              target="_blank"
+              rel="noopener noreferrer"
+              style={{ color: cat.color, fontSize: 11, fontFamily: "monospace", textDecoration: "underline" }}
+            >
+              原文連結
+            </a>
+          </div>
+        )}
+      </>
+    );
+  }
+
+  // 多則：標題列 + 可滑動清單
   return (
     <>
-      <div style={{ display: "flex", alignItems: "center", gap: 6, marginBottom: 6 }}>
-        <div style={{ width: 10, height: 10, borderRadius: "50%", background: cat.color, flexShrink: 0 }} />
+      <div style={{
+        display: "flex", alignItems: "center", gap: 6, marginBottom: 8,
+        paddingBottom: 6, borderBottom: "1px solid rgba(255,255,255,0.1)",
+      }}>
+        <div style={{ fontSize: 14, lineHeight: 1 }}>📰</div>
         <div style={{ fontSize: 13, fontWeight: 700, color: "#fff", letterSpacing: 0.5, lineHeight: 1.4 }}>
-          {String(props.title ?? "Unknown Event")}
+          {location}
+        </div>
+        <div style={{
+          marginLeft: "auto", fontSize: 10, padding: "1px 6px", borderRadius: 3,
+          background: "rgba(255,255,255,0.12)", color: "rgba(255,255,255,0.9)", fontWeight: 600,
+        }}>
+          {eventCount} 則
         </div>
       </div>
-      <Row label="摘要" value={String(props.summary ?? "")} />
-      <Row label="地點" value={String(props.location_name ?? "")} />
-      <Row label="分類" value={cat.label} color={cat.color} />
-      <Row label="時間" value={String(props.published ?? "")} />
-      {link && (
-        <div style={{ marginTop: 6 }}>
-          <a
-            href={link}
-            target="_blank"
-            rel="noopener noreferrer"
-            style={{ color: cat.color, fontSize: 11, fontFamily: "monospace", textDecoration: "underline" }}
-          >
-            原文連結
-          </a>
-        </div>
-      )}
+      <div style={{
+        display: "flex", flexDirection: "column", gap: 6,
+        maxHeight: 240, overflowY: "auto", paddingRight: 4,
+      }}>
+        {events.map((e) => {
+          const cat = getNewsCategoryDef(e.category);
+          return (
+            <div key={e.id} style={{ display: "flex", gap: 6, alignItems: "flex-start" }}>
+              <div style={{
+                width: 8, height: 8, borderRadius: "50%",
+                background: cat.color, marginTop: 5, flexShrink: 0,
+              }} />
+              <div style={{ flex: 1, minWidth: 0 }}>
+                <a
+                  href={e.url ?? "#"}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  style={{
+                    color: "rgba(255,255,255,0.92)", fontSize: 11.5, fontWeight: 600,
+                    textDecoration: "none", lineHeight: 1.4, display: "block",
+                  }}
+                >
+                  {e.title}
+                </a>
+                <div style={{
+                  fontSize: 10, color: "rgba(255,255,255,0.4)", marginTop: 2,
+                  display: "flex", gap: 6, flexWrap: "wrap",
+                }}>
+                  <span style={{ color: cat.color }}>{cat.label}</span>
+                  <span>·</span>
+                  <span>{formatTs(e.published_ts)}</span>
+                  {e.source && <span>· {e.source.toUpperCase()}</span>}
+                </div>
+              </div>
+            </div>
+          );
+        })}
+      </div>
     </>
   );
 }

--- a/src/data/newsEventsLoader.ts
+++ b/src/data/newsEventsLoader.ts
@@ -4,10 +4,15 @@ import { cachedOnce, cachedByKey } from "../lib/loaderCache";
 
 /**
  * 新聞事件 (CNA 等來源 geocoded) loader
- * - 來源：Supabase RPC get_news_events_day(p_day) / get_news_event_dates()
- * - Supabase 未設定時 fallback 靜態檔 ./geo/news_events.geojson（舊行為：全量、不分日）
- * - properties 形狀與 public/geo/news_events.geojson 完全相同，
- *   下游（overlayRegistry newsEvents / useNewsTimeline / NewsEventPanel）零改動
+ * - 來源：Supabase RPC get_news_events_day_clustered（階段 B：按鄉鎮聚合）
+ *         + get_news_event_dates（日期清單）
+ * - Supabase 未設定時 fallback 靜態檔 ./geo/news_events.geojson
+ *
+ * 階段 B 輸出 properties（每個 Feature 代表一個鄉鎮 cluster）：
+ *  - title/summary/category/link/published/published_ts/confidence/is_primary
+ *    皆對應該 cluster「最新一則」事件（向後相容既有 useNewsTimeline filter + popup）
+ *  - event_count：cluster 內事件數（給 paint 半徑放大用）
+ *  - events_json：jsonb 字串，含整批事件清單（給 popup 多則清單渲染）
  */
 
 export interface NewsEventDateInfo {
@@ -15,18 +20,28 @@ export interface NewsEventDateInfo {
   event_count: number;
 }
 
-interface RawRow {
-  id: number;
-  source: string | null;
-  url: string | null;
-  title: string | null;
-  summary: string | null;
-  category: string | null;
-  location_name: string | null;
-  county: string | null;
+/** RPC get_news_events_day_clustered 回傳 row */
+interface RawCluster {
   lon: number | null;
   lat: number | null;
-  published_ts: string | null; // timestamptz → ISO string
+  county: string | null;
+  location_name: string | null;
+  event_count: number | null;
+  latest_category: string | null;
+  latest_published_ts: string | null; // timestamptz → ISO string
+  events: ClusterEvent[] | null;       // jsonb array
+}
+
+/** events_json 內每一則的 shape（RPC jsonb_build_object 對齊） */
+export interface ClusterEvent {
+  id: number;
+  title: string;
+  summary: string | null;
+  category: string | null;
+  source: string | null;
+  url: string | null;
+  /** unix 秒（RPC 已 extract epoch） */
+  published_ts: number;
   confidence: number | null;
 }
 
@@ -42,33 +57,36 @@ function formatPublished(tsSec: number): string {
   });
 }
 
-/** RPC rows → 與靜態檔相同 properties 形狀的 FeatureCollection */
-function rowsToGeoJSON(rows: RawRow[]): GeoJSON.FeatureCollection {
+/** Clustered RPC rows → FeatureCollection（每個 Feature 是一個鄉鎮 cluster） */
+function clustersToGeoJSON(rows: RawCluster[]): GeoJSON.FeatureCollection {
   const features: GeoJSON.Feature[] = [];
   for (const r of rows) {
     if (r.lon == null || r.lat == null) continue;
-    const tsSec = r.published_ts ? Math.floor(Date.parse(r.published_ts) / 1000) : 0;
+    const events = (r.events ?? []) as ClusterEvent[];
+    if (events.length === 0) continue;
+    const latest = events[0]; // RPC 已按 published_ts DESC 排
+    if (!latest) continue;
     features.push({
       type: "Feature",
       geometry: { type: "Point", coordinates: [r.lon, r.lat] },
       properties: {
-        // ── 與 public/geo/news_events.geojson 完全相同的欄位（下游契約） ──
-        title: r.title ?? "",
-        summary: r.summary ?? "",
-        category: r.category ?? "",
+        // ── 向後相容欄位（既有 useNewsTimeline filter、舊版 popup、paint 都讀這些） ──
+        title: latest.title ?? "",
+        summary: latest.summary ?? "",
+        category: r.latest_category ?? latest.category ?? "",
         rss_category: "",
-        link: r.url ?? "",
-        published: formatPublished(tsSec),
+        link: latest.url ?? "",
+        published: formatPublished(latest.published_ts ?? 0),
         location_name: r.location_name ?? "",
         location_type: "",
-        confidence: r.confidence ?? 0,
+        confidence: latest.confidence ?? 0,
         note: "",
-        is_primary: true, // RPC 每事件僅一點，皆為主要地點
-        published_ts: tsSec, // unix 秒（useNewsTimeline filter 用）
-        // ── RPC 額外欄位（additive，不影響既有下游） ──
-        id: r.id,
-        source: r.source ?? "",
+        is_primary: true,
+        published_ts: latest.published_ts ?? 0, // unix 秒（useNewsTimeline filter 用）
+        // ── 階段 B 新增 ──
+        event_count: r.event_count ?? events.length,
         county: r.county ?? "",
+        events_json: JSON.stringify(events), // popup 多則清單渲染
       },
     });
   }
@@ -116,13 +134,17 @@ async function fetchNewsEventsDayUncached(date: string): Promise<GeoJSON.Feature
   const { data, error } = await withLoading(
     `news-events:${date}`,
     `新聞事件 ${date}`,
-    supabase.rpc("get_news_events_day", { p_day: date }),
+    supabase.rpc("get_news_events_day_clustered", { p_day: date }),
   );
-  if (error) throw new Error(`get_news_events_day(${date}): ${error.message}`);
+  if (error) throw new Error(`get_news_events_day_clustered(${date}): ${error.message}`);
 
-  const fc = rowsToGeoJSON((data ?? []) as RawRow[]);
+  const fc = clustersToGeoJSON((data ?? []) as RawCluster[]);
+  const totalEvents = fc.features.reduce(
+    (acc, f) => acc + (typeof f.properties?.event_count === "number" ? f.properties.event_count : 0),
+    0,
+  );
   console.log(
-    `[NewsEvents] Loaded ${fc.features.length} events for ${date} in ${(performance.now() - t0).toFixed(0)}ms`,
+    `[NewsEvents] Loaded ${fc.features.length} clusters (${totalEvents} events) for ${date} in ${(performance.now() - t0).toFixed(0)}ms`,
   );
   return fc;
 }

--- a/src/hooks/useMapInteraction.ts
+++ b/src/hooks/useMapInteraction.ts
@@ -190,7 +190,7 @@ export function useMapInteraction(
           { layers: ["medical-pharmacies-circle"], type: "medicalPOI" },
           { layers: ["medical-aed-circle"], type: "medicalPOI" },
           { layers: ["medical-ltc-circle"], type: "medicalPOI" },
-          { layers: ["news-events-circle", "news-events-glow"], type: "newsEvent" },
+          { layers: ["news-events-circle", "news-events-glow", "news-events-count"], type: "newsEvent" },
           { layers: DISASTER_ALERT_CLICK_LAYERS, type: "disasterAlert" },
           { layers: ["roadEvents-fill", "roadEvents-line", "roadEvents-point"], type: "roadEvent" },
           { layers: ["aqi-stations-circle", "aqi-stations-glow"], type: "aqiStation" },

--- a/src/hooks/useNewsTimeline.ts
+++ b/src/hooks/useNewsTimeline.ts
@@ -19,7 +19,7 @@ const RIPPLE_COUNT = 2;
 /** ripple 動畫更新間隔（毫秒），~30fps */
 const FRAME_INTERVAL = 33;
 
-const NEWS_LAYER_IDS = ["news-events-glow", "news-events-circle"];
+const NEWS_LAYER_IDS = ["news-events-glow", "news-events-circle", "news-events-count"];
 const RIPPLE_IDS = Array.from({ length: RIPPLE_COUNT }, (_, i) => `news-events-ripple-${i}`);
 
 export function useNewsTimeline(

--- a/src/map/overlayRegistry.ts
+++ b/src/map/overlayRegistry.ts
@@ -1613,18 +1613,24 @@ export const OVERLAY_REGISTRY: OverlayConfig[] = [
         type: "circle",
         paint: (isDark, params) => {
           const s = params?.newsScale ?? 1;
+          // 階段 B：event_count 1→1x、5→1.6x、15→2.4x、50→3.2x
+          const countMult = [
+            "interpolate", ["linear"], ["coalesce", ["get", "event_count"], 1],
+            1, 1, 5, 1.6, 15, 2.4, 50, 3.2,
+          ];
           return {
             "circle-radius": [
               "interpolate", ["linear"], ["zoom"],
-              5, 3 * s, 10, 5 * s, 14, 8 * s,
-            ],
+              5, ["*", 3 * s, countMult],
+              10, ["*", 5 * s, countMult],
+              14, ["*", 8 * s, countMult],
+            ] as unknown as number,
             "circle-color": NEWS_CATEGORY_COLOR_EXPR as unknown as string,
             "circle-stroke-color": isDark ? "rgba(255,255,255,0.5)" : "rgba(0,0,0,0.3)",
             "circle-stroke-width": [
               "interpolate", ["linear"], ["zoom"],
               5, 0, 10, 0.5, 14, 1,
             ],
-            // other 類降透明度避免占據視覺重量
             "circle-opacity": [
               "case",
               ["==", ["get", "category"], "other"],
@@ -1633,6 +1639,31 @@ export const OVERLAY_REGISTRY: OverlayConfig[] = [
             ] as unknown as number,
           };
         },
+      },
+      {
+        // 階段 B：event_count ≥ 2 時在點上顯示數字
+        suffix: "count",
+        type: "symbol",
+        layout: {
+          "text-field": [
+            "case",
+            [">=", ["coalesce", ["get", "event_count"], 0], 2],
+            ["to-string", ["get", "event_count"]],
+            "",
+          ] as unknown as string,
+          "text-size": [
+            "interpolate", ["linear"], ["zoom"],
+            5, 9, 10, 11, 14, 13,
+          ],
+          "text-font": ["DIN Pro Bold", "Arial Unicode MS Bold"],
+          "text-allow-overlap": true,
+          "text-ignore-placement": true,
+        },
+        paint: (isDark) => ({
+          "text-color": isDark ? "#fff" : "#1a1a1a",
+          "text-halo-color": isDark ? "rgba(0,0,0,0.7)" : "rgba(255,255,255,0.9)",
+          "text-halo-width": 1.2,
+        }),
       },
     ],
   },

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -462,7 +462,7 @@ export interface BusTrail {
 
 export interface OverlayLayerSpec {
   suffix: string;
-  type: "line" | "fill" | "circle" | "fill-extrusion";
+  type: "line" | "fill" | "circle" | "fill-extrusion" | "symbol";
   layout?: Record<string, unknown>;
   paint: (isDark: boolean, params?: Record<string, number>) => Record<string, unknown>;
   minzoom?: number;


### PR DESCRIPTION
## Summary
依賴 [gis-platform#6](https://github.com/ianlkl11234s/gis-platform/pull/6) (migration 163 已 apply 至線上)。

切到 clustered RPC 後，每個 Feature 代表一個鄉鎮 cluster：
- 點大小依事件數放大、≥2 顯示數字
- popup 多則時改成可滾動清單，每行一則新聞
- popup 單則保持原版型（向後相容）

## 自我檢查
- ✅ tsc -b 通過
- ✅ npm test 55 tests pass
- ✅ 瀏覽器實測 100 cluster (370 events)
  - max 51 (臺北市) / ≥10 共 6 個 / ≥5 共 17 個 / ≥2 共 49 個
  - 數字標籤正確顯示（51 / 32 / 31 / 21 / 17 / 13 ...）
  - 多則 popup 清單可滾動，單則維持舊版型
- ✅ console 無 [NewsEvents] error
- ✅ ripple 動畫保留（latest_published_ts 觸發）

## P0 規則
- ✅ loadingRegistry 接好（既有，沒動）
- ✅ currentTime 不進 useEffect deps（既有 timeStore 訂閱）
- ✅ UX 四鐵則維持（透明度/圖例/popup/dropdown）

🤖 Generated with [Claude Code](https://claude.com/claude-code)