### PR TITLE
satconsole: 視覺重做 — §F TW-centric / §A 嚴重度 / §D 遙測 breakdown + UI 互斥

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1432,7 +1432,7 @@ export default function App() {
             onClose={() => satelliteConsoleStore.setOpen(false)}
             layerVisibility={layerVisibility}
             setLayerVisibility={(next) => setLayerVisibility({ ...layerVisibility, ...next })}
-            onFlyTo={(lon, lat) => mapRef.current?.flyTo({ center: [lon, lat], zoom: 5.5, speed: 1.4, pitch: 0 })}
+            onFlyTo={(lon, lat) => mapRef.current?.flyTo({ center: [lon, lat], zoom: 3.5, speed: 1.4, pitch: 0 })}
           />
 
           {/* 即時情報 Intel Panel */}

--- a/src/components/IconRailSidebar.tsx
+++ b/src/components/IconRailSidebar.tsx
@@ -249,7 +249,15 @@ export function IconRailSidebar({
   }, [onWidthChange]);
 
   const togglePanel = (panel: PanelId) => {
-    setActivePanel((prev) => (prev === panel ? null : panel));
+    setActivePanel((prev) => {
+      const next = prev === panel ? null : panel;
+      // 開啟 Layers/Locations 時，順便關掉 Intel / Satellite（左側 panel 互斥）
+      if (next !== null) {
+        if (intelActive && onIntelToggle) onIntelToggle();
+        if (satelliteActive && onSatelliteToggle) onSatelliteToggle();
+      }
+      return next;
+    });
   };
 
   const closePanel = () => setActivePanel(null);

--- a/src/components/satelliteConsole/CoverageStatsSection.tsx
+++ b/src/components/satelliteConsole/CoverageStatsSection.tsx
@@ -41,6 +41,13 @@ interface PassTick {
   startMinFromNow: number; // 相對 now 的分鐘
 }
 
+/** 遙測偵察類 — 主要會「拍照」的衛星群 */
+const RECON_CATS = new Set(["china_yaogan", "china_jilin", "china_gaofen", "taiwan"]);
+
+function isRecon(cat: string): boolean {
+  return RECON_CATS.has(cat);
+}
+
 function distanceKm(aLon: number, aLat: number, bLon: number, bLat: number): number {
   const dLat = (bLat - aLat) * Math.PI / 180;
   const dLon = (bLon - aLon) * Math.PI / 180;
@@ -78,6 +85,8 @@ export function CoverageStatsSection({ maneuvers }: Props) {
   const [passes, setPasses] = useState<PassTick[]>([]);
   const [expanded, setExpanded] = useState(false);
   const [computingScan, setComputingScan] = useState(false);
+  // 預設只看「遙測偵察」（Yaogan/Jilin/Gaofen + TW）
+  const [reconOnly, setReconOnly] = useState(true);
   // 訂閱時間軸 — 「現在覆蓋」與 6h scan 起點都跟著走
   const timelineSec = useTimeStoreTime(500);
 
@@ -172,9 +181,37 @@ export function CoverageStatsSection({ maneuvers }: Props) {
     return s;
   }, [maneuvers]);
 
+  // 覆蓋台灣中 — 按 cat 分群算 breakdown
+  const coverageBreakdown = useMemo(() => {
+    let cn = 0, tw = 0, recon = 0;
+    for (const p of coveringNow) {
+      const cat = p.rec.category;
+      if (cat === "taiwan") tw++;
+      else cn++;
+      if (RECON_CATS.has(cat)) recon++;
+    }
+    return { total: coveringNow.length, cn, tw, recon };
+  }, [coveringNow]);
+
+  // 6h 通過 — 按 cat 分群算 breakdown + 過濾顯示
+  const passBreakdown = useMemo(() => {
+    let cn = 0, tw = 0, recon = 0;
+    for (const p of passes) {
+      if (p.cat === "taiwan") tw++;
+      else cn++;
+      if (RECON_CATS.has(p.cat)) recon++;
+    }
+    return { total: passes.length, cn, tw, recon };
+  }, [passes]);
+
+  // 依 toggle 過濾的 timeline tick 清單
+  const filteredPasses = useMemo(() => {
+    return reconOnly ? passes.filter((p) => isRecon(p.cat)) : passes;
+  }, [passes, reconOnly]);
+
   return (
     <div style={{ padding: "10px 14px 8px", borderBottom: `1px solid ${COLORS.borderSoft}`, fontFamily: FONT_CJK }}>
-      {/* 主數字列 */}
+      {/* 主數字列 — 覆蓋中 + 6h 通過 + breakdown */}
       <div style={{ display: "flex", alignItems: "center", gap: 12, fontSize: 11 }}>
         <div>
           <span style={{ color: COLORS.textDim }}>覆蓋台灣中</span>
@@ -209,10 +246,34 @@ export function CoverageStatsSection({ maneuvers }: Props) {
         </button>
       </div>
 
+      {/* breakdown 細項 — CN/TW + 遙測類 */}
+      {coveringNow.length > 0 && (
+        <div style={{
+          marginTop: 5,
+          display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap",
+          fontFamily: FONT_DATA, fontSize: 10, color: COLORS.textMuted,
+        }}>
+          <span>CN <span style={{ color: COLORS.textDefault, fontWeight: 600 }}>{coverageBreakdown.cn}</span></span>
+          <span>/ TW <span style={{ color: "#4fc3f7", fontWeight: 600 }}>{coverageBreakdown.tw}</span></span>
+          <span style={{ color: COLORS.textFaint }}>·</span>
+          <span title="Yaogan/Jilin/Gaofen + Taiwan 整體遙測偵察">
+            遙測類 <span style={{ color: coverageBreakdown.recon > 0 ? "#22c55e" : COLORS.textMuted, fontWeight: 700 }}>
+              {coverageBreakdown.recon}
+            </span> 顆
+          </span>
+          {!computingScan && passes.length > 0 && (
+            <>
+              <span style={{ marginLeft: "auto", color: COLORS.textFaint }}>6h 內</span>
+              <span>遙測 <span style={{ color: passBreakdown.recon > 0 ? "#22c55e" : COLORS.textMuted, fontWeight: 600 }}>{passBreakdown.recon}</span> 次</span>
+            </>
+          )}
+        </div>
+      )}
+
       {/* 覆蓋中 sats 縮略 */}
       {coveringNow.length > 0 && (
         <div style={{
-          marginTop: 6,
+          marginTop: 4,
           fontFamily: FONT_DATA,
           fontSize: 10,
           color: COLORS.textMuted,
@@ -228,6 +289,42 @@ export function CoverageStatsSection({ maneuvers }: Props) {
       {/* 6h timeline 展開 */}
       {expanded && (
         <div style={{ marginTop: 10, padding: 10, borderRadius: 6, background: "rgba(0,0,0,0.25)" }}>
+          {/* 過濾 toggle */}
+          <div style={{
+            display: "flex", alignItems: "center", gap: 8, marginBottom: 8,
+            fontFamily: FONT_CJK, fontSize: 10.5,
+          }}>
+            <span style={{ color: COLORS.textMuted }}>顯示</span>
+            <button
+              onClick={() => setReconOnly(true)}
+              style={{
+                padding: "3px 8px",
+                borderRadius: 4,
+                background: reconOnly ? "rgba(34,197,94,0.16)" : "transparent",
+                border: `1px solid ${reconOnly ? "rgba(34,197,94,0.55)" : COLORS.borderMid}`,
+                color: reconOnly ? "#22c55e" : COLORS.textMuted,
+                fontFamily: FONT_CJK, fontSize: 10.5, fontWeight: reconOnly ? 600 : 400, cursor: "pointer",
+              }}
+            >
+              只看遙測偵察
+            </button>
+            <button
+              onClick={() => setReconOnly(false)}
+              style={{
+                padding: "3px 8px",
+                borderRadius: 4,
+                background: !reconOnly ? COLORS.accentFaint : "transparent",
+                border: `1px solid ${!reconOnly ? COLORS.borderAccent : COLORS.borderMid}`,
+                color: !reconOnly ? "#cfe4ff" : COLORS.textMuted,
+                fontFamily: FONT_CJK, fontSize: 10.5, fontWeight: !reconOnly ? 600 : 400, cursor: "pointer",
+              }}
+            >
+              全部
+            </button>
+            <span style={{ marginLeft: "auto", fontFamily: FONT_DATA, fontSize: 9.5, color: COLORS.textFaint }}>
+              {filteredPasses.length} / {passes.length} 次
+            </span>
+          </div>
           {/* axis */}
           <div style={{ position: "relative", height: 18, marginBottom: 8 }}>
             <div style={{ position: "absolute", left: 0, right: 0, top: 14, height: 1, background: COLORS.borderMid }} />
@@ -245,14 +342,14 @@ export function CoverageStatsSection({ maneuvers }: Props) {
               </div>
             ))}
           </div>
-          {/* tick rows: limit to 12 for readability */}
+          {/* tick rows */}
           <div style={{ position: "relative", maxHeight: 220, overflowY: "auto" }} className="mtp-scroll">
-            {passes.length === 0 ? (
+            {filteredPasses.length === 0 ? (
               <div style={{ fontFamily: FONT_CJK, fontSize: 10, color: COLORS.textFaint, padding: "8px 0", textAlign: "center" }}>
-                {computingScan ? "計算中…" : "未來 6h 無預計通過"}
+                {computingScan ? "計算中…" : reconOnly ? "未來 6h 無遙測偵察類通過" : "未來 6h 無預計通過"}
               </div>
             ) : (
-              passes.slice(0, 80).map((p, i) => {
+              filteredPasses.slice(0, 80).map((p, i) => {
                 const left = (p.startMinFromNow / (SCAN_HOURS * 60)) * 100;
                 const color = SATELLITE_COLORS[p.cat as keyof typeof SATELLITE_COLORS] || COLORS.textDim;
                 const isManeuver = maneuverNorads.has(p.norad);
@@ -287,9 +384,9 @@ export function CoverageStatsSection({ maneuvers }: Props) {
                 );
               })
             )}
-            {passes.length > 80 && (
+            {filteredPasses.length > 80 && (
               <div style={{ padding: "4px 0", fontFamily: FONT_DATA, fontSize: 9, color: COLORS.textFaint, textAlign: "center" }}>
-                共 {passes.length} 次 · 顯示前 80
+                共 {filteredPasses.length} 次 · 顯示前 80
               </div>
             )}
           </div>

--- a/src/components/satelliteConsole/ManeuverAlertSection.tsx
+++ b/src/components/satelliteConsole/ManeuverAlertSection.tsx
@@ -1,16 +1,22 @@
 /**
- * §A 變軌警報區
+ * §A 變軌警報區（v2 — 嚴重度分級 + 影響 TW chip + 例行折疊）
  *
- * 紅色 banner（近 24h CN/TW 變軌計數）+ 橫向卡片清單。
- * PLANE_CHANGE 強閃為敘事重點。
- *
- * 卡片資料全部來自 satellite_maneuvers MV（migration 169 RPC）。
+ * 排序：red → orange → grey，副 key 時間 DESC
+ * 卡片：依嚴重度上色（紅閃 / 橘 / 灰例行）
+ * 例行（grey）折疊成「N 筆例行機動」按鈕展開
+ * 影響 TW：async 計算前後 7 天過台次數差，差 != 0 標「影響 TW」綠 chip
  */
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import { COLORS, FONT_CJK, FONT_DATA, MANEUVER_TOKEN, CN_GROUP_TO_CATEGORY } from "./satelliteConsoleTokens";
 import { SATELLITE_COLORS } from "../../data/satelliteTypes";
 import type { ManeuverRow } from "../../data/satelliteManeuversLoader";
-import { formatManeuverDetail, formatRelTime } from "../../data/satelliteManeuversLoader";
+import {
+  formatManeuverDetail,
+  formatRelTime,
+  getManeuverSeverity,
+  type ManeuverSeverity,
+} from "../../data/satelliteManeuversLoader";
+import { useManeuverImpacts } from "../../hooks/useManeuverImpacts";
 
 interface Props {
   maneuvers: ManeuverRow[];
@@ -20,24 +26,41 @@ interface Props {
 }
 
 const TAIWAN_GROUP = new Set(["TAIWAN"]);
+const CN_GROUPS = new Set(["YAOGAN", "JILIN", "GAOFEN", "TJS", "BEIDOU", "SHIYAN"]);
+
+/** 嚴重度視覺 token */
+const SEV_TOKEN: Record<ManeuverSeverity, { color: string; soft: string; border: string; label: string; pulse: boolean }> = {
+  red:    { color: "#ef4444", soft: "rgba(239,68,68,0.12)",  border: "rgba(239,68,68,0.55)",  label: "重大", pulse: true },
+  orange: { color: "#f97316", soft: "rgba(249,115,22,0.10)", border: "rgba(249,115,22,0.50)", label: "注意", pulse: false },
+  grey:   { color: "#9ca3af", soft: "rgba(255,255,255,0.02)",border: "rgba(255,255,255,0.12)",label: "例行", pulse: false },
+};
 
 export function ManeuverAlertSection({ maneuvers, onSelectNorad, onOpenCompare }: Props) {
-  const { cnCount, twCount, sorted } = useMemo(() => {
+  const [expandedGrey, setExpandedGrey] = useState(false);
+
+  const { cnCount, twCount, sortedRed, sortedOrange, sortedGrey } = useMemo(() => {
     let cn = 0, tw = 0;
+    const red: ManeuverRow[] = [];
+    const orange: ManeuverRow[] = [];
+    const grey: ManeuverRow[] = [];
     for (const m of maneuvers) {
       if (TAIWAN_GROUP.has(m.cn_group) || m.country_operator === "Taiwan") tw++;
-      else cn++;
+      else if (m.country_operator === "China" || CN_GROUPS.has(m.cn_group)) cn++;
+      const sev = getManeuverSeverity(m);
+      if (sev === "red") red.push(m);
+      else if (sev === "orange") orange.push(m);
+      else grey.push(m);
     }
-    // 排序：PLANE_CHANGE 最前 → 再依時間遞減
-    const order: Record<string, number> = { PLANE_CHANGE: 0, ALTITUDE_CHANGE: 1, SHAPE_CHANGE: 2 };
-    const sorted = [...maneuvers].sort((a, b) => {
-      const da = order[a.maneuver_type] ?? 9;
-      const db = order[b.maneuver_type] ?? 9;
-      if (da !== db) return da - db;
-      return new Date(b.curr_fetched_at).getTime() - new Date(a.curr_fetched_at).getTime();
-    });
-    return { cnCount: cn, twCount: tw, sorted };
+    const byTime = (a: ManeuverRow, b: ManeuverRow) =>
+      new Date(b.curr_fetched_at).getTime() - new Date(a.curr_fetched_at).getTime();
+    red.sort(byTime);
+    orange.sort(byTime);
+    grey.sort(byTime);
+    return { cnCount: cn, twCount: tw, sortedRed: red, sortedOrange: orange, sortedGrey: grey };
   }, [maneuvers]);
+
+  // affects TW 計算（非阻塞）
+  const impacts = useManeuverImpacts(maneuvers);
 
   if (maneuvers.length === 0) {
     return (
@@ -61,6 +84,10 @@ export function ManeuverAlertSection({ maneuvers, onSelectNorad, onOpenCompare }
     );
   }
 
+  const featured = [...sortedRed, ...sortedOrange];
+  const hasGrey = sortedGrey.length > 0;
+  const hasFeatured = featured.length > 0;
+
   return (
     <div style={{ padding: "12px 14px", borderBottom: `1px solid ${COLORS.borderSoft}` }}>
       {/* Banner */}
@@ -71,141 +98,281 @@ export function ManeuverAlertSection({ maneuvers, onSelectNorad, onOpenCompare }
         padding: "8px 10px",
         marginBottom: 9,
         borderRadius: 6,
-        background: "rgba(239,68,68,0.12)",
-        border: "1px solid rgba(239,68,68,0.45)",
+        background: hasFeatured ? "rgba(239,68,68,0.12)" : "rgba(156,163,175,0.10)",
+        border: hasFeatured ? "1px solid rgba(239,68,68,0.45)" : `1px solid ${COLORS.borderMid}`,
         fontFamily: FONT_CJK,
         fontSize: 11.5,
         color: COLORS.textStrong,
       }}>
         <span style={{
           width: 7, height: 7, borderRadius: "50%",
-          background: COLORS.statusErr,
-          boxShadow: `0 0 6px ${COLORS.statusErr}`,
-          animation: "satManeuverPulse 1.1s ease-in-out infinite",
+          background: hasFeatured ? COLORS.statusErr : COLORS.textDim,
+          boxShadow: hasFeatured ? `0 0 6px ${COLORS.statusErr}` : "none",
+          animation: hasFeatured ? "satManeuverPulse 1.1s ease-in-out infinite" : "none",
         }} />
         <span style={{ fontWeight: 600 }}>近 24h 變軌偵測</span>
         <span style={{ marginLeft: "auto", fontFamily: FONT_DATA, color: COLORS.textDefault, letterSpacing: "0.3px" }}>
-          CN <span style={{ color: COLORS.statusErr, fontWeight: 700 }}>{cnCount}</span> 顆
+          CN <span style={{ color: hasFeatured ? COLORS.statusErr : COLORS.textDefault, fontWeight: 700 }}>{cnCount}</span> 顆
           {" / "}
           TW <span style={{ color: twCount > 0 ? COLORS.statusErr : COLORS.textDim, fontWeight: 700 }}>{twCount}</span> 顆
         </span>
       </div>
 
-      {/* 橫向 cards */}
-      <div className="mtp-chips" style={{
-        display: "flex",
-        gap: 8,
-        overflowX: "auto",
-        paddingBottom: 4,
-        scrollSnapType: "x mandatory",
-      }}>
-        {sorted.slice(0, 20).map((m) => {
-          const token = MANEUVER_TOKEN[m.maneuver_type];
-          if (!token) return null;
-          const catKey = CN_GROUP_TO_CATEGORY[m.cn_group] || "china_shiyan";
-          const groupColor = SATELLITE_COLORS[catKey as keyof typeof SATELLITE_COLORS] || COLORS.textDim;
-          return (
-            <div key={`${m.norad_id}-${m.curr_epoch}`} style={{
-              flex: "0 0 auto",
-              width: 232,
-              padding: "10px 11px",
-              borderRadius: 8,
-              background: token.soft,
-              border: `1px solid ${token.color}66`,
-              scrollSnapAlign: "start",
-              display: "flex",
-              flexDirection: "column",
-              gap: 6,
-            }}>
-              {/* 上行：群色點 + 名稱 + maneuver chip */}
-              <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
-                <span style={{
-                  width: 8, height: 8, borderRadius: "50%",
-                  background: groupColor, flexShrink: 0,
-                }} />
-                <span
-                  title={`點看百科卡 NORAD ${m.norad_id}`}
-                  onClick={() => onSelectNorad(m.norad_id)}
-                  style={{
-                    fontFamily: FONT_CJK,
-                    fontSize: 12,
-                    fontWeight: 600,
-                    color: COLORS.textStrong,
-                    whiteSpace: "nowrap",
-                    overflow: "hidden",
-                    textOverflow: "ellipsis",
-                    cursor: "pointer",
-                    flex: 1,
-                  }}
-                >
-                  {m.name}
-                </span>
-                <span style={{
-                  display: "inline-flex", alignItems: "center", gap: 3,
-                  padding: "1px 6px",
-                  borderRadius: 3,
-                  background: `${token.color}26`,
-                  border: `1px solid ${token.color}66`,
-                  fontFamily: FONT_DATA,
-                  fontSize: 9,
-                  fontWeight: 700,
-                  color: token.color,
-                  flexShrink: 0,
-                  animation: token.pulse ? "satManeuverPulse 1.1s ease-in-out infinite" : "none",
-                }}>
-                  <span>{token.icon}</span>
-                  {m.maneuver_type === "PLANE_CHANGE" ? "PLANE" : m.maneuver_type === "ALTITUDE_CHANGE" ? "ALT" : "SHAPE"}
-                </span>
-              </div>
-
-              {/* 中行：detail + relTime */}
-              <div style={{
-                display: "flex", alignItems: "center", gap: 8,
-                fontFamily: FONT_DATA, fontSize: 10, color: COLORS.textMuted,
-              }}>
-                <span>{formatManeuverDetail(m)}</span>
-                <span style={{ marginLeft: "auto", color: COLORS.textDim }}>{formatRelTime(m.curr_fetched_at)}</span>
-              </div>
-
-              {/* 下行：2 顆按鈕 */}
-              <div style={{ display: "flex", gap: 6, marginTop: 2 }}>
-                <button
-                  onClick={() => onSelectNorad(m.norad_id)}
-                  style={btn(COLORS.borderMid, COLORS.textDefault, "transparent")}
-                >
-                  詳情
-                </button>
-                <button
-                  onClick={() => onOpenCompare(m)}
-                  style={btn("rgba(100,170,255,0.55)", "#cfe4ff", "rgba(100,170,255,0.16)")}
-                >
-                  覆蓋變化
-                </button>
-              </div>
-            </div>
-          );
-        })}
-      </div>
-
-      {sorted.length > 20 && (
+      {/* 嚴重度說明 inline */}
+      {(sortedRed.length > 0 || sortedOrange.length > 0) && (
         <div style={{
-          marginTop: 6,
-          fontFamily: FONT_DATA,
-          fontSize: 9,
-          color: COLORS.textFaint,
-          textAlign: "center",
+          marginBottom: 8,
+          fontFamily: FONT_DATA, fontSize: 9, color: COLORS.textFaint,
+          display: "flex", alignItems: "center", gap: 8,
         }}>
-          顯示前 20 筆 · 共 {sorted.length} 筆變軌
+          <SevDot s="red" /> 重大 {sortedRed.length}
+          <SevDot s="orange" /> 注意 {sortedOrange.length}
+          {sortedGrey.length > 0 && <><SevDot s="grey" /> 例行 {sortedGrey.length}</>}
+        </div>
+      )}
+
+      {/* Featured (red + orange) — 直立排列，每張卡完整資訊 */}
+      {hasFeatured && (
+        <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+          {featured.map((m) => (
+            <ManeuverCard
+              key={`${m.norad_id}-${m.curr_epoch}`}
+              row={m}
+              severity={getManeuverSeverity(m)}
+              impact={impacts.get(m.norad_id)}
+              onSelectNorad={onSelectNorad}
+              onOpenCompare={onOpenCompare}
+            />
+          ))}
+        </div>
+      )}
+
+      {/* Grey (例行) — 折疊 */}
+      {hasGrey && (
+        <div style={{ marginTop: hasFeatured ? 8 : 0 }}>
+          <button
+            onClick={() => setExpandedGrey((v) => !v)}
+            style={{
+              width: "100%",
+              padding: "6px 10px",
+              borderRadius: 5,
+              background: "rgba(255,255,255,0.025)",
+              border: `1px dashed ${COLORS.borderMid}`,
+              color: COLORS.textMuted,
+              fontFamily: FONT_CJK,
+              fontSize: 11,
+              cursor: "pointer",
+              display: "flex",
+              alignItems: "center",
+              gap: 6,
+            }}
+          >
+            <SevDot s="grey" />
+            <span>{sortedGrey.length} 筆例行機動 (drift/station-keeping)</span>
+            <span style={{ marginLeft: "auto", color: COLORS.textDim }}>{expandedGrey ? "▾ 收合" : "▸ 展開"}</span>
+          </button>
+          {expandedGrey && (
+            <div style={{ display: "flex", flexDirection: "column", gap: 5, marginTop: 6 }}>
+              {sortedGrey.map((m) => (
+                <ManeuverCard
+                  key={`${m.norad_id}-${m.curr_epoch}`}
+                  row={m}
+                  severity="grey"
+                  impact={impacts.get(m.norad_id)}
+                  onSelectNorad={onSelectNorad}
+                  onOpenCompare={onOpenCompare}
+                  compact
+                />
+              ))}
+            </div>
+          )}
         </div>
       )}
     </div>
   );
 }
 
-function btn(border: string, color: string, bg: string) {
+function SevDot({ s }: { s: ManeuverSeverity }) {
+  return (
+    <span style={{
+      width: 6, height: 6, borderRadius: "50%",
+      background: SEV_TOKEN[s].color,
+      animation: SEV_TOKEN[s].pulse ? "satManeuverPulse 1.1s ease-in-out infinite" : "none",
+    }} />
+  );
+}
+
+interface CardProps {
+  row: ManeuverRow;
+  severity: ManeuverSeverity;
+  impact: ReturnType<ReturnType<typeof useManeuverImpacts>["get"]>;
+  onSelectNorad: (n: number) => void;
+  onOpenCompare: (m: ManeuverRow) => void;
+  compact?: boolean;
+}
+
+function ManeuverCard({ row, severity, impact, onSelectNorad, onOpenCompare, compact }: CardProps) {
+  const sev = SEV_TOKEN[severity];
+  const typeToken = MANEUVER_TOKEN[row.maneuver_type];
+  if (!typeToken) return null;
+  const catKey = CN_GROUP_TO_CATEGORY[row.cn_group] || "china_shiyan";
+  const groupColor = SATELLITE_COLORS[catKey as keyof typeof SATELLITE_COLORS] || COLORS.textDim;
+
+  return (
+    <div style={{
+      padding: compact ? "5px 9px" : "9px 11px",
+      borderRadius: 7,
+      background: sev.soft,
+      border: `1px solid ${sev.border}`,
+      display: "flex",
+      flexDirection: "column",
+      gap: compact ? 3 : 5,
+      animation: sev.pulse && !compact ? "satManeuverPulse 1.5s ease-in-out infinite" : "none",
+    }}>
+      {/* 上行 */}
+      <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
+        <span style={{ width: 7, height: 7, borderRadius: "50%", background: groupColor, flexShrink: 0 }} />
+        <span
+          onClick={() => onSelectNorad(row.norad_id)}
+          style={{
+            fontFamily: FONT_CJK,
+            fontSize: compact ? 11 : 12,
+            fontWeight: 600,
+            color: COLORS.textStrong,
+            whiteSpace: "nowrap",
+            overflow: "hidden",
+            textOverflow: "ellipsis",
+            cursor: "pointer",
+            flex: 1,
+          }}
+        >
+          {row.name}
+        </span>
+        {/* 嚴重度 chip */}
+        <span style={{
+          padding: "1px 6px",
+          borderRadius: 3,
+          background: `${sev.color}22`,
+          border: `1px solid ${sev.color}55`,
+          fontFamily: FONT_DATA,
+          fontSize: 9,
+          fontWeight: 700,
+          color: sev.color,
+          flexShrink: 0,
+        }}>
+          {sev.label}
+        </span>
+        {/* 類型 chip */}
+        <span style={{
+          padding: "1px 6px",
+          borderRadius: 3,
+          background: `${typeToken.color}22`,
+          border: `1px solid ${typeToken.color}55`,
+          fontFamily: FONT_DATA,
+          fontSize: 9,
+          fontWeight: 700,
+          color: typeToken.color,
+          flexShrink: 0,
+          display: "inline-flex",
+          alignItems: "center",
+          gap: 2,
+        }}>
+          <span>{typeToken.icon}</span>
+          {row.maneuver_type === "PLANE_CHANGE" ? "PLANE" : row.maneuver_type === "ALTITUDE_CHANGE" ? "ALT" : "SHAPE"}
+        </span>
+      </div>
+
+      {/* 中行：detail + relTime */}
+      <div style={{
+        display: "flex", alignItems: "center", gap: 8,
+        fontFamily: FONT_DATA, fontSize: 10, color: COLORS.textMuted,
+      }}>
+        <span>{formatManeuverDetail(row)}</span>
+        <span style={{ marginLeft: "auto", color: COLORS.textDim }}>{formatRelTime(row.curr_fetched_at)}</span>
+      </div>
+
+      {/* 下行：影響 TW chip + 按鈕（compact 模式只顯 chip + 飛到按鈕） */}
+      {!compact ? (
+        <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
+          <ImpactChip impact={impact} />
+          <button
+            onClick={() => onSelectNorad(row.norad_id)}
+            style={btnStyle(COLORS.borderMid, COLORS.textDefault, "transparent")}
+          >
+            詳情
+          </button>
+          <button
+            onClick={() => onOpenCompare(row)}
+            style={btnStyle("rgba(100,170,255,0.55)", "#cfe4ff", "rgba(100,170,255,0.16)")}
+          >
+            覆蓋變化
+          </button>
+        </div>
+      ) : (
+        <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
+          <ImpactChip impact={impact} small />
+          <button
+            onClick={() => onOpenCompare(row)}
+            style={{ ...btnStyle("rgba(100,170,255,0.35)", "#cfe4ff", "transparent"), fontSize: 10, padding: "3px 8px" }}
+          >
+            對比
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ImpactChip({ impact, small }: { impact: ReturnType<ReturnType<typeof useManeuverImpacts>["get"]>; small?: boolean }) {
+  // 計算中
+  if (!impact) {
+    return (
+      <span style={{
+        padding: small ? "1px 6px" : "2px 7px",
+        borderRadius: 3,
+        background: "rgba(255,255,255,0.04)",
+        border: `1px solid ${COLORS.borderMid}`,
+        fontFamily: FONT_DATA, fontSize: 9, color: COLORS.textDim,
+      }}>
+        計算 TW 影響中…
+      </span>
+    );
+  }
+  // 影響
+  if (impact.affectsTw) {
+    return (
+      <span style={{
+        padding: small ? "1px 6px" : "2px 7px",
+        borderRadius: 3,
+        background: "rgba(34,197,94,0.16)",
+        border: "1px solid rgba(34,197,94,0.55)",
+        fontFamily: FONT_CJK, fontSize: 10, color: "#22c55e", fontWeight: 600,
+        display: "inline-flex", alignItems: "center", gap: 3,
+      }}>
+        ✓ 影響 TW
+        <span style={{ fontFamily: FONT_DATA, fontSize: 9, opacity: 0.8 }}>
+          ({impact.passBefore}→{impact.passAfter})
+        </span>
+      </span>
+    );
+  }
+  // 無影響
+  return (
+    <span style={{
+      padding: small ? "1px 6px" : "2px 7px",
+      borderRadius: 3,
+      background: "rgba(255,255,255,0.03)",
+      border: `1px solid ${COLORS.borderSoft}`,
+      fontFamily: FONT_CJK, fontSize: 10, color: COLORS.textFaint,
+    }}>
+      過台不變 ({impact.passBefore}=)
+    </span>
+  );
+}
+
+function btnStyle(border: string, color: string, bg: string) {
   return {
-    flex: 1 as const,
-    padding: "5px 0",
+    padding: "5px 10px",
     borderRadius: 4,
     background: bg,
     border: `1px solid ${border}`,
@@ -214,5 +381,6 @@ function btn(border: string, color: string, bg: string) {
     fontSize: 11,
     cursor: "pointer",
     transition: "all 0.15s ease",
+    flexShrink: 0,
   };
 }

--- a/src/components/satelliteConsole/ManeuverCompareModal.tsx
+++ b/src/components/satelliteConsole/ManeuverCompareModal.tsx
@@ -1,15 +1,15 @@
 /**
  * §F 變軌前後覆蓋對比 modal
  *
- * 點變軌警報「覆蓋變化」→ 開啟此 modal
- * 左右兩張 SVG mini-map：變軌前 7 天 ground track vs 變軌後 7 天 ground track
- * 下方差異摘要：新增 / 失去覆蓋區域、過台頻次差
+ * v2 設計（TW-centric + bbox 上色 + headline 過台頻次）：
+ * - 主敘事：過台頻次 N→M (±%) 大字 + 進度條對比
+ * - 雙 mini-map 統一框到 TW 區域（lng 108–145, lat 5–35）
+ * - 12 個 TW 關聯 region 直接畫 bbox 在地圖上
+ *   gained = 綠 / lost = 紅 / 不變 = 微灰
+ * - 區域差異縮成一行 chips
+ * - out-of-frame 區域改邊緣箭頭 chip
  *
- * 資料：
- * - get_satellite_tle_pair(norad, prev_epoch, curr_epoch)
- * - 用 satellite.js SGP4 propagate 7 天（10 min 步進）
- * - 區域命中 = ground track 經過該 bbox 至少 1 次
- * - 過台頻次差 = scan 7 天 elevation>10° 邊緣事件數
+ * 起點 = 變軌事件本身（curr_fetched_at），不跟現實 now 不跟時間軸
  */
 import { useEffect, useMemo, useState } from "react";
 import * as satellite from "satellite.js";
@@ -25,26 +25,32 @@ interface Props {
 const TW_CENTER = { lon: 121.0, lat: 23.7 };
 const R_EARTH = 6371;
 
+/** TW-centric 顯示框（日本九州北界 + 菲律賓呂宋南界） */
+const TW_FRAME = { lngMin: 108, lngMax: 145, latMin: 5, latMax: 35 } as const;
+
 interface Region {
   key: string;
   zh: string;
   bbox: [number, number, number, number]; // [west, south, east, north]
 }
 
-/** TW 關聯區域（給「新增 / 失去覆蓋」比對用） */
+/** TW 關聯區域（含 frame 內 / 外） */
 const TW_RELEVANT_REGIONS: Region[] = [
+  // ── frame 內（會畫 bbox） ─────────────────────────────
   { key: "tw",       zh: "台灣本島",       bbox: [120.0, 21.8, 122.0, 25.3] },
   { key: "okinawa",  zh: "日本沖繩",       bbox: [123.0, 24.0, 130.0, 28.5] },
+  { key: "kyushu",   zh: "日本九州",       bbox: [129.5, 30.5, 132.5, 34.5] },
   { key: "luzon_n",  zh: "菲律賓呂宋北部", bbox: [119.5, 16.0, 122.5, 18.7] },
+  { key: "luzon_s",  zh: "菲律賓呂宋南部", bbox: [120.5, 12.5, 124.5, 16.0] },
   { key: "south_china_sea", zh: "南海北部", bbox: [114.0, 16.0, 120.0, 22.0] },
   { key: "east_china_sea",  zh: "東海", bbox: [122.0, 28.0, 128.0, 33.0] },
-  { key: "japan_main", zh: "日本本州", bbox: [130.0, 33.0, 142.0, 41.0] },
-  { key: "korea",    zh: "朝鮮半島",       bbox: [124.5, 33.0, 130.5, 41.0] },
+  { key: "korea_s",  zh: "朝鮮半島南部",   bbox: [124.5, 33.0, 130.5, 35.0] },
   { key: "dongsha",  zh: "東沙群島",       bbox: [116.5, 20.4, 117.0, 20.9] },
   { key: "bashi",    zh: "巴士海峽",       bbox: [120.5, 20.5, 122.0, 21.7] },
   { key: "lanyu",    zh: "蘭嶼",           bbox: [121.4, 21.9, 121.7, 22.1] },
-  { key: "aleutian", zh: "阿留申群島",     bbox: [170.0, 51.0, 195.0, 55.0] },
-  { key: "alaska_w", zh: "阿拉斯加西部",   bbox: [-170.0, 56.0, -150.0, 71.0] },
+  // ── frame 外（用邊緣 chip 顯示） ─────────────────────
+  { key: "japan_main", zh: "日本本州", bbox: [130.0, 35.0, 142.0, 41.0] },
+  { key: "korea_n",  zh: "朝鮮半島北部",   bbox: [124.5, 39.0, 130.5, 41.0] },
 ];
 
 function distanceKm(aLon: number, aLat: number, bLon: number, bLat: number): number {
@@ -78,7 +84,6 @@ function computeGroundTrack(row: TleHistoryRow, anchorMs: number): GroundTrack |
     return null;
   }
 
-  // 從變軌事件 fetched_at 起算 7 天（不用現實 now、不用時間軸 — 對比 modal 是看「這次變軌」）
   const start = anchorMs;
   const STEP_MIN = 10;
   const SPAN_HOURS = 7 * 24;
@@ -99,15 +104,12 @@ function computeGroundTrack(row: TleHistoryRow, anchorMs: number): GroundTrack |
       const altKm = geo.height;
       points.push({ lon, lat, altKm });
 
-      // 區域命中
       for (const r of TW_RELEVANT_REGIONS) {
         const [w, s, e, n] = r.bbox;
-        // 處理跨越 antimeridian 的 bbox（w > e）
         const inLon = w <= e ? (lon >= w && lon <= e) : (lon >= w || lon <= e);
         if (inLon && lat >= s && lat <= n) coveredRegions.add(r.key);
       }
 
-      // TW 過境計數（elevation>10°）
       const radius = coverageRadiusKm(altKm);
       const distTW = distanceKm(lon, lat, TW_CENTER.lon, TW_CENTER.lat);
       const inside = distTW < radius;
@@ -123,30 +125,74 @@ function computeGroundTrack(row: TleHistoryRow, anchorMs: number): GroundTrack |
   return { points, twPasses, coveredRegions };
 }
 
+/** TW-centric 框內的 region 子集 */
+const FRAME_REGIONS = TW_RELEVANT_REGIONS.filter((r) => {
+  const [w, s, e, n] = r.bbox;
+  return e >= TW_FRAME.lngMin && w <= TW_FRAME.lngMax &&
+         n >= TW_FRAME.latMin && s <= TW_FRAME.latMax;
+});
+
+
+interface MiniMapProps {
+  track: GroundTrack | null;
+  prevTrack: GroundTrack | null;
+  label: string;
+  color: string;
+  width?: number;
+  height?: number;
+  side: "before" | "after";
+}
+
 function MiniMap({
-  track, label, color, width = 320, height = 200,
-}: { track: GroundTrack | null; label: string; color: string; width?: number; height?: number }) {
-  const path = useMemo(() => {
+  track, prevTrack, label, color, width = 320, height = 260, side,
+}: MiniMapProps) {
+  // 投影：lng 線性映射；lat 反向（北上南下）
+  const projX = (lon: number) => ((lon - TW_FRAME.lngMin) / (TW_FRAME.lngMax - TW_FRAME.lngMin)) * width;
+  const projY = (lat: number) => ((TW_FRAME.latMax - lat) / (TW_FRAME.latMax - TW_FRAME.latMin)) * height;
+  const inFrame = (lon: number, lat: number) =>
+    lon >= TW_FRAME.lngMin && lon <= TW_FRAME.lngMax &&
+    lat >= TW_FRAME.latMin && lat <= TW_FRAME.latMax;
+
+  // 把點切成「進框 → 離框」的線段（避免框外無關線段）
+  const segments = useMemo(() => {
     if (!track) return [];
-    // 用簡單 Mercator-ish 投影（lon 直接映射，lat 截斷）
     const segs: string[] = [];
     let cur = "";
-    let prevX = -1;
+    let prevIn = false;
     for (const p of track.points) {
-      const x = ((p.lon + 180) / 360) * width;
-      const y = ((90 - p.lat) / 180) * height;
-      if (prevX >= 0 && Math.abs(x - prevX) > width * 0.5) {
-        // antimeridian wrap — 斷開
-        if (cur) segs.push(cur);
-        cur = `M${x.toFixed(1)},${y.toFixed(1)}`;
-      } else {
-        cur += (cur ? "L" : "M") + `${x.toFixed(1)},${y.toFixed(1)}`;
+      if (!inFrame(p.lon, p.lat)) {
+        if (cur) { segs.push(cur); cur = ""; }
+        prevIn = false;
+        continue;
       }
-      prevX = x;
+      const x = projX(p.lon);
+      const y = projY(p.lat);
+      cur += (prevIn ? "L" : "M") + `${x.toFixed(1)},${y.toFixed(1)}`;
+      prevIn = true;
     }
     if (cur) segs.push(cur);
     return segs;
-  }, [track, width, height]);
+  }, [track]);
+
+  // region bbox 上色：gained / lost / 不變
+  const regionColors = useMemo(() => {
+    if (!track || !prevTrack) return new Map<string, { fill: string; stroke: string }>();
+    const m = new Map<string, { fill: string; stroke: string }>();
+    for (const r of FRAME_REGIONS) {
+      const wasIn = prevTrack.coveredRegions.has(r.key);
+      const nowIn = track.coveredRegions.has(r.key);
+      if (side === "after") {
+        if (!wasIn && nowIn) m.set(r.key, { fill: "rgba(34,197,94,0.22)", stroke: "rgba(34,197,94,0.75)" });   // gained 綠
+        else if (wasIn && nowIn) m.set(r.key, { fill: "rgba(255,255,255,0.04)", stroke: "rgba(255,255,255,0.18)" }); // 不變
+        else if (wasIn && !nowIn) m.set(r.key, { fill: "rgba(239,68,68,0.10)", stroke: "rgba(239,68,68,0.45)" });    // 顯示 lost 但較弱
+      } else {
+        if (wasIn && !nowIn) m.set(r.key, { fill: "rgba(239,68,68,0.22)", stroke: "rgba(239,68,68,0.75)" });   // lost 紅
+        else if (wasIn && nowIn) m.set(r.key, { fill: "rgba(255,255,255,0.04)", stroke: "rgba(255,255,255,0.18)" });
+        else if (!wasIn && nowIn) m.set(r.key, { fill: "rgba(34,197,94,0.10)", stroke: "rgba(34,197,94,0.45)" });
+      }
+    }
+    return m;
+  }, [track, prevTrack, side]);
 
   return (
     <div style={{ flex: 1 }}>
@@ -156,28 +202,54 @@ function MiniMap({
           {label}
         </span>
         {track && (
-          <span style={{ marginLeft: "auto", fontFamily: FONT_DATA, fontSize: 9.5, color: COLORS.textFaint }}>
+          <span style={{ marginLeft: "auto", fontFamily: FONT_DATA, fontSize: 10, color: COLORS.textDefault, fontWeight: 600 }}>
             過台 {track.twPasses} 次 / 7d
           </span>
         )}
       </div>
       <svg width={width} height={height} viewBox={`0 0 ${width} ${height}`}
            style={{ background: "#0b0f14", border: `1px solid ${COLORS.borderSoft}`, borderRadius: 6, display: "block" }}>
-        {/* 等高線：簡單赤道 + TW 點 */}
-        <line x1={0} y1={height / 2} x2={width} y2={height / 2} stroke="rgba(255,255,255,0.05)" />
-        <line x1={width / 2} y1={0} x2={width / 2} y2={height} stroke="rgba(255,255,255,0.05)" />
-        {/* TW 標記 */}
-        <circle
-          cx={((TW_CENTER.lon + 180) / 360) * width}
-          cy={((90 - TW_CENTER.lat) / 180) * height}
-          r={3}
-          fill="#4fc3f7"
-          stroke="white"
-          strokeWidth={0.5}
-        />
+        {/* 經緯線（每 5°） */}
+        {Array.from({ length: 8 }).map((_, i) => {
+          const lng = TW_FRAME.lngMin + i * 5;
+          if (lng > TW_FRAME.lngMax) return null;
+          const x = projX(lng);
+          return <line key={`v${i}`} x1={x} y1={0} x2={x} y2={height} stroke="rgba(255,255,255,0.04)" />;
+        })}
+        {Array.from({ length: 7 }).map((_, i) => {
+          const lat = TW_FRAME.latMin + i * 5;
+          if (lat > TW_FRAME.latMax) return null;
+          const y = projY(lat);
+          return <line key={`h${i}`} x1={0} y1={y} x2={width} y2={y} stroke="rgba(255,255,255,0.04)" />;
+        })}
+
+        {/* region bbox */}
+        {FRAME_REGIONS.map((r) => {
+          const rc = regionColors.get(r.key);
+          if (!rc) return null;
+          const [w, s, e, n] = r.bbox;
+          const x = projX(w);
+          const y = projY(n);
+          const rw = projX(e) - x;
+          const rh = projY(s) - y;
+          return (
+            <g key={r.key}>
+              <rect x={x} y={y} width={Math.max(2, rw)} height={Math.max(2, rh)}
+                    fill={rc.fill} stroke={rc.stroke} strokeWidth={1} rx={1.5} />
+            </g>
+          );
+        })}
+
+        {/* TW 中心點 */}
+        <circle cx={projX(TW_CENTER.lon)} cy={projY(TW_CENTER.lat)} r={4}
+                fill="#4fc3f7" stroke="white" strokeWidth={1} />
+        <text x={projX(TW_CENTER.lon) + 6} y={projY(TW_CENTER.lat) + 3}
+              fontFamily="ui-monospace, monospace" fontSize={9} fill="#4fc3f7">TW</text>
+
         {/* ground track */}
-        {path.map((d, i) => (
-          <path key={i} d={d} stroke={color} strokeWidth={0.9} fill="none" opacity={0.7} />
+        {segments.map((d, i) => (
+          <path key={i} d={d} stroke={color} strokeWidth={1.6} fill="none" opacity={0.85}
+                strokeLinecap="round" strokeLinejoin="round" />
         ))}
       </svg>
     </div>
@@ -199,7 +271,6 @@ export function ManeuverCompareModal({ maneuver, onClose }: Props) {
     return () => { alive = false; };
   }, [maneuver.norad_id, maneuver.prev_epoch, maneuver.curr_epoch]);
 
-  // §F 7 天軌跡的起點 = 變軌事件本身的時間，不跟時間軸也不跟現實 now
   const eventMs = useMemo(() => new Date(maneuver.curr_fetched_at).getTime(), [maneuver.curr_fetched_at]);
   const prevTrack = useMemo(() => (pair.prev ? computeGroundTrack(pair.prev, eventMs) : null), [pair.prev, eventMs]);
   const currTrack = useMemo(() => (pair.curr ? computeGroundTrack(pair.curr, eventMs) : null), [pair.curr, eventMs]);
@@ -216,12 +287,17 @@ export function ManeuverCompareModal({ maneuver, onClose }: Props) {
       if (!wasIn && nowIn) gained.push(r);
       else if (wasIn && !nowIn) lost.push(r);
     }
+    const twDiff = currTrack.twPasses - prevTrack.twPasses;
+    const pct = prevTrack.twPasses > 0
+      ? Math.round((twDiff / prevTrack.twPasses) * 100)
+      : (currTrack.twPasses > 0 ? 100 : 0);
     return {
       gained,
       lost,
-      twDiff: currTrack.twPasses - prevTrack.twPasses,
+      twDiff,
       twBefore: prevTrack.twPasses,
       twAfter: currTrack.twPasses,
+      pct,
     };
   }, [prevTrack, currTrack]);
 
@@ -241,7 +317,7 @@ export function ManeuverCompareModal({ maneuver, onClose }: Props) {
       <div
         onClick={(e) => e.stopPropagation()}
         style={{
-          width: 800, maxWidth: "100%", maxHeight: "92vh",
+          width: 760, maxWidth: "100%", maxHeight: "92vh",
           background: COLORS.panelBg, border: `1px solid ${COLORS.panelBorder}`,
           borderRadius: 10, fontFamily: FONT_CJK, color: COLORS.textDefault,
           display: "flex", flexDirection: "column", overflow: "hidden",
@@ -283,7 +359,7 @@ export function ManeuverCompareModal({ maneuver, onClose }: Props) {
           >×</button>
         </div>
 
-        <div className="mtp-scroll" style={{ flex: 1, overflowY: "auto", padding: 16 }}>
+        <div className="mtp-scroll" style={{ flex: 1, overflowY: "auto", padding: "14px 16px 16px" }}>
           {loading ? (
             <div style={{ padding: "40px 0", textAlign: "center", color: COLORS.textFaint, fontSize: 11 }}>
               載入 TLE pair + 計算 7 天 ground track…
@@ -294,61 +370,168 @@ export function ManeuverCompareModal({ maneuver, onClose }: Props) {
             </div>
           ) : (
             <>
-              {/* 兩張 mini-map */}
-              <div style={{ display: "flex", gap: 14 }}>
-                <MiniMap track={prevTrack} label="BEFORE · 變軌前" color="#ff9800" />
-                <MiniMap track={currTrack} label="AFTER · 變軌後" color="#4fc3f7" />
+              {/* ── headline 過台頻次 ── */}
+              {diff && <PassDiffHeadline diff={diff} />}
+
+              {/* ── 雙 mini-map（TW-centric） ── */}
+              <div style={{ display: "flex", gap: 14, marginTop: 14 }}>
+                <MiniMap track={prevTrack} prevTrack={prevTrack} label="BEFORE · 變軌前 7 天" color="#ff9800" side="before" />
+                <MiniMap track={currTrack} prevTrack={prevTrack} label="AFTER · 變軌後 7 天" color="#4fc3f7" side="after" />
               </div>
 
-              {/* diff 摘要 */}
+              {/* ── 區域差異 chips ── */}
               {diff && (
-                <div style={{ marginTop: 18, padding: 12, borderRadius: 6, background: "rgba(0,0,0,0.3)" }}>
-                  <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr 1fr", gap: 14 }}>
-                    <div>
-                      <div style={{ fontFamily: FONT_DATA, fontSize: 9, letterSpacing: "1.5px", color: COLORS.textFaint, marginBottom: 5 }}>
-                        新增覆蓋
-                      </div>
-                      {diff.gained.length === 0 ? (
-                        <div style={{ fontSize: 11, color: COLORS.textFaint }}>—</div>
-                      ) : diff.gained.map((r) => (
-                        <div key={r.key} style={{ fontSize: 11.5, color: "#4fc3f7", padding: "1px 0" }}>+ {r.zh}</div>
-                      ))}
-                    </div>
-                    <div>
-                      <div style={{ fontFamily: FONT_DATA, fontSize: 9, letterSpacing: "1.5px", color: COLORS.textFaint, marginBottom: 5 }}>
-                        失去覆蓋
-                      </div>
-                      {diff.lost.length === 0 ? (
-                        <div style={{ fontSize: 11, color: COLORS.textFaint }}>—</div>
-                      ) : diff.lost.map((r) => (
-                        <div key={r.key} style={{ fontSize: 11.5, color: COLORS.statusWarn, padding: "1px 0" }}>− {r.zh}</div>
-                      ))}
-                    </div>
-                    <div>
-                      <div style={{ fontFamily: FONT_DATA, fontSize: 9, letterSpacing: "1.5px", color: COLORS.textFaint, marginBottom: 5 }}>
-                        過台頻次（7 天）
-                      </div>
-                      <div style={{ fontFamily: FONT_DATA, fontSize: 11.5, color: COLORS.textDefault }}>
-                        {diff.twBefore} → {diff.twAfter}
-                        <span style={{
-                          marginLeft: 6,
-                          fontWeight: 700,
-                          color: diff.twDiff === 0 ? COLORS.textMuted : diff.twDiff > 0 ? "#4fc3f7" : COLORS.statusWarn,
-                        }}>
-                          ({diff.twDiff > 0 ? "+" : ""}{diff.twDiff})
-                        </span>
-                      </div>
-                    </div>
-                  </div>
-                  <div style={{ marginTop: 10, fontFamily: FONT_DATA, fontSize: 9, color: COLORS.textFaint }}>
-                    比對方法：前後兩條 TLE 各跑 SGP4 7 天（10 min 步進）→ 命中 {TW_RELEVANT_REGIONS.length} 個 TW 關聯區域 + elevation&gt;10° 入境邊緣 = 1 次過台
-                  </div>
+                <div style={{ marginTop: 14 }}>
+                  <RegionDiffChips gained={diff.gained} lost={diff.lost} />
                 </div>
               )}
+
+              <div style={{ marginTop: 10, fontFamily: FONT_DATA, fontSize: 9, color: COLORS.textFaint }}>
+                顯示框：經度 {TW_FRAME.lngMin}–{TW_FRAME.lngMax}°E · 緯度 {TW_FRAME.latMin}–{TW_FRAME.latMax}°N
+                ｜ 比對方法：前後兩條 TLE 跑 SGP4 7 天（10 min 步進），elevation&gt;10° 入境邊緣 = 1 次過台
+              </div>
             </>
           )}
         </div>
       </div>
     </div>
+  );
+}
+
+/** 過台頻次 headline — 主敘事 */
+function PassDiffHeadline({ diff }: { diff: { twBefore: number; twAfter: number; twDiff: number; pct: number } }) {
+  const isUp = diff.twDiff > 0;
+  const isDown = diff.twDiff < 0;
+  const maxPasses = Math.max(diff.twBefore, diff.twAfter, 5);
+  const barColor = isUp ? "#4fc3f7" : isDown ? COLORS.statusWarn : COLORS.textMuted;
+  const pctColor = isUp ? "#4fc3f7" : isDown ? COLORS.statusErr : COLORS.textMuted;
+
+  return (
+    <div style={{
+      padding: "12px 14px",
+      borderRadius: 8,
+      background: "rgba(255,255,255,0.025)",
+      border: `1px solid ${COLORS.borderSoft}`,
+    }}>
+      <div style={{
+        fontFamily: FONT_DATA, fontSize: 9, letterSpacing: "2px",
+        color: COLORS.textFaint, marginBottom: 8,
+      }}>
+        OVERHEAD PASSES · 過台頻次 7 天
+      </div>
+      <div style={{ display: "flex", alignItems: "stretch", gap: 16 }}>
+        <PassBar label="BEFORE" value={diff.twBefore} max={maxPasses} color="rgba(255,152,0,0.55)" />
+        <div style={{
+          display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center",
+          minWidth: 80, gap: 2,
+        }}>
+          <span style={{
+            fontFamily: FONT_DATA, fontSize: 22, fontWeight: 800, color: pctColor, lineHeight: 1,
+          }}>
+            {isUp ? "+" : ""}{diff.pct}%
+          </span>
+          <span style={{ fontFamily: FONT_DATA, fontSize: 10, color: COLORS.textMuted }}>
+            {isUp ? "↑ 增加" : isDown ? "↓ 減少" : "持平"}
+            {" "}
+            {isUp || isDown ? `${Math.abs(diff.twDiff)} 次` : ""}
+          </span>
+        </div>
+        <PassBar label="AFTER" value={diff.twAfter} max={maxPasses} color={barColor} />
+      </div>
+    </div>
+  );
+}
+
+function PassBar({ label, value, max, color }: { label: string; value: number; max: number; color: string }) {
+  const pct = max > 0 ? (value / max) * 100 : 0;
+  return (
+    <div style={{ flex: 1, display: "flex", flexDirection: "column", justifyContent: "center", gap: 4 }}>
+      <div style={{ display: "flex", alignItems: "baseline", gap: 6 }}>
+        <span style={{ fontFamily: FONT_DATA, fontSize: 9, letterSpacing: "1.5px", color: COLORS.textFaint }}>
+          {label}
+        </span>
+        <span style={{ marginLeft: "auto", fontFamily: FONT_DATA, fontSize: 18, fontWeight: 700, color: COLORS.textStrong, lineHeight: 1 }}>
+          {value}
+        </span>
+        <span style={{ fontFamily: FONT_DATA, fontSize: 10, color: COLORS.textDim }}>次</span>
+      </div>
+      <div style={{ position: "relative", height: 8, borderRadius: 4, background: "rgba(255,255,255,0.05)" }}>
+        <div style={{
+          position: "absolute", left: 0, top: 0, bottom: 0, width: `${pct}%`,
+          background: color, borderRadius: 4, transition: "width 0.3s ease",
+        }} />
+      </div>
+    </div>
+  );
+}
+
+/** 區域差異 chips（含 in-frame + off-frame 邊緣提示） */
+function RegionDiffChips({ gained, lost }: { gained: Region[]; lost: Region[] }) {
+  const gainedInFrame = gained.filter((r) => FRAME_REGIONS.includes(r));
+  const gainedOff = gained.filter((r) => !FRAME_REGIONS.includes(r));
+  const lostInFrame = lost.filter((r) => FRAME_REGIONS.includes(r));
+  const lostOff = lost.filter((r) => !FRAME_REGIONS.includes(r));
+
+  if (gained.length === 0 && lost.length === 0) {
+    return (
+      <div style={{ fontFamily: FONT_CJK, fontSize: 11, color: COLORS.textFaint, padding: "4px 0" }}>
+        7 天內覆蓋區域無實質差異（軌道平面微移，bbox 命中不變）
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ display: "flex", flexWrap: "wrap", alignItems: "center", gap: 6 }}>
+      {gained.length > 0 && (
+        <>
+          <span style={{ fontFamily: FONT_DATA, fontSize: 9, color: COLORS.textFaint, letterSpacing: "1.5px" }}>
+            新增覆蓋
+          </span>
+          {gainedInFrame.map((r) => (
+            <Chip key={r.key} color="#22c55e" zh={r.zh} prefix="+" />
+          ))}
+          {gainedOff.map((r) => (
+            <Chip key={r.key} color="#22c55e" zh={r.zh} prefix="+" offFrame />
+          ))}
+        </>
+      )}
+      {lost.length > 0 && (
+        <>
+          {gained.length > 0 && <span style={{ color: COLORS.borderMid }}>·</span>}
+          <span style={{ fontFamily: FONT_DATA, fontSize: 9, color: COLORS.textFaint, letterSpacing: "1.5px" }}>
+            失去覆蓋
+          </span>
+          {lostInFrame.map((r) => (
+            <Chip key={r.key} color={COLORS.statusErr} zh={r.zh} prefix="−" />
+          ))}
+          {lostOff.map((r) => (
+            <Chip key={r.key} color={COLORS.statusErr} zh={r.zh} prefix="−" offFrame />
+          ))}
+        </>
+      )}
+    </div>
+  );
+}
+
+function Chip({ color, zh, prefix, offFrame }: { color: string; zh: string; prefix: string; offFrame?: boolean }) {
+  return (
+    <span
+      title={offFrame ? "顯示框外（北方）" : undefined}
+      style={{
+        display: "inline-flex", alignItems: "center", gap: 3,
+        padding: "2px 7px",
+        borderRadius: 4,
+        background: `${color}22`,
+        border: `1px solid ${color}66`,
+        fontFamily: FONT_CJK,
+        fontSize: 11,
+        color,
+        opacity: offFrame ? 0.75 : 1,
+      }}
+    >
+      <span style={{ fontWeight: 700 }}>{prefix}</span>
+      {zh}
+      {offFrame && <span style={{ fontSize: 9, opacity: 0.8 }}>(框外)</span>}
+    </span>
   );
 }

--- a/src/data/satelliteManeuversLoader.ts
+++ b/src/data/satelliteManeuversLoader.ts
@@ -77,6 +77,33 @@ export function formatManeuverDetail(row: ManeuverRow): string {
   }
 }
 
+/** 變軌嚴重度 — 給 §A 卡片上色 + 排序用 */
+export type ManeuverSeverity = "grey" | "orange" | "red";
+
+const SEV_THRESHOLDS = {
+  PLANE_CHANGE: { orange: 0.02, red: 0.1 },       // 絕對值 °
+  ALTITUDE_CHANGE: { orange: 0.1, red: 0.5 },     // 絕對值 min
+  SHAPE_CHANGE: { orange: 1e-4, red: 5e-4 },      // 絕對值（無單位）
+} as const;
+
+export function getManeuverSeverity(row: ManeuverRow): ManeuverSeverity {
+  const th = SEV_THRESHOLDS[row.maneuver_type];
+  let v = 0;
+  switch (row.maneuver_type) {
+    case "PLANE_CHANGE":    v = Math.abs(row.delta_inclination ?? 0); break;
+    case "ALTITUDE_CHANGE": v = Math.abs(row.delta_period_min ?? 0); break;
+    case "SHAPE_CHANGE":    v = Math.abs(row.delta_eccentricity ?? 0); break;
+  }
+  if (v >= th.red) return "red";
+  if (v >= th.orange) return "orange";
+  return "grey";
+}
+
+/** 排序 rank — 數字大優先（red=2 > orange=1 > grey=0） */
+export function severityRank(s: ManeuverSeverity): number {
+  return s === "red" ? 2 : s === "orange" ? 1 : 0;
+}
+
 /** "14 分鐘前" / "2 小時前" / "已超過 24h" */
 export function formatRelTime(iso: string): string {
   const ms = Date.now() - new Date(iso).getTime();

--- a/src/hooks/useManeuverImpacts.ts
+++ b/src/hooks/useManeuverImpacts.ts
@@ -1,0 +1,84 @@
+/**
+ * 對一組變軌計算「是否影響台灣」（async）
+ *
+ * 對每筆變軌：
+ *   1. 從 satellite_tle_history 撈 prev/curr TLE pair
+ *   2. 兩條 TLE 各跑 7 天 SGP4 數過台次數
+ *   3. 兩者差異 != 0 → 影響台灣
+ *
+ * 結果 cache by `${norad}:${prev_epoch}:${curr_epoch}`，
+ * 同一筆變軌不會重算；新筆會 incremental fetch。
+ */
+import { useEffect, useState } from "react";
+import { fetchTlePair } from "../data/satelliteHistoryLoader";
+import { countTwPasses, type ManeuverImpact } from "../utils/maneuverImpact";
+import type { ManeuverRow } from "../data/satelliteManeuversLoader";
+
+const cache = new Map<string, ManeuverImpact>();
+
+function keyOf(row: ManeuverRow): string {
+  return `${row.norad_id}:${row.prev_epoch}:${row.curr_epoch}`;
+}
+
+export function useManeuverImpacts(rows: ManeuverRow[]): Map<number, ManeuverImpact> {
+  const [result, setResult] = useState<Map<number, ManeuverImpact>>(() => {
+    const m = new Map<number, ManeuverImpact>();
+    for (const r of rows) {
+      const cached = cache.get(keyOf(r));
+      if (cached) m.set(r.norad_id, cached);
+    }
+    return m;
+  });
+
+  useEffect(() => {
+    let alive = true;
+    const missing = rows.filter((r) => !cache.has(keyOf(r)));
+    if (missing.length === 0) {
+      // 全 hit cache — 直接組
+      const m = new Map<number, ManeuverImpact>();
+      for (const r of rows) {
+        const c = cache.get(keyOf(r));
+        if (c) m.set(r.norad_id, c);
+      }
+      setResult(m);
+      return;
+    }
+    // 平行抓 + 算
+    Promise.all(
+      missing.map(async (r) => {
+        const pair = await fetchTlePair(r.norad_id, r.prev_epoch, r.curr_epoch);
+        if (!pair.prev || !pair.curr) return { row: r, impact: null };
+        const anchorMs = new Date(r.curr_fetched_at).getTime();
+        const before = countTwPasses(pair.prev, anchorMs);
+        const after = countTwPasses(pair.curr, anchorMs);
+        if (before == null || after == null) return { row: r, impact: null };
+        const impact: ManeuverImpact = {
+          passBefore: before,
+          passAfter: after,
+          passDiff: after - before,
+          affectsTw: after - before !== 0,
+        };
+        cache.set(keyOf(r), impact);
+        return { row: r, impact };
+      }),
+    ).then((results) => {
+      if (!alive) return;
+      const m = new Map<number, ManeuverImpact>();
+      // 先把 cache 既有的塞進來
+      for (const r of rows) {
+        const c = cache.get(keyOf(r));
+        if (c) m.set(r.norad_id, c);
+      }
+      // 新算的也塞（cache 已 set 過）
+      for (const r of results) {
+        if (r.impact) m.set(r.row.norad_id, r.impact);
+      }
+      setResult(m);
+    });
+
+    return () => { alive = false; };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [rows.map(keyOf).join("|")]);
+
+  return result;
+}

--- a/src/utils/maneuverImpact.ts
+++ b/src/utils/maneuverImpact.ts
@@ -1,0 +1,73 @@
+/**
+ * Maneuver impact calculator — 給 §A 變軌警報判斷「是否影響台灣」用
+ *
+ * 用 SGP4 跑 7 天 ground track 數「過台灣次數」（elevation > 10°），
+ * 比較變軌前後差異。
+ *
+ * 與 §F ManeuverCompareModal 同邏輯但只算過台次數（不算 region），更快。
+ */
+import * as satellite from "satellite.js";
+import type { TleHistoryRow } from "../data/satelliteHistoryLoader";
+
+const TW_CENTER = { lon: 121.0, lat: 23.7 };
+const R_EARTH = 6371;
+
+function distanceKm(aLon: number, aLat: number, bLon: number, bLat: number): number {
+  const dLat = (bLat - aLat) * Math.PI / 180;
+  const dLon = (bLon - aLon) * Math.PI / 180;
+  const s = Math.sin(dLat / 2) ** 2 +
+    Math.cos(aLat * Math.PI / 180) * Math.cos(bLat * Math.PI / 180) * Math.sin(dLon / 2) ** 2;
+  return 2 * R_EARTH * Math.asin(Math.min(1, Math.sqrt(s)));
+}
+
+function coverageRadiusKm(altKm: number): number {
+  const elev = 10 * Math.PI / 180;
+  const ratio = R_EARTH / (R_EARTH + altKm);
+  const eta = Math.asin(ratio * Math.cos(elev));
+  const lambda = Math.PI / 2 - elev - eta;
+  return Math.max(120, R_EARTH * lambda);
+}
+
+/** 從一條 TLE 跑 7 天，數過台灣的次數（elevation > 10° 入境邊緣） */
+export function countTwPasses(row: TleHistoryRow, anchorMs: number): number | null {
+  if (!row.tle_line1 || !row.tle_line2) return null;
+  let satrec: satellite.SatRec;
+  try {
+    satrec = satellite.twoline2satrec(row.tle_line1, row.tle_line2);
+  } catch {
+    return null;
+  }
+  const STEP_MIN = 10;
+  const SPAN_HOURS = 7 * 24;
+  let passes = 0;
+  let inside = false;
+  for (let m = 0; m <= SPAN_HOURS * 60; m += STEP_MIN) {
+    const t = new Date(anchorMs + m * 60 * 1000);
+    try {
+      const pv = satellite.propagate(satrec, t);
+      if (typeof pv.position === "boolean" || !pv.position) continue;
+      const gmst = satellite.gstime(t);
+      const geo = satellite.eciToGeodetic(pv.position, gmst);
+      const lon = satellite.degreesLong(geo.longitude);
+      const lat = satellite.degreesLat(geo.latitude);
+      const altKm = geo.height;
+      const radius = coverageRadiusKm(altKm);
+      const dist = distanceKm(lon, lat, TW_CENTER.lon, TW_CENTER.lat);
+      const inNow = dist < radius;
+      if (inNow && !inside) {
+        inside = true;
+        passes++;
+      } else if (!inNow && inside) {
+        inside = false;
+      }
+    } catch { /* skip */ }
+  }
+  return passes;
+}
+
+export interface ManeuverImpact {
+  passBefore: number;
+  passAfter: number;
+  passDiff: number;
+  affectsTw: boolean;
+}


### PR DESCRIPTION
## Summary

3 個視覺/敘事重做 + 2 個 UX 修正，沿用前面 PR 的時間軸對齊與 Console 結構。

### 1. 飛到衛星 zoom 5.5 → 3.5（看到更寬範圍）
原本 z=5.5 ≈ 600 km 半徑，太近看不出脈絡。
改 z=3.5 ≈ 3500 km 半徑，衛星與台灣常可同框。

### 2. §F 變軌前後對比 modal v2 — TW-centric + bbox 上色 + headline 過台頻次
原版「兩張全球小地圖 + 三欄文字列表」差異看不清。

**重做後**：
- 雙圖縮到 TW frame（經 108–145°E / 緯 5–35°N），日本九州 + 菲律賓呂宋全進框
- 12 個 TW 關聯區域 bbox 直接畫在地圖上（gained 綠 / lost 紅 / 不變灰）
- headline 區「過台頻次 BEFORE → AFTER (+X%)」雙進度條 + 中央大字
- 框外區域（本州 / 朝鮮北）改邊緣 chip 提示

### 3. 左側 4 個 panel 完整互斥（Layers / Locations / Intel / Satellite）
原本 Layers 開啟時不會關 Intel/Satellite。修法：togglePanel 開啟時順便調用對方 toggle。

### 4. §A 嚴重度分級 + 影響 TW chip + 例行折疊
- \`getManeuverSeverity\`：依 \`Δi\`/\`Δp\`/\`Δe\` 絕對值分 red/orange/grey
  - PLANE_CHANGE: <0.02° 灰, <0.1° 橘, ≥0.1° 紅
  - ALTITUDE_CHANGE: <0.1min 灰, <0.5min 橘, ≥0.5min 紅
  - SHAPE_CHANGE: <1e-4 灰, <5e-4 橘, ≥5e-4 紅
- 排序 red → orange → grey 再時間 DESC
- 紅卡（重大）整張 pulse 1.5s 動畫；灰卡（例行）摺疊到「N 筆例行機動」展開按鈕
- \`useManeuverImpacts\` hook：每筆變軌 async 抓 TLE pair + 7d SGP4 → 算過台前後差
- 「✓ 影響 TW (5→7)」綠 chip / 「過台不變」淡灰 chip

### 5. §D 覆蓋數 breakdown + 只看遙測偵察 toggle
回應「覆蓋台灣中 84 顆」是什麼意思 — 加 breakdown：
- 「CN 70 / TW 14 · 遙測類 12 顆」三層分
- 遙測類 = china_yaogan/jilin/gaofen + taiwan
- timeline 展開新增「只看遙測 / 全部」兩按鈕（預設遙測）
- 過濾掉 Beidou/TJS/Shiyan 長尾，timeline tick 排得清楚

## Test plan

- [x] \`npx tsc -b\` / vitest 102/102 通過
- [ ] §F modal 開啟 → 雙圖 TW 區域 + 過台頻次 headline + 區域 bbox 上色
- [ ] §A 卡片排序：紅 → 橘 → 灰
- [ ] 「N 筆例行機動」可折疊
- [ ] §D 「只看遙測」toggle 切換 timeline 內容

🤖 Generated with [Claude Code](https://claude.com/claude-code)