### PR TITLE
Monitor Mode Phase 2 — 戰情看板 + 新聞直播牆

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -78,6 +78,7 @@ import { LocationJump } from "./components/AirportSelector";
 import { LayerSidebar } from "./components/LayerSidebar";
 import { IconRailSidebar } from "./components/IconRailSidebar";
 import { IntelPanel } from "./components/intel/IntelPanel";
+import { MonitorPanel } from "./components/intel/monitor/MonitorPanel";
 import { SatelliteConsole } from "./components/satelliteConsole/SatelliteConsole";
 import { satelliteConsoleStore, useSatelliteConsole } from "./state/satelliteConsoleStore";
 import { useSatelliteManeuvers } from "./hooks/useSatelliteManeuvers";
@@ -425,6 +426,8 @@ export default function App() {
 
   // ── Intel Panel（即時情報，IconRail 開關） ──
   const [intelOpen, setIntelOpen] = useState(false);
+  // ── Monitor Mode（戰情看板，底部上拉） ──
+  const [monitorOpen, setMonitorOpen] = useState(false);
   const satConsole = useSatelliteConsole();
   const satManeuvers = useSatelliteManeuvers(satConsole.open);
   const maneuverNorads = useMemo(() => {
@@ -1459,6 +1462,22 @@ export default function App() {
             }}
           />
 
+          {/* Monitor Mode 戰情看板（底部上拉） */}
+          <MonitorPanel
+            open={monitorOpen}
+            onClose={() => setMonitorOpen(false)}
+            filter={newsFilter}
+            onFilterChange={(next) => {
+              transportParams.setNewsMinRelevance(next.minRelevance);
+              transportParams.setNewsEventsOnly(next.eventsOnly);
+              transportParams.setNewsMinSeverity(next.minSeverity);
+            }}
+            onSelectLocation={(lon, lat) => {
+              mapRef.current?.flyTo({ center: [lon, lat], zoom: 11, speed: 1.2 });
+            }}
+          />
+
+
           {/* 時間軸：依 mode 切換 realtime / historical */}
           {appMode === "realtime" ? (
             <TimelineControls
@@ -1539,23 +1558,44 @@ export default function App() {
               Capture
             </button>
             <button
-              onClick={() => setRenderMode((m) => (m === "3d" ? "2d" : "3d"))}
+              onClick={() => {
+                if (!monitorOpen) {
+                  setIntelOpen(false);
+                  satelliteConsoleStore.setOpen(false);
+                }
+                setMonitorOpen((v) => !v);
+              }}
+              title="監看模式 Monitor"
               style={{
+                display: "inline-flex",
+                alignItems: "center",
+                gap: 6,
                 padding: "6px 14px",
-                background: renderMode === "3d"
-                  ? (isDarkTheme ? "rgba(80,140,255,0.25)" : "rgba(80,140,255,0.15)")
-                  : (isDarkTheme ? "rgba(255,170,68,0.25)" : "rgba(255,170,68,0.15)"),
-                border: `1px solid ${renderMode === "3d" ? "rgba(80,140,255,0.5)" : "rgba(255,170,68,0.5)"}`,
+                background: monitorOpen
+                  ? "#64aaff"
+                  : (isDarkTheme ? "rgba(80,140,255,0.25)" : "rgba(80,140,255,0.15)"),
+                border: `1px solid ${monitorOpen ? "#64aaff" : "rgba(80,140,255,0.5)"}`,
                 borderRadius: 6,
-                color: isDarkTheme ? "#fff" : "#333",
+                color: monitorOpen ? "#04121f" : (isDarkTheme ? "#fff" : "#333"),
                 fontSize: 12,
                 fontFamily: "monospace",
+                fontWeight: monitorOpen ? 700 : 400,
                 cursor: "pointer",
                 backdropFilter: "blur(8px)",
                 letterSpacing: 1,
               }}
             >
-              {renderMode === "3d" ? "3D Altitude" : "2D Flat"}
+              <svg
+                width={13} height={13} viewBox="0 0 24 24" fill="none"
+                stroke="currentColor" strokeWidth={1.8}
+                strokeLinecap="round" strokeLinejoin="round"
+              >
+                <path d="M3 3h7v7H3z" />
+                <path d="M14 3h7v7h-7z" />
+                <path d="M14 14h7v7h-7z" />
+                <path d="M3 14h7v7H3z" />
+              </svg>
+              Monitor
             </button>
           </div>
 

--- a/src/components/intel/intelTokens.ts
+++ b/src/components/intel/intelTokens.ts
@@ -90,3 +90,55 @@ export function fmtCountdown(sec: number): string {
   const s = Math.floor(sec % 60);
   return `${String(m).padStart(2, "0")}:${String(s).padStart(2, "0")}`;
 }
+
+// ─── Monitor Mode Phase 2 ─────────────────────────────────────────
+
+/** 4 檔戰情等級（壓力指數 0–100 對應顏色 + 動畫） */
+export type PressureLevelKey = "peace" | "notice" | "alert" | "emergency";
+
+export interface PressureLevelDef {
+  key: PressureLevelKey;
+  label: string;
+  en: string;
+  min: number;
+  max: number;
+  color: string;
+  soft: string;
+  glow: string;
+  anim: "none" | "breathe" | "pulse";
+  period: number;
+}
+
+export const PRESSURE_LEVELS: PressureLevelDef[] = [
+  { key: "peace",     label: "平時", en: "PEACETIME", min: 0,  max: 35,  color: "#4caf50",
+    soft: "rgba(76,175,80,0.16)",  glow: "rgba(76,175,80,0)",     anim: "none",    period: 0 },
+  { key: "notice",    label: "留意", en: "NOTICE",    min: 36, max: 55,  color: "#eab308",
+    soft: "rgba(234,179,8,0.16)",  glow: "rgba(234,179,8,0)",     anim: "breathe", period: 4 },
+  { key: "alert",     label: "警戒", en: "ALERT",     min: 56, max: 75,  color: "#ff9800",
+    soft: "rgba(255,152,0,0.16)",  glow: "rgba(255,152,0,0.35)",  anim: "breathe", period: 2 },
+  { key: "emergency", label: "緊急", en: "EMERGENCY", min: 76, max: 100, color: "#ff3b30",
+    soft: "rgba(255,59,48,0.18)",  glow: "rgba(255,59,48,0.55)",  anim: "pulse",   period: 1 },
+];
+
+export function pressureLevel(score: number): PressureLevelDef {
+  const clamped = Math.max(0, Math.min(100, Math.round(score)));
+  return PRESSURE_LEVELS.find((l) => clamped >= l.min && clamped <= l.max) ?? PRESSURE_LEVELS[0]!;
+}
+
+/** Monitor 模式的補充 icon set（沿用 IntelIcon 的 lucide-flavor stroke） */
+export const MICON: Record<string, string[]> = {
+  grid:      ["M3 3h7v7H3z", "M14 3h7v7h-7z", "M14 14h7v7h-7z", "M3 14h7v7H3z"],
+  maximize:  ["M8 3H5a2 2 0 0 0-2 2v3", "M21 8V5a2 2 0 0 0-2-2h-3", "M3 16v3a2 2 0 0 0 2 2h3", "M16 21h3a2 2 0 0 0 2-2v-3"],
+  minimize:  ["M8 3v3a2 2 0 0 1-2 2H3", "M21 8h-3a2 2 0 0 1-2-2V3", "M3 16h3a2 2 0 0 1 2 2v3", "M16 21v-3a2 2 0 0 1 2-2h3"],
+  flame:     ["M8.5 14.5A2.5 2.5 0 0 0 11 12c0-1.38-.5-2-1-3-1.07-2.14-.22-4.05 2-6 .5 2.5 2 4.9 4 6.5 2 1.6 3 3.5 3 5.5a7 7 0 1 1-14 0c0-1.15.43-2.29 1-3a2.5 2.5 0 0 0 2.5 2.5z"],
+  plane:     ["M17.8 19.2 16 11l3.5-3.5C21 6 21.5 4 21 3c-1-.5-3 0-4.5 1.5L13 8 4.8 6.2c-.5-.1-.9.1-1.1.5l-.3.5c-.2.5-.1 1 .3 1.3L9 12l-2 3H4l-1 1 3 2 2 3 1-1v-3l3-2 3.5 5.3c.3.4.8.5 1.3.3l.5-.2c.4-.3.6-.7.5-1.2z"],
+  trendUp:   ["M22 7 13.5 15.5 8.5 10.5 2 17", "M16 7h6v6"],
+  trendDown: ["M22 17 13.5 8.5 8.5 13.5 2 7", "M16 17h6v-6"],
+  pulse:     ["M22 12h-4l-3 9L9 3l-3 9H2"],
+};
+
+/** 5min EMA 平滑（30s polling, N=10 → alpha≈0.18）。score=null 表示首次採樣，直接回新值。 */
+export function smoothPressure(prev: number | null, next: number, alpha = 0.18): number {
+  if (prev == null || Number.isNaN(prev)) return next;
+  return prev + (next - prev) * alpha;
+}

--- a/src/components/intel/monitor/IndicatorPanel.tsx
+++ b/src/components/intel/monitor/IndicatorPanel.tsx
@@ -1,0 +1,444 @@
+import { useMemo } from "react";
+import { IntelIcon } from "../IntelIcon";
+import {
+  COLORS, FONT_CJK, FONT_DATA, MICON, GIS_LEVELS, SEV_LEVELS,
+} from "../intelTokens";
+import {
+  NEWS_CATEGORIES, getNewsCategoryDef, type NewsCategory,
+} from "../../../data/newsEventTypes";
+import type { ClusterEvent } from "../../../data/newsEventsLoader";
+import type {
+  PressureIndexNow, MarketIndex, PlaActivity, PublicHealthWeek, SourceHealthSummary,
+} from "../../../data/intelLoaders";
+import { SectionLabel, Widget } from "./PressureRing";
+import { SituationOverview } from "./SituationOverview";
+import { SituationCards } from "./SituationCards";
+import { LiveWall } from "./LiveWall";
+
+interface Props {
+  events: ClusterEvent[];
+  countyByEventId: Map<number, string>;
+  pressure: PressureIndexNow;
+  smoothedScore: number;
+  market: MarketIndex;
+  pla: PlaActivity;
+  health: PublicHealthWeek;
+  sourceHealth: SourceHealthSummary;
+  /** 全天總則數，給 hourly 直方圖 + KPI */
+  totalToday: number;
+  /** 點熱區 row → 切到該縣市 */
+  onPickHotspot: (county: string) => void;
+}
+
+interface Hotspot {
+  county: string;
+  n: number;
+  topCat: NewsCategory;
+  surge: number;
+  cats: Record<string, number>;
+}
+
+function rankHotspots(events: ClusterEvent[], countyById: Map<number, string>): Hotspot[] {
+  const byCounty: Record<string, { n: number; cats: Record<string, number> }> = {};
+  for (const e of events) {
+    const county = countyById.get(e.id);
+    if (!county || county === "全國" || county === "全部") continue;
+    if (!byCounty[county]) byCounty[county] = { n: 0, cats: {} };
+    const slot = byCounty[county]!;
+    slot.n += 1;
+    const cat = (e.category ?? "other") as string;
+    slot.cats[cat] = (slot.cats[cat] ?? 0) + 1;
+  }
+  const out: Hotspot[] = [];
+  for (const [county, v] of Object.entries(byCounty)) {
+    const top = Object.entries(v.cats).sort((a, b) => b[1] - a[1])[0];
+    const topCat = (top?.[0] ?? "other") as NewsCategory;
+    out.push({
+      county, n: v.n, topCat,
+      surge: +(1 + v.n * 0.28).toFixed(1),
+      cats: v.cats,
+    });
+  }
+  out.sort((a, b) => b.n - a.n);
+  return out;
+}
+
+interface HourlyBucket {
+  h: number;
+  c: Record<NewsCategory, number>;
+  total: number;
+}
+
+const CAT_KEYS = NEWS_CATEGORIES.map((c) => c.key);
+
+function bucketByHour(events: ClusterEvent[]): HourlyBucket[] {
+  const buckets: HourlyBucket[] = Array.from({ length: 24 }, (_, h) => ({
+    h,
+    c: { accident: 0, crime: 0, disaster: 0, traffic: 0, health: 0, policy: 0, other: 0 },
+    total: 0,
+  }));
+  for (const e of events) {
+    if (!e.published_ts) continue;
+    const h = new Date(e.published_ts * 1000).getHours();
+    const k = (CAT_KEYS.includes((e.category ?? "other") as NewsCategory)
+      ? (e.category as NewsCategory)
+      : "other") as NewsCategory;
+    const bucket = buckets[h];
+    if (!bucket) continue;
+    bucket.c[k] += 1;
+    bucket.total += 1;
+  }
+  return buckets;
+}
+
+function DistBar({
+  label, levels, counts,
+}: {
+  label: string;
+  levels: { label: string; color: string }[];
+  counts: number[];
+}) {
+  const total = counts.reduce((a, b) => a + b, 0) || 1;
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+      <span
+        style={{
+          fontFamily: FONT_DATA, fontSize: 9, letterSpacing: "0.5px",
+          color: COLORS.textDim,
+        }}
+      >
+        {label}
+      </span>
+      <div
+        style={{
+          display: "flex", height: 9, borderRadius: 3, overflow: "hidden",
+          background: "rgba(255,255,255,0.04)",
+        }}
+      >
+        {levels.map((lv, i) =>
+          counts[i] ? (
+            <span
+              key={i}
+              title={`${lv.label} · ${counts[i]}`}
+              style={{
+                width: `${((counts[i] ?? 0) / total) * 100}%`, background: lv.color,
+              }}
+            />
+          ) : null,
+        )}
+      </div>
+      <div style={{ display: "flex", flexWrap: "wrap", gap: "3px 9px" }}>
+        {levels.map((lv, i) => (
+          <span
+            key={i}
+            style={{
+              display: "inline-flex", alignItems: "center", gap: 4,
+              fontFamily: FONT_CJK, fontSize: 9.5,
+              color: counts[i] ? COLORS.textDefault : COLORS.textGhost,
+              whiteSpace: "nowrap",
+            }}
+          >
+            <span
+              style={{
+                width: 7, height: 7, borderRadius: 2, background: lv.color,
+                opacity: counts[i] ? 1 : 0.4,
+              }}
+            />
+            {lv.label}{" "}
+            <b
+              style={{
+                fontFamily: FONT_DATA,
+                color: counts[i] ? "#fff" : COLORS.textFaint,
+              }}
+            >
+              {counts[i] ?? 0}
+            </b>
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export function IndicatorPanel({
+  events, countyByEventId, pressure, smoothedScore, market, pla, health,
+  sourceHealth, totalToday, onPickHotspot,
+}: Props) {
+  const stats = useMemo(() => {
+    const ranked = rankHotspots(events, countyByEventId);
+    const severe = events.filter((e) => (e.severity ?? 0) >= 3).length;
+    return { ranked, severe };
+  }, [events, countyByEventId]);
+
+  const buckets = useMemo(() => bucketByHour(events), [events]);
+  const peak = Math.max(1, ...buckets.map((b) => b.total));
+  const nowHour = new Date().getHours();
+
+  const tri = useMemo(() => {
+    const gis = [0, 0, 0, 0];
+    const sev = [0, 0, 0, 0];
+    let ev = 0, st = 0;
+    for (const e of events) {
+      const g = Math.max(0, Math.min(3, e.gis_relevance ?? 0));
+      const s = Math.max(0, Math.min(3, e.severity ?? 0));
+      gis[g] = (gis[g] ?? 0) + 1;
+      sev[s] = (sev[s] ?? 0) + 1;
+      if (e.is_event === false) st += 1;
+      else ev += 1;
+    }
+    return { gis, sev, event: ev, statement: st };
+  }, [events]);
+
+  const maxHot = stats.ranked.length ? stats.ranked[0]!.n : 1;
+
+  return (
+    <div
+      className="mtp-scroll"
+      style={{
+        flex: 1, minWidth: 0, overflowY: "auto",
+        padding: "14px 16px 18px",
+        display: "grid", gridTemplateColumns: "1fr 1.3fr",
+        gap: 13, alignContent: "start",
+      }}
+    >
+      <SituationOverview
+        pressure={pressure}
+        smoothedScore={smoothedScore}
+        market={market}
+        sourceHealth={sourceHealth}
+        totalEvents={events.length}
+        severeCount={stats.severe}
+      />
+
+      <SituationCards pla={pla} health={health} />
+
+      <LiveWall />
+
+      {/* 熱區 Top 5 */}
+      <Widget>
+        <SectionLabel>熱區 Top 5 · HOTSPOTS</SectionLabel>
+        <div style={{ display: "flex", flexDirection: "column", gap: 7 }}>
+          {stats.ranked.slice(0, 5).map((r, i) => {
+            const cat = getNewsCategoryDef(r.topCat);
+            return (
+              <button
+                key={r.county}
+                onClick={() => onPickHotspot(r.county)}
+                style={{
+                  display: "flex", alignItems: "center", gap: 9,
+                  padding: "6px 8px", borderRadius: 6, cursor: "pointer",
+                  background: "rgba(255,255,255,0.02)",
+                  border: `1px solid ${COLORS.borderSoft}`,
+                  textAlign: "left", transition: "background .12s",
+                }}
+                onMouseEnter={(ev) =>
+                  (ev.currentTarget.style.background = "rgba(255,255,255,0.06)")
+                }
+                onMouseLeave={(ev) =>
+                  (ev.currentTarget.style.background = "rgba(255,255,255,0.02)")
+                }
+              >
+                <span
+                  style={{
+                    fontFamily: FONT_DATA, fontSize: 11, fontWeight: 700,
+                    color: COLORS.textDim, width: 14,
+                  }}
+                >
+                  {i + 1}
+                </span>
+                <span
+                  style={{
+                    width: 8, height: 8, borderRadius: "50%",
+                    background: cat.color, flexShrink: 0,
+                  }}
+                />
+                <span
+                  style={{
+                    fontFamily: FONT_CJK, fontSize: 12,
+                    color: COLORS.textStrong, whiteSpace: "nowrap",
+                  }}
+                >
+                  {r.county}
+                </span>
+                <span
+                  style={{
+                    fontFamily: FONT_CJK, fontSize: 9.5, color: cat.color,
+                    padding: "1px 6px", borderRadius: 3,
+                    background: `${cat.color}1f`, whiteSpace: "nowrap",
+                  }}
+                >
+                  {cat.label}
+                </span>
+                <div
+                  style={{
+                    flex: 1, height: 5, borderRadius: 3,
+                    background: "rgba(255,255,255,0.05)",
+                    overflow: "hidden", minWidth: 20,
+                  }}
+                >
+                  <span
+                    style={{
+                      display: "block", height: "100%",
+                      width: `${(r.n / maxHot) * 100}%`,
+                      background: cat.color, opacity: 0.7,
+                    }}
+                  />
+                </div>
+                <span
+                  style={{
+                    fontFamily: FONT_DATA, fontSize: 13, fontWeight: 700,
+                    color: "#fff", width: 18, textAlign: "right",
+                  }}
+                >
+                  {r.n}
+                </span>
+                <span
+                  style={{
+                    display: "inline-flex", alignItems: "center", gap: 2,
+                    fontFamily: FONT_DATA, fontSize: 9.5,
+                    color: r.surge >= 2 ? COLORS.statusWarn : COLORS.textDim,
+                    width: 40,
+                  }}
+                >
+                  {r.surge >= 2 && (
+                    <IntelIcon d={MICON.flame!} size={10} color={COLORS.statusWarn} />
+                  )}
+                  ×{r.surge}
+                </span>
+              </button>
+            );
+          })}
+          {stats.ranked.length === 0 && (
+            <div
+              style={{
+                fontFamily: FONT_CJK, fontSize: 11, color: COLORS.textFaint,
+                padding: "10px 2px",
+              }}
+            >
+              ⚠ 尚無資料
+            </div>
+          )}
+        </div>
+      </Widget>
+
+      {/* 24h stacked histogram */}
+      <Widget>
+        <div
+          style={{
+            display: "flex", alignItems: "center", justifyContent: "space-between",
+          }}
+        >
+          <SectionLabel>24h 事件直方圖 · BREAKDOWN</SectionLabel>
+          <div
+            style={{
+              display: "flex", flexWrap: "wrap", justifyContent: "flex-end",
+              gap: "4px 9px", marginBottom: 9, maxWidth: "62%",
+            }}
+          >
+            {NEWS_CATEGORIES.map((c) => (
+              <span
+                key={c.key}
+                style={{
+                  display: "inline-flex", alignItems: "center", gap: 3,
+                  fontFamily: FONT_CJK, fontSize: 9, color: COLORS.textDim,
+                  whiteSpace: "nowrap",
+                }}
+              >
+                <span
+                  style={{
+                    width: 7, height: 7, borderRadius: 2, background: c.color,
+                  }}
+                />
+                {c.label}
+              </span>
+            ))}
+          </div>
+        </div>
+        <div
+          style={{
+            display: "flex", alignItems: "flex-end", gap: 2,
+            height: 118, position: "relative",
+          }}
+        >
+          {[0.5, 1].map((g) => (
+            <span
+              key={g}
+              style={{
+                position: "absolute", left: 0, right: 0, bottom: `${g * 100}%`,
+                height: 1, background: "rgba(255,255,255,0.05)",
+              }}
+            />
+          ))}
+          {buckets.map((hd) => {
+            const isFuture = hd.h > nowHour;
+            return (
+              <div
+                key={hd.h}
+                title={`${String(hd.h).padStart(2, "0")}:00 · ${hd.total} 則`}
+                style={{
+                  flex: 1, display: "flex", flexDirection: "column-reverse",
+                  height: `${(hd.total / peak) * 100}%`,
+                  minHeight: hd.total ? 3 : 0,
+                  borderRadius: 2, overflow: "hidden",
+                  opacity: isFuture ? 0.25 : 1,
+                }}
+              >
+                {NEWS_CATEGORIES.map((c) =>
+                  hd.c[c.key] ? (
+                    <span
+                      key={c.key}
+                      style={{
+                        height: `${(hd.c[c.key] / hd.total) * 100}%`,
+                        background: c.color, opacity: 0.82,
+                      }}
+                    />
+                  ) : null,
+                )}
+              </div>
+            );
+          })}
+        </div>
+        <div
+          style={{
+            display: "flex", justifyContent: "space-between", marginTop: 4,
+            fontFamily: FONT_DATA, fontSize: 9, color: COLORS.textFaint,
+          }}
+        >
+          <span>00:00</span>
+          <span>06:00</span>
+          <span>12:00</span>
+          <span>18:00</span>
+          <span>23:59</span>
+        </div>
+      </Widget>
+
+      {/* TRIAGE */}
+      <Widget style={{ gridColumn: "1 / -1" }}>
+        <SectionLabel>信號分級 · TRIAGE</SectionLabel>
+        <div style={{ display: "grid", gridTemplateColumns: "repeat(3, 1fr)", gap: 18 }}>
+          <DistBar label="地理相關 GIS_RELEVANCE" levels={GIS_LEVELS} counts={tri.gis} />
+          <DistBar label="嚴重程度 SEVERITY" levels={SEV_LEVELS} counts={tri.sev} />
+          <DistBar
+            label="事件性質 IS_EVENT"
+            levels={[
+              { label: "事件", color: COLORS.accent },
+              { label: "聲明", color: "rgba(255,255,255,0.3)" },
+            ]}
+            counts={[tri.event, tri.statement]}
+          />
+        </div>
+      </Widget>
+
+      {/* small footer with today total */}
+      <div
+        style={{
+          gridColumn: "1 / -1",
+          fontFamily: FONT_DATA, fontSize: 9, color: COLORS.textFaint,
+          textAlign: "right",
+        }}
+      >
+        今日累計 {totalToday} 則
+      </div>
+    </div>
+  );
+}

--- a/src/components/intel/monitor/LiveWall.tsx
+++ b/src/components/intel/monitor/LiveWall.tsx
@@ -382,8 +382,8 @@ function LiveSlot({
 }
 
 export function LiveWall() {
-  // 預設 4 格：公視 + TVBS + 華視 + 台視
-  const [slots, setSlots] = useState(["pts", "tvbs", "cts", "ttv"]);
+  // 預設 4 格：公視 + 中視 + 三立 + 民視
+  const [slots, setSlots] = useState(["pts", "ctv", "set", "ftv"]);
   const setSlot = (i: number) => (id: string) =>
     setSlots((prev) => prev.map((v, k) => (k === i ? id : v)));
   const ctsLive = slots.includes("cts");

--- a/src/components/intel/monitor/LiveWall.tsx
+++ b/src/components/intel/monitor/LiveWall.tsx
@@ -1,0 +1,472 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import { COLORS, FONT_CJK, FONT_DATA } from "../intelTokens";
+import { fetchLiveVideos, type YtLiveVideo } from "../../../data/intelLoaders";
+
+export interface LiveChannel {
+  id: string;
+  name: string;
+  en: string;
+  tag: "公廣" | "綜合" | "財經";
+  /** YouTube @handle —— 與 collector HANDLES + realtime.yt_live_current.handle 對齊 */
+  handle: string;
+  note?: string;
+  emergency?: boolean;
+  emergencyLabel?: string;
+}
+
+/**
+ * 14 家 24h YouTube 新聞直播 —— 依屬性分組
+ *
+ * 實際 video_id 由 `realtime.yt_live_current` 提供（collector 5 min cron 解析）。
+ * 前端用 `embed/<video_id>` 才可靠（`embed/live_stream?channel=` 多數頻道找不到 primary live）。
+ * 對應 collector：data-collectors/collectors/yt_live_video_resolver.py
+ */
+export const LIVE_CHANNELS: LiveChannel[] = [
+  { id: "pts",    name: "公視新聞", en: "PTS",       tag: "公廣", handle: "@ptslivestream", note: "公廣保底，訊號最穩" },
+  { id: "cts",    name: "華視新聞", en: "CTS",       tag: "公廣", handle: "@CtsTw", emergency: true, emergencyLabel: "防災直播", note: "災防可切防災直播" },
+  { id: "tvbs",   name: "TVBS",     en: "TVBS NEWS", tag: "綜合", handle: "@TVBSNEWS01", note: "觀看數最高" },
+  { id: "set",    name: "三立新聞", en: "SET",       tag: "綜合", handle: "@SETN", note: "iNEWS 24h" },
+  { id: "ebc",    name: "東森新聞", en: "EBC",       tag: "綜合", handle: "@newsebc" },
+  { id: "ftv",    name: "民視新聞", en: "FTV",       tag: "綜合", handle: "@FTV_News" },
+  { id: "era",    name: "年代新聞", en: "ERA",       tag: "綜合", handle: "@era_news" },
+  { id: "mnews",  name: "鏡新聞",   en: "MIRROR",    tag: "綜合", handle: "@MnewsTw", note: "⏳ handle 待修" },
+  { id: "ttv",    name: "台視新聞", en: "TTV",       tag: "綜合", handle: "@TTV_NEWS" },
+  { id: "ctv",    name: "中視新聞", en: "CTV",       tag: "綜合", handle: "@twctvnews" },
+  { id: "global", name: "寰宇新聞", en: "GLOBAL",    tag: "綜合", handle: "@globalnewstw" },
+  { id: "ustv",   name: "非凡新聞", en: "USTV",      tag: "財經", handle: "@ustvnews", note: "⏳ handle 待修" },
+  { id: "cna",    name: "中央社",   en: "CNA",       tag: "財經", handle: "@CNAvideo", note: "即時影音" },
+];
+
+function videoEmbedSrc(videoId: string): string {
+  return `https://www.youtube.com/embed/${videoId}?autoplay=1&mute=1&playsinline=1`;
+}
+
+function channelEmbedSrc(channelId: string): string {
+  return `https://www.youtube.com/embed/live_stream?channel=${channelId}&autoplay=1&mute=1&playsinline=1`;
+}
+
+interface MenuProps {
+  value: string;
+  onPick: (id: string) => void;
+  usedIds: string[];
+}
+
+function ChannelMenu({ value, onPick, usedIds }: MenuProps) {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+  const cur = LIVE_CHANNELS.find((c) => c.id === value) ?? LIVE_CHANNELS[0]!;
+
+  useEffect(() => {
+    if (!open) return;
+    const close = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+    };
+    document.addEventListener("mousedown", close);
+    return () => document.removeEventListener("mousedown", close);
+  }, [open]);
+
+  return (
+    <div ref={ref} style={{ position: "relative" }}>
+      <button
+        onClick={() => setOpen((v) => !v)}
+        style={{
+          display: "inline-flex", alignItems: "center", gap: 6, padding: "3px 9px", borderRadius: 5,
+          background: "rgba(0,0,0,0.72)", color: "#fff",
+          border: `1px solid ${COLORS.borderMid}`, cursor: "pointer",
+          backdropFilter: "blur(6px)", WebkitBackdropFilter: "blur(6px)",
+          fontFamily: FONT_CJK, fontSize: 10.5,
+        }}
+      >
+        <span style={{ fontWeight: 700 }}>{cur.name}</span>
+        <span
+          style={{
+            fontFamily: FONT_DATA, fontSize: 8,
+            color: "rgba(255,255,255,0.5)", letterSpacing: "0.5px",
+          }}
+        >
+          {cur.en}
+        </span>
+        <span
+          style={{
+            display: "inline-block",
+            transform: open ? "rotate(180deg)" : "none",
+            transition: "transform .2s",
+            fontSize: 8, color: "rgba(255,255,255,0.6)",
+          }}
+        >
+          ▾
+        </span>
+      </button>
+
+      {open && (
+        <div
+          style={{
+            position: "absolute", bottom: "calc(100% + 6px)", left: 0,
+            width: 232, zIndex: 30, borderRadius: 9, overflow: "hidden",
+            border: `1px solid ${COLORS.borderMid}`,
+            background: "rgba(10,10,20,0.94)",
+            backdropFilter: "blur(14px)", WebkitBackdropFilter: "blur(14px)",
+            boxShadow: "0 8px 32px rgba(0,0,0,0.55)",
+            animation: "drawerOpen .18s cubic-bezier(.22,1,.36,1)",
+          }}
+        >
+          <div
+            style={{
+              display: "flex", alignItems: "center", gap: 6, padding: "8px 11px 7px",
+              borderBottom: `1px solid ${COLORS.borderSoft}`,
+            }}
+          >
+            <span
+              style={{
+                fontFamily: FONT_DATA, fontSize: 8.5, letterSpacing: "1.4px",
+                color: COLORS.textDim,
+              }}
+            >
+              SELECT CHANNEL
+            </span>
+            <div style={{ flex: 1 }} />
+            <span style={{ fontFamily: FONT_CJK, fontSize: 8.5, color: COLORS.textFaint }}>
+              {LIVE_CHANNELS.length} 家 24h 直播
+            </span>
+          </div>
+          <div className="mtp-scroll" style={{ maxHeight: 320, overflowY: "auto" }}>
+            {LIVE_CHANNELS.map((c, i) => {
+              const active = c.id === value;
+              const inOther = !active && usedIds.includes(c.id);
+              const prev = LIVE_CHANNELS[i - 1];
+              const newGroup = i === 0 || prev?.tag !== c.tag;
+              return (
+                <div key={c.id}>
+                  {newGroup && (
+                    <div
+                      style={{
+                        display: "flex", alignItems: "center", gap: 7,
+                        padding: "7px 11px 3px",
+                      }}
+                    >
+                      <span
+                        style={{
+                          fontFamily: FONT_CJK, fontSize: 8.5, letterSpacing: "1px",
+                          color: COLORS.textDim,
+                        }}
+                      >
+                        {c.tag}
+                      </span>
+                      <span style={{ flex: 1, height: 1, background: COLORS.borderSoft }} />
+                      <span style={{ fontFamily: FONT_DATA, fontSize: 8, color: COLORS.textFaint }}>
+                        {LIVE_CHANNELS.filter((x) => x.tag === c.tag).length}
+                      </span>
+                    </div>
+                  )}
+                  <button
+                    disabled={inOther}
+                    onClick={() => {
+                      onPick(c.id);
+                      setOpen(false);
+                    }}
+                    style={{
+                      width: "100%", display: "flex", alignItems: "center", gap: 9,
+                      padding: "8px 11px",
+                      background: active ? "rgba(100,170,255,0.12)" : "transparent",
+                      border: "none",
+                      borderLeft: active ? `2px solid ${COLORS.accent}` : "2px solid transparent",
+                      cursor: inOther ? "not-allowed" : "pointer",
+                      opacity: inOther ? 0.4 : 1, textAlign: "left",
+                      transition: "background .12s",
+                    }}
+                  >
+                    <span
+                      style={{
+                        width: 6, height: 6, borderRadius: "50%", flexShrink: 0,
+                        background: c.emergency ? COLORS.statusWarn : "#ff3b30",
+                        boxShadow: `0 0 5px ${c.emergency ? COLORS.statusWarn : "#ff3b30"}`,
+                        animation: "intelRing 1.6s ease-in-out infinite",
+                      }}
+                    />
+                    <span
+                      style={{
+                        display: "flex", flexDirection: "column", gap: 1,
+                        minWidth: 0, flex: 1,
+                      }}
+                    >
+                      <span style={{ display: "flex", alignItems: "baseline", gap: 6 }}>
+                        <span
+                          style={{
+                            fontFamily: FONT_CJK, fontSize: 11.5, fontWeight: 700,
+                            color: active ? "#fff" : COLORS.textDefault,
+                          }}
+                        >
+                          {c.name}
+                        </span>
+                        <span
+                          style={{
+                            fontFamily: FONT_DATA, fontSize: 8,
+                            color: COLORS.textFaint, letterSpacing: "0.5px",
+                          }}
+                        >
+                          {c.en}
+                        </span>
+                        {c.emergency && (
+                          <span
+                            style={{
+                              fontFamily: FONT_CJK, fontSize: 8, color: "#04121f", fontWeight: 700,
+                              padding: "0px 5px", borderRadius: 3,
+                              background: COLORS.statusWarn,
+                            }}
+                          >
+                            防災
+                          </span>
+                        )}
+                      </span>
+                      {(c.note || inOther) && (
+                        <span
+                          style={{
+                            fontFamily: FONT_CJK, fontSize: 8.5,
+                            color: inOther ? COLORS.accent : COLORS.textFaint,
+                            whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis",
+                          }}
+                        >
+                          {inOther ? "另一格播放中" : c.note}
+                        </span>
+                      )}
+                    </span>
+                    {active && (
+                      <span
+                        style={{
+                          fontFamily: FONT_DATA, fontSize: 11, color: COLORS.accent, flexShrink: 0,
+                        }}
+                      >
+                        ✓
+                      </span>
+                    )}
+                  </button>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function LiveSlot({
+  chId, onPick, usedIds, resolved,
+}: {
+  chId: string;
+  onPick: (id: string) => void;
+  usedIds: string[];
+  resolved: YtLiveVideo | undefined;
+}) {
+  const ch = LIVE_CHANNELS.find((c) => c.id === chId) ?? LIVE_CHANNELS[0]!;
+  const emergency = !!ch.emergency;
+  // 優先用 resolver 拿到的 video_id（embed/<videoId> 最可靠）
+  // 否則退到 channel_id（embed/live_stream?channel=UCxxx，部分頻道仍會壞）
+  // 都沒有 → 顯示等待占位
+  const src =
+    resolved?.video_id ? videoEmbedSrc(resolved.video_id) :
+    resolved?.channel_id ? channelEmbedSrc(resolved.channel_id) :
+    null;
+  return (
+    <div
+      style={{
+        position: "relative", borderRadius: 8, overflow: "visible",
+        aspectRatio: "16 / 9", background: "#000",
+        border: emergency ? "1px solid rgba(255,152,0,0.55)" : `1px solid ${COLORS.borderSoft}`,
+      }}
+    >
+      <div style={{ position: "absolute", inset: 0, borderRadius: 8, overflow: "hidden" }}>
+        {src ? (
+          <iframe
+            key={src}
+            title={ch.name}
+            src={src}
+            style={{
+              position: "absolute", inset: 0, width: "100%", height: "100%",
+              border: "none", display: "block",
+            }}
+            allow="autoplay; encrypted-media; picture-in-picture"
+            allowFullScreen
+            referrerPolicy="strict-origin-when-cross-origin"
+            loading="lazy"
+          />
+        ) : (
+          <div
+            style={{
+              position: "absolute", inset: 0, display: "flex",
+              flexDirection: "column", alignItems: "center", justifyContent: "center",
+              gap: 6, color: COLORS.textFaint,
+              fontFamily: FONT_CJK, fontSize: 11, textAlign: "center", padding: 16,
+            }}
+          >
+            <span style={{ fontFamily: FONT_DATA, fontSize: 9, letterSpacing: "1.5px" }}>
+              {resolved?.last_error ? "RESOLVER ERROR" : "RESOLVING…"}
+            </span>
+            <span>
+              {resolved?.last_error
+                ? `${ch.name}：${resolved.last_error}`
+                : `等待 ${ch.handle} 的直播解析`}
+            </span>
+          </div>
+        )}
+
+        <div
+          style={{
+            position: "absolute", top: 0, left: 0, right: 0,
+            display: "flex", alignItems: "center", gap: 6,
+            padding: "7px 8px", pointerEvents: "none",
+            background: "linear-gradient(180deg, rgba(0,0,0,0.7), transparent)",
+          }}
+        >
+          <span
+            style={{
+              display: "inline-flex", alignItems: "center", gap: 4,
+              padding: "1px 6px", borderRadius: 3,
+              background: "rgba(239,68,68,0.9)",
+            }}
+          >
+            <span
+              style={{
+                width: 5, height: 5, borderRadius: "50%", background: "#fff",
+                animation: "intelRing 1.6s ease-in-out infinite",
+              }}
+            />
+            <span
+              style={{
+                fontFamily: FONT_DATA, fontSize: 8.5, fontWeight: 700,
+                color: "#fff", letterSpacing: "0.5px",
+              }}
+            >
+              LIVE
+            </span>
+          </span>
+          <span
+            style={{
+              fontFamily: FONT_CJK, fontSize: 11, fontWeight: 700, color: "#fff",
+              textShadow: "0 1px 4px rgba(0,0,0,0.8)",
+            }}
+          >
+            {ch.name}
+          </span>
+          {emergency && (
+            <span
+              style={{
+                fontFamily: FONT_CJK, fontSize: 9, color: "#04121f", fontWeight: 700,
+                padding: "1px 6px", borderRadius: 3, background: COLORS.statusWarn,
+              }}
+            >
+              目前播放：{ch.emergencyLabel}
+            </span>
+          )}
+        </div>
+      </div>
+
+      <div
+        style={{
+          position: "absolute", bottom: 7, left: 8,
+          display: "flex", alignItems: "center", gap: 8, zIndex: 20,
+        }}
+      >
+        <ChannelMenu value={chId} onPick={onPick} usedIds={usedIds} />
+        <span
+          style={{
+            fontFamily: FONT_DATA, fontSize: 8, color: "rgba(255,255,255,0.55)",
+            textShadow: "0 1px 3px rgba(0,0,0,0.9)", pointerEvents: "none",
+          }}
+        >
+          🔇 點擊解除靜音
+        </span>
+      </div>
+    </div>
+  );
+}
+
+export function LiveWall() {
+  // 預設 4 格：公視 + TVBS + 華視 + 台視
+  const [slots, setSlots] = useState(["pts", "tvbs", "cts", "ttv"]);
+  const setSlot = (i: number) => (id: string) =>
+    setSlots((prev) => prev.map((v, k) => (k === i ? id : v)));
+  const ctsLive = slots.includes("cts");
+
+  // 抓 realtime.yt_live_current → handle→video_id 對照（10 min refresh）
+  const [resolvedRows, setResolvedRows] = useState<YtLiveVideo[]>([]);
+  useEffect(() => {
+    let alive = true;
+    const tick = () => {
+      fetchLiveVideos(false).then((rows) => {
+        if (alive) setResolvedRows(rows);
+      });
+    };
+    tick();
+    const id = window.setInterval(tick, 10 * 60 * 1000);
+    return () => {
+      alive = false;
+      window.clearInterval(id);
+    };
+  }, []);
+  const resolvedMap = useMemo(() => {
+    const m = new Map<string, YtLiveVideo>();
+    for (const r of resolvedRows) m.set(r.handle, r);
+    return m;
+  }, [resolvedRows]);
+
+  return (
+    <div
+      style={{
+        gridColumn: "1 / -1", borderRadius: 9,
+        border: `1px solid ${COLORS.panelBorder}`,
+        background: "rgba(255,255,255,0.022)",
+        padding: 13, display: "flex", flexDirection: "column",
+      }}
+    >
+      <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 11 }}>
+        <span style={{ width: 3, height: 12, borderRadius: 2, background: COLORS.accent }} />
+        <span
+          style={{
+            fontFamily: FONT_DATA, fontSize: 10, letterSpacing: "1.5px",
+            color: COLORS.textDefault,
+          }}
+        >
+          新聞直播 · LIVE WALL
+        </span>
+        <div style={{ flex: 1 }} />
+        {ctsLive ? (
+          <span
+            style={{
+              fontFamily: FONT_CJK, fontSize: 9, color: COLORS.statusWarn,
+              padding: "2px 8px", borderRadius: 3,
+              background: COLORS.statusWarnSoft,
+              border: "1px solid rgba(255,152,0,0.3)",
+            }}
+          >
+            ⚠ 華視已切換防災直播
+          </span>
+        ) : (
+          <span style={{ fontFamily: FONT_CJK, fontSize: 9, color: COLORS.textFaint }}>
+            4 格同步 · 可切換 {LIVE_CHANNELS.length} 家
+          </span>
+        )}
+      </div>
+      <div
+        style={{
+          display: "grid", gridTemplateColumns: "1fr 1fr",
+          gridTemplateRows: "1fr 1fr", gap: 10,
+        }}
+      >
+        {slots.map((chId, i) => {
+          const ch = LIVE_CHANNELS.find((c) => c.id === chId);
+          const resolved = ch ? resolvedMap.get(ch.handle) : undefined;
+          return (
+            <LiveSlot
+              key={i}
+              chId={chId}
+              onPick={setSlot(i)}
+              usedIds={slots}
+              resolved={resolved}
+            />
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/components/intel/monitor/LiveWall.tsx
+++ b/src/components/intel/monitor/LiveWall.tsx
@@ -467,6 +467,18 @@ export function LiveWall() {
           );
         })}
       </div>
+      <div
+        style={{
+          marginTop: 7,
+          textAlign: "center",
+          fontFamily: FONT_CJK,
+          fontSize: 9.5,
+          color: COLORS.textFaint,
+          lineHeight: 1.5,
+        }}
+      >
+        ⓘ 因為與 YouTube 的連線關係，不一定每格都會有辦法顯示
+      </div>
     </div>
   );
 }

--- a/src/components/intel/monitor/MonitorPanel.tsx
+++ b/src/components/intel/monitor/MonitorPanel.tsx
@@ -1,0 +1,622 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import { IntelIcon, ICON } from "../IntelIcon";
+import { COLORS, FONT_CJK, FONT_DATA, MICON, smoothPressure } from "../intelTokens";
+import { IntelCard, type IntelCardEvent } from "../IntelCard";
+import { IntelFilters, type TimeRange } from "../IntelFilters";
+import {
+  fetchSourceHealth, fetchNewsTrending, trendingKeys as buildTrendingKeys,
+  fetchPressureIndex, fetchMarketIndex, fetchPlaActivity, fetchPublicHealthWeekly,
+  type SourceHealthSummary, type TrendingRow,
+  type PressureIndexNow, type MarketIndex, type PlaActivity, type PublicHealthWeek,
+} from "../../../data/intelLoaders";
+import {
+  fetchNewsEventsDayClusters, type NewsFilter,
+} from "../../../data/newsEventsLoader";
+import type { NewsCategory } from "../../../data/newsEventTypes";
+import { timeStore } from "../../../state/timeStore";
+import { TimelineDock } from "./TimelineDock";
+import { IndicatorPanel } from "./IndicatorPanel";
+
+const EMPTY_HEALTH: SourceHealthSummary = {
+  total: 0, ok: 0, lagging: 0, degraded: 0, unknown: 0, rows: [],
+};
+const EMPTY_PRESSURE: PressureIndexNow = {
+  composite: 0, level: null, vs_baseline: 0, vs_1h_ago: 0, per_signal: [], asof: null,
+};
+const EMPTY_MARKET: MarketIndex = {
+  index: 0, prev_close: 0, open: 0, high: 0, low: 0, change: 0, change_pct: 0,
+  turnover: null, time: null, status: null,
+};
+const EMPTY_PLA: PlaActivity = {
+  sorties: 0, crossed_median: 0, plan_vessels: 0, official_ships: 0,
+  adiz: [
+    { key: "north", label: "北", active: false },
+    { key: "central", label: "中", active: false },
+    { key: "southwest", label: "西南", active: false },
+    { key: "east", label: "東", active: false },
+  ],
+  as_of: "今日 06:00",
+  source: "中華民國國防部 @MoNDefense · 每日 06:00 (UTC+8) 截止",
+  title: "中共解放軍臺海周邊海、空域動態",
+};
+const EMPTY_HEALTH_WEEK: PublicHealthWeek = { week: 0, diseases: [] };
+
+const RANGE_SEC: Record<TimeRange, number> = { "1h": 3600, "6h": 21600, "24h": 86400 };
+
+/** Taipei 00:00 of a YYYY-MM-DD string → unix seconds */
+function dayKeyToStartTs(key: string): number {
+  if (!key || key.length < 10) return Math.floor(Date.now() / 1000) - 8 * 3600;
+  // "2026-06-13" → "2026-06-13T00:00:00+08:00"
+  const ms = Date.parse(`${key}T00:00:00+08:00`);
+  return Math.floor(ms / 1000);
+}
+
+interface Cluster {
+  county: string | null;
+  location_name: string | null;
+  lon: number | null;
+  lat: number | null;
+  events: IntelCardEvent[];
+}
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  filter: NewsFilter;
+  onFilterChange: (next: NewsFilter) => void;
+  onSelectLocation?: (lon: number, lat: number) => void;
+  externalSelectedId?: number | null;
+}
+
+export function MonitorPanel({
+  open, onClose, filter, onFilterChange, onSelectLocation, externalSelectedId,
+}: Props) {
+  // ── playback state（與 Phase 1 IntelPanel 各自獨立）──
+  const [now, setNow] = useState(() => Math.floor(Date.now() / 1000));
+  const [isLive, setIsLive] = useState(true);
+  const [playbackTs, setPlaybackTs] = useState(now);
+  const [playing, setPlaying] = useState(false);
+  const [timeRange, setTimeRange] = useState<TimeRange>("24h");
+  const [cats, setCats] = useState<NewsCategory[]>([]);
+  const [county, setCounty] = useState("全部");
+  const [selectedId, setSelectedId] = useState<number | null>(null);
+  const [expandedId, setExpandedId] = useState<number | null>(null);
+
+  const [dayKey, setDayKey] = useState(() => timeStore.getDateKey());
+
+  // ── 面板尺寸 + wall mode ──
+  const [height, setHeight] = useState(0.62);
+  const [wall, setWall] = useState(false);
+
+  // ── 全部資料 ──
+  const [sourceHealth, setSourceHealth] = useState<SourceHealthSummary>(EMPTY_HEALTH);
+  const [trending, setTrending] = useState<TrendingRow[]>([]);
+  const [pressure, setPressure] = useState<PressureIndexNow>(EMPTY_PRESSURE);
+  const [smoothed, setSmoothed] = useState<number>(0);
+  const [market, setMarket] = useState<MarketIndex>(EMPTY_MARKET);
+  const [pla, setPla] = useState<PlaActivity>(EMPTY_PLA);
+  const [health, setHealth] = useState<PublicHealthWeek>(EMPTY_HEALTH_WEEK);
+  const [clusters, setClusters] = useState<Cluster[]>([]);
+
+  // tick now（顯示 + countdown）
+  useEffect(() => {
+    if (!open) return;
+    const id = window.setInterval(() => setNow(Math.floor(Date.now() / 1000)), 1000);
+    return () => window.clearInterval(id);
+  }, [open]);
+
+  // 30s pressure + market + source health + trending
+  useEffect(() => {
+    if (!open) return;
+    let alive = true;
+    const tick = () => {
+      fetchPressureIndex().then((p) => {
+        if (!alive) return;
+        setPressure(p);
+        setSmoothed((prev) => smoothPressure(prev || null, p.composite));
+      });
+      fetchMarketIndex().then((m) => alive && setMarket(m));
+      fetchSourceHealth().then((s) => alive && setSourceHealth(s));
+      fetchNewsTrending(1, 50).then((t) => alive && setTrending(t));
+    };
+    tick();
+    const id = window.setInterval(tick, 30_000);
+    return () => {
+      alive = false;
+      window.clearInterval(id);
+    };
+  }, [open]);
+
+  // 30min PLA + week-once Health
+  useEffect(() => {
+    if (!open) return;
+    let alive = true;
+    fetchPlaActivity().then((p) => alive && setPla(p));
+    fetchPublicHealthWeekly().then((h) => alive && setHealth(h));
+    const id = window.setInterval(() => {
+      if (!alive) return;
+      fetchPlaActivity().then((p) => alive && setPla(p));
+    }, 30 * 60 * 1000);
+    return () => {
+      alive = false;
+      window.clearInterval(id);
+    };
+  }, [open]);
+
+  // ── 訂閱 timeStore 日期變化（rule 6）→ 重抓 clusters ──
+  const fKey = `${filter.minRelevance}|${filter.eventsOnly ? 1 : 0}|${filter.minSeverity}`;
+  useEffect(() => {
+    if (!open) return;
+    let alive = true;
+    const handler = (key: string) => {
+      if (!key) return;
+      setDayKey(key);
+      fetchNewsEventsDayClusters(key, filter).then((rows) => {
+        if (!alive) return;
+        const built: Cluster[] = rows.map((r) => {
+          const events = (r.events ?? []).map<IntelCardEvent>((e, idx, arr) => ({
+            ...e,
+            county: r.county ?? undefined,
+            location_name: r.location_name ?? undefined,
+            related_count: Math.max(0, arr.length - 1 - idx),
+          }));
+          return {
+            county: r.county,
+            location_name: r.location_name,
+            lon: r.lon,
+            lat: r.lat,
+            events,
+          };
+        });
+        setClusters(built);
+      });
+    };
+    handler(timeStore.getDateKey());
+    const unsub = timeStore.subscribeDate(handler);
+    return () => {
+      alive = false;
+      unsub();
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, fKey]);
+
+  // playback animation
+  const spanRef = useRef(RANGE_SEC[timeRange]);
+  spanRef.current = RANGE_SEC[timeRange];
+  useEffect(() => {
+    if (!playing) return;
+    const id = window.setInterval(() => {
+      setPlaybackTs((p) => {
+        const next = p + spanRef.current / 90;
+        const nowNow = Math.floor(Date.now() / 1000);
+        if (next >= nowNow) {
+          setPlaying(false);
+          setIsLive(true);
+          return nowNow;
+        }
+        return next;
+      });
+    }, 70);
+    return () => window.clearInterval(id);
+  }, [playing]);
+
+  // external selection
+  useEffect(() => {
+    if (externalSelectedId == null) return;
+    setSelectedId(externalSelectedId);
+    setExpandedId(externalSelectedId);
+  }, [externalSelectedId]);
+
+  const effectivePlayback = isLive ? now : playbackTs;
+  const dayStartTs = useMemo(() => dayKeyToStartTs(dayKey), [dayKey]);
+
+  // flat events (filtered)
+  const flatEvents = useMemo<IntelCardEvent[]>(() => {
+    const out: IntelCardEvent[] = [];
+    const windowStart = isLive ? dayStartTs : now - RANGE_SEC[timeRange];
+    for (const c of clusters) {
+      for (const e of c.events) {
+        if (e.published_ts < windowStart) continue;
+        if (e.published_ts > effectivePlayback) continue;
+        if (cats.length > 0 && !cats.includes((e.category ?? "other") as NewsCategory)) continue;
+        if (county !== "全部" && (c.county ?? "") !== county) continue;
+        out.push(e);
+      }
+    }
+    out.sort((a, b) => b.published_ts - a.published_ts);
+    return out;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [clusters, cats, county, effectivePlayback, timeRange, isLive, dayStartTs]);
+
+  // 全天版本（給 TimelineDock + IndicatorPanel histogram 用，不受 timeRange 窗影響）
+  const allEventsToday = useMemo<IntelCardEvent[]>(() => {
+    const out: IntelCardEvent[] = [];
+    for (const c of clusters) {
+      for (const e of c.events) {
+        if (cats.length > 0 && !cats.includes((e.category ?? "other") as NewsCategory)) continue;
+        if (county !== "全部" && (c.county ?? "") !== county) continue;
+        out.push(e);
+      }
+    }
+    out.sort((a, b) => b.published_ts - a.published_ts);
+    return out;
+  }, [clusters, cats, county]);
+
+  const countyByEventId = useMemo(() => {
+    const m = new Map<number, string>();
+    for (const c of clusters) for (const e of c.events) m.set(e.id, c.county ?? "");
+    return m;
+  }, [clusters]);
+
+  const locByEventId = useMemo(() => {
+    const m = new Map<number, { lon: number; lat: number }>();
+    for (const c of clusters) {
+      if (c.lon == null || c.lat == null) continue;
+      for (const e of c.events) m.set(e.id, { lon: c.lon, lat: c.lat });
+    }
+    return m;
+  }, [clusters]);
+
+  const trendingKeySet = useMemo(() => buildTrendingKeys(trending), [trending]);
+  const isTrendingFor = (e: IntelCardEvent) => {
+    const c = countyByEventId.get(e.id);
+    if (!c) return false;
+    return trendingKeySet.has(`${c}|${e.category ?? "other"}`);
+  };
+
+  // resize drag
+  const draggingRef = useRef(false);
+  useEffect(() => {
+    if (!open || wall) return;
+    const move = (e: MouseEvent) => {
+      if (!draggingRef.current) return;
+      const f = (window.innerHeight - e.clientY) / window.innerHeight;
+      setHeight(Math.max(0.3, Math.min(0.92, f)));
+    };
+    const up = () => {
+      draggingRef.current = false;
+      document.body.style.cursor = "";
+    };
+    window.addEventListener("mousemove", move);
+    window.addEventListener("mouseup", up);
+    return () => {
+      window.removeEventListener("mousemove", move);
+      window.removeEventListener("mouseup", up);
+    };
+  }, [open, wall]);
+
+  if (!open) return null;
+
+  const onScrub = (ts: number) => {
+    setPlaybackTs(ts);
+    setIsLive(ts >= now);
+    setPlaying(false);
+  };
+  const goLive = () => {
+    setIsLive(true);
+    setPlaying(false);
+    setPlaybackTs(now);
+  };
+  const togglePlay = () => {
+    if (playing) {
+      setPlaying(false);
+      return;
+    }
+    if (isLive || playbackTs >= now) setPlaybackTs(now - RANGE_SEC[timeRange]);
+    setIsLive(false);
+    setPlaying(true);
+  };
+  const onSelectCard = (id: number) => {
+    setSelectedId(id);
+    const loc = locByEventId.get(id);
+    if (loc && onSelectLocation) onSelectLocation(loc.lon, loc.lat);
+  };
+  const onToggleExpand = (id: number) => setExpandedId((p) => (p === id ? null : id));
+  const toggleCat = (k: NewsCategory) =>
+    setCats((c) => (c.includes(k) ? c.filter((x) => x !== k) : [...c, k]));
+
+  const onPickHotspot = (cty: string) => {
+    setCounty(cty);
+    const ev = allEventsToday.find(
+      (e) => countyByEventId.get(e.id) === cty && e.published_ts <= effectivePlayback,
+    );
+    if (ev) {
+      setSelectedId(ev.id);
+      setExpandedId(ev.id);
+      const loc = locByEventId.get(ev.id);
+      if (loc && onSelectLocation) onSelectLocation(loc.lon, loc.lat);
+    }
+  };
+
+  return (
+    <div
+      style={{
+        position: "fixed",
+        left: wall ? 0 : 64,
+        right: 14,
+        bottom: wall ? 0 : 14,
+        top: wall ? 0 : "auto",
+        height: wall ? "auto" : `${height * 100}vh`,
+        background: wall ? "rgba(6,7,11,0.97)" : "rgba(8,9,13,0.86)",
+        backdropFilter: "blur(18px)",
+        WebkitBackdropFilter: "blur(18px)",
+        borderTop: wall ? "none" : `1px solid ${COLORS.borderMid}`,
+        border: wall ? "none" : `1px solid ${COLORS.panelBorder}`,
+        borderRadius: wall ? 0 : 10,
+        zIndex: 40,
+        display: "flex", flexDirection: "column",
+        overflow: "hidden",
+        boxShadow: wall ? "none" : "0 -16px 50px rgba(0,0,0,0.5)",
+        animation: "monitorRise .32s cubic-bezier(0.22,1,0.36,1)",
+      }}
+    >
+      {/* drag handle + header */}
+      <div
+        style={{
+          flexShrink: 0, position: "relative",
+          display: "flex", alignItems: "center", gap: 10,
+          padding: "8px 14px",
+          borderBottom: `1px solid ${COLORS.panelBorder}`,
+          cursor: wall ? "default" : "ns-resize",
+        }}
+        onMouseDown={(e) => {
+          if (!wall) {
+            draggingRef.current = true;
+            document.body.style.cursor = "ns-resize";
+            e.preventDefault();
+          }
+        }}
+      >
+        {!wall && (
+          <span
+            style={{
+              position: "absolute", left: "50%", top: 5,
+              transform: "translateX(-50%)",
+              width: 44, height: 4, borderRadius: 3,
+              background: COLORS.borderStrong,
+            }}
+          />
+        )}
+        <div
+          style={{
+            display: "flex", alignItems: "center", gap: 8,
+            marginTop: wall ? 0 : 4,
+          }}
+        >
+          <IntelIcon d={MICON.grid!} size={15} color={COLORS.accent} />
+          <span style={{ fontFamily: FONT_CJK, fontSize: 13, fontWeight: 700, color: "#fff" }}>
+            監看模式
+          </span>
+          <span
+            style={{
+              fontFamily: FONT_DATA, fontSize: 9, letterSpacing: "2.5px", color: COLORS.textDim,
+            }}
+          >
+            MONITOR
+          </span>
+        </div>
+        <span
+          style={{
+            fontFamily: FONT_DATA, fontSize: 10, color: COLORS.textFaint,
+            marginTop: wall ? 0 : 4, whiteSpace: "nowrap",
+          }}
+        >
+          今日 {allEventsToday.length} 則 · SITUATIONAL AWARENESS
+        </span>
+        <div style={{ flex: 1 }} />
+        <button
+          onClick={(e) => {
+            e.stopPropagation();
+            setWall((v) => !v);
+          }}
+          onMouseDown={(e) => e.stopPropagation()}
+          style={{
+            display: "inline-flex", alignItems: "center", gap: 6,
+            padding: "5px 11px", borderRadius: 6, cursor: "pointer",
+            marginTop: wall ? 0 : 4, fontFamily: FONT_CJK, fontSize: 11,
+            whiteSpace: "nowrap",
+            background: wall ? COLORS.accentFaint : "rgba(255,255,255,0.05)",
+            border: wall ? `1px solid ${COLORS.accentSoft}` : `1px solid ${COLORS.borderMid}`,
+            color: wall ? COLORS.accent : COLORS.textDefault,
+          }}
+        >
+          <IntelIcon
+            d={wall ? MICON.minimize! : MICON.maximize!}
+            size={13}
+            color={wall ? COLORS.accent : "currentColor"}
+          />
+          Wall mode
+        </button>
+        <button
+          onClick={(e) => {
+            e.stopPropagation();
+            onClose();
+          }}
+          onMouseDown={(e) => e.stopPropagation()}
+          style={{
+            display: "inline-flex", alignItems: "center", gap: 6,
+            padding: "5px 11px", borderRadius: 6, cursor: "pointer",
+            marginTop: wall ? 0 : 4,
+            fontFamily: FONT_CJK, fontSize: 11, whiteSpace: "nowrap",
+            background: "rgba(255,255,255,0.05)",
+            border: `1px solid ${COLORS.borderMid}`,
+            color: COLORS.textDefault,
+          }}
+        >
+          <IntelIcon d={ICON.x} size={12} /> 退出
+        </button>
+      </div>
+
+      <TimelineDock
+        events={allEventsToday}
+        dayStartTs={dayStartTs}
+        nowTs={now}
+        playbackTs={effectivePlayback}
+        isLive={isLive}
+        playing={playing}
+        onScrub={onScrub}
+        onLive={goLive}
+        onTogglePlay={togglePlay}
+      />
+
+      {/* body: feed (left) + indicators (right) */}
+      <div style={{ flex: 1, minHeight: 0, display: "flex" }}>
+        {/* News Feed column (reuses IntelCard + IntelFilters) */}
+        <div
+          style={{
+            width: "40%", minWidth: 340, maxWidth: 520, flexShrink: 0,
+            display: "flex", flexDirection: "column",
+            borderRight: `1px solid ${COLORS.panelBorder}`, overflow: "hidden",
+          }}
+        >
+          <div
+            style={{
+              flexShrink: 0,
+              display: "flex", alignItems: "center", gap: 8,
+              padding: "11px 14px 9px",
+            }}
+          >
+            <IntelIcon d={ICON.radio} size={15} color={COLORS.accent} />
+            <span
+              style={{
+                fontFamily: FONT_CJK, fontSize: 12.5, fontWeight: 700,
+                color: COLORS.textStrong, whiteSpace: "nowrap",
+              }}
+            >
+              新聞 Feed
+            </span>
+            <span
+              style={{
+                display: "inline-flex", alignItems: "center", gap: 4,
+                padding: "1px 7px", borderRadius: 4,
+                background: COLORS.statusLiveSoft,
+                border: `1px solid ${COLORS.statusLiveBorder}`,
+              }}
+            >
+              <span
+                style={{
+                  width: 5, height: 5, borderRadius: "50%",
+                  background: COLORS.statusLive,
+                  boxShadow: `0 0 5px ${COLORS.statusLive}`,
+                  animation: "intelRing 1.6s ease-in-out infinite",
+                }}
+              />
+              <span
+                style={{
+                  fontFamily: FONT_DATA, fontSize: 9, fontWeight: 700,
+                  color: COLORS.statusLive,
+                }}
+              >
+                LIVE
+              </span>
+            </span>
+            <div style={{ flex: 1 }} />
+            <span style={{ fontFamily: FONT_DATA, fontSize: 10.5, color: COLORS.textMuted }}>
+              {flatEvents.length} 則
+            </span>
+          </div>
+
+          <IntelFilters
+            cats={cats}
+            onToggleCat={toggleCat}
+            onResetCats={() => setCats([])}
+            timeRange={timeRange}
+            onTimeRange={(r) => {
+              setTimeRange(r);
+              goLive();
+            }}
+            county={county}
+            onCounty={setCounty}
+            minRelevance={filter.minRelevance}
+            onMinRelevance={(v) => onFilterChange({ ...filter, minRelevance: v })}
+            eventsOnly={filter.eventsOnly}
+            onEventsOnly={(v) => onFilterChange({ ...filter, eventsOnly: v })}
+            minSeverity={filter.minSeverity}
+            onMinSeverity={(v) => onFilterChange({ ...filter, minSeverity: v })}
+          />
+
+          <div
+            className="mtp-scroll"
+            style={{ flex: 1, overflowY: "auto", padding: "12px 14px 16px" }}
+          >
+            {flatEvents.length === 0 ? (
+              <div
+                style={{
+                  display: "flex", flexDirection: "column",
+                  alignItems: "center", justifyContent: "center",
+                  height: "100%", gap: 8, textAlign: "center", padding: 24,
+                }}
+              >
+                <IntelIcon d={ICON.radio} size={26} color={COLORS.textGhost} />
+                <div style={{ fontFamily: FONT_CJK, fontSize: 12, color: COLORS.textMuted }}>
+                  目前無符合條件的事件
+                </div>
+                <div style={{ fontFamily: FONT_CJK, fontSize: 10, color: COLORS.textFaint }}>
+                  調整分類 / 縣市，或回到即時
+                </div>
+              </div>
+            ) : (
+              <div style={{ position: "relative", display: "flex", flexDirection: "column", gap: 10 }}>
+                <span
+                  style={{
+                    position: "absolute", left: 12, top: 6, bottom: 6,
+                    width: 1.5,
+                    background: `linear-gradient(${COLORS.borderMid}, ${COLORS.borderSoft} 90%, transparent)`,
+                  }}
+                />
+                {flatEvents.map((e) => (
+                  <IntelCard
+                    key={e.id}
+                    e={e}
+                    selected={e.id === selectedId}
+                    expanded={e.id === expandedId}
+                    trending={isTrendingFor(e)}
+                    onSelect={onSelectCard}
+                    onToggle={onToggleExpand}
+                    nowTs={now}
+                  />
+                ))}
+              </div>
+            )}
+          </div>
+        </div>
+
+        {/* Indicators column */}
+        <IndicatorPanel
+          events={allEventsToday}
+          countyByEventId={countyByEventId}
+          pressure={pressure}
+          smoothedScore={smoothed}
+          market={market}
+          pla={pla}
+          health={health}
+          sourceHealth={sourceHealth}
+          totalToday={allEventsToday.length}
+          onPickHotspot={onPickHotspot}
+        />
+      </div>
+
+      <style>{`
+        @keyframes monitorRise {
+          from { transform: translateY(18px); opacity: 0; }
+          to   { transform: translateY(0); opacity: 1; }
+        }
+        @keyframes drawerOpen {
+          from { opacity: 0; transform: translateY(-8px); }
+          to   { opacity: 1; transform: translateY(0); }
+        }
+        @keyframes presBreathe {
+          0%, 100% { opacity: 1; }
+          50% { opacity: 0.62; }
+        }
+        @keyframes presPulse {
+          0%, 100% { opacity: 1; }
+          50% { opacity: 0.45; }
+        }
+        @media (prefers-reduced-motion: reduce) {
+          [style*="presBreathe"], [style*="presPulse"] { animation: none !important; }
+        }
+      `}</style>
+    </div>
+  );
+}

--- a/src/components/intel/monitor/PressureRing.tsx
+++ b/src/components/intel/monitor/PressureRing.tsx
@@ -1,0 +1,214 @@
+import { COLORS, FONT_CJK, FONT_DATA, type PressureLevelDef } from "../intelTokens";
+import type { MarketIndex } from "../../../data/intelLoaders";
+
+/** 270° SVG gauge — 主環 + 動畫，中央留洞給數字（caller 負責疊上 score 文字） */
+export function PressureRing({
+  score,
+  level,
+  size = 132,
+}: {
+  score: number;
+  level: PressureLevelDef;
+  size?: number;
+}) {
+  const r = 52;
+  const c = 2 * Math.PI * r;
+  const sweep = 0.75; // 270°
+  const track = sweep * c;
+  const val = sweep * c * (Math.max(0, Math.min(100, score)) / 100);
+  const animName =
+    level.anim === "pulse" ? "presPulse" : level.anim === "breathe" ? "presBreathe" : null;
+  const animStyle = animName ? { animation: `${animName} ${level.period}s ease-in-out infinite` } : {};
+  const hasGlow = level.glow !== "rgba(255,59,48,0)" && level.glow !== "rgba(255,152,0,0)" && level.glow !== "rgba(76,175,80,0)" && level.glow !== "rgba(234,179,8,0)";
+  return (
+    <div style={{ position: "relative", width: size, height: size, flexShrink: 0 }}>
+      <svg
+        width={size}
+        height={size}
+        viewBox="0 0 132 132"
+        style={{ transform: "rotate(135deg)", overflow: "visible", ...animStyle }}
+      >
+        <circle
+          cx="66" cy="66" r={r} fill="none" stroke="rgba(255,255,255,0.07)"
+          strokeWidth="9" strokeDasharray={`${track} ${c}`} strokeLinecap="round"
+        />
+        <circle
+          cx="66" cy="66" r={r} fill="none" stroke={level.color}
+          strokeWidth="9" strokeDasharray={`${val} ${c}`} strokeLinecap="round"
+          style={{
+            transition: "stroke-dasharray .6s cubic-bezier(.22,1,.36,1), stroke .4s",
+            filter: hasGlow ? `drop-shadow(0 0 6px ${level.glow})` : "none",
+          }}
+        />
+      </svg>
+      <div
+        style={{
+          position: "absolute", inset: 0, display: "flex", flexDirection: "column",
+          alignItems: "center", justifyContent: "center", gap: 1,
+        }}
+      >
+        <span
+          style={{
+            fontFamily: FONT_DATA, fontSize: 40, fontWeight: 700, lineHeight: 1,
+            color: "#fff", letterSpacing: "-1px",
+          }}
+        >
+          {Math.round(score)}
+        </span>
+        <span style={{ fontFamily: FONT_CJK, fontSize: 13, fontWeight: 700, color: level.color }}>
+          {level.label}
+        </span>
+        <span
+          style={{ fontFamily: FONT_DATA, fontSize: 7.5, letterSpacing: "2px", color: COLORS.textFaint }}
+        >
+          {level.en}
+        </span>
+      </div>
+    </div>
+  );
+}
+
+export function CompareLine({ delta, label }: { delta: number; label: string }) {
+  const up = delta >= 0;
+  return (
+    <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
+      <span
+        style={{
+          fontFamily: FONT_DATA, fontSize: 12, fontWeight: 700, width: 40,
+          color: up ? COLORS.statusWarn : COLORS.statusLive,
+        }}
+      >
+        {up ? "↗" : "↘"}{up ? "+" : ""}{Math.round(delta)}
+      </span>
+      <span style={{ fontFamily: FONT_CJK, fontSize: 10.5, color: COLORS.textMuted, whiteSpace: "nowrap" }}>
+        {label}
+      </span>
+    </div>
+  );
+}
+
+export function TwseTicker({ data }: { data: MarketIndex }) {
+  const up = data.change >= 0;
+  // 台股慣例：漲紅跌綠
+  const mk = up ? "#ff4d4f" : "#16c784";
+  const closed = (data.status ?? "") !== "盤中";
+  const has = data.index > 0;
+  return (
+    <div
+      style={{
+        borderRadius: 8,
+        border: `1px solid ${COLORS.panelBorder}`,
+        background: "linear-gradient(160deg, rgba(255,255,255,0.04), rgba(255,255,255,0.01))",
+        padding: "10px 14px",
+        display: "flex", flexDirection: "column", gap: 6, minWidth: 208,
+      }}
+    >
+      <div style={{ display: "flex", alignItems: "center", gap: 7 }}>
+        <span
+          style={{
+            fontFamily: FONT_DATA, fontSize: 9, letterSpacing: "1.2px",
+            color: COLORS.textDim, whiteSpace: "nowrap",
+          }}
+        >
+          TAIEX 加權指數
+        </span>
+        <div style={{ flex: 1 }} />
+        <span
+          style={{
+            fontFamily: FONT_CJK, fontSize: 8.5, color: COLORS.textFaint,
+            padding: "1px 6px", borderRadius: 3, background: "rgba(255,255,255,0.05)", whiteSpace: "nowrap",
+          }}
+        >
+          {data.status ?? "—"} {data.time ?? ""}
+        </span>
+      </div>
+      <div style={{ display: "flex", alignItems: "baseline", gap: 9, whiteSpace: "nowrap" }}>
+        <span
+          style={{
+            fontFamily: FONT_DATA, fontSize: 24, fontWeight: 700, lineHeight: 1,
+            color: closed ? "rgba(255,255,255,0.92)" : "#fff",
+          }}
+        >
+          {has ? data.index.toLocaleString() : "—"}
+        </span>
+        {has && (
+          <>
+            <span style={{ fontFamily: FONT_DATA, fontSize: 13, fontWeight: 700, color: mk }}>
+              {up ? "▲" : "▼"} {up ? "+" : ""}{data.change.toLocaleString()}
+            </span>
+            <span style={{ fontFamily: FONT_DATA, fontSize: 12, fontWeight: 700, color: mk }}>
+              {up ? "+" : ""}{data.change_pct}%
+            </span>
+          </>
+        )}
+      </div>
+      <div
+        style={{
+          display: "flex", gap: 12, fontFamily: FONT_DATA, fontSize: 9,
+          color: COLORS.textDim, whiteSpace: "nowrap",
+        }}
+      >
+        <span>H <b style={{ color: COLORS.textDefault }}>{data.high.toLocaleString()}</b></span>
+        <span>L <b style={{ color: COLORS.textDefault }}>{data.low.toLocaleString()}</b></span>
+        <span>額 <b style={{ color: COLORS.textDefault }}>{data.turnover ?? "—"}</b></span>
+      </div>
+    </div>
+  );
+}
+
+export function Sparkline({
+  data, color, w = 64, h = 20,
+}: { data: number[]; color: string; w?: number; h?: number }) {
+  if (data.length < 2) return <svg width={w} height={h} />;
+  const max = Math.max(...data);
+  const min = Math.min(...data);
+  const rng = max - min || 1;
+  const pts = data
+    .map((v, i) => `${(i / (data.length - 1)) * w},${h - ((v - min) / rng) * (h - 2) - 1}`)
+    .join(" ");
+  return (
+    <svg width={w} height={h} style={{ flexShrink: 0, overflow: "visible" }}>
+      <polyline
+        points={pts} fill="none" stroke={color}
+        strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round" opacity="0.85"
+      />
+    </svg>
+  );
+}
+
+export function SectionLabel({ children, color }: { children: React.ReactNode; color?: string }) {
+  return (
+    <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 9 }}>
+      <span
+        style={{
+          width: 3, height: 12, borderRadius: 2, background: color ?? COLORS.accent,
+        }}
+      />
+      <span
+        style={{
+          fontFamily: FONT_DATA, fontSize: 10, letterSpacing: "1.5px",
+          color: COLORS.textDefault, textTransform: "uppercase",
+        }}
+      >
+        {children}
+      </span>
+    </div>
+  );
+}
+
+export function Widget({
+  children, style,
+}: { children: React.ReactNode; style?: React.CSSProperties }) {
+  return (
+    <div
+      style={{
+        borderRadius: 9, border: `1px solid ${COLORS.panelBorder}`,
+        background: "rgba(255,255,255,0.022)", padding: 13,
+        display: "flex", flexDirection: "column", ...style,
+      }}
+    >
+      {children}
+    </div>
+  );
+}
+

--- a/src/components/intel/monitor/SituationCards.tsx
+++ b/src/components/intel/monitor/SituationCards.tsx
@@ -1,0 +1,242 @@
+import { IntelIcon } from "../IntelIcon";
+import { COLORS, FONT_CJK, FONT_DATA, MICON } from "../intelTokens";
+import { Sparkline } from "./PressureRing";
+import type { PlaActivity, PublicHealthWeek, CdcDisease } from "../../../data/intelLoaders";
+
+function PlaCard({ data }: { data: PlaActivity }) {
+  const adizActive = data.adiz.some((z) => z.active);
+  return (
+    <div
+      style={{
+        borderRadius: 9,
+        border: `1px solid ${COLORS.panelBorder}`,
+        background: "linear-gradient(160deg, rgba(239,68,68,0.06), rgba(255,255,255,0.012))",
+        padding: "12px 13px",
+        display: "flex", flexDirection: "column", gap: 9,
+      }}
+    >
+      <div style={{ display: "flex", alignItems: "center", gap: 7 }}>
+        <IntelIcon d={MICON.plane!} size={13} color="#ff6b6b" />
+        <span
+          style={{
+            fontFamily: FONT_DATA, fontSize: 9, letterSpacing: "1.2px", color: COLORS.textDim,
+          }}
+        >
+          PLA ACTIVITY
+        </span>
+        <div style={{ flex: 1 }} />
+        <span
+          style={{
+            fontFamily: FONT_CJK, fontSize: 8.5, color: COLORS.textFaint,
+            padding: "1px 6px", borderRadius: 3, background: "rgba(255,255,255,0.05)",
+            whiteSpace: "nowrap",
+          }}
+        >
+          {data.as_of ?? "—"}
+        </span>
+      </div>
+
+      <div style={{ display: "flex", alignItems: "baseline", gap: 8 }}>
+        <span
+          style={{ fontFamily: FONT_DATA, fontSize: 32, fontWeight: 700, lineHeight: 1, color: "#fff" }}
+        >
+          {data.sorties}
+        </span>
+        <span style={{ fontFamily: FONT_CJK, fontSize: 11, color: COLORS.textMuted }}>架次</span>
+        <div style={{ flex: 1 }} />
+        {data.crossed_median > 0 && (
+          <span
+            style={{
+              display: "inline-flex", alignItems: "center", gap: 4, padding: "3px 8px",
+              borderRadius: 5,
+              background: "rgba(239,68,68,0.16)",
+              border: "1px solid rgba(239,68,68,0.5)",
+            }}
+          >
+            <span
+              style={{
+                fontFamily: FONT_DATA, fontSize: 14, fontWeight: 700, color: "#ff5a5a", lineHeight: 1,
+              }}
+            >
+              {data.crossed_median}
+            </span>
+            <span style={{ fontFamily: FONT_CJK, fontSize: 9.5, color: "#ff8080" }}>越中線</span>
+          </span>
+        )}
+      </div>
+
+      <div style={{ display: "flex", gap: 6 }}>
+        {data.adiz.map((z) => (
+          <span
+            key={z.key}
+            style={{
+              flex: 1, display: "flex", alignItems: "center", justifyContent: "center", gap: 4,
+              padding: "3px 0", borderRadius: 4,
+              background: z.active ? "rgba(255,152,0,0.12)" : "rgba(255,255,255,0.03)",
+              border: z.active ? "1px solid rgba(255,152,0,0.4)" : `1px solid ${COLORS.borderSoft}`,
+            }}
+          >
+            <span
+              style={{
+                width: 5, height: 5, borderRadius: "50%",
+                background: z.active ? COLORS.statusWarn : COLORS.textGhost,
+                boxShadow: z.active ? `0 0 5px ${COLORS.statusWarn}` : "none",
+              }}
+            />
+            <span
+              style={{
+                fontFamily: FONT_CJK, fontSize: 9.5,
+                color: z.active ? COLORS.textDefault : COLORS.textFaint,
+              }}
+            >
+              {z.label}
+            </span>
+          </span>
+        ))}
+      </div>
+
+      <div style={{ display: "flex", gap: 14, fontFamily: FONT_DATA, fontSize: 10, color: COLORS.textDim }}>
+        <span>
+          海軍 <b style={{ color: COLORS.textDefault }}>{data.plan_vessels}</b> 艦
+        </span>
+        <span>
+          公務船 <b style={{ color: COLORS.textDefault }}>{data.official_ships}</b>
+        </span>
+        {!adizActive && data.sorties === 0 && (
+          <span style={{ color: COLORS.textFaint }}>· 等待今日上午 8 點前更新</span>
+        )}
+      </div>
+
+      <div style={{ marginTop: "auto", paddingTop: 7, borderTop: `1px solid ${COLORS.borderSoft}` }}>
+        <div style={{ fontFamily: FONT_CJK, fontSize: 9.5, color: COLORS.textMuted, lineHeight: 1.4 }}>
+          {data.title}
+        </div>
+        <div style={{ fontFamily: FONT_CJK, fontSize: 8, color: COLORS.textFaint, marginTop: 3, lineHeight: 1.4 }}>
+          {data.source}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function DiseaseCard({ d, week }: { d: CdcDisease; week: number }) {
+  // 疾病：升 = 警示 → 紅；降 = 改善 → 綠
+  const worse = d.yoy >= 0;
+  const yc = worse ? COLORS.statusWarn : COLORS.statusLive;
+  return (
+    <div
+      style={{
+        borderRadius: 9, border: `1px solid ${COLORS.panelBorder}`,
+        background: "linear-gradient(160deg, rgba(255,255,255,0.04), rgba(255,255,255,0.012))",
+        padding: "12px 13px", display: "flex", flexDirection: "column", gap: 9,
+      }}
+    >
+      <div style={{ display: "flex", alignItems: "center", gap: 7 }}>
+        <span
+          style={{
+            width: 8, height: 8, borderRadius: "50%", background: d.color, flexShrink: 0,
+          }}
+        />
+        <span
+          style={{ fontFamily: FONT_CJK, fontSize: 12, fontWeight: 700, color: COLORS.textStrong }}
+        >
+          {d.label}
+        </span>
+        <div style={{ flex: 1 }} />
+        <span
+          style={{
+            fontFamily: FONT_DATA, fontSize: 8.5, color: COLORS.textFaint,
+            padding: "1px 6px", borderRadius: 3, background: "rgba(255,255,255,0.05)",
+          }}
+        >
+          W{week}
+        </span>
+      </div>
+
+      <div style={{ display: "flex", alignItems: "baseline", gap: 5, whiteSpace: "nowrap" }}>
+        <span
+          style={{
+            fontFamily: FONT_DATA, fontSize: 26, fontWeight: 700, lineHeight: 1, color: "#fff",
+          }}
+        >
+          {d.value}
+        </span>
+        <span style={{ fontFamily: FONT_CJK, fontSize: 9.5, color: COLORS.textMuted }}>{d.unit}</span>
+      </div>
+
+      <div
+        style={{
+          display: "flex", alignItems: "flex-end", justifyContent: "space-between", gap: 8,
+        }}
+      >
+        <span style={{ display: "inline-flex", alignItems: "center", gap: 3 }}>
+          <span style={{ fontFamily: FONT_DATA, fontSize: 11, fontWeight: 700, color: yc }}>
+            {worse ? "↑" : "↓"}
+            {worse ? "+" : ""}
+            {d.yoy}%
+          </span>
+          <span style={{ fontFamily: FONT_CJK, fontSize: 9, color: COLORS.textFaint }}>
+            vs 去年同期
+          </span>
+        </span>
+        <Sparkline data={d.spark} color={d.color} w={62} h={20} />
+      </div>
+
+      <div
+        style={{
+          marginTop: "auto", fontFamily: FONT_CJK, fontSize: 9.5,
+          color: COLORS.textDim, whiteSpace: "nowrap",
+          overflow: "hidden", textOverflow: "ellipsis",
+        }}
+      >
+        {d.note}
+      </div>
+    </div>
+  );
+}
+
+interface Props {
+  pla: PlaActivity;
+  health: PublicHealthWeek;
+}
+
+export function SituationCards({ pla, health }: Props) {
+  return (
+    <div style={{ gridColumn: "1 / -1", display: "flex", flexDirection: "column", gap: 10 }}>
+      <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+        <span style={{ width: 3, height: 12, borderRadius: 2, background: COLORS.accent }} />
+        <span
+          style={{
+            fontFamily: FONT_DATA, fontSize: 10, letterSpacing: "1.5px", color: COLORS.textDefault,
+          }}
+        >
+          情勢 · SITUATION BOARD
+        </span>
+        <div style={{ flex: 1 }} />
+        <span style={{ fontFamily: FONT_CJK, fontSize: 9, color: COLORS.textFaint }}>
+          共機每日 06:00 · CDC 截至 ISO 第 W{health.week} 週
+        </span>
+      </div>
+      <div style={{ display: "grid", gridTemplateColumns: "repeat(4, 1fr)", gap: 10 }}>
+        <PlaCard data={pla} />
+        {health.diseases.map((d) => (
+          <DiseaseCard key={d.id} d={d} week={health.week} />
+        ))}
+        {health.diseases.length === 0 && (
+          <>
+            <div style={emptyCardStyle}>等待 CDC 週報資料…</div>
+            <div style={emptyCardStyle}>等待 CDC 週報資料…</div>
+            <div style={emptyCardStyle}>等待 CDC 週報資料…</div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+const emptyCardStyle: React.CSSProperties = {
+  borderRadius: 9, border: `1px dashed ${COLORS.borderSoft}`,
+  background: "rgba(255,255,255,0.01)", padding: "12px 13px",
+  fontFamily: FONT_CJK, fontSize: 10, color: COLORS.textFaint,
+  display: "flex", alignItems: "center", justifyContent: "center",
+};

--- a/src/components/intel/monitor/SituationOverview.tsx
+++ b/src/components/intel/monitor/SituationOverview.tsx
@@ -1,0 +1,262 @@
+import { useState } from "react";
+import { IntelIcon, ICON } from "../IntelIcon";
+import {
+  COLORS, FONT_CJK, FONT_DATA, PRESSURE_LEVELS, pressureLevel,
+} from "../intelTokens";
+import { PressureRing, CompareLine, TwseTicker, Widget } from "./PressureRing";
+import type {
+  PressureIndexNow, PressureSignal, MarketIndex, SourceHealthSummary,
+} from "../../../data/intelLoaders";
+
+function MiniStat({
+  label, en, value, color,
+}: { label: string; en: string; value: string | number; color?: string }) {
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 3, minWidth: 0 }}>
+      <span
+        style={{
+          fontFamily: FONT_DATA, fontSize: 8.5, letterSpacing: "1.2px", color: COLORS.textDim,
+        }}
+      >
+        {en}
+      </span>
+      <div style={{ display: "flex", alignItems: "baseline", gap: 4 }}>
+        <span
+          style={{
+            fontFamily: FONT_DATA, fontSize: 20, fontWeight: 700, lineHeight: 1,
+            color: color ?? "#fff",
+          }}
+        >
+          {value}
+        </span>
+        <span
+          style={{ fontFamily: FONT_CJK, fontSize: 10, color: COLORS.textMuted, whiteSpace: "nowrap" }}
+        >
+          {label}
+        </span>
+      </div>
+    </div>
+  );
+}
+
+/** 10 軌 signal 抽屜 — 按貢獻排序 */
+function PressureDrawer({ signals }: { signals: PressureSignal[] }) {
+  if (signals.length === 0) {
+    return (
+      <div
+        style={{
+          marginTop: 12, paddingTop: 12, borderTop: `1px dashed ${COLORS.borderMid}`,
+          fontFamily: FONT_CJK, fontSize: 11, color: COLORS.textFaint,
+          animation: "drawerOpen .32s cubic-bezier(.22,1,.36,1)",
+        }}
+      >
+        ⚠ 尚無 signal 細節（後端未回 per_signal）
+      </div>
+    );
+  }
+  const sorted = [...signals].sort((a, b) => b.contribution - a.contribution);
+  const maxC = Math.max(...sorted.map((s) => s.contribution)) || 1;
+  return (
+    <div
+      style={{
+        marginTop: 12, paddingTop: 12, borderTop: `1px dashed ${COLORS.borderMid}`,
+        animation: "drawerOpen .32s cubic-bezier(.22,1,.36,1)",
+      }}
+    >
+      <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 10 }}>
+        <span
+          style={{
+            fontFamily: FONT_DATA, fontSize: 9, letterSpacing: "1.5px", color: COLORS.textDefault,
+          }}
+        >
+          指數組成 · SIGNAL BREAKDOWN
+        </span>
+        <span style={{ fontFamily: FONT_CJK, fontSize: 9, color: COLORS.textFaint }}>
+          權重「災害重」· 5min EMA
+        </span>
+      </div>
+      <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: "7px 22px" }}>
+        {sorted.map((s) => {
+          const lvl = pressureLevel(s.raw);
+          return (
+            <div key={s.id} style={{ display: "flex", alignItems: "center", gap: 9 }}>
+              <span style={{ width: 56, flexShrink: 0, display: "flex", alignItems: "baseline", gap: 4 }}>
+                <span
+                  style={{
+                    fontFamily: FONT_CJK, fontSize: 11, color: COLORS.textDefault, whiteSpace: "nowrap",
+                  }}
+                >
+                  {s.label}
+                </span>
+              </span>
+              <span
+                style={{
+                  fontFamily: FONT_DATA, fontSize: 8, color: COLORS.textFaint,
+                  width: 30, flexShrink: 0,
+                }}
+              >
+                ×{s.weight.toFixed(2)}
+              </span>
+              <div
+                style={{
+                  flex: 1, height: 7, borderRadius: 4, background: "rgba(255,255,255,0.05)",
+                  overflow: "hidden", minWidth: 26,
+                }}
+              >
+                <span
+                  style={{
+                    display: "block", height: "100%",
+                    width: `${(s.contribution / maxC) * 100}%`,
+                    background: lvl.color, borderRadius: 4, opacity: 0.9,
+                    transition: "width .5s cubic-bezier(.22,1,.36,1)",
+                  }}
+                />
+              </div>
+              <span
+                title={s.note ?? undefined}
+                style={{
+                  fontFamily: FONT_DATA, fontSize: 11, fontWeight: 700,
+                  color: lvl.color, width: 30, textAlign: "right", flexShrink: 0,
+                }}
+              >
+                {Math.round(s.raw)}
+              </span>
+            </div>
+          );
+        })}
+      </div>
+      {/* 4-檔戰情等級 legend */}
+      <div
+        style={{
+          display: "flex", flexWrap: "wrap", gap: "5px 14px",
+          marginTop: 12, paddingTop: 10, borderTop: `1px solid ${COLORS.borderSoft}`,
+        }}
+      >
+        {PRESSURE_LEVELS.map((l) => (
+          <span
+            key={l.key}
+            style={{
+              display: "inline-flex", alignItems: "center", gap: 5,
+              fontFamily: FONT_CJK, fontSize: 9.5, color: COLORS.textMuted,
+            }}
+          >
+            <span style={{ width: 8, height: 8, borderRadius: "50%", background: l.color }} />
+            {l.label}{" "}
+            <span style={{ fontFamily: FONT_DATA, color: COLORS.textFaint }}>
+              {l.min}–{l.max}
+            </span>
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+interface Props {
+  pressure: PressureIndexNow;
+  smoothedScore: number;
+  market: MarketIndex;
+  sourceHealth: SourceHealthSummary;
+  totalEvents: number;
+  severeCount: number;
+}
+
+export function SituationOverview({
+  pressure, smoothedScore, market, sourceHealth, totalEvents, severeCount,
+}: Props) {
+  const [open, setOpen] = useState(false);
+  const level = pressureLevel(smoothedScore);
+
+  return (
+    <Widget
+      style={{
+        gridColumn: "1 / -1", padding: 15, position: "relative",
+        background: `linear-gradient(150deg, ${level.soft}, rgba(255,255,255,0.012) 46%)`,
+        borderColor: open ? `${level.color}66` : COLORS.panelBorder,
+        transition: "border-color .3s",
+      }}
+    >
+      {level.key === "emergency" && (
+        <span
+          style={{
+            position: "absolute", inset: 0, borderRadius: 9, pointerEvents: "none",
+            boxShadow: `inset 0 0 30px ${level.glow}`,
+            animation: "presPulse 1s ease-in-out infinite",
+          }}
+        />
+      )}
+      <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 13 }}>
+        <span style={{ width: 3, height: 12, borderRadius: 2, background: level.color }} />
+        <span
+          style={{
+            fontFamily: FONT_DATA, fontSize: 10, letterSpacing: "1.5px", color: COLORS.textDefault,
+          }}
+        >
+          戰情概覽 · PRESSURE INDEX
+        </span>
+        <span
+          style={{
+            fontFamily: FONT_CJK, fontSize: 9, color: COLORS.textFaint, whiteSpace: "nowrap",
+          }}
+        >
+          10 訊號加權 0–100
+        </span>
+      </div>
+
+      <div style={{ display: "flex", alignItems: "center", gap: 20, flexWrap: "wrap" }}>
+        <button
+          onClick={() => setOpen((v) => !v)}
+          title="點環看指數組成"
+          style={{
+            border: "none", background: "transparent", padding: 0,
+            cursor: "pointer", position: "relative", lineHeight: 0,
+          }}
+        >
+          <PressureRing score={smoothedScore} level={level} />
+          <span
+            style={{
+              position: "absolute", bottom: 6, left: "50%", transform: "translateX(-50%)",
+              display: "inline-flex", alignItems: "center", gap: 3, padding: "2px 7px",
+              borderRadius: 10, background: "rgba(0,0,0,0.45)",
+              border: `1px solid ${COLORS.borderSoft}`,
+              fontFamily: FONT_CJK, fontSize: 8.5, color: COLORS.textMuted, whiteSpace: "nowrap",
+            }}
+          >
+            {open ? "收合" : "組成"}
+            <span
+              style={{
+                display: "inline-block",
+                transform: open ? "rotate(180deg)" : "none",
+                transition: "transform .3s",
+              }}
+            >
+              <IntelIcon d={ICON.chevDown} size={9} color={COLORS.textMuted} />
+            </span>
+          </span>
+        </button>
+
+        <div style={{ display: "flex", flexDirection: "column", gap: 9, minWidth: 150 }}>
+          <CompareLine delta={pressure.vs_baseline} label="vs 平常週日同時段" />
+          <CompareLine delta={pressure.vs_1h_ago} label="vs 1 小時前" />
+          <div style={{ height: 1, background: COLORS.borderSoft, margin: "1px 0" }} />
+          <div style={{ display: "flex", gap: 18 }}>
+            <MiniStat en="EVENTS" label="事件" value={totalEvents} />
+            <MiniStat
+              en="SEVERE ≥3" label="嚴重" value={severeCount}
+              color={severeCount > 0 ? COLORS.statusWarn : "#fff"}
+            />
+            <MiniStat
+              en="SOURCES" label="來源"
+              value={`${sourceHealth.ok}/${sourceHealth.total}`}
+            />
+          </div>
+        </div>
+
+        <div style={{ flex: 1 }} />
+        <TwseTicker data={market} />
+      </div>
+
+      {open && <PressureDrawer signals={pressure.per_signal} />}
+    </Widget>
+  );
+}

--- a/src/components/intel/monitor/TimelineDock.tsx
+++ b/src/components/intel/monitor/TimelineDock.tsx
@@ -1,0 +1,333 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import { IntelIcon, ICON } from "../IntelIcon";
+import { COLORS, FONT_CJK, FONT_DATA, clockTime } from "../intelTokens";
+import { NEWS_CATEGORIES, type NewsCategory } from "../../../data/newsEventTypes";
+import type { ClusterEvent } from "../../../data/newsEventsLoader";
+
+interface Props {
+  /** 過濾後的當日 events（用於畫直方圖） */
+  events: ClusterEvent[];
+  /** 當日 00:00 unix 秒（asia/taipei） */
+  dayStartTs: number;
+  /** 當下 unix 秒 */
+  nowTs: number;
+  /** 當前 playback unix 秒（live 時 = nowTs） */
+  playbackTs: number;
+  isLive: boolean;
+  playing: boolean;
+  onScrub: (ts: number) => void;
+  onLive: () => void;
+  onTogglePlay: () => void;
+}
+
+interface HourlyBucket {
+  h: number;
+  c: Record<NewsCategory, number>;
+  total: number;
+}
+
+const CAT_KEYS = NEWS_CATEGORIES.map((c) => c.key);
+
+function bucketByHour(events: ClusterEvent[], dayStartTs: number): HourlyBucket[] {
+  const buckets: HourlyBucket[] = Array.from({ length: 24 }, (_, h) => ({
+    h,
+    c: { accident: 0, crime: 0, disaster: 0, traffic: 0, health: 0, policy: 0, other: 0 },
+    total: 0,
+  }));
+  for (const e of events) {
+    if (!e.published_ts) continue;
+    const diff = e.published_ts - dayStartTs;
+    if (diff < 0 || diff >= 86400) continue;
+    const h = Math.floor(diff / 3600);
+    if (h < 0 || h > 23) continue;
+    const k = (CAT_KEYS.includes((e.category ?? "other") as NewsCategory)
+      ? (e.category as NewsCategory)
+      : "other") as NewsCategory;
+    const bucket = buckets[h]!;
+    bucket.c[k] += 1;
+    bucket.total += 1;
+  }
+  return buckets;
+}
+
+const TICKS = [0, 6, 12, 18, 24];
+
+export function TimelineDock({
+  events, dayStartTs, nowTs, playbackTs, isLive, playing,
+  onScrub, onLive, onTogglePlay,
+}: Props) {
+  const [hoverH, setHoverH] = useState<number | null>(null);
+  const areaRef = useRef<HTMLDivElement>(null);
+  const draggingRef = useRef(false);
+
+  const SPAN = 86400;
+  const frac = Math.max(0, Math.min(1, (playbackTs - dayStartTs) / SPAN));
+  const nowFrac = Math.max(0, Math.min(1, (nowTs - dayStartTs) / SPAN));
+
+  const buckets = useMemo(() => bucketByHour(events, dayStartTs), [events, dayStartTs]);
+  const peak = Math.max(1, ...buckets.map((b) => b.total));
+
+  const tsFromClientX = (clientX: number): number | null => {
+    const el = areaRef.current;
+    if (!el) return null;
+    const r = el.getBoundingClientRect();
+    const f = Math.max(0, Math.min(1, (clientX - r.left) / r.width));
+    return Math.min(nowTs, dayStartTs + f * SPAN);
+  };
+  const scrubFromEvent = (e: { clientX: number }) => {
+    const ts = tsFromClientX(e.clientX);
+    if (ts != null) onScrub(ts);
+  };
+
+  useEffect(() => {
+    const move = (e: MouseEvent) => {
+      if (draggingRef.current) scrubFromEvent(e);
+    };
+    const up = () => {
+      draggingRef.current = false;
+    };
+    window.addEventListener("mousemove", move);
+    window.addEventListener("mouseup", up);
+    return () => {
+      window.removeEventListener("mousemove", move);
+      window.removeEventListener("mouseup", up);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const hovered = hoverH != null ? buckets[hoverH]! : null;
+
+  return (
+    <div
+      style={{
+        flexShrink: 0, padding: "10px 16px 8px",
+        borderBottom: `1px solid ${COLORS.panelBorder}`,
+        background: "rgba(0,0,0,0.28)",
+      }}
+    >
+      {/* top row */}
+      <div style={{ display: "flex", alignItems: "center", gap: 10, marginBottom: 8 }}>
+        <span
+          style={{
+            fontFamily: FONT_DATA, fontSize: 9, letterSpacing: "2px",
+            color: COLORS.textMuted, whiteSpace: "nowrap",
+          }}
+        >
+          時間軸 TIMELINE DOCK
+        </span>
+        <span style={{ fontFamily: FONT_CJK, fontSize: 9.5, color: COLORS.textFaint, whiteSpace: "nowrap" }}>
+          新聞密度 · 每小時
+        </span>
+        <div style={{ flex: 1 }} />
+        <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+          {NEWS_CATEGORIES.map((c) => (
+            <span
+              key={c.key}
+              title={c.label}
+              style={{
+                width: 8, height: 8, borderRadius: 2, background: c.color, opacity: 0.85,
+              }}
+            />
+          ))}
+        </div>
+        <span style={{ width: 1, height: 16, background: COLORS.borderMid, margin: "0 2px" }} />
+        <button
+          onClick={onTogglePlay}
+          title="play/pause"
+          style={{
+            width: 26, height: 26, borderRadius: 5,
+            border: `1px solid ${COLORS.borderMid}`,
+            background: "rgba(255,255,255,0.05)",
+            color: COLORS.textDefault, cursor: "pointer",
+            display: "flex", alignItems: "center", justifyContent: "center",
+          }}
+        >
+          <IntelIcon
+            d={playing ? ICON.pause : ICON.play}
+            size={12}
+            fill={playing ? "none" : "currentColor"}
+          />
+        </button>
+        <span
+          style={{
+            fontFamily: FONT_DATA, fontSize: 12, fontWeight: 700,
+            minWidth: 58, textAlign: "center",
+            color: isLive ? COLORS.statusLive : COLORS.statusWarn,
+          }}
+        >
+          {isLive ? "即時 NOW" : clockTime(playbackTs)}
+        </span>
+        <button
+          onClick={onLive}
+          style={{
+            display: "inline-flex", alignItems: "center", gap: 5,
+            padding: "4px 10px", borderRadius: 5, cursor: "pointer",
+            fontFamily: FONT_DATA, fontSize: 10, fontWeight: 700, letterSpacing: "0.5px",
+            background: isLive ? COLORS.statusLiveSoft : "rgba(255,255,255,0.05)",
+            border: isLive ? `1px solid ${COLORS.statusLiveBorder}` : `1px solid ${COLORS.borderMid}`,
+            color: isLive ? COLORS.statusLive : COLORS.textMuted,
+          }}
+        >
+          <span
+            style={{
+              width: 6, height: 6, borderRadius: "50%",
+              background: isLive ? COLORS.statusLive : COLORS.textDim,
+              boxShadow: isLive ? `0 0 6px ${COLORS.statusLive}` : "none",
+            }}
+          />
+          LIVE
+        </button>
+      </div>
+
+      {/* chart */}
+      <div
+        ref={areaRef}
+        onMouseDown={(e) => {
+          draggingRef.current = true;
+          scrubFromEvent(e);
+        }}
+        onMouseLeave={() => setHoverH(null)}
+        style={{ position: "relative", height: 84, cursor: "pointer", userSelect: "none" }}
+      >
+        {[0, 0.25, 0.5, 0.75, 1].map((g) => (
+          <span
+            key={g}
+            style={{
+              position: "absolute", left: 0, right: 0, top: `${g * 100}%`,
+              height: 1, background: "rgba(255,255,255,0.05)",
+            }}
+          />
+        ))}
+        <span
+          style={{
+            position: "absolute", top: 0, bottom: 0,
+            left: `${nowFrac * 100}%`, right: 0,
+            background: "rgba(0,0,0,0.32)",
+            borderLeft: "1px dashed rgba(255,255,255,0.12)",
+          }}
+        />
+
+        <div style={{ position: "absolute", inset: 0, display: "flex", alignItems: "flex-end", gap: 2 }}>
+          {buckets.map((hd) => {
+            const isHover = hoverH === hd.h;
+            const isFuture = hd.h > Math.floor(nowFrac * 24);
+            const hPct = (hd.total / peak) * 100;
+            return (
+              <div
+                key={hd.h}
+                onMouseEnter={() => setHoverH(hd.h)}
+                style={{
+                  flex: 1, height: "100%",
+                  display: "flex", flexDirection: "column", justifyContent: "flex-end",
+                  position: "relative", opacity: isFuture ? 0.25 : 1,
+                }}
+              >
+                <div
+                  style={{
+                    display: "flex", flexDirection: "column-reverse",
+                    height: `${hPct}%`, minHeight: hd.total ? 3 : 0,
+                    borderRadius: 2, overflow: "hidden",
+                    outline: isHover ? "1px solid rgba(255,255,255,0.35)" : "none",
+                  }}
+                >
+                  {NEWS_CATEGORIES.map((c) =>
+                    hd.c[c.key] ? (
+                      <span
+                        key={c.key}
+                        style={{
+                          height: `${(hd.c[c.key] / hd.total) * 100}%`,
+                          background: c.color, opacity: isHover ? 1 : 0.82,
+                        }}
+                      />
+                    ) : null,
+                  )}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+
+        <span
+          style={{
+            position: "absolute", top: -3, bottom: -3,
+            left: `${frac * 100}%`, width: 2, marginLeft: -1,
+            background: isLive ? COLORS.statusLive : COLORS.accent,
+            boxShadow: `0 0 8px ${isLive ? COLORS.statusLive : COLORS.accent}`,
+            pointerEvents: "none", zIndex: 3,
+          }}
+        >
+          <span
+            style={{
+              position: "absolute", top: -4, left: -3,
+              width: 8, height: 8, borderRadius: "50%",
+              background: isLive ? COLORS.statusLive : COLORS.accent,
+            }}
+          />
+        </span>
+
+        {hovered && (
+          <div
+            style={{
+              position: "absolute", bottom: "100%", marginBottom: 6,
+              left: `${((hovered.h + 0.5) / 24) * 100}%`,
+              transform: "translateX(-50%)", zIndex: 5,
+              background: "rgba(0,0,0,0.88)",
+              border: `1px solid ${COLORS.borderMid}`, borderRadius: 7,
+              padding: "7px 9px", whiteSpace: "nowrap", pointerEvents: "none",
+              backdropFilter: "blur(8px)", WebkitBackdropFilter: "blur(8px)",
+              boxShadow: "0 6px 20px rgba(0,0,0,0.5)",
+            }}
+          >
+            <div
+              style={{
+                fontFamily: FONT_DATA, fontSize: 10.5,
+                color: "#fff", fontWeight: 700, marginBottom: 4,
+              }}
+            >
+              {String(hovered.h).padStart(2, "0")}:00 · {hovered.total} 則
+            </div>
+            <div style={{ display: "flex", gap: 7, flexWrap: "wrap", maxWidth: 180 }}>
+              {NEWS_CATEGORIES.filter((c) => hovered.c[c.key]).map((c) => (
+                <span
+                  key={c.key}
+                  style={{
+                    display: "inline-flex", alignItems: "center", gap: 3,
+                    fontFamily: FONT_DATA, fontSize: 9.5, color: COLORS.textDefault,
+                  }}
+                >
+                  <span
+                    style={{
+                      width: 6, height: 6, borderRadius: "50%", background: c.color,
+                    }}
+                  />
+                  {c.label} {hovered.c[c.key]}
+                </span>
+              ))}
+              {hovered.total === 0 && (
+                <span style={{ fontFamily: FONT_CJK, fontSize: 9.5, color: COLORS.textFaint }}>
+                  無事件
+                </span>
+              )}
+            </div>
+          </div>
+        )}
+      </div>
+
+      <div style={{ position: "relative", height: 14, marginTop: 3 }}>
+        {TICKS.map((t) => (
+          <span
+            key={t}
+            style={{
+              position: "absolute", left: `${(t / 24) * 100}%`,
+              transform:
+                t === 0 ? "none" : t === 24 ? "translateX(-100%)" : "translateX(-50%)",
+              fontFamily: FONT_DATA, fontSize: 9, color: COLORS.textFaint,
+            }}
+          >
+            {t === 24 ? "23:59" : `${String(t).padStart(2, "0")}:00`}
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/data/intelLoaders.ts
+++ b/src/data/intelLoaders.ts
@@ -90,3 +90,286 @@ export function trendingKeys(rows: TrendingRow[], threshold = 2): Set<string> {
   }
   return s;
 }
+
+// ── Monitor Phase 2 ──────────────────────────────────────────────
+
+/** 壓力指數 0-100 + 10 signal 細節（get_pressure_index_now()） */
+export interface PressureSignal {
+  id: string;
+  label: string;
+  en: string;
+  weight: number;
+  raw: number;          // 0-100
+  contribution: number; // weight * raw
+  note: string | null;
+}
+
+export interface PressureIndexNow {
+  composite: number;     // 0-100 加權後
+  level: string | null;  // peace / notice / alert / emergency
+  vs_baseline: number;   // 與「平常同時段」差
+  vs_1h_ago: number;     // 與 1h 前差
+  per_signal: PressureSignal[];
+  asof: string | null;   // ISO
+}
+
+const EMPTY_PRESSURE: PressureIndexNow = {
+  composite: 0, level: null, vs_baseline: 0, vs_1h_ago: 0, per_signal: [], asof: null,
+};
+
+export async function fetchPressureIndex(): Promise<PressureIndexNow> {
+  if (!supabaseConfigured) return EMPTY_PRESSURE;
+  const { data, error } = await withLoading(
+    "intel:pressure-index",
+    "壓力指數",
+    supabase.rpc("get_pressure_index_now"),
+  );
+  if (error) {
+    console.warn("[Intel] get_pressure_index_now failed:", error.message);
+    return EMPTY_PRESSURE;
+  }
+  // RPC 可能回 single row 或 array，做防呆攤平
+  const row = Array.isArray(data) ? data[0] : data;
+  if (!row) return EMPTY_PRESSURE;
+  return {
+    composite: Number(row.composite ?? 0),
+    level: row.level ?? null,
+    vs_baseline: Number(row.vs_baseline ?? 0),
+    vs_1h_ago: Number(row.vs_1h_ago ?? 0),
+    per_signal: (row.per_signal ?? []) as PressureSignal[],
+    asof: row.asof ?? null,
+  };
+}
+
+/** 多軌 signal 時間序列（給 TimelineDock Phase 2 multi-track） */
+export interface SignalsTimelinePoint {
+  signal: string;
+  hour: string;     // ISO hour bucket
+  score: number;    // 0-100
+  level: string | null;
+}
+
+export async function fetchSignalsTimeline(
+  hours = 24,
+  signals?: string[],
+): Promise<SignalsTimelinePoint[]> {
+  if (!supabaseConfigured) return [];
+  const { data, error } = await withLoading(
+    "intel:signals-timeline",
+    "信號時間軸",
+    supabase.rpc("get_signals_timeline", {
+      p_hours: hours,
+      p_signals: signals ?? null,
+    }),
+  );
+  if (error) {
+    console.warn("[Intel] get_signals_timeline failed:", error.message);
+    return [];
+  }
+  return (data ?? []) as SignalsTimelinePoint[];
+}
+
+/** TWSE 加權指數 — realtime.market_index_current（取最新一列） */
+export interface MarketIndex {
+  index: number;
+  prev_close: number;
+  open: number;
+  high: number;
+  low: number;
+  change: number;
+  change_pct: number;
+  turnover: string | null;  // 顯示用「1.22 兆」
+  time: string | null;      // "13:33"
+  status: string | null;    // 盤中 / 收盤 / 休市
+}
+
+const EMPTY_MARKET: MarketIndex = {
+  index: 0, prev_close: 0, open: 0, high: 0, low: 0,
+  change: 0, change_pct: 0, turnover: null, time: null, status: null,
+};
+
+export async function fetchMarketIndex(): Promise<MarketIndex> {
+  if (!supabaseConfigured) return EMPTY_MARKET;
+  // realtime.* 不能直接打，走 public RPC wrapper（後端已上線 get_market_index_now）
+  const { data, error } = await withLoading(
+    "intel:market-index",
+    "加權指數",
+    supabase.rpc("get_market_index_now"),
+  );
+  if (error) {
+    console.warn("[Intel] get_market_index_now failed:", error.message);
+    return EMPTY_MARKET;
+  }
+  const row = Array.isArray(data) ? data[0] : data;
+  if (!row) return EMPTY_MARKET;
+  const index = Number(row.index ?? row.idx ?? 0);
+  const prev = Number(row.prev_close ?? row.y ?? 0);
+  const change = Number(row.change ?? (index - prev).toFixed(2));
+  const pct = Number(row.change_pct ?? (prev ? +((change / prev) * 100).toFixed(2) : 0));
+  return {
+    index,
+    prev_close: prev,
+    open: Number(row.open ?? 0),
+    high: Number(row.high ?? 0),
+    low: Number(row.low ?? 0),
+    change,
+    change_pct: pct,
+    turnover: row.turnover ?? null,
+    time: row.time ?? null,
+    status: row.status ?? null,
+  };
+}
+
+/** 共機動態 — realtime.pla_activity_daily（最新一日） */
+export interface PlaAdizZone {
+  key: "north" | "central" | "southwest" | "east";
+  label: string;
+  active: boolean;
+}
+
+export interface PlaActivity {
+  sorties: number;
+  crossed_median: number;
+  plan_vessels: number;
+  official_ships: number;
+  adiz: PlaAdizZone[];
+  as_of: string | null;   // "今日 06:00"
+  source: string;
+  title: string;
+}
+
+const PLA_FALLBACK_LABELS: Record<PlaAdizZone["key"], string> = {
+  north: "北", central: "中", southwest: "西南", east: "東",
+};
+const EMPTY_PLA: PlaActivity = {
+  sorties: 0, crossed_median: 0, plan_vessels: 0, official_ships: 0,
+  adiz: (["north", "central", "southwest", "east"] as const).map((k) => ({
+    key: k, label: PLA_FALLBACK_LABELS[k], active: false,
+  })),
+  as_of: null,
+  source: "中華民國國防部 @MoNDefense · 每日 06:00 (UTC+8) 截止",
+  title: "中共解放軍臺海周邊海、空域動態",
+};
+
+export async function fetchPlaActivity(): Promise<PlaActivity> {
+  if (!supabaseConfigured) return EMPTY_PLA;
+  const { data, error } = await withLoading(
+    "intel:pla-activity",
+    "共機動態",
+    supabase.rpc("get_pla_activity_latest"),
+  );
+  if (error) {
+    console.warn("[Intel] get_pla_activity_latest failed:", error.message);
+    return EMPTY_PLA;
+  }
+  const row = Array.isArray(data) ? data[0] : data;
+  if (!row) return EMPTY_PLA;
+  return {
+    sorties: Number(row.sorties ?? 0),
+    crossed_median: Number(row.crossed_median ?? 0),
+    plan_vessels: Number(row.plan_vessels ?? 0),
+    official_ships: Number(row.official_ships ?? 0),
+    adiz: (["north", "central", "southwest", "east"] as const).map((k) => ({
+      key: k,
+      label: PLA_FALLBACK_LABELS[k],
+      active: Boolean(row[`adiz_${k}`] ?? false),
+    })),
+    as_of: row.as_of ?? "今日 06:00",
+    source: row.source ?? EMPTY_PLA.source,
+    title: row.title ?? EMPTY_PLA.title,
+  };
+}
+
+/** CDC 公衛週報 — realtime.public_health_weekly（最新 ISO 週的 3 個指標） */
+export interface CdcDisease {
+  id: "flu" | "dengue" | "entero";
+  label: string;
+  en: string;
+  value: string;
+  unit: string;
+  spark: number[];
+  yoy: number;
+  note: string;
+  color: string;
+}
+
+export interface PublicHealthWeek {
+  week: number;            // ISO 週
+  diseases: CdcDisease[];
+}
+
+const EMPTY_HEALTH: PublicHealthWeek = { week: 0, diseases: [] };
+
+const HEALTH_DEFAULTS: Record<CdcDisease["id"], { label: string; en: string; unit: string; color: string }> = {
+  flu:    { label: "類流感", en: "ILI",         unit: "門急診/週", color: "#22c55e" },
+  dengue: { label: "登革熱", en: "DENGUE",      unit: "本週確診",  color: "#f97316" },
+  entero: { label: "腸病毒", en: "ENTEROVIRUS", unit: "急診人次",  color: "#eab308" },
+};
+
+/**
+ * YouTube live video resolver — Monitor Mode LiveWall 用
+ * 對應 gis-platform migration 209，collector 每 5 min 把 14 家新聞台
+ * 當前直播 video_id 解析寫進 realtime.yt_live_current。
+ *
+ * 為何要這支：YouTube `embed/live_stream?channel=UCxxx` 在很多頻道解析不到
+ * primary live event（跳「無法播放這部影片」）。改用 `embed/<video_id>` 才可靠。
+ */
+export interface YtLiveVideo {
+  handle: string;        // '@TVBSNEWS01'
+  channel_id: string | null;  // UCxxx
+  video_id: string | null;    // 11-char current live videoId
+  title: string | null;
+  is_live: boolean;
+  view_count: number | null;
+  last_error: string | null;
+  observed_at: string | null;
+  updated_at: string;
+}
+
+export async function fetchLiveVideos(onlyLive = false): Promise<YtLiveVideo[]> {
+  if (!supabaseConfigured) return [];
+  const { data, error } = await withLoading(
+    "intel:yt-live-videos",
+    "YouTube 直播解析",
+    supabase.rpc("get_yt_live_videos", { p_only_live: onlyLive }),
+  );
+  if (error) {
+    console.warn("[Intel] get_yt_live_videos failed:", error.message);
+    return [];
+  }
+  return (data ?? []) as YtLiveVideo[];
+}
+
+export async function fetchPublicHealthWeekly(): Promise<PublicHealthWeek> {
+  if (!supabaseConfigured) return EMPTY_HEALTH;
+  const { data, error } = await withLoading(
+    "intel:public-health",
+    "CDC 公衛週報",
+    supabase.rpc("get_public_health_weekly"),
+  );
+  if (error) {
+    console.warn("[Intel] get_public_health_weekly failed:", error.message);
+    return EMPTY_HEALTH;
+  }
+  const rows = Array.isArray(data) ? data : data ? [data] : [];
+  if (rows.length === 0) return EMPTY_HEALTH;
+  const week = Number(rows[0]?.week ?? 0);
+  const diseases: CdcDisease[] = [];
+  for (const r of rows) {
+    const id = r.id as CdcDisease["id"];
+    const def = HEALTH_DEFAULTS[id];
+    if (!def) continue;
+    diseases.push({
+      id,
+      label: r.label ?? def.label,
+      en: r.en ?? def.en,
+      value: String(r.value ?? "—"),
+      unit: r.unit ?? def.unit,
+      spark: Array.isArray(r.spark) ? r.spark.map(Number) : [],
+      yoy: Number(r.yoy ?? 0),
+      note: r.note ?? "",
+      color: r.color ?? def.color,
+    });
+  }
+  return { week, diseases };
+}


### PR DESCRIPTION
## Summary

Monitor Mode 2.0：從底部上拉的全寬戰情看板。

- 左 40% 復用 IntelCard + IntelFilters
- 右 60% IndicatorPanel：壓力指數環 / TWSE / 共機 / CDC / 新聞直播 4 格 / 熱區 / 直方圖 / 信號分級
- 全寬 TimelineDock（拖拉 scrubber + LIVE 切換）
- Wall mode 全螢幕，拖拉 handle 改高度
- 右上 chrome：3D Altitude → Monitor toggle

LiveWall 直播解析改吃 \`realtime.yt_live_current\`（B1 方案），collector 5min cron 解析 13 家 handle → videoId。

## Backend deps

- gis-platform migration 209（已套）
- data-collectors yt_live_video_resolver collector（已部署、Zeabur env 已開）

## Test plan

- [ ] 點右上 Monitor → 看板從底部升起 + 動畫
- [ ] 4 格 YouTube 直播載入（公視 / TVBS / 華視 / 台視）
- [ ] 下拉切換到非預設頻道，iframe 換源
- [ ] 拖拉 timeline scrubber → feed / KPI 同步
- [ ] 壓力環點開 → 10 軌 signal 抽屜
- [ ] Wall mode 全螢幕 → 還原
- [ ] Phase 1 IntelPanel 不受影響

🤖 Generated with [Claude Code](https://claude.com/claude-code)