### PR TITLE
feat(intel): 警訊整合 — NCDR 災害示警 + CWA 地震

### DIFF
--- a/.claude/memory/BACKLOG.md
+++ b/.claude/memory/BACKLOG.md
@@ -168,22 +168,44 @@
 
 | ID | 優先級 | 項目 | 狀態 | 備註 / 估時 |
 |---|---|---|---|---|
-| MO-1 | P1 | **Monitor Mode 前端整體（Phase 1）** | open | `ModeToggle` + `MonitorPanel` (拖拉手把) + `TimelineDock` (uPlot 單軌新聞密度) + `NewsFeedPanel` (升溫 chip + 集群展開) + `IndicatorPanel` (KPI/熱區Top5/24h widget/直播 slot)。時間同步 `timeStore`、Loading/空狀態、卡片進場動畫。**~7 工作日** |
-| MO-2 | P1 | **Monitor 後端 pre-aggregate RPC** | open | gis-platform migration 加 `realtime.news_events_hourly_county_cat` (普通 table + refresh function 加進 cron job 55 循序步驟，**禁止拆新 job**) + `get_news_trending_hotspots(window_hours, limit)` + `get_news_hourly_breakdown(day)`。surge_ratio = window 計數 / 24h 同時段均值。**~1.5d**。MO-1 阻塞於此 |
-| MO-3 | P2 | 信號接入 — 共機擾台 | open | 國防部 PDF 或 `EyesOnPLA` GitHub。Phase 2 第一信號（⭐⭐⭐ 最高優先）|
-| MO-4 | P2 | 信號接入 — 電網備轉容量 | open | 台電 Open Data，⭐⭐⭐ |
-| MO-5 | P2 | 信號接入 — 地震即時 | open | CWA Open API（已有 earthquakes layer 資料可共用，主要做 monitor 端 widget），⭐⭐⭐ |
-| MO-6 | P3 | 信號接入 — 加權指數 / 匯率 | open | 證交所 / 央行，⭐⭐ |
-| MO-7 | P3 | 信號接入 — Cofacts 假訊息 | open | MyGoPen / Cofacts API，⭐⭐ |
-| MO-8 | P3 | 信號接入 — Cloudflare Radar 連通性 | open | 海纜中斷 / 國際連通異常，⭐ |
-| MO-9 | P3 | 信號接入 — 疾管署公衛週報 | open | ⭐ |
-| MO-10 | P3 | 通用信號表 + Phase 2 schema 設計 | open | 統一 `realtime.signals(source, metric, value, ts)` + 通用 widget factory。MO-3~9 共用基礎建設 |
-| MO-11 | P3 | 新聞直播嵌入 (iframe widget) | open | 候選：中央社 YT live / 公視 / 民視 / TVBS / PTS。Phase 1 預留外殼，Phase 2 接 |
-| MO-12 | P3 | Realtime push 升級（Phase 3）| open | polling 20min → Supabase Realtime channel 訂閱 news_events INSERT，真正秒級推送。涉及 gis-platform RLS + replication slot 設定 |
+| MO-1 | P1 | **Monitor Mode 前端整體（Phase 1）** | **done** | 2026-06-16 上線（PR #18）：右上 Monitor button + 底部上拉 + Wall mode + TimelineDock + IntelCard column + IndicatorPanel |
+| MO-2 | P1 | **Monitor 後端 pre-aggregate RPC** | **done** | 既有 `get_news_trending` + `get_source_health` 已足；新聞 hourly breakdown 在前端用 events array bucket（資料量小不需 pre-agg）|
+| MO-3 | P2 | 信號接入 — 共機擾台 | **done** | 2026-06-17 上線：data-collectors `pla_activity_daily` + gis-platform migration 205 + `get_pla_activity_latest()` RPC（migration 210）+ 前端 SituationCards PlaCard。30 min cron |
+| MO-4 | P2 | 信號接入 — 電網備轉容量 | open | 台電 Open Data，⭐⭐⭐。已進壓力指數 power signal，獨立 widget 待做 |
+| MO-5 | P2 | 信號接入 — 地震即時 | **partial** | earthquake_events 已進壓力指數 signal；獨立 monitor widget 計入 AI-1 警訊整合的「地震卡」 |
+| MO-6 | P3 | 信號接入 — 加權指數 / 匯率 | **done (TWSE)** | 2026-06-17 上線：TWSE 加權指數 ticker（collector twse_market_index + migration 204 + `get_market_index_now()` RPC）。匯率仍 open |
+| MO-7 | P3 | 信號接入 — Cofacts 假訊息 | open | TimelineDock 「Phase 2 多軌」預留位有提到 |
+| MO-8 | P3 | 信號接入 — Cloudflare Radar 連通性 | open | ⭐ |
+| MO-9 | P3 | 信號接入 — 疾管署公衛週報 | **done** | 2026-06-17 上線：collector cdc_public_health_weekly + migration 206 + `get_public_health_weekly()` RPC（migration 210）+ 前端 DiseaseCard ×3。週四 11:00 跑 |
+| MO-10 | P3 | 通用信號表 + Phase 2 schema 設計 | **done** | migration 207 `realtime.signals_hourly` + `pressure_index_now` + `compute_pressure_index('disaster')` cron 5min |
+| MO-11 | P3 | 新聞直播嵌入 (iframe widget) | **done** | 2026-06-17 上線 LiveWall 4 格 + 14 家頻道下拉 + B1 yt_live_video_resolver collector + migration 209 + `get_yt_live_videos()` RPC。embed/<videoId> 路徑。9/13 家當下可播 |
+| MO-12 | P3 | Realtime push 升級（Phase 3）| open | polling 30s → Supabase Realtime channel。仍待 |
 
-### 規劃文件總覽（2026-06-14 集中索引）
+### Monitor Mode Phase 2+ 衍生待辦（2026-06-17 加）
+
+| ID | 優先級 | 項目 | 狀態 | 備註 |
+|---|---|---|---|---|
+| MO-13 | P2 | 補 3 家 YT live handle | open | 鏡新聞 @MnewsTw / 非凡 @ustvnews 目前 /live 404；中天移除。找到正確 @handle 後改 `data-collectors/collectors/yt_live_video_resolver.py` HANDLES + `LiveWall.tsx` LIVE_CHANNELS |
+| MO-14 | P3 | TWSE turnover 格式漂亮化 | open | migration 210 RPC 目前回「12215293 千」，應顯示「1.22 兆」。改 `get_market_index_now()` 的 turnover CASE |
+| MO-15 | P3 | LiveWall 被擋頻道 fallback | open | 部分台後台可能關 embed（TVBS / 三立 / 東森常見），iframe 仍會跳「無法播放」。candidates：(a) 拿掉、(b) 改「另開分頁觀看」占位卡片 |
+| MO-16 | P3 | 加權指數 turnover 修 + 匯率接入 | open | TWSE 已上、匯率（央行）未接 |
+
+### AI 警訊整合（AI 系列，2026-06-17 加 — 規劃完整在 `docs/proposal/alerts-integration-impl.md`）
+
+**定位**：把 NCDR 災害示警（5 群組）+ CWA 地震整合進 IntelPanel + Monitor。設計師 v2 已交稿，5 個新元件（AlertSummaryBar / FeedTabs / AlertCard / AlertBoard / AlertsTrack）+ migration 211（3 RPC）+ alertsLoader.ts。**handoff doc 自帶 task list、設計 URL、Verification walkthrough — 另一 session 接手即用**。
+
+| ID | 優先級 | 項目 | 狀態 | 備註 / 估時 |
+|---|---|---|---|---|
+| AI-1 | P1 | **警訊整合 Phase 1（NCDR + 地震）** | open | impl doc 12 顆 task：migration 211 + tokens + loader + 5 元件 + 4 檔接線 + browser walkthrough。**估 4-5 hr** |
+| AI-2 | P2 | 地圖警報點 visual 重整（B2 方案）| open | alert 圓點 +60% size + 白邊 2.5px + active pulse 動畫，避免跟新聞圓點混淆。`useDisasterAlertLayer.ts` paint 微調 + earthquakes layer 對齊 |
+| AI-3 | P3 | 警報統計接 pressure index signal | open | 已有 signals_hourly framework，加 alert_count + alert_severe signal |
+
+### 規劃文件總覽（2026-06-17 更新）
 
 | 文件 | 對應 backlog | 狀態 |
 |---|---|---|
 | `docs/proposal/satellite-console.md` | SAT-1~7 | Phase 0 衛星圖層已上線，Phase A-D 規劃完成待動工 |
-| `docs/proposal/monitor-mode.md` | MO-1~12 | 完整提案，Phase 1 工程清單就緒待動工 |
+| `docs/proposal/monitor-mode.md` | MO-1~12 | Phase 1 + Phase 2 大半已上線（PR #18） |
+| `docs/proposal/monitor-mode-phase2-handoff.md` | MO-3/6/9/11 | 3 個 collector + LiveWall 全部上線 ✅ |
+| `docs/proposal/alerts-integration-handoff.md` | AI-1 | 設計需求說明，設計師已交 v2 ✅ |
+| `docs/proposal/alerts-integration-impl.md` | AI-1 | 完整實作交接，待另一 session 接手 |

--- a/.claude/memory/INCIDENTS.md
+++ b/.claude/memory/INCIDENTS.md
@@ -720,3 +720,63 @@ working tree 有跨分支 WIP / 未追蹤草稿時極度危險，改 `git add <�
 總 CPU 不增但視覺流暢。
 
 **PRINCIPLES**：視覺「順暢」可能是 effect 重綁副產物，修穩定性後要顯式設更新頻率。
+
+---
+
+## 2026-06-17 Monitor 卡片全空白 — RPC 名前端後端對不上
+
+**症狀**：Monitor Mode 上線後實測，戰情概覽顯示「26 平時」（壓力指數正常），但旁邊 vs+0 / vs+0、TWSE ticker 全 0、PLA 0 架次、3 張 CDC 卡顯示「等待 CDC 週報資料…」、CDC 截至 ISO 第 W0 週。
+
+**直覺診斷**：以為是 collector 沒跑 / Zeabur env 沒開。
+
+**實際根因**：跑 `SELECT count(*)` 查每張 realtime 表，**全部有資料**（pressure_index_now 1 / market_index_current 2 / pla_activity_daily 5 / public_health_weekly 25720）。問題在前端 loader 寫的 RPC 名跟後端對不上：
+- `get_market_index_now` ❌ 不存在
+- `get_pla_activity_latest` ❌ 不存在
+- `get_public_health_weekly` ❌ 不存在
+- `get_pressure_index_now` ✅ 存在（migration 207 那次有建）
+
+前端 loader 失敗時 `console.warn` + return 空殼，UI 照樣渲染 → 用戶看到「等待中」而不是錯誤。
+
+**怎麼修**：migration 210 補建 3 個薄 RPC（select + 簡單 transform），grant anon。實測：
+- TWSE 45,809.19 收盤 +412.20 (+0.91%)
+- PLA 0 架次 / 6 海軍艦 / 2026-06-15
+- CDC W23：流感 1.9萬 -41% / 登革熱 10 +150% / 腸病毒 378 +27%
+
+**Why 漏建**：寫 Monitor Phase 2 前端時直接從設計師 handoff doc 抄 RPC 名（doc 寫「沿用同樣命名規律」），假設後端會跟著做。實際只有 pressure 那支建好，其他 3 個變成「假設不存在」。
+
+**PRINCIPLES**：handoff doc 寫前端時，**ship 前一定要 `psql -c "SELECT proname FROM pg_proc WHERE proname LIKE 'get_xxx'"` 確認 RPC 真的存在**。loader fallback 空殼會讓問題藏到使用者實測時才暴露。
+
+---
+
+## 2026-06-17 YT @handle + `live_stream?channel=` 整套失敗（B1 救援）
+
+**症狀**：LiveWall 4 格全部「無法播放這部影片」。原以為頻道沒在直播 / UC ID 寫錯 / `@handle` 在 `channel=` 不認。
+
+**第一輪修法（無效）**：把 @handle 替成 UC channel ID（從 youtube.com 頁面 HTML 撈 `browseId`）。修了 5 家 (PTS/CTS/TVBS/TTV/CTV)。結果：仍然只有 PTS / CTV 能播。
+
+**真正根因（curl + 拆 embed page）**：
+```
+=== PTS === VIDEO_ID="quwqlazU-c8"   ✅
+=== CTV === VIDEO_ID="TCnaIE_SAtM"   ✅
+=== CTS === VIDEO_ID="live_stream"   ❌ 沒解析到
+=== TVBS=== VIDEO_ID="live_stream"   ❌
+=== TTV === VIDEO_ID="live_stream"   ❌
+```
+
+YouTube `embed/live_stream?channel=UCxxx` 要查頻道的「primary live event」設定。**多數新聞台沒設這個欄位**，即使有 24h 直播也找不到。是 YouTube 端的頻道後台問題，不是我們的 bug。
+
+**B1 方案救援**（用戶選定，三 repo 串通）：
+1. data-collectors 寫 `yt_live_video_resolver.py`（5 min cron）抓 14 家 `youtube.com/@handle/live` 解析當前 videoId
+2. gis-platform migration 209 建 `realtime.yt_live_current` (PK=handle) + `get_yt_live_videos()` RPC
+3. 前端 LiveWall 改用 `embed/<videoId>` 而非 `embed/live_stream?channel=`
+
+**第二輪 collector bug**：第一版 regex 抓「第一個 videoId」+「第一個 isLiveContent」。@FTV_News /live page 沒 24h 直播時會 redirect 到頻道頭推薦影片（一支三立的非直播 video）→ collector 報 video_id=`3lH66WWmUUs` 是 live，實際 `isLiveContent:false`。
+
+**第三輪正確判定**：改用 `ytInitialPlayerResponse` JSON block 取 `videoDetails.videoId + isLiveContent` + `microformat.playerMicroformatRenderer.liveBroadcastDetails.isLiveNow` + `playabilityStatus.status === 'OK'` 全部對得上才寫 video_id。結果 9/13 真的可播，4 家正確標 not live。
+
+**Why 一開始猜錯**：頻道頁 HTML 有非常多 video meta（推薦影片 / 相關影片），regex 抓「第一個」基本是亂猜。
+
+**PRINCIPLES**：
+- YouTube `embed/live_stream?channel=` **不可靠**，必須改用 `embed/<videoId>` + cron 解析（B1 模式）
+- 解析 YouTube page metadata 用 `ytInitialPlayerResponse` JSON 區塊，不要用獨立 regex 抓「第一個」
+- video_id 約 1-7 天 rotate（直播重啟），cron 間隔 5 min 安全

--- a/.claude/memory/PLAYBOOKS.md
+++ b/.claude/memory/PLAYBOOKS.md
@@ -854,3 +854,76 @@ types/index.ts → satelliteTypes.ts (colors/labels/regex) → satelliteSGP4.ts 
 - ❌ recompute 入 useCallback deps（effect 頻繁重綁 + throttle 殭屍 closure）
 - ❌ 直接走 CelesTrak 不測瀏覽器（部署後才發現 403 整天 0 顆）
 - ❌ 只看 country_operator 不靠名稱保底（FS-8A 找半天）
+
+---
+
+## 新增 realtime collector → Supabase 表 → 前端 5 處 SOP（2026-06-17）
+
+> 從零加一支新 realtime 管線（如 yt_live_video_resolver / pla / cdc / twse_market_index）的標準步驟。
+
+### data-collectors（5 處檔案，缺一即靜默失敗）
+
+```
+collectors/<name>.py              # 1. collector class（繼承 BaseCollector）
+collectors/registry.py            # 2. import + CollectorEntry tuple
+config.py                         # 3. _COLLECTOR_TOGGLES 加 (PREFIX, default_enabled, interval)
+storage/supabase_tables.py        # 4. 加表 schema (history/current/columns/upsert_key/strategy)
+storage/supabase_writer.py        # 5. _transform_<name> 方法 + TRANSFORMERS dict ⚠ 易忘第二步
+```
+
+### gis-platform（1 個 migration）
+
+```sql
+-- migrations/<NNN>_realtime_<name>.sql
+CREATE TABLE realtime.<name>_history (... UNIQUE(...));
+CREATE TABLE realtime.<name>_current (PK=key, UPSERT);
+ALTER TABLE ... ENABLE ROW LEVEL SECURITY;
+CREATE POLICY ... FOR SELECT TO anon USING (true);
+CREATE OR REPLACE FUNCTION public.get_<name>_xxx() RETURNS TABLE (...)
+  LANGUAGE sql STABLE AS $$ SELECT ... FROM realtime.<name>_current $$;
+GRANT EXECUTE ON FUNCTION public.get_<name>_xxx() TO anon, authenticated;
+```
+
+### mini-taiwan-pulse（前端）
+
+```
+src/data/<name>Loader.ts          # fetchXxx() 包 withLoading()，type 完整
+src/components/.../XxxComponent.tsx  # UI
+src/App.tsx 或對應 Panel           # 接線 + 30s polling
+```
+
+### Verification（ship 前必跑）
+
+```sh
+# 1. collector 離線跑一次
+cd data-collectors && SUPABASE_ENABLED=true <PREFIX>_ENABLED=true python3 -m collectors.<name>
+
+# 2. 確認資料進 Supabase（不是只 buffer）
+psql "$DATABASE_URL" -c "SELECT count(*) FROM realtime.<name>_current"
+# 應 > 0；若 = 0 → 通常漏 step 5（transformer 註冊到 TRANSFORMERS dict）
+
+# 3. 確認 RPC 真的存在
+psql "$DATABASE_URL" -c "SELECT proname FROM pg_proc p JOIN pg_namespace n ON p.pronamespace=n.oid
+  WHERE n.nspname='public' AND proname LIKE 'get_<name>%'"
+# 應有；若無 → migration 還沒 apply 或函數名拼錯
+
+# 4. RPC 真的回資料
+psql "$DATABASE_URL" -c "SELECT * FROM public.get_<name>_xxx() LIMIT 3"
+
+# 5. 前端 tsc + 開瀏覽器看 console 沒 [Xxx] failed warn
+```
+
+### Zeabur 部署
+
+```sh
+# 1. push 三 repo
+# 2. 啟用 collector env
+npx zeabur@latest variable create --id <data-collectors service id> -k "<PREFIX>_ENABLED=true" -y -i=false
+# 3. 等 ~1-2 min 部署 + interval_min 內首輪 run
+```
+
+### 反例（本 session 教訓）
+
+- ❌ 跳過 step 5 `supabase_writer.py` transformer 註冊 → collector log 顯示「✓ 已儲存」但 DB 0 rows，靜默失敗
+- ❌ Handoff doc 寫了 RPC 名沒實際建 → 前端跑時 fallback 空殼，使用者看到「等待中」
+- ❌ 用 regex 抓 page 上「第一個」videoId / 第一個 isLiveContent → 頻道頭推薦影片會混入

--- a/.claude/memory/PRINCIPLES.md
+++ b/.claude/memory/PRINCIPLES.md
@@ -484,3 +484,39 @@ const overlayParams = useMemo<Record<string, number>>(() => ({
 - **Claude review prompt 必明確「只看 diff、無問題單行 LGTM」**：未限制時會主動展開讀檔，跑 6-10 分鐘消耗訂閱
 - **首次 PR 修 workflow 檔本身會跳過 Claude review**：安全機制 "Action skipped due to workflow validation error"，不是 bug
 - **不開公司級嚴格 PR 流程**：個人 side project 不需要 2 approvers / 強制 staging，那是給多人團隊的；用 PR 主要為「強迫慢一拍 + 自動跑檢查 + 開放 AI review」
+
+## Handoff doc 必含三要素（2026-06-17）
+
+> 設計 / 規格 / 實作交接給「另一 session」或「另一個人」時，文件必須**自帶足夠資訊**讓接手方不用回問。
+
+**三個必含項目**：
+
+1. **後端 RPC signature 完整列出** — 不只「需要一支 get_xxx RPC」，要寫到 `RETURNS TABLE (...)` 級別 + 實作關鍵語句（CASE WHEN、UNION、台北時區處理）
+2. **前端元件 Props + 對應設計 jsx 行號** — 例「依設計 `AlertCards.jsx:36-127`、Props 為 `{ summary, expanded, onToggle, activeGroups, onPickGroup }`」。讓接手方視覺照搬不用看設計重新理解
+3. **設計檔再抓 URL** — 寫在文件最上方，另一 session 可以 `WebFetch` 拉 bundle，不用回原 session 拿
+
+**反例**：只寫「按這份設計實作 5 個元件」→ 接手方必須翻全設計檔猜 Props、猜 prop 流向，浪費 30 min。
+
+**Why**：本 session 寫 `alerts-integration-impl.md` 時這麼做了 → 用戶可以直接複製貼到新 session 開工。若漏了 RPC signature，新 session 一定回來問「RPC 該叫什麼名字 / 該回什麼欄位」。
+
+**How to apply**：寫 handoff doc 時 checklist：(a) 有 RPC signature? (b) 有元件 Props + 設計檔行號? (c) 有設計 URL? 三項缺一就補。
+
+## 跨 repo 新管線必過 5 處（2026-06-17）
+
+> 加一支新 realtime collector（如 yt_live_video_resolver / cdc / pla）時，**data-collectors repo 內有 5 個檔案要全動**，缺一資料寫不進 Supabase 或前端讀不到。
+
+**5 處 checklist**：
+
+1. `collectors/<name>.py` — collector 本身（BaseCollector 子類）
+2. `collectors/registry.py` — 加 `from .<name> import XCollector` + `CollectorEntry(...)` 進 `COLLECTOR_REGISTRY`
+3. `config.py` — `_COLLECTOR_TOGGLES` tuple 加 `('<PREFIX>', default_enabled, default_interval)`
+4. `storage/supabase_tables.py` — 加表對應（`history` / `current` / `columns` / `upsert_key` / `upsert_strategy`）
+5. `storage/supabase_writer.py` — 加 `_transform_<name>` 方法 **AND** 註冊到 `TRANSFORMERS` dict（容易忘第二步！）
+
+**對應 gis-platform**：1 個 migration 建 `realtime.<name>_history` + `realtime.<name>_current` + `public.get_<name>_xxx()` RPC + RLS + grant anon
+
+**對應前端**：`src/data/<name>Loader.ts` 用 `withLoading()` 包 supabase.rpc
+
+**Why**：本 session yt_live_video_resolver 第一次跑出現「Supabase 寫入 ✓ 但 DB 0 rows」— 因為漏了 `supabase_writer.py` 的 transformer 註冊（只加 supabase_tables 不夠）。collector run 不會報錯，靜默失敗。
+
+**How to apply**：開新 collector 時把這 5 處貼成 task checklist，逐項打勾才算完。Supabase pre-ship smoke：`psql -c "SELECT count(*) FROM realtime.<name>_current"` 第一輪跑完應該 > 0，否則回頭查 transformer。

--- a/.claude/memory/REFLECTIONS.md
+++ b/.claude/memory/REFLECTIONS.md
@@ -575,3 +575,25 @@ memory commit 意外帶上前 session 已 staged 的 5 個 screenshot rename + d
 6. **提案文件 `docs/proposal/` 是不錯的雙模式**：當下動手是 Phase 0，
    後續 Phase A/B/C/D 寫進提案文件，commit 上 master 讓記憶 + 未來 session
    都看得到完整藍圖。
+
+---
+
+## 2026-06-17 Monitor Phase 2 + YT B1 + 警訊 handoff 反省
+
+本 session 一氣呵成 3 個主題：Monitor Phase 2（10 元件 + 5 loader + 2 RPC）→ YT 直播 B1（三 repo 同步）→ 警訊整合 handoff（給下個 session 接）。3 PR merge 進 master。
+
+**做得好**：
+1. **設計師 jsx 程式碼直接 port**：Monitor 全套（PressureRing/TwseTicker/SituationOverview/SituationCards/LiveWall/TimelineDock/IndicatorPanel/MonitorPanel）幾乎照搬，**只把 CSS var 換成 ts const、mock data 換 supabase loader**，視覺幾乎 1:1。下次有設計交接照這個 SOP 走，不要重新設計。
+2. **跨 repo SOP 已寫進 PLAYBOOKS**：本 session 第一次完整跑 data-collectors + gis-platform + mini-taiwan-pulse 三 repo 同步部署，過程踩到的坑（transformer 漏註冊、RPC 名對不上、@handle 不認）全固化進 PRINCIPLES + INCIDENTS + PLAYBOOKS。
+3. **alerts handoff 寫成自帶 task list 的 impl doc**：另一 session 拿了 `docs/proposal/alerts-integration-impl.md` + 一段 prompt 就能開工。寫的時候用 PRINCIPLES「三要素」（RPC signature / 元件 Props / 設計 URL）逐項檢查。
+
+**該改進**：
+1. **Monitor 卡空白 bug 該在 ship 前就抓到**：我寫前端 loader 時假設後端 RPC 跟著 handoff doc 建好，但只 pressure 那支真的有。下次 ship 前一定要 `psql proname` 一條一條比對。
+2. **資料載入失敗 fallback 空殼會藏 bug**：rule 3 `withLoading` 失敗時 console.warn + return 空陣列是好設計（不 crash），但使用者看到「等待中」沒辦法區分「資料剛抓中」vs「RPC 根本不存在」。考慮 loader 內部加 `lastError` 欄位，UI 顯示「⚠ 資料來源異常」而不是「等待中」。
+3. **YT 直播 video_id 第一輪沒驗就 ship**：拿到 collector regex 結果就直接寫進前端 LIVE_CHANNELS，沒實際 verify 那些 video 真的是 24h 新聞直播。用戶看到民視在播政論節目當下覺得「不是直播」才回頭查。下次資料來自外部 API 時要在 sample data 階段就驗證內容。
+4. **跨 repo 工作不要拆多 session**：本來想說 collector 跟 migration 可以下次再做，結果用戶很自然地說「你幫我都動」。一氣呵成反而省下大量 context switch + 重新讀 schema 的成本。**Default：跨 repo 同主題 commits 盡量在一個 session 串完。**
+5. **`gh pr merge` 沒 `-y` flag**：被 `-y` 卡了一次。實際語法是 `--squash --delete-branch`，不需要 confirmation flag。記在 GLOSSARY 沒必要，但下次 PR 動作直接寫對。
+6. **設計師命名跟 layer 既有命名不一致要早一步做 mapping**：alerts handoff 寫到一半才意識到設計師用短形 `weather/flood/...`，現有 layer 用長形 `weatherAlerts/floodAlerts/...`。在 impl doc 加 mapping fn 段落解決。下次看到外部交付的 enum/key 命名先過一次「跟我們既有同義詞」對照表。
+7. **同類問題：群組色 vs 既有 LAYER_COLORS 也要對照**：設計師用 `#d946ef/#38bdf8/#2dd4bf/...` 給 alert 群組，跟 `disasterAlertTypes.ts` 既有 `#a855f7/#3b82f6/...` 不同。impl doc 已說明 mapping，但下次設計師若沒主動避開既有色票，第一輪 review 就要提醒。
+
+**memo 給下個 session**：alerts 整合執行時，記得先讀 `PRINCIPLES.md` 末 2 條 + `PLAYBOOKS.md` 末 1 條 + `INCIDENTS.md` 末 2 篇。三者構成本 session 的「不要再踩」清單。

--- a/.claude/memory/STATUS.md
+++ b/.claude/memory/STATUS.md
@@ -1,9 +1,82 @@
 # Status
 
-**最後更新**：2026-06-14（衛星 + 新聞 v2 雙線當日上線、本地完全同步 origin）
-**分支**：`master`（已 push `18429d3`）。本地剩 `feat/fire-rescue` + `medical/poi-layers` 保留（24 個已合 master 的舊 branch 全清）。
+**最後更新**：2026-06-17（Monitor Phase 2 + YT 直播 B1 一日上線、警訊整合 handoff 寫好待接手、本地與 origin/master 完全同步）
+**分支**：`master`（最新 commit `a4d6118`，全部已 push）。本地剩 `feat/fire-rescue` + `medical/poi-layers`，PR 分支 `feat/monitor-mode-phase2` + `docs/alerts-integration` merge 後自動刪除。
 
-## 2026-06-13 衛星 SPACE 圖層上線（PR #10，10 個 commit）
+## 2026-06-17 三 PR 合進 master（Monitor Phase 2 + YT B1 + 警訊 handoff）
+
+| PR | 主題 | merge commit |
+|---|---|---|
+| #18 | Monitor Mode Phase 2 — 戰情看板 + 新聞直播牆 | `4d005c1` |
+| #19 | 警訊整合 handoff（設計需求 + 實作交接）| `4412255` |
+| —  | CLAUDE.md 加 Karpathy 4 條前言（直 commit master）| `5d47257` |
+
+### Monitor Mode Phase 2（PR #18，共 10 元件 + 5 loader）
+
+新檔（`src/components/intel/monitor/`）：
+- `MonitorPanel.tsx` — 底部上拉容器，拖拉 ns-resize 30-92%、Wall mode 全螢幕、退出
+- `TimelineDock.tsx` — 全寬 24h 直方圖 + 拖拉 scrubber + 播放 / LIVE 切換
+- `IndicatorPanel.tsx` — 右 60% grid，組 6 個 widget
+- `PressureRing.tsx` — 270° gauge + TwseTicker + CompareLine + Sparkline + Widget/SectionLabel
+- `SituationOverview.tsx` — 環 + 雙比較 + KPI + ticker + 10 軌 signal 抽屜
+- `SituationCards.tsx` — PLA 卡 + 3 CDC 疾病卡（含 sparkline）
+- `LiveWall.tsx` — 4 格 YouTube + 14 家頻道下拉
+- 順手把右上 3D Altitude button 換成 Monitor toggle（`src/App.tsx`）
+
+`src/data/intelLoaders.ts` 加 5 loader：`fetchPressureIndex` / `fetchSignalsTimeline` / `fetchMarketIndex` / `fetchPlaActivity` / `fetchPublicHealthWeekly`。
+
+### YT 直播 B1 解析三 repo 串通（同日衍生）
+
+**動機**：LiveWall 跳「無法播放這部影片」。診斷後發現 YouTube `embed/live_stream?channel=UCxxx` 在多數新聞台找不到 primary live event。
+
+**B1 方案**（三 repo 同步）：
+- **data-collectors** `e7d2d80` — `collectors/yt_live_video_resolver.py` 5 min cron 抓 14 家 `@handle/live` page → 解析 `ytInitialPlayerResponse` JSON 拿當前 videoId（@handle 不能用 channel= 認）
+- **gis-platform** migration 209 — `realtime.yt_live_current` (PK=handle) + `realtime.yt_live_history` + `get_yt_live_videos()` RPC
+- **mini-taiwan-pulse** — LiveWall 改用 `embed/<videoId>` 而非 channel ID，加 fetchLiveVideos loader
+
+**13 家當下狀態**（移除中天）：9 家可播 / 2 家拿到 videoId 但非 24h 直播（年代 / 中央社）/ 2 家 @handle 待補（鏡新聞 / 非凡）。
+
+### Monitor 卡空白 hotfix（同日，migration 210）
+
+實測發現戰情卡 / TWSE / PLA / CDC 全空。根因：前端 loader 用了 3 個不存在的 RPC（migration 207 只建了 pressure 那支）。
+
+`gis-platform` migration 210 補建 3 個薄 RPC：
+- `get_market_index_now()` → 取 t00.tw 最新 + 漲跌算好
+- `get_pla_activity_latest()` → 最新 report_date
+- `get_public_health_weekly()` → 最新 ISO 週 3 疾病 sum + 4 週 sparkline + YoY
+
+實測：TWSE 45,809.19 +412.20 (+0.91%) / CDC W23 / PLA 0 架次 6 海軍艦。詳見 INCIDENTS 「Monitor 卡片全空白」。
+
+### Zeabur 部署
+
+- `gis-data-collectors` service 啟 `YT_LIVE_VIDEO_RESOLVER_ENABLED=true`，cron 5min
+- migration 209/210 已套用 Supabase（gis-platform）
+
+### 警訊整合 handoff（PR #19，純文件無程式）
+
+兩份 docs/proposal/ 文件：
+- `alerts-integration-handoff.md` — 設計需求（給設計師）
+- `alerts-integration-impl.md` — 實作交接（給另一 session）
+
+含 migration 211 三 RPC signature / 5 元件 Props + 對應設計 jsx 行號 / 12 顆 task list / verification walkthrough / 不在範圍清單。**設計師 v2 設計檔已收到（URL 在 doc 第一段）**，下個 session 拉設計 bundle + 看 impl doc 就能開工。
+
+### 下個 session 入口
+
+```
+1. 讀 docs/proposal/alerts-integration-impl.md
+2. WebFetch 設計 URL（doc 第一段）拉 design bundle
+3. tar -xzf 解壓 → 看 intel/alerts.jsx / AlertCards.jsx / AlertBoard.jsx / IntelFeed.jsx / TimelineDock.jsx
+4. 對 impl doc §10 verification checklist 跑 browser walkthrough
+5. 開 feat/alerts-integration 分支 + PR
+```
+
+預計 4-5 hr。
+
+---
+
+## 過往里程碑（保留索引）
+
+### 2026-06-13 衛星 SPACE 圖層上線（PR #10，10 個 commit）
 
 從零做到上線、含 Phase A-D 完整提案，分階段拆 commits：
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1596,6 +1596,23 @@ export default function App() {
                 <path d="M3 14h7v7H3z" />
               </svg>
               Monitor
+              <span
+                style={{
+                  marginLeft: 2,
+                  padding: "1px 5px",
+                  borderRadius: 3,
+                  background: monitorOpen
+                    ? "rgba(4,18,31,0.18)"
+                    : "rgba(255,152,0,0.18)",
+                  border: `1px solid ${monitorOpen ? "rgba(4,18,31,0.35)" : "rgba(255,152,0,0.55)"}`,
+                  fontSize: 8,
+                  fontWeight: 700,
+                  letterSpacing: 1,
+                  color: monitorOpen ? "#04121f" : "#ff9800",
+                }}
+              >
+                BETA
+              </span>
             </button>
           </div>
 

--- a/src/components/intel/IntelPanel.tsx
+++ b/src/components/intel/IntelPanel.tsx
@@ -1,11 +1,14 @@
 import { useEffect, useMemo, useRef, useState } from "react";
-import { COLORS, FONT_CJK } from "./intelTokens";
+import { COLORS, FONT_CJK, FONT_DATA, type AlertGroupShort } from "./intelTokens";
 import { IntelIcon, ICON } from "./IntelIcon";
 import { IntelHeader } from "./IntelHeader";
 import { IntelReplay } from "./IntelReplay";
 import { IntelFilters, type TimeRange } from "./IntelFilters";
 import { IntelSituation } from "./IntelSituation";
 import { IntelCard, type IntelCardEvent } from "./IntelCard";
+import { AlertSummaryBar } from "./alerts/AlertSummaryBar";
+import { FeedTabs, type FeedTab } from "./alerts/FeedTabs";
+import { AlertCard } from "./alerts/AlertCard";
 import {
   fetchSourceHealth,
   fetchNewsTrending,
@@ -17,6 +20,14 @@ import {
   fetchNewsEventsDayClusters,
   type NewsFilter,
 } from "../../data/newsEventsLoader";
+import {
+  fetchAlertSummary,
+  fetchActiveAlerts,
+  tallySummary,
+  EMPTY_TALLY,
+  type ActiveAlert,
+  type AlertSummary,
+} from "../../data/alertsLoader";
 import type { NewsCategory } from "../../data/newsEventTypes";
 import { timeStore } from "../../state/timeStore";
 
@@ -65,6 +76,16 @@ export function IntelPanel({
   const [selectedId, setSelectedId] = useState<number | null>(null);
   const [expandedId, setExpandedId] = useState<number | null>(null);
 
+  // ── alerts state ──
+  const [feedTab, setFeedTab] = useState<FeedTab>("all");
+  const [alertsExpanded, setAlertsExpanded] = useState(false);
+  const [pickedGroups, setPickedGroups] = useState<AlertGroupShort[]>([]);
+  const [severityMin, setSeverityMin] = useState<1 | 2 | 3 | 4>(1);
+  const [alertSummaryRows, setAlertSummaryRows] = useState<AlertSummary[]>([]);
+  const [activeAlerts, setActiveAlerts] = useState<ActiveAlert[]>([]);
+  const [alertSelectedId, setAlertSelectedId] = useState<string | null>(null);
+  const [alertExpandedId, setAlertExpandedId] = useState<string | null>(null);
+
   const [sourceHealth, setSourceHealth] = useState<SourceHealthSummary>(EMPTY_HEALTH);
   const [trending, setTrending] = useState<TrendingRow[]>([]);
   const [clusters, setClusters] = useState<
@@ -99,6 +120,37 @@ export function IntelPanel({
       window.clearInterval(id);
     };
   }, [open]);
+
+  // 30s polling alert summary
+  useEffect(() => {
+    if (!open) return;
+    let alive = true;
+    const tick = () => {
+      fetchAlertSummary().then((s) => alive && setAlertSummaryRows(s));
+    };
+    tick();
+    const id = window.setInterval(tick, 30_000);
+    return () => {
+      alive = false;
+      window.clearInterval(id);
+    };
+  }, [open]);
+
+  // active alerts list — re-fetch when tab / filter change
+  const groupKey = pickedGroups.length === 1 ? pickedGroups[0]! : null;
+  const needsAlertList = feedTab !== "news";
+  useEffect(() => {
+    if (!open || !needsAlertList) return;
+    let alive = true;
+    fetchActiveAlerts(groupKey, severityMin).then((rows) => {
+      if (!alive) return;
+      const filtered = pickedGroups.length > 1
+        ? rows.filter((r) => pickedGroups.includes(r.group))
+        : rows;
+      setActiveAlerts(filtered);
+    });
+    return () => { alive = false; };
+  }, [open, needsAlertList, groupKey, severityMin, pickedGroups]);
 
   // 跟著 timeStore 日期載資料 + filter 變動觸發重抓
   const fKey = `${filter.minRelevance}|${filter.eventsOnly ? 1 : 0}|${filter.minSeverity}`;
@@ -204,6 +256,11 @@ export function IntelPanel({
     return trendingKeySet.has(`${c}|${e.category ?? "other"}`);
   };
 
+  const alertTally = useMemo(
+    () => (alertSummaryRows.length ? tallySummary(alertSummaryRows) : EMPTY_TALLY),
+    [alertSummaryRows],
+  );
+
   if (!open) return null;
 
   const countdownSec = secsToNextCron(now);
@@ -237,6 +294,16 @@ export function IntelPanel({
   const toggleCat = (k: NewsCategory) =>
     setCats((c) => (c.includes(k) ? c.filter((x) => x !== k) : [...c, k]));
 
+  const onAlertSelect = (id: string) => setAlertSelectedId(id);
+  const onAlertToggle = (id: string) =>
+    setAlertExpandedId((p) => (p === id ? null : id));
+
+  const onPickGroup = (g: AlertGroupShort) => {
+    setFeedTab("alerts");
+    setAlertsExpanded(true);
+    setPickedGroups((cur) => (cur.includes(g) ? cur.filter((x) => x !== g) : [...cur, g]));
+  };
+
   return (
     <div
       style={{
@@ -268,30 +335,237 @@ export function IntelPanel({
         onClose={onClose}
       />
 
-      <IntelFilters
-        cats={cats}
-        onToggleCat={toggleCat}
-        onResetCats={() => setCats([])}
-        timeRange={timeRange}
-        onTimeRange={setTimeRange}
-        county={county}
-        onCounty={setCounty}
-        minRelevance={filter.minRelevance}
-        onMinRelevance={(v) => onFilterChange({ ...filter, minRelevance: v })}
-        eventsOnly={filter.eventsOnly}
-        onEventsOnly={(v) => onFilterChange({ ...filter, eventsOnly: v })}
-        minSeverity={filter.minSeverity}
-        onMinSeverity={(v) => onFilterChange({ ...filter, minSeverity: v })}
+      <AlertSummaryBar
+        tally={alertTally}
+        expanded={alertsExpanded}
+        onToggle={() => setAlertsExpanded((v) => !v)}
+        activeGroups={pickedGroups}
+        onPickGroup={onPickGroup}
       />
 
-      <IntelSituation
-        events={flatEvents}
-        countyByEventId={countyByEventId}
-        trending={trending}
+      <FeedTabs
+        tab={feedTab}
+        onTab={(t) => setFeedTab(t)}
+        newsCount={flatEvents.length}
+        alertCount={alertTally.total}
+        alertSevere={alertTally.severe}
       />
+
+      {feedTab === "news" ? (
+        <IntelFilters
+          cats={cats}
+          onToggleCat={toggleCat}
+          onResetCats={() => setCats([])}
+          timeRange={timeRange}
+          onTimeRange={setTimeRange}
+          county={county}
+          onCounty={setCounty}
+          minRelevance={filter.minRelevance}
+          onMinRelevance={(v) => onFilterChange({ ...filter, minRelevance: v })}
+          eventsOnly={filter.eventsOnly}
+          onEventsOnly={(v) => onFilterChange({ ...filter, eventsOnly: v })}
+          minSeverity={filter.minSeverity}
+          onMinSeverity={(v) => onFilterChange({ ...filter, minSeverity: v })}
+        />
+      ) : feedTab === "alerts" ? (
+        <div
+          style={{
+            display: "flex", alignItems: "center", gap: 5,
+            padding: "8px 14px 8px",
+            borderBottom: `1px solid ${COLORS.borderSoft}`,
+          }}
+        >
+          <span
+            style={{
+              fontFamily: FONT_DATA, fontSize: 9, letterSpacing: "1.5px",
+              color: COLORS.textFaint, marginRight: 4,
+            }}
+          >
+            SEVERITY ≥
+          </span>
+          {([1, 2, 3, 4] as const).map((lv) => {
+            const labels = ["留意", "警戒", "嚴重", "緊急"];
+            const active = severityMin === lv;
+            return (
+              <button
+                key={lv}
+                onClick={() => setSeverityMin(lv)}
+                style={{
+                  padding: "3px 9px", borderRadius: 4,
+                  background: active ? COLORS.accentFaint : "rgba(255,255,255,0.04)",
+                  border: `1px solid ${active ? COLORS.accentSoft : COLORS.borderMid}`,
+                  color: active ? COLORS.accent : COLORS.textMuted,
+                  fontFamily: FONT_CJK, fontSize: 10.5, cursor: "pointer",
+                }}
+              >
+                {labels[lv - 1]}
+              </button>
+            );
+          })}
+          {pickedGroups.length > 0 && (
+            <>
+              <div style={{ flex: 1 }} />
+              <button
+                onClick={() => setPickedGroups([])}
+                style={{
+                  padding: "3px 8px", borderRadius: 4,
+                  background: "rgba(255,255,255,0.04)",
+                  border: `1px solid ${COLORS.borderMid}`,
+                  color: COLORS.textMuted, fontFamily: FONT_CJK, fontSize: 10.5,
+                  cursor: "pointer",
+                }}
+              >
+                清除群組 ({pickedGroups.length})
+              </button>
+            </>
+          )}
+        </div>
+      ) : (
+        <div
+          style={{
+            display: "flex", alignItems: "center", gap: 5,
+            padding: "8px 14px 8px",
+            borderBottom: `1px solid ${COLORS.borderSoft}`,
+          }}
+        >
+          <span
+            style={{
+              fontFamily: FONT_DATA, fontSize: 9, letterSpacing: "1.5px",
+              color: COLORS.textFaint, marginRight: 4,
+            }}
+          >
+            RANGE
+          </span>
+          {(["1h", "6h", "24h"] as TimeRange[]).map((r) => {
+            const active = timeRange === r;
+            return (
+              <button
+                key={r}
+                onClick={() => setTimeRange(r)}
+                style={{
+                  padding: "3px 10px", borderRadius: 4,
+                  background: active ? COLORS.accentFaint : "rgba(255,255,255,0.04)",
+                  border: `1px solid ${active ? COLORS.accentSoft : COLORS.borderMid}`,
+                  color: active ? COLORS.accent : COLORS.textMuted,
+                  fontFamily: FONT_DATA, fontSize: 10.5, fontWeight: 700,
+                  cursor: "pointer",
+                }}
+              >
+                {r.toUpperCase()}
+              </button>
+            );
+          })}
+        </div>
+      )}
+
+      {feedTab === "news" && (
+        <IntelSituation
+          events={flatEvents}
+          countyByEventId={countyByEventId}
+          trending={trending}
+        />
+      )}
 
       <div className="mtp-scroll" style={{ flex: 1, overflowY: "auto", padding: "12px 14px 14px" }}>
-        {flatEvents.length === 0 ? (
+        {feedTab === "alerts" ? (
+          activeAlerts.length === 0 ? (
+            <div
+              style={{
+                display: "flex", flexDirection: "column",
+                alignItems: "center", justifyContent: "center",
+                height: "100%", gap: 8, textAlign: "center", padding: 24,
+              }}
+            >
+              <IntelIcon d={ICON.alert} size={28} color={COLORS.textGhost} />
+              <div style={{ fontFamily: FONT_CJK, fontSize: 12, color: COLORS.textMuted }}>
+                目前無符合條件的警報
+              </div>
+            </div>
+          ) : (
+            <div style={{ position: "relative", display: "flex", flexDirection: "column", gap: 10 }}>
+              <span
+                style={{
+                  position: "absolute", left: 12, top: 6, bottom: 6,
+                  width: 1.5,
+                  background: `linear-gradient(${COLORS.borderMid}, ${COLORS.borderSoft} 90%, transparent)`,
+                }}
+              />
+              {activeAlerts.map((a) => (
+                <AlertCard
+                  key={a.id}
+                  a={a}
+                  selected={a.id === alertSelectedId}
+                  expanded={a.id === alertExpandedId}
+                  onSelect={onAlertSelect}
+                  onToggle={onAlertToggle}
+                  nowTs={now}
+                />
+              ))}
+            </div>
+          )
+        ) : feedTab === "all" ? (
+          (() => {
+            const merged: Array<
+              { kind: "news"; ts: number; e: IntelCardEvent } |
+              { kind: "alert"; ts: number; a: ActiveAlert }
+            > = [
+              ...flatEvents.map((e) => ({ kind: "news" as const, ts: e.published_ts, e })),
+              ...activeAlerts.map((a) => ({ kind: "alert" as const, ts: a.sent_ts, a })),
+            ];
+            merged.sort((x, y) => y.ts - x.ts);
+            if (merged.length === 0) {
+              return (
+                <div
+                  style={{
+                    display: "flex", flexDirection: "column",
+                    alignItems: "center", justifyContent: "center",
+                    height: "100%", gap: 8, textAlign: "center", padding: 24,
+                  }}
+                >
+                  <IntelIcon d={ICON.radio} size={28} color={COLORS.textGhost} />
+                  <div style={{ fontFamily: FONT_CJK, fontSize: 12, color: COLORS.textMuted }}>
+                    目前無事件 / 警報
+                  </div>
+                </div>
+              );
+            }
+            return (
+              <div style={{ position: "relative", display: "flex", flexDirection: "column", gap: 10 }}>
+                <span
+                  style={{
+                    position: "absolute", left: 12, top: 6, bottom: 6,
+                    width: 1.5,
+                    background: `linear-gradient(${COLORS.borderMid}, ${COLORS.borderSoft} 90%, transparent)`,
+                  }}
+                />
+                {merged.map((row) =>
+                  row.kind === "news" ? (
+                    <IntelCard
+                      key={`n${row.e.id}`}
+                      e={row.e}
+                      selected={row.e.id === selectedId}
+                      expanded={row.e.id === expandedId}
+                      trending={isTrendingFor(row.e)}
+                      onSelect={onSelectCard}
+                      onToggle={onToggleExpand}
+                      nowTs={now}
+                    />
+                  ) : (
+                    <AlertCard
+                      key={`a${row.a.id}`}
+                      a={row.a}
+                      selected={row.a.id === alertSelectedId}
+                      expanded={row.a.id === alertExpandedId}
+                      onSelect={onAlertSelect}
+                      onToggle={onAlertToggle}
+                      nowTs={now}
+                    />
+                  ),
+                )}
+              </div>
+            );
+          })()
+        ) : flatEvents.length === 0 ? (
           <div
             style={{
               display: "flex",
@@ -359,6 +633,19 @@ export function IntelPanel({
         @keyframes intelRing {
           0%, 100% { opacity: 1; transform: scale(1); }
           50% { opacity: 0.4; transform: scale(0.78); }
+        }
+        @keyframes alertBreathe { 0%,100%{opacity:1} 50%{opacity:0.62} }
+        @keyframes alertPulse   { 0%,100%{opacity:1} 50%{opacity:0.45} }
+        @keyframes alertEdge {
+          0%,100% { box-shadow: 0 0 0 0 rgba(239,68,68,0); }
+          50%     { box-shadow: 0 0 16px 0 rgba(239,68,68,0.42); }
+        }
+        @keyframes drawerOpen {
+          from { opacity: 0; transform: translateY(-6px); }
+          to   { opacity: 1; transform: translateY(0); }
+        }
+        @media (prefers-reduced-motion: reduce) {
+          [style*="alertBreathe"],[style*="alertPulse"],[style*="alertEdge"] { animation: none !important; }
         }
       `}</style>
     </div>

--- a/src/components/intel/alerts/AlertBoard.tsx
+++ b/src/components/intel/alerts/AlertBoard.tsx
@@ -1,0 +1,455 @@
+import { useEffect, useState } from "react";
+import { IntelIcon } from "../IntelIcon";
+import {
+  COLORS, FONT_CJK, FONT_DATA, MICON,
+  ALERT_GROUPS_DEF, ALERT_GROUP_ORDER, alertSeverity, relTime,
+  type AlertGroupShort,
+} from "../intelTokens";
+import {
+  fetchActiveAlerts,
+  type AlertTally,
+  type ActiveAlert,
+} from "../../../data/alertsLoader";
+
+interface Props {
+  tally: AlertTally;
+  series: Record<AlertGroupShort, number[]>;
+  accent: string;
+  nowTs: number;
+}
+
+// ─── AlertTrend — 24h 全 group 加總 area-line ──────────────────
+function AlertTrend({
+  series, accent,
+}: { series: Record<AlertGroupShort, number[]>; accent: string }) {
+  const totals = Array.from({ length: 24 }, (_, h) =>
+    ALERT_GROUP_ORDER.reduce((sum, g) => sum + (series[g][h] ?? 0), 0),
+  );
+  const peak = Math.max(1, ...totals);
+  const W = 100;
+  const H = 28;
+
+  const points = totals
+    .map((v, i) => {
+      const x = (i / 23) * W;
+      const y = H - (v / peak) * H;
+      return `${x.toFixed(2)},${y.toFixed(2)}`;
+    })
+    .join(" ");
+  const area = `0,${H} ${points} ${W},${H}`;
+
+  return (
+    <div
+      style={{
+        padding: "8px 10px",
+        borderRadius: 7,
+        background: "rgba(255,255,255,0.025)",
+        border: `1px solid ${COLORS.borderMid}`,
+        marginBottom: 10,
+      }}
+    >
+      <div
+        style={{
+          display: "flex", alignItems: "baseline", gap: 8, marginBottom: 5,
+        }}
+      >
+        <span
+          style={{
+            fontFamily: FONT_DATA, fontSize: 9, letterSpacing: "1.5px",
+            color: COLORS.textFaint,
+          }}
+        >
+          24H TREND
+        </span>
+        <span style={{ flex: 1 }} />
+        <span
+          style={{
+            fontFamily: FONT_DATA, fontSize: 10,
+            color: COLORS.textMuted,
+          }}
+        >
+          Peak {peak}
+        </span>
+      </div>
+      <svg
+        width="100%"
+        height={H + 6}
+        viewBox={`0 0 ${W} ${H + 6}`}
+        preserveAspectRatio="none"
+        style={{ display: "block" }}
+      >
+        <polygon points={area} fill={`${accent}33`} />
+        <polyline
+          points={points}
+          fill="none"
+          stroke={accent}
+          strokeWidth={0.8}
+          vectorEffect="non-scaling-stroke"
+        />
+      </svg>
+    </div>
+  );
+}
+
+// ─── Sparkline (per-group) ──────────────────
+function Sparkline({ data, color }: { data: number[]; color: string }) {
+  const peak = Math.max(1, ...data);
+  const W = 100;
+  const H = 16;
+  const pts = data
+    .map((v, i) => {
+      const x = (i / 23) * W;
+      const y = H - (v / peak) * H;
+      return `${x.toFixed(2)},${y.toFixed(2)}`;
+    })
+    .join(" ");
+  return (
+    <svg
+      width="100%"
+      height={H}
+      viewBox={`0 0 ${W} ${H}`}
+      preserveAspectRatio="none"
+      style={{ display: "block", opacity: 0.85 }}
+    >
+      <polyline
+        points={pts}
+        fill="none"
+        stroke={color}
+        strokeWidth={0.8}
+        vectorEffect="non-scaling-stroke"
+      />
+    </svg>
+  );
+}
+
+// ─── GroupCard ───────────────────────────────
+function GroupCard({
+  group, count, severe, topTerm, spark, hot, onClick,
+}: {
+  group: AlertGroupShort;
+  count: number;
+  severe: number;
+  topTerm: string | null;
+  spark: number[];
+  hot: boolean;
+  onClick: () => void;
+}) {
+  const def = ALERT_GROUPS_DEF[group];
+  const dim = count === 0;
+  return (
+    <button
+      onClick={onClick}
+      disabled={dim}
+      style={{
+        textAlign: "left",
+        padding: "9px 10px",
+        borderRadius: 7,
+        background: dim
+          ? "rgba(255,255,255,0.015)"
+          : hot
+            ? `${def.color}10`
+            : "rgba(255,255,255,0.04)",
+        border: `1px solid ${hot ? `${def.color}55` : COLORS.borderMid}`,
+        opacity: dim ? 0.38 : 1,
+        cursor: dim ? "default" : "pointer",
+        display: "flex", flexDirection: "column", gap: 4,
+        animation: hot ? "alertEdge 2s ease-in-out infinite" : undefined,
+      }}
+    >
+      <div style={{ display: "flex", alignItems: "center", gap: 5 }}>
+        <IntelIcon d={MICON[def.iconKey]!} size={11} color={def.color} />
+        <span
+          style={{
+            fontFamily: FONT_CJK, fontSize: 11, fontWeight: 600,
+            color: COLORS.textDefault,
+          }}
+        >
+          {def.label}
+        </span>
+        <div style={{ flex: 1 }} />
+        <span
+          style={{
+            fontFamily: FONT_DATA, fontSize: 9, color: def.color,
+            letterSpacing: "0.5px",
+          }}
+        >
+          {def.en}
+        </span>
+      </div>
+      <div style={{ display: "flex", alignItems: "baseline", gap: 6 }}>
+        <span
+          style={{
+            fontFamily: FONT_DATA, fontSize: 22, fontWeight: 700,
+            color: hot ? def.color : COLORS.textStrong,
+            lineHeight: 1,
+          }}
+        >
+          {count}
+        </span>
+        {severe > 0 && (
+          <span
+            style={{
+              fontFamily: FONT_DATA, fontSize: 9.5, fontWeight: 700,
+              color: "#ef4444",
+            }}
+          >
+            ⚠ {severe} 嚴重
+          </span>
+        )}
+      </div>
+      <span
+        style={{
+          fontFamily: FONT_CJK, fontSize: 10, color: COLORS.textFaint,
+          height: 12, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap",
+        }}
+      >
+        {topTerm ?? "—"}
+      </span>
+      <Sparkline data={spark} color={def.color} />
+    </button>
+  );
+}
+
+// ─── AlertDrawer — 點開後展明細 ──────────────
+function AlertDrawer({
+  group, nowTs,
+}: { group: AlertGroupShort; nowTs: number }) {
+  const def = ALERT_GROUPS_DEF[group];
+  const [rows, setRows] = useState<ActiveAlert[] | null>(null);
+
+  useEffect(() => {
+    let alive = true;
+    fetchActiveAlerts(group, 1).then((data) => {
+      if (alive) setRows(data);
+    });
+    return () => { alive = false; };
+  }, [group]);
+
+  if (rows === null) {
+    return (
+      <div
+        style={{
+          padding: "10px 12px", fontFamily: FONT_CJK, fontSize: 11,
+          color: COLORS.textFaint,
+        }}
+      >
+        載入中…
+      </div>
+    );
+  }
+
+  if (rows.length === 0) {
+    return (
+      <div
+        style={{
+          padding: "10px 12px", fontFamily: FONT_CJK, fontSize: 11,
+          color: COLORS.textFaint,
+        }}
+      >
+        無 {def.label} 警報
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className="mtp-scroll"
+      style={{
+        maxHeight: 220, overflowY: "auto",
+        padding: "6px 10px 10px",
+        animation: "drawerOpen .25s ease-out",
+      }}
+    >
+      {rows.slice(0, 12).map((r) => {
+        const sev = alertSeverity(r.severity);
+        return (
+          <div
+            key={r.id}
+            style={{
+              display: "flex", alignItems: "center", gap: 7,
+              padding: "5px 0",
+              borderBottom: `1px solid ${COLORS.borderSoft}`,
+            }}
+          >
+            <span
+              style={{
+                width: 6, height: 6, borderRadius: "50%",
+                background: sev.color, flexShrink: 0,
+                boxShadow: r.severity >= 3 ? `0 0 5px ${sev.color}` : "none",
+              }}
+            />
+            <span
+              style={{
+                fontFamily: FONT_CJK, fontSize: 11,
+                color: COLORS.textDefault, flex: 1,
+                overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap",
+              }}
+              title={r.headline}
+            >
+              <span style={{ color: COLORS.textMuted, fontSize: 10 }}>{r.county} · </span>
+              {r.headline || r.term}
+            </span>
+            <span style={{ fontFamily: FONT_DATA, fontSize: 9.5, color: COLORS.textFaint }}>
+              {relTime(r.sent_ts, nowTs)}
+            </span>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+// ─── AlertBoard 主元件 ───────────────────────
+export function AlertBoard({ tally, series, accent, nowTs }: Props) {
+  const [openGroup, setOpenGroup] = useState<AlertGroupShort | null>(null);
+
+  // 0-state — 單條綠訊息
+  if (tally.total === 0) {
+    return (
+      <div
+        style={{
+          padding: "9px 12px",
+          borderRadius: 7,
+          background: "rgba(34,197,94,0.06)",
+          border: `1px solid ${COLORS.statusLiveBorder}`,
+          display: "flex", alignItems: "center", gap: 7,
+          marginBottom: 12,
+        }}
+      >
+        <IntelIcon d={MICON.check!} size={12} color={COLORS.statusLive} />
+        <span
+          style={{
+            fontFamily: FONT_CJK, fontSize: 11.5, color: COLORS.statusLive, fontWeight: 600,
+          }}
+        >
+          目前全國無 active 警報
+        </span>
+        <div style={{ flex: 1 }} />
+        <span
+          style={{
+            fontFamily: FONT_DATA, fontSize: 9, letterSpacing: "1.5px",
+            color: COLORS.textFaint,
+          }}
+        >
+          ALL CLEAR
+        </span>
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ marginBottom: 12 }}>
+      {/* section label */}
+      <div
+        style={{
+          display: "flex", alignItems: "center", gap: 8,
+          padding: "0 2px 6px",
+        }}
+      >
+        <IntelIcon d={MICON.warn!} size={12} color="#ef4444" />
+        <span
+          style={{
+            fontFamily: FONT_CJK, fontSize: 11, fontWeight: 700,
+            color: COLORS.textStrong, letterSpacing: "0.5px",
+          }}
+        >
+          警訊整合
+        </span>
+        <span
+          style={{
+            fontFamily: FONT_DATA, fontSize: 9, letterSpacing: "1.5px",
+            color: COLORS.textDim,
+          }}
+        >
+          NCDR + CWA
+        </span>
+        <div style={{ flex: 1 }} />
+        <span style={{ fontFamily: FONT_DATA, fontSize: 10, color: COLORS.textMuted }}>
+          {tally.total} 則
+        </span>
+        {tally.severe > 0 && (
+          <span
+            style={{
+              padding: "1px 6px", borderRadius: 4,
+              background: "rgba(239,68,68,0.18)",
+              border: "1px solid rgba(239,68,68,0.45)",
+              fontFamily: FONT_DATA, fontSize: 9, fontWeight: 700,
+              color: "#ef4444",
+              animation: "alertBreathe 2s ease-in-out infinite",
+            }}
+          >
+            {tally.severe} 嚴重
+          </span>
+        )}
+      </div>
+
+      <AlertTrend series={series} accent={accent} />
+
+      <div
+        style={{
+          display: "grid", gridTemplateColumns: "repeat(3, 1fr)", gap: 6,
+        }}
+      >
+        {ALERT_GROUP_ORDER.map((g) => {
+          const s = tally.byGroup.get(g);
+          return (
+            <GroupCard
+              key={g}
+              group={g}
+              count={s?.count ?? 0}
+              severe={s?.severe ?? 0}
+              topTerm={s?.top_term ?? null}
+              spark={series[g] ?? Array.from({ length: 24 }, () => 0)}
+              hot={(s?.severe ?? 0) > 0}
+              onClick={() => setOpenGroup((p) => (p === g ? null : g))}
+            />
+          );
+        })}
+      </div>
+
+      {openGroup && (
+        <div
+          style={{
+            marginTop: 8,
+            borderRadius: 7,
+            background: "rgba(0,0,0,0.32)",
+            border: `1px solid ${COLORS.borderMid}`,
+          }}
+        >
+          <div
+            style={{
+              display: "flex", alignItems: "center", gap: 6,
+              padding: "7px 10px",
+              borderBottom: `1px solid ${COLORS.borderSoft}`,
+            }}
+          >
+            <IntelIcon
+              d={MICON[ALERT_GROUPS_DEF[openGroup].iconKey]!}
+              size={11}
+              color={ALERT_GROUPS_DEF[openGroup].color}
+            />
+            <span
+              style={{
+                fontFamily: FONT_CJK, fontSize: 11.5, fontWeight: 700,
+                color: COLORS.textStrong,
+              }}
+            >
+              {ALERT_GROUPS_DEF[openGroup].label}明細
+            </span>
+            <div style={{ flex: 1 }} />
+            <button
+              onClick={() => setOpenGroup(null)}
+              style={{
+                background: "none", border: "none", cursor: "pointer",
+                color: COLORS.textMuted, padding: 2,
+              }}
+            >
+              <IntelIcon d={MICON.chevUp!} size={11} />
+            </button>
+          </div>
+          <AlertDrawer group={openGroup} nowTs={nowTs} />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/intel/alerts/AlertCard.tsx
+++ b/src/components/intel/alerts/AlertCard.tsx
@@ -1,0 +1,228 @@
+import { useEffect, useState } from "react";
+import { IntelIcon } from "../IntelIcon";
+import {
+  COLORS, FONT_CJK, FONT_DATA, MICON,
+  ALERT_GROUPS_DEF, alertSeverity, fmtExpiry, relTime, clockTime,
+} from "../intelTokens";
+import type { ActiveAlert } from "../../../data/alertsLoader";
+
+interface Props {
+  a: ActiveAlert;
+  selected: boolean;
+  expanded: boolean;
+  onSelect: (id: string) => void;
+  onToggle: (id: string) => void;
+  nowTs: number;
+}
+
+export function AlertCard({ a, selected, expanded, onSelect, onToggle, nowTs }: Props) {
+  const def = ALERT_GROUPS_DEF[a.group];
+  const sev = alertSeverity(a.severity);
+
+  // 倒數即時刷新（僅在 expanded 或 severity>=3 時 1s tick）
+  const [tick, setTick] = useState(nowTs);
+  useEffect(() => {
+    if (!expanded && a.severity < 3) return;
+    const id = window.setInterval(() => setTick(Math.floor(Date.now() / 1000)), 1000);
+    return () => window.clearInterval(id);
+  }, [expanded, a.severity]);
+
+  const effNow = expanded || a.severity >= 3 ? tick : nowTs;
+  const expiresInSec = a.expires_ts - effNow;
+  const expired = expiresInSec <= 0;
+
+  const onCardClick = () => {
+    onSelect(a.id);
+    onToggle(a.id);
+  };
+
+  const stop = (e: React.MouseEvent) => e.stopPropagation();
+
+  return (
+    <div style={{ position: "relative", paddingLeft: 26 }}>
+      {/* spine dot */}
+      <span
+        style={{
+          position: "absolute",
+          left: 7, top: 14,
+          width: 11, height: 11,
+          borderRadius: "50%",
+          background: sev.color,
+          border: "2px solid #0a0a14",
+          zIndex: 1,
+          boxShadow: selected ? `0 0 0 3px ${sev.color}55` : "none",
+          animation: sev.anim ?? undefined,
+        }}
+      />
+      <div
+        onClick={onCardClick}
+        style={{
+          cursor: "pointer",
+          padding: "10px 12px",
+          borderRadius: 7,
+          background: selected ? "rgba(100,170,255,0.06)" : "rgba(255,255,255,0.025)",
+          border: `1px solid ${selected ? COLORS.borderAccent : COLORS.borderMid}`,
+          animation: a.severity >= 3 ? "alertEdge 2s ease-in-out infinite" : undefined,
+        }}
+      >
+        {/* chip row */}
+        <div style={{ display: "flex", alignItems: "center", gap: 6, flexWrap: "wrap", marginBottom: 6 }}>
+          <span
+            style={{
+              display: "inline-flex", alignItems: "center", gap: 4,
+              padding: "1px 7px", borderRadius: 4,
+              background: `${def.color}22`,
+              border: `1px solid ${def.color}55`,
+              fontFamily: FONT_DATA, fontSize: 9.5, fontWeight: 700,
+              color: def.color, letterSpacing: "0.5px",
+            }}
+          >
+            <IntelIcon d={MICON[def.iconKey]!} size={10} color={def.color} />
+            {def.label}
+          </span>
+          <span
+            style={{
+              padding: "1px 7px", borderRadius: 4,
+              background: `${sev.color}22`,
+              border: `1px solid ${sev.color}55`,
+              fontFamily: FONT_DATA, fontSize: 9.5, fontWeight: 700,
+              color: sev.color, letterSpacing: "0.5px",
+              animation: sev.anim ?? undefined,
+            }}
+          >
+            {sev.label}
+          </span>
+          <span
+            style={{
+              fontFamily: FONT_DATA, fontSize: 9.5,
+              color: COLORS.textFaint,
+            }}
+          >
+            {a.term}
+          </span>
+          <div style={{ flex: 1 }} />
+          <span
+            style={{
+              fontFamily: FONT_DATA, fontSize: 9.5,
+              color: expired ? COLORS.textFaint : COLORS.textMuted,
+            }}
+          >
+            {expired ? "已過期" : fmtExpiry(a.expires_ts, effNow)}
+          </span>
+        </div>
+
+        {/* headline */}
+        <div
+          style={{
+            fontFamily: FONT_CJK, fontSize: 13, fontWeight: 600,
+            color: COLORS.textStrong, lineHeight: 1.45, marginBottom: 4,
+          }}
+        >
+          {a.headline || a.term}
+        </div>
+
+        {/* location + time */}
+        <div style={{ display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap" }}>
+          <span style={{ display: "inline-flex", alignItems: "center", gap: 3 }}>
+            <IntelIcon d={MICON.pin!} size={10} color={COLORS.textMuted} />
+            <span style={{ fontFamily: FONT_CJK, fontSize: 11, color: COLORS.textMuted }}>
+              {a.county}
+              {a.area_count > 1 && (
+                <span style={{ color: COLORS.textFaint }}> · {a.area_count} 區</span>
+              )}
+            </span>
+          </span>
+          <span style={{ display: "inline-flex", alignItems: "center", gap: 3 }}>
+            <IntelIcon d={MICON.clock!} size={10} color={COLORS.textMuted} />
+            <span style={{ fontFamily: FONT_DATA, fontSize: 10.5, color: COLORS.textMuted }}>
+              {relTime(a.sent_ts, effNow)}
+            </span>
+          </span>
+        </div>
+
+        {/* expanded */}
+        {expanded && (
+          <div
+            onClick={stop}
+            style={{
+              marginTop: 9, paddingTop: 9,
+              borderTop: `1px solid ${COLORS.borderSoft}`,
+              animation: "drawerOpen .25s ease-out",
+            }}
+          >
+            {a.description && (
+              <div
+                style={{
+                  fontFamily: FONT_CJK, fontSize: 11.5,
+                  color: COLORS.textDefault, lineHeight: 1.55,
+                  marginBottom: 8,
+                }}
+              >
+                {a.description}
+              </div>
+            )}
+            {a.instruction && (
+              <div
+                style={{
+                  padding: "7px 9px",
+                  borderRadius: 5,
+                  background: `${def.color}10`,
+                  border: `1px solid ${def.color}33`,
+                  marginBottom: 8,
+                }}
+              >
+                <div
+                  style={{
+                    fontFamily: FONT_DATA, fontSize: 9, fontWeight: 700,
+                    color: def.color, letterSpacing: "1px", marginBottom: 3,
+                  }}
+                >
+                  處置指引
+                </div>
+                <div
+                  style={{
+                    fontFamily: FONT_CJK, fontSize: 11.5,
+                    color: COLORS.textDefault, lineHeight: 1.55,
+                  }}
+                >
+                  {a.instruction}
+                </div>
+              </div>
+            )}
+
+            {/* meta grid */}
+            <div
+              style={{
+                display: "grid", gridTemplateColumns: "auto 1fr", gap: "4px 10px",
+                fontFamily: FONT_DATA, fontSize: 10,
+              }}
+            >
+              <span style={{ color: COLORS.textFaint }}>發佈</span>
+              <span style={{ color: COLORS.textMuted }}>{clockTime(a.sent_ts)}</span>
+              <span style={{ color: COLORS.textFaint }}>失效</span>
+              <span style={{ color: COLORS.textMuted }}>{clockTime(a.expires_ts)}</span>
+              {a.magnitude != null && (
+                <>
+                  <span style={{ color: COLORS.textFaint }}>規模</span>
+                  <span style={{ color: COLORS.textStrong, fontWeight: 700 }}>M {a.magnitude}</span>
+                </>
+              )}
+              {a.depth_km != null && (
+                <>
+                  <span style={{ color: COLORS.textFaint }}>深度</span>
+                  <span style={{ color: COLORS.textMuted }}>{a.depth_km} km</span>
+                </>
+              )}
+              {a.area_desc && a.area_desc !== a.county && (
+                <>
+                  <span style={{ color: COLORS.textFaint }}>範圍</span>
+                  <span style={{ color: COLORS.textMuted, lineHeight: 1.5 }}>{a.area_desc}</span>
+                </>
+              )}
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/intel/alerts/AlertSummaryBar.tsx
+++ b/src/components/intel/alerts/AlertSummaryBar.tsx
@@ -1,0 +1,176 @@
+import { IntelIcon } from "../IntelIcon";
+import {
+  COLORS, FONT_CJK, FONT_DATA, MICON,
+  ALERT_GROUPS_DEF, ALERT_GROUP_ORDER,
+  type AlertGroupShort,
+} from "../intelTokens";
+import type { AlertTally } from "../../../data/alertsLoader";
+
+interface Props {
+  tally: AlertTally;
+  expanded: boolean;
+  onToggle: () => void;
+  activeGroups: AlertGroupShort[];
+  onPickGroup: (g: AlertGroupShort) => void;
+}
+
+export function AlertSummaryBar({
+  tally, expanded, onToggle, activeGroups, onPickGroup,
+}: Props) {
+  const { total, severe, byGroup } = tally;
+
+  // 0-state — 極簡單條
+  if (total === 0) {
+    return (
+      <div
+        style={{
+          flexShrink: 0,
+          display: "flex", alignItems: "center", gap: 6,
+          padding: "6px 14px",
+          fontFamily: FONT_CJK, fontSize: 11,
+          color: COLORS.textFaint,
+          borderBottom: `1px solid ${COLORS.borderSoft}`,
+        }}
+      >
+        <IntelIcon d={MICON.check!} size={12} color={COLORS.statusLive} />
+        <span>目前全國無 active 警報</span>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      style={{
+        flexShrink: 0,
+        borderBottom: `1px solid ${COLORS.panelBorder}`,
+        background: severe > 0 ? "rgba(239,68,68,0.04)" : "transparent",
+      }}
+    >
+      <button
+        onClick={onToggle}
+        style={{
+          width: "100%",
+          display: "flex", alignItems: "center", gap: 10,
+          padding: "9px 14px",
+          background: "transparent",
+          border: "none",
+          color: COLORS.textDefault,
+          cursor: "pointer",
+          textAlign: "left",
+        }}
+      >
+        <IntelIcon
+          d={MICON.warn!}
+          size={14}
+          color={severe > 0 ? "#ef4444" : COLORS.statusWarn}
+        />
+        <span style={{ fontFamily: FONT_CJK, fontSize: 12.5, fontWeight: 700, color: COLORS.textStrong }}>
+          {total} 則警報
+        </span>
+        {severe > 0 && (
+          <span
+            style={{
+              display: "inline-flex", alignItems: "center", gap: 4,
+              padding: "1px 7px", borderRadius: 4,
+              background: "rgba(239,68,68,0.18)",
+              border: "1px solid rgba(239,68,68,0.45)",
+              fontFamily: FONT_DATA, fontSize: 9.5, fontWeight: 700,
+              color: "#ef4444",
+              animation: "alertBreathe 2s ease-in-out infinite",
+            }}
+          >
+            含 {severe} 則嚴重
+          </span>
+        )}
+        {!expanded && (
+          <div style={{ display: "inline-flex", gap: 4, marginLeft: 6 }}>
+            {ALERT_GROUP_ORDER.map((g) => {
+              const s = byGroup.get(g);
+              if (!s || s.count === 0) return null;
+              const def = ALERT_GROUPS_DEF[g];
+              const hot = s.severe > 0;
+              return (
+                <span
+                  key={g}
+                  title={`${def.label} ${s.count}`}
+                  style={{
+                    width: 7, height: 7, borderRadius: "50%",
+                    background: def.color,
+                    boxShadow: hot ? `0 0 6px ${def.color}` : "none",
+                    opacity: hot ? 1 : 0.78,
+                  }}
+                />
+              );
+            })}
+          </div>
+        )}
+        <div style={{ flex: 1 }} />
+        <IntelIcon
+          d={(expanded ? MICON.chevUp : MICON.chevDown)!}
+          size={12}
+          color={COLORS.textMuted}
+        />
+      </button>
+
+      {expanded && (
+        <div
+          style={{
+            display: "grid",
+            gridTemplateColumns: "repeat(3, 1fr)",
+            gap: 6,
+            padding: "2px 12px 11px",
+          }}
+        >
+          {ALERT_GROUP_ORDER.map((g) => {
+            const s = byGroup.get(g);
+            const def = ALERT_GROUPS_DEF[g];
+            const cnt = s?.count ?? 0;
+            const sev = s?.severe ?? 0;
+            const active = activeGroups.includes(g);
+            const dim = cnt === 0;
+            return (
+              <button
+                key={g}
+                onClick={() => onPickGroup(g)}
+                disabled={dim}
+                style={{
+                  display: "flex", alignItems: "center", gap: 6,
+                  padding: "6px 8px",
+                  borderRadius: 6,
+                  background: active
+                    ? "rgba(100,170,255,0.14)"
+                    : dim
+                      ? "rgba(255,255,255,0.02)"
+                      : "rgba(255,255,255,0.05)",
+                  border: `1px solid ${active ? COLORS.borderAccent : COLORS.borderMid}`,
+                  cursor: dim ? "default" : "pointer",
+                  opacity: dim ? 0.38 : 1,
+                  animation: sev > 0 ? "alertBreathe 3s ease-in-out infinite" : undefined,
+                }}
+              >
+                <IntelIcon d={MICON[def.iconKey]!} size={12} color={def.color} />
+                <span
+                  style={{
+                    fontFamily: FONT_CJK, fontSize: 11, fontWeight: 600,
+                    color: COLORS.textDefault, whiteSpace: "nowrap",
+                  }}
+                >
+                  {def.label}
+                </span>
+                <div style={{ flex: 1 }} />
+                <span
+                  style={{
+                    fontFamily: FONT_DATA, fontSize: 11, fontWeight: 700,
+                    color: sev > 0 ? "#ef4444" : COLORS.textStrong,
+                  }}
+                >
+                  {cnt}
+                </span>
+              </button>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/intel/alerts/AlertsTrack.tsx
+++ b/src/components/intel/alerts/AlertsTrack.tsx
@@ -1,0 +1,168 @@
+import { useMemo, useRef, useState } from "react";
+import {
+  COLORS, FONT_DATA,
+  ALERT_GROUPS_DEF, ALERT_GROUP_ORDER,
+  type AlertGroupShort,
+} from "../intelTokens";
+
+interface Props {
+  series: Record<AlertGroupShort, number[]>;
+  /** 0-1 — 當下時間在 24h 中的相對位置 */
+  nowFrac: number;
+  /** 0-1 — 播放指針位置 */
+  playbackFrac: number;
+  isLive: boolean;
+  /** frac 0-1 對應 24h 位置 */
+  onScrubFrac: (frac: number) => void;
+}
+
+const TRACK_H = 30;
+
+export function AlertsTrack({
+  series, nowFrac, playbackFrac, isLive, onScrubFrac,
+}: Props) {
+  const areaRef = useRef<HTMLDivElement>(null);
+  const [hoverH, setHoverH] = useState<number | null>(null);
+  const draggingRef = useRef(false);
+
+  const fracFromClientX = (clientX: number): number => {
+    const el = areaRef.current;
+    if (!el) return 0;
+    const r = el.getBoundingClientRect();
+    return Math.max(0, Math.min(1, (clientX - r.left) / r.width));
+  };
+
+  const buckets = useMemo(() => {
+    const out: { h: number; total: number; parts: Record<AlertGroupShort, number> }[] = [];
+    for (let h = 0; h < 24; h++) {
+      const parts = {} as Record<AlertGroupShort, number>;
+      let total = 0;
+      for (const g of ALERT_GROUP_ORDER) {
+        const v = series[g]?.[h] ?? 0;
+        parts[g] = v;
+        total += v;
+      }
+      out.push({ h, total, parts });
+    }
+    return out;
+  }, [series]);
+
+  const peak = Math.max(1, ...buckets.map((b) => b.total));
+
+  return (
+    <div
+      style={{
+        padding: "4px 14px 6px",
+        borderTop: `1px solid ${COLORS.borderSoft}`,
+      }}
+    >
+      <div
+        style={{
+          display: "flex", alignItems: "center", gap: 8, marginBottom: 3,
+        }}
+      >
+        <span
+          style={{
+            fontFamily: FONT_DATA, fontSize: 8.5, letterSpacing: "1.8px",
+            color: COLORS.textFaint,
+          }}
+        >
+          ALERTS 24H
+        </span>
+        <div style={{ flex: 1 }} />
+        {hoverH != null && buckets[hoverH] && (
+          <span style={{ fontFamily: FONT_DATA, fontSize: 9.5, color: COLORS.textMuted }}>
+            {String(hoverH).padStart(2, "0")}:00 · {buckets[hoverH].total} 則
+          </span>
+        )}
+      </div>
+
+      <div
+        ref={areaRef}
+        onMouseDown={(e) => {
+          draggingRef.current = true;
+          onScrubFrac(fracFromClientX(e.clientX));
+        }}
+        onMouseMove={(e) => {
+          const f = fracFromClientX(e.clientX);
+          setHoverH(Math.min(23, Math.floor(f * 24)));
+          if (draggingRef.current) onScrubFrac(f);
+        }}
+        onMouseUp={() => { draggingRef.current = false; }}
+        onMouseLeave={() => {
+          setHoverH(null);
+          draggingRef.current = false;
+        }}
+        style={{
+          position: "relative",
+          height: TRACK_H,
+          cursor: "pointer",
+          userSelect: "none",
+        }}
+      >
+        {/* future cover */}
+        <span
+          style={{
+            position: "absolute", top: 0, bottom: 0,
+            left: `${nowFrac * 100}%`, right: 0,
+            background: "rgba(0,0,0,0.32)",
+            borderLeft: "1px dashed rgba(255,255,255,0.12)",
+          }}
+        />
+
+        <div style={{ position: "absolute", inset: 0, display: "flex", alignItems: "flex-end", gap: 2 }}>
+          {buckets.map((b) => {
+            const hPct = (b.total / peak) * 100;
+            const isFuture = b.h > Math.floor(nowFrac * 24);
+            const isHover = hoverH === b.h;
+            return (
+              <div
+                key={b.h}
+                style={{
+                  flex: 1, height: "100%",
+                  display: "flex", flexDirection: "column", justifyContent: "flex-end",
+                  opacity: isFuture ? 0.25 : 1,
+                }}
+              >
+                <div
+                  style={{
+                    display: "flex", flexDirection: "column-reverse",
+                    height: `${hPct}%`, minHeight: b.total ? 2 : 0,
+                    borderRadius: 1.5, overflow: "hidden",
+                    outline: isHover ? "1px solid rgba(255,255,255,0.35)" : "none",
+                  }}
+                >
+                  {ALERT_GROUP_ORDER.map((g) => {
+                    const v = b.parts[g];
+                    if (!v) return null;
+                    return (
+                      <span
+                        key={g}
+                        style={{
+                          height: `${(v / b.total) * 100}%`,
+                          background: ALERT_GROUPS_DEF[g].color,
+                          opacity: isHover ? 1 : 0.82,
+                        }}
+                      />
+                    );
+                  })}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+
+        {/* playhead */}
+        <span
+          style={{
+            position: "absolute", top: -2, bottom: -2,
+            left: `${playbackFrac * 100}%`, width: 2, marginLeft: -1,
+            background: isLive ? COLORS.statusLive : COLORS.accent,
+            boxShadow: `0 0 6px ${isLive ? COLORS.statusLive : COLORS.accent}`,
+            pointerEvents: "none", zIndex: 3,
+          }}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/components/intel/alerts/FeedTabs.tsx
+++ b/src/components/intel/alerts/FeedTabs.tsx
@@ -1,0 +1,74 @@
+import { COLORS, FONT_CJK, FONT_DATA } from "../intelTokens";
+
+export type FeedTab = "all" | "news" | "alerts";
+
+interface Props {
+  tab: FeedTab;
+  onTab: (t: FeedTab) => void;
+  newsCount: number;
+  alertCount: number;
+  alertSevere: number;
+}
+
+const TABS: { key: FeedTab; label: string }[] = [
+  { key: "all",    label: "全部" },
+  { key: "news",   label: "新聞" },
+  { key: "alerts", label: "警報" },
+];
+
+export function FeedTabs({ tab, onTab, newsCount, alertCount, alertSevere }: Props) {
+  return (
+    <div
+      style={{
+        flexShrink: 0,
+        display: "flex", gap: 4,
+        padding: "8px 14px 6px",
+        borderBottom: `1px solid ${COLORS.borderSoft}`,
+      }}
+    >
+      {TABS.map((t) => {
+        const active = tab === t.key;
+        const isAlerts = t.key === "alerts";
+        const hot = isAlerts && alertSevere > 0;
+        const count =
+          t.key === "news" ? newsCount
+            : t.key === "alerts" ? alertCount
+              : newsCount + alertCount;
+        return (
+          <button
+            key={t.key}
+            onClick={() => onTab(t.key)}
+            style={{
+              flex: 1,
+              display: "flex", alignItems: "center", justifyContent: "center", gap: 5,
+              padding: "5px 8px",
+              borderRadius: 5,
+              cursor: "pointer",
+              background: active
+                ? (hot ? "rgba(239,68,68,0.16)" : COLORS.accentFaint)
+                : "rgba(255,255,255,0.04)",
+              border: `1px solid ${active
+                ? (hot ? "rgba(239,68,68,0.55)" : COLORS.accentSoft)
+                : COLORS.borderMid}`,
+              color: active
+                ? (hot ? "#ef4444" : COLORS.accent)
+                : COLORS.textMuted,
+              fontFamily: FONT_CJK, fontSize: 11.5, fontWeight: 600,
+            }}
+          >
+            {t.label}
+            <span
+              style={{
+                fontFamily: FONT_DATA, fontSize: 10, fontWeight: 700,
+                color: hot && active ? "#ef4444" : "inherit",
+                opacity: 0.9,
+              }}
+            >
+              {count}
+            </span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/intel/intelTokens.ts
+++ b/src/components/intel/intelTokens.ts
@@ -135,7 +135,76 @@ export const MICON: Record<string, string[]> = {
   trendUp:   ["M22 7 13.5 15.5 8.5 10.5 2 17", "M16 7h6v6"],
   trendDown: ["M22 17 13.5 8.5 8.5 13.5 2 7", "M16 17h6v-6"],
   pulse:     ["M22 12h-4l-3 9L9 3l-3 9H2"],
+  // Alerts
+  quake:     ["M3 12h3l2-7 4 14 2-7 3 7 2-4 2 4h2"],
+  cloud:     ["M17.5 19a4.5 4.5 0 1 0-1.4-8.8 5 5 0 1 0-9.5 2.3A3.5 3.5 0 0 0 7 19h10.5z"],
+  wave:      ["M2 12c2 0 2-2 4-2s2 2 4 2 2-2 4-2 2 2 4 2 2-2 4-2", "M2 18c2 0 2-2 4-2s2 2 4 2 2-2 4-2 2 2 4 2 2-2 4-2"],
+  cone:      ["M12 2 4 22h16L12 2z", "M7 14h10"],
+  plug:      ["M9 2v6", "M15 2v6", "M5 8h14v3a7 7 0 0 1-14 0V8z", "M12 18v4"],
+  warn:      ["M12 9v4", "M12 17h.01", "M10.3 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"],
+  check:     ["M20 6 9 17l-5-5"],
+  chevUp:    ["M18 15l-6-6-6 6"],
+  chevDown:  ["M6 9l6 6 6-6"],
+  pin:       ["M12 22s7-7 7-12a7 7 0 1 0-14 0c0 5 7 12 7 12z", "M12 11a2 2 0 1 0 0-4 2 2 0 0 0 0 4z"],
+  clock:     ["M12 6v6l4 2", "M12 22a10 10 0 1 0 0-20 10 10 0 0 0 0 20z"],
 };
+
+// ─── Alerts ─────────────────────────────────────────────
+
+export type AlertGroupShort =
+  | "earthquake" | "weather" | "flood" | "transit" | "lifeline" | "safety";
+
+export interface AlertGroupDef {
+  id: AlertGroupShort;
+  label: string;
+  en: string;
+  color: string;
+  iconKey: keyof typeof MICON;
+}
+
+export const ALERT_GROUPS_DEF: Record<AlertGroupShort, AlertGroupDef> = {
+  earthquake: { id: "earthquake", label: "地震", en: "EQ",       color: "#d946ef", iconKey: "quake" },
+  weather:    { id: "weather",    label: "氣象", en: "WEATHER",  color: "#38bdf8", iconKey: "cloud" },
+  flood:      { id: "flood",      label: "水文", en: "WATER",    color: "#2dd4bf", iconKey: "wave"  },
+  transit:    { id: "transit",    label: "交通", en: "TRANSIT",  color: "#fb923c", iconKey: "cone"  },
+  lifeline:   { id: "lifeline",   label: "民生", en: "LIFELINE", color: "#a3e635", iconKey: "plug"  },
+  safety:     { id: "safety",     label: "安全", en: "SAFETY",   color: "#fb7185", iconKey: "flame" },
+};
+
+export const ALERT_GROUP_ORDER: AlertGroupShort[] = [
+  "earthquake", "weather", "flood", "transit", "lifeline", "safety",
+];
+
+export interface AlertSeverityDef {
+  key: "minor" | "moderate" | "severe" | "extreme";
+  label: string;
+  en: string;
+  color: string;
+  /** CSS animation value, null = static */
+  anim: string | null;
+}
+
+export const ALERT_SEVERITY: (AlertSeverityDef | null)[] = [
+  null,
+  { key: "minor",    label: "留意", en: "MINOR",    color: "#eab308", anim: null },
+  { key: "moderate", label: "警戒", en: "MODERATE", color: "#f97316", anim: "alertBreathe 4s ease-in-out infinite" },
+  { key: "severe",   label: "嚴重", en: "SEVERE",   color: "#ef4444", anim: "alertBreathe 2s ease-in-out infinite" },
+  { key: "extreme",  label: "緊急", en: "EXTREME",  color: "#dc2626", anim: "alertPulse 1s ease-in-out infinite" },
+];
+
+export function alertSeverity(severityIdx: number): AlertSeverityDef {
+  const i = Math.max(1, Math.min(4, Math.floor(severityIdx)));
+  return ALERT_SEVERITY[i]!;
+}
+
+/** 倒數 HH:MM:SS（負值或 0 → 00:00:00） */
+export function fmtExpiry(expiresTs: number, nowTs: number): string {
+  let s = Math.max(0, Math.floor(expiresTs - nowTs));
+  const h = Math.floor(s / 3600); s -= h * 3600;
+  const m = Math.floor(s / 60);
+  const sec = s % 60;
+  return `${String(h).padStart(2,"0")}:${String(m).padStart(2,"0")}:${String(sec).padStart(2,"0")}`;
+}
 
 /** 5min EMA 平滑（30s polling, N=10 → alpha≈0.18）。score=null 表示首次採樣，直接回新值。 */
 export function smoothPressure(prev: number | null, next: number, alpha = 0.18): number {

--- a/src/components/intel/monitor/IndicatorPanel.tsx
+++ b/src/components/intel/monitor/IndicatorPanel.tsx
@@ -221,12 +221,14 @@ export function IndicatorPanel({
 
       <LiveWall />
 
-      <AlertBoard
-        tally={alertTally}
-        series={alertSeries}
-        accent={COLORS.accent}
-        nowTs={nowTs}
-      />
+      <div style={{ gridColumn: "1 / -1" }}>
+        <AlertBoard
+          tally={alertTally}
+          series={alertSeries}
+          accent={COLORS.accent}
+          nowTs={nowTs}
+        />
+      </div>
 
       {/* 熱區 Top 5 */}
       <Widget>

--- a/src/components/intel/monitor/IndicatorPanel.tsx
+++ b/src/components/intel/monitor/IndicatorPanel.tsx
@@ -2,7 +2,10 @@ import { useMemo } from "react";
 import { IntelIcon } from "../IntelIcon";
 import {
   COLORS, FONT_CJK, FONT_DATA, MICON, GIS_LEVELS, SEV_LEVELS,
+  type AlertGroupShort,
 } from "../intelTokens";
+import { AlertBoard } from "../alerts/AlertBoard";
+import type { AlertTally } from "../../../data/alertsLoader";
 import {
   NEWS_CATEGORIES, getNewsCategoryDef, type NewsCategory,
 } from "../../../data/newsEventTypes";
@@ -28,6 +31,9 @@ interface Props {
   totalToday: number;
   /** 點熱區 row → 切到該縣市 */
   onPickHotspot: (county: string) => void;
+  alertTally: AlertTally;
+  alertSeries: Record<AlertGroupShort, number[]>;
+  nowTs: number;
 }
 
 interface Hotspot {
@@ -163,6 +169,7 @@ function DistBar({
 export function IndicatorPanel({
   events, countyByEventId, pressure, smoothedScore, market, pla, health,
   sourceHealth, totalToday, onPickHotspot,
+  alertTally, alertSeries, nowTs,
 }: Props) {
   const stats = useMemo(() => {
     const ranked = rankHotspots(events, countyByEventId);
@@ -213,6 +220,13 @@ export function IndicatorPanel({
       <SituationCards pla={pla} health={health} />
 
       <LiveWall />
+
+      <AlertBoard
+        tally={alertTally}
+        series={alertSeries}
+        accent={COLORS.accent}
+        nowTs={nowTs}
+      />
 
       {/* 熱區 Top 5 */}
       <Widget>

--- a/src/components/intel/monitor/MonitorPanel.tsx
+++ b/src/components/intel/monitor/MonitorPanel.tsx
@@ -412,6 +412,19 @@ export function MonitorPanel({
           >
             MONITOR
           </span>
+          <span
+            style={{
+              padding: "1px 7px", borderRadius: 4,
+              background: "rgba(255,152,0,0.16)",
+              border: "1px solid rgba(255,152,0,0.45)",
+              fontFamily: FONT_DATA, fontSize: 9, fontWeight: 700, letterSpacing: "1px",
+              color: COLORS.statusWarn,
+              animation: "presBreathe 3s ease-in-out infinite",
+            }}
+            title="本模式仍在打磨中，數據與互動可能還會調整"
+          >
+            BETA
+          </span>
         </div>
         <span
           style={{

--- a/src/components/intel/monitor/MonitorPanel.tsx
+++ b/src/components/intel/monitor/MonitorPanel.tsx
@@ -12,6 +12,11 @@ import {
 import {
   fetchNewsEventsDayClusters, type NewsFilter,
 } from "../../../data/newsEventsLoader";
+import {
+  fetchAlertSummary, fetchAlertSeries24h,
+  tallySummary, indexSeries, EMPTY_TALLY, emptySeries,
+  type AlertSummary, type AlertSeriesPoint,
+} from "../../../data/alertsLoader";
 import type { NewsCategory } from "../../../data/newsEventTypes";
 import { timeStore } from "../../../state/timeStore";
 import { TimelineDock } from "./TimelineDock";
@@ -97,6 +102,8 @@ export function MonitorPanel({
   const [pla, setPla] = useState<PlaActivity>(EMPTY_PLA);
   const [health, setHealth] = useState<PublicHealthWeek>(EMPTY_HEALTH_WEEK);
   const [clusters, setClusters] = useState<Cluster[]>([]);
+  const [alertSummaryRows, setAlertSummaryRows] = useState<AlertSummary[]>([]);
+  const [alertSeriesRows, setAlertSeriesRows] = useState<AlertSeriesPoint[]>([]);
 
   // tick now（顯示 + countdown）
   useEffect(() => {
@@ -118,6 +125,8 @@ export function MonitorPanel({
       fetchMarketIndex().then((m) => alive && setMarket(m));
       fetchSourceHealth().then((s) => alive && setSourceHealth(s));
       fetchNewsTrending(1, 50).then((t) => alive && setTrending(t));
+      fetchAlertSummary().then((s) => alive && setAlertSummaryRows(s));
+      fetchAlertSeries24h().then((s) => alive && setAlertSeriesRows(s));
     };
     tick();
     const id = window.setInterval(tick, 30_000);
@@ -256,6 +265,15 @@ export function MonitorPanel({
     }
     return m;
   }, [clusters]);
+
+  const alertTally = useMemo(
+    () => (alertSummaryRows.length ? tallySummary(alertSummaryRows) : EMPTY_TALLY),
+    [alertSummaryRows],
+  );
+  const alertSeries = useMemo(
+    () => (alertSeriesRows.length ? indexSeries(alertSeriesRows) : emptySeries()),
+    [alertSeriesRows],
+  );
 
   const trendingKeySet = useMemo(() => buildTrendingKeys(trending), [trending]);
   const isTrendingFor = (e: IntelCardEvent) => {
@@ -457,6 +475,7 @@ export function MonitorPanel({
         onScrub={onScrub}
         onLive={goLive}
         onTogglePlay={togglePlay}
+        alertSeries={alertSeries}
       />
 
       {/* body: feed (left) + indicators (right) */}
@@ -593,6 +612,9 @@ export function MonitorPanel({
           sourceHealth={sourceHealth}
           totalToday={allEventsToday.length}
           onPickHotspot={onPickHotspot}
+          alertTally={alertTally}
+          alertSeries={alertSeries}
+          nowTs={now}
         />
       </div>
 
@@ -613,8 +635,17 @@ export function MonitorPanel({
           0%, 100% { opacity: 1; }
           50% { opacity: 0.45; }
         }
+        @keyframes alertBreathe { 0%,100%{opacity:1} 50%{opacity:0.62} }
+        @keyframes alertPulse   { 0%,100%{opacity:1} 50%{opacity:0.45} }
+        @keyframes alertEdge {
+          0%,100% { box-shadow: 0 0 0 0 rgba(239,68,68,0); }
+          50%     { box-shadow: 0 0 16px 0 rgba(239,68,68,0.42); }
+        }
         @media (prefers-reduced-motion: reduce) {
-          [style*="presBreathe"], [style*="presPulse"] { animation: none !important; }
+          [style*="presBreathe"], [style*="presPulse"],
+          [style*="alertBreathe"], [style*="alertPulse"], [style*="alertEdge"] {
+            animation: none !important;
+          }
         }
       `}</style>
     </div>

--- a/src/components/intel/monitor/TimelineDock.tsx
+++ b/src/components/intel/monitor/TimelineDock.tsx
@@ -1,8 +1,12 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { IntelIcon, ICON } from "../IntelIcon";
-import { COLORS, FONT_CJK, FONT_DATA, clockTime } from "../intelTokens";
+import {
+  COLORS, FONT_CJK, FONT_DATA, clockTime,
+  type AlertGroupShort,
+} from "../intelTokens";
 import { NEWS_CATEGORIES, type NewsCategory } from "../../../data/newsEventTypes";
 import type { ClusterEvent } from "../../../data/newsEventsLoader";
+import { AlertsTrack } from "../alerts/AlertsTrack";
 
 interface Props {
   /** 過濾後的當日 events（用於畫直方圖） */
@@ -18,6 +22,8 @@ interface Props {
   onScrub: (ts: number) => void;
   onLive: () => void;
   onTogglePlay: () => void;
+  /** 警報軌資料（24h × 6 group），無資料時傳空 series */
+  alertSeries: Record<AlertGroupShort, number[]>;
 }
 
 interface HourlyBucket {
@@ -54,7 +60,7 @@ const TICKS = [0, 6, 12, 18, 24];
 
 export function TimelineDock({
   events, dayStartTs, nowTs, playbackTs, isLive, playing,
-  onScrub, onLive, onTogglePlay,
+  onScrub, onLive, onTogglePlay, alertSeries,
 }: Props) {
   const [hoverH, setHoverH] = useState<number | null>(null);
   const areaRef = useRef<HTMLDivElement>(null);
@@ -328,6 +334,14 @@ export function TimelineDock({
           </span>
         ))}
       </div>
+
+      <AlertsTrack
+        series={alertSeries}
+        nowFrac={nowFrac}
+        playbackFrac={frac}
+        isLive={isLive}
+        onScrubFrac={(f) => onScrub(Math.min(nowTs, dayStartTs + f * SPAN))}
+      />
     </div>
   );
 }

--- a/src/data/alertsLoader.ts
+++ b/src/data/alertsLoader.ts
@@ -1,0 +1,258 @@
+/**
+ * Alerts Loader — 警訊整合（NCDR 災害示警 + CWA 地震）
+ *
+ * 後端：gis-platform migration 211 的 3 RPC
+ *   - get_alert_summary()
+ *   - get_active_alerts(p_group, p_severity_min)
+ *   - get_alert_series_24h()
+ *
+ * 群組短形 key：earthquake / weather / flood / transit / lifeline / safety
+ */
+
+import { supabase } from "../lib/supabase";
+import { withLoading } from "../lib/loadingRegistry";
+import {
+  ALERT_GROUP_ORDER,
+  type AlertGroupShort,
+} from "../components/intel/intelTokens";
+
+export interface AlertSummary {
+  group: AlertGroupShort;
+  count: number;
+  severe: number;
+  top_term: string | null;
+  sev_minor: number;
+  sev_moderate: number;
+  sev_severe: number;
+  sev_extreme: number;
+}
+
+export interface ActiveAlert {
+  id: string;
+  group: AlertGroupShort;
+  term: string;
+  severity: number;      // 1-4
+  urgency: string;
+  headline: string;
+  area_desc: string;
+  area_count: number;
+  sent_ts: number;
+  expires_ts: number;
+  description: string | null;
+  instruction: string | null;
+  magnitude: number | null;
+  depth_km: number | null;
+  occurred_ts: number | null;
+  county: string;
+}
+
+export interface AlertSeriesPoint {
+  group: AlertGroupShort;
+  h: number;
+  count: number;
+}
+
+interface SummaryRaw {
+  group: string;
+  count: number;
+  severe: number;
+  top_term: string | null;
+  sev_minor: number;
+  sev_moderate: number;
+  sev_severe: number;
+  sev_extreme: number;
+}
+
+interface ActiveRaw {
+  id: string;
+  group: string;
+  term: string;
+  severity: number;
+  urgency: string;
+  headline: string;
+  area_desc: string;
+  area_count: number;
+  sent_ts: number | string;
+  expires_ts: number | string;
+  description: string | null;
+  instruction: string | null;
+  magnitude: number | null;
+  depth_km: number | null;
+  occurred_ts: number | string | null;
+  county: string;
+}
+
+interface SeriesRaw {
+  group: string;
+  h: number;
+  count: number;
+}
+
+const VALID_GROUPS = new Set<string>(ALERT_GROUP_ORDER);
+
+function asGroup(s: string): AlertGroupShort | null {
+  return VALID_GROUPS.has(s) ? (s as AlertGroupShort) : null;
+}
+
+function asNum(v: number | string | null | undefined): number {
+  if (v == null) return 0;
+  return typeof v === "number" ? v : Number(v);
+}
+
+export async function fetchAlertSummary(): Promise<AlertSummary[]> {
+  try {
+    const { data, error } = await withLoading(
+      "alert-summary",
+      "警報摘要",
+      supabase.rpc("get_alert_summary"),
+    );
+    if (error) throw error;
+    const rows = (data ?? []) as SummaryRaw[];
+    return rows
+      .map((r): AlertSummary | null => {
+        const g = asGroup(r.group);
+        if (!g) return null;
+        return {
+          group: g,
+          count: r.count ?? 0,
+          severe: r.severe ?? 0,
+          top_term: r.top_term ?? null,
+          sev_minor: r.sev_minor ?? 0,
+          sev_moderate: r.sev_moderate ?? 0,
+          sev_severe: r.sev_severe ?? 0,
+          sev_extreme: r.sev_extreme ?? 0,
+        };
+      })
+      .filter((x): x is AlertSummary => x !== null);
+  } catch (err) {
+    console.warn("[alertsLoader] fetchAlertSummary failed:", err);
+    return [];
+  }
+}
+
+export async function fetchActiveAlerts(
+  group?: AlertGroupShort | null,
+  severityMin: number = 1,
+): Promise<ActiveAlert[]> {
+  try {
+    const key = `alert-list:${group ?? "all"}:${severityMin}`;
+    const label = group
+      ? `警報細節 ${group}`
+      : "警報細節";
+    const { data, error } = await withLoading(
+      key,
+      label,
+      supabase.rpc("get_active_alerts", {
+        p_group: group ?? null,
+        p_severity_min: severityMin,
+      }),
+    );
+    if (error) throw error;
+    const rows = (data ?? []) as ActiveRaw[];
+    return rows
+      .map((r): ActiveAlert | null => {
+        const g = asGroup(r.group);
+        if (!g) return null;
+        return {
+          id: String(r.id),
+          group: g,
+          term: r.term ?? "",
+          severity: Math.max(1, Math.min(4, r.severity ?? 1)),
+          urgency: r.urgency ?? "unknown",
+          headline: r.headline ?? "",
+          area_desc: r.area_desc ?? "",
+          area_count: r.area_count ?? 0,
+          sent_ts: asNum(r.sent_ts),
+          expires_ts: asNum(r.expires_ts),
+          description: r.description,
+          instruction: r.instruction,
+          magnitude: r.magnitude == null ? null : Number(r.magnitude),
+          depth_km: r.depth_km == null ? null : Number(r.depth_km),
+          occurred_ts: r.occurred_ts == null ? null : asNum(r.occurred_ts),
+          county: r.county ?? "全國",
+        };
+      })
+      .filter((x): x is ActiveAlert => x !== null);
+  } catch (err) {
+    console.warn("[alertsLoader] fetchActiveAlerts failed:", err);
+    return [];
+  }
+}
+
+export async function fetchAlertSeries24h(): Promise<AlertSeriesPoint[]> {
+  try {
+    const { data, error } = await withLoading(
+      "alert-series-24h",
+      "警報 24h",
+      supabase.rpc("get_alert_series_24h"),
+    );
+    if (error) throw error;
+    const rows = (data ?? []) as SeriesRaw[];
+    return rows
+      .map((r): AlertSeriesPoint | null => {
+        const g = asGroup(r.group);
+        if (!g) return null;
+        return { group: g, h: r.h, count: r.count ?? 0 };
+      })
+      .filter((x): x is AlertSeriesPoint => x !== null);
+  } catch (err) {
+    console.warn("[alertsLoader] fetchAlertSeries24h failed:", err);
+    return [];
+  }
+}
+
+// ─── helpers ──────────────────────────────────────────────
+
+export function indexSummary(
+  rows: AlertSummary[],
+): Map<AlertGroupShort, AlertSummary> {
+  const m = new Map<AlertGroupShort, AlertSummary>();
+  for (const r of rows) m.set(r.group, r);
+  return m;
+}
+
+export function indexSeries(
+  rows: AlertSeriesPoint[],
+): Record<AlertGroupShort, number[]> {
+  const out = {} as Record<AlertGroupShort, number[]>;
+  for (const g of ALERT_GROUP_ORDER) {
+    out[g] = Array.from({ length: 24 }, () => 0);
+  }
+  for (const r of rows) {
+    if (r.h < 0 || r.h > 23) continue;
+    out[r.group][r.h] = r.count;
+  }
+  return out;
+}
+
+export interface AlertTally {
+  total: number;
+  severe: number;
+  byGroup: Map<AlertGroupShort, AlertSummary>;
+}
+
+export function tallySummary(rows: AlertSummary[]): AlertTally {
+  let total = 0;
+  let severe = 0;
+  const byGroup = new Map<AlertGroupShort, AlertSummary>();
+  for (const r of rows) {
+    total += r.count;
+    severe += r.severe;
+    byGroup.set(r.group, r);
+  }
+  return { total, severe, byGroup };
+}
+
+export const EMPTY_TALLY: AlertTally = {
+  total: 0,
+  severe: 0,
+  byGroup: new Map(),
+};
+
+export function emptySeries(): Record<AlertGroupShort, number[]> {
+  const out = {} as Record<AlertGroupShort, number[]>;
+  for (const g of ALERT_GROUP_ORDER) {
+    out[g] = Array.from({ length: 24 }, () => 0);
+  }
+  return out;
+}

--- a/src/data/newsEventsLoader.ts
+++ b/src/data/newsEventsLoader.ts
@@ -61,9 +61,9 @@ export interface NewsFilter {
   minSeverity: 0 | 1 | 2;
 }
 
-/** 預設 ≈ 舊「important」 */
+/** 預設「重大」(minRelevance=3) — 新聞 / 全部 tab 進來就只看重大級 */
 export const DEFAULT_NEWS_FILTER: NewsFilter = {
-  minRelevance: 2,
+  minRelevance: 3,
   eventsOnly: true,
   minSeverity: 1,
 };

--- a/src/hooks/useTransportParams.ts
+++ b/src/hooks/useTransportParams.ts
@@ -240,8 +240,8 @@ export function useTransportParams() {
   //   minRelevance: 0 全部 / 2 地方+ / 3 重大（對應 RPC p_min_gis_relevance）
   //   eventsOnly:   true 只看事件（對應 RPC p_require_event）
   //   minSeverity:  0 全部 / 1 個案+ / 2 區域+（對應 RPC p_min_severity）
-  // 預設 (2, true, 1) ≈ 舊「重要」級
-  const [newsMinRelevance, setNewsMinRelevance] = useState<0 | 2 | 3>(2);
+  // 預設 (3, true, 1) ≈「重大」級 — 新聞 / 全部 tab 進來只看重大
+  const [newsMinRelevance, setNewsMinRelevance] = useState<0 | 2 | 3>(3);
   const [newsEventsOnly, setNewsEventsOnly] = useState<boolean>(true);
   const [newsMinSeverity, setNewsMinSeverity] = useState<0 | 1 | 2>(1);
   // Socioeconomic (村里社經)


### PR DESCRIPTION
## Summary

把 **NCDR 災害示警（5 群組）+ CWA 地震** 整合進「即時情報 Intel Panel」與「Monitor 戰情看板」，照 [`docs/proposal/alerts-integration-impl.md`](https://github.com/ianlkl11234s/mini-taiwan-pulse/blob/master/docs/proposal/alerts-integration-impl.md) 規格做完整實作。

### 後端（gis-platform）
`migrations/211_monitor_alert_rpcs.sql` — 3 個薄 RPC（全部 STABLE + GRANT anon/authenticated）：
- `get_alert_summary()` → 6 群組摘要（count / severe / top_term / 4 級 sev）
- `get_active_alerts(p_group, p_severity_min)` → 列表 UNION 地震，severity DESC + sent_ts DESC
- `get_alert_series_24h()` → 24h × 6 group sparkline（台北 TZ）

### 前端（本 PR）
- `src/data/alertsLoader.ts` — 3 fetch 全包 `withLoading` + 3 helper（`tallySummary` / `indexSeries` / `EMPTY_TALLY`）
- `src/components/intel/intelTokens.ts` — 新增 `ALERT_GROUPS_DEF` / `ALERT_SEVERITY` / `fmtExpiry` + `MICON` 11 個 icon
- `src/components/intel/alerts/`
  - `AlertSummaryBar.tsx` — 0-state 極簡 / 收合 mini dots / 展開 6 群組 chip
  - `FeedTabs.tsx` — 全部 / 新聞 / 警報 3 tab + badge
  - `AlertCard.tsx` — spine + chip + headline + countdown，severity≥3 自動 1s tick + `alertEdge`
  - `AlertBoard.tsx` — Monitor widget，含 `AlertTrend` / `GroupCard` / `AlertDrawer` 三子元件
  - `AlertsTrack.tsx` — TimelineDock 警報軌（24h × 6 stacked bar，共用 scrub）
- `IntelPanel` / `MonitorPanel` / `IndicatorPanel` / `TimelineDock` 接線；keyframes `alertBreathe / alertPulse / alertEdge` + reduced-motion

### 群組 key 對應
新檔用**短形** `earthquake / weather / flood / transit / lifeline / safety`，跟既有 `disasterAlertTypes.ts` 長形 layer key 走 mapping，不動 layer 端。

## Verification（瀏覽器 walkthrough 實測通過）

- ✅ Intel Panel SummaryBar 顯示 81 則警報 / 21 嚴重 + 6 mini dots
- ✅ 展開 → 6 群組 chip grid（氣象 12 / 水文 22 / 交通 1 / 民生 29 / 安全 17 / 地震 0）
- ✅ 點氣象 chip → 自動切「警報 tab」+ filter，顯示 AlertCard
- ✅ AlertCard 顯示 severity 動畫 + countdown (`HH:MM:SS`) + 處置指引
- ✅ FeedTabs 全部 296 / 新聞 215 / 警報 81，merge by ts 正確
- ✅ Monitor → IndicatorPanel 出現「警訊整合 NCDR + CWA」widget + 24H TREND + 3×2 GroupCard
- ✅ TimelineDock 下方 ALERTS 24H 多色堆疊條，scrub 共用
- ✅ Loading registry 顯示「警報摘要 / 警報 24h / 警報細節 …」

## Out of scope（下個 PR）

- 地圖警報點視覺重整（B2 pulse / B3 icon）
- 警報統計進壓力指數 signal
- Mobile 響應式
- 警報歷史檢索（目前只有 active）

## Test plan

- [x] `npx tsc -b` 通過
- [x] `pnpm test --run` 102/102 pass
- [x] Browser walkthrough（impl doc §10 checklist 13 項全通）
- [ ] Reviewer：核 design 細節（顏色 / icon / 動畫）
- [ ] Reviewer：核 RPC SQL（event_term mapping / 地震 UNION）
- [ ] Reviewer：reduced-motion 偏好實測

🤖 Generated with [Claude Code](https://claude.com/claude-code)