### PR TITLE
feat(design-system): 建立 design tokens SSOT — 6 phase 收斂 60+ 元件 1200+ inline 值

### DIFF
--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -182,15 +182,15 @@ style={{ fontFamily: "monospace" }}          // 改用 FONT_DATA
 
 ## 6. 遷移狀態
 
-| Phase | 範圍 | 狀態 |
-|---|---|---|
-| 0 | 建 `designTokens.ts` + 本文件 | ✅ 完成 |
-| 1 | 統一面板背景 + 陰影（→ SURFACE / ELEVATION） | pending |
-| 2 | fontFamily 統一（`"monospace"` → `FONT_DATA`） | pending |
-| 3 | 文字色階梯統一（散落 rgba 白 → `COLORS.text*`） | pending |
-| 4 | borderRadius / fontSize 收斂 | pending |
-| 5 | 災害語意色對齊（以 `LAYER_COLORS` 為基準） | pending |
-| 6 | CloseButton / Loading 統一 | pending |
+| Phase | 範圍 | 狀態 | Commit |
+|---|---|---|---|
+| 0 | 建 `designTokens.ts` + 本文件 | ✅ | `d9aaf28` |
+| 1 | 統一面板背景 + 陰影（→ SURFACE / ELEVATION） | ✅ | `1cb6f9b` |
+| 2 | fontFamily 統一（`"monospace"` → `FONT_DATA`） | ✅ | `86391f4` |
+| 3 | 文字色階梯統一（散落 rgba 白 → `COLORS.text*`） | ✅ | `cc744e1` |
+| 4 | borderRadius / fontSize 收斂 | ✅ | `7ee817b` |
+| 5 | 災害語意色對齊（以 `LAYER_COLORS` 為基準） | ✅ | `c6a4e7e` |
+| 6 | CloseButton / Loading 統一 | ✅ | `22c8d64` |
 
 ## 7. KEEP OUT — 不做的事
 
@@ -212,7 +212,67 @@ style={{ fontFamily: "monospace" }}          // 改用 FONT_DATA
 - **Breakpoint tokens** — 桌機 / 手機分流目前用 JS `isMobile` 判斷，無 CSS breakpoint scale。
 - **Control sizing**（button height / icon size / hit-area）— Phase 6 統一 CloseButton 時順手定，但不擴展為通用 scale。
 
-## 9. 相關文件
+## 9. 新元件 checklist（寫新元件 / 新 panel 時抄這份）
+
+寫一個全新 panel / card / popup 時，照下面順序檢查，**沒查到的值才考慮新增 token**（不要直接 inline 硬寫）。
+
+### 9.1 容器外框
+
+```tsx
+import { SURFACE, BORDER, RADIUS, ELEVATION } from "../styles/designTokens";
+
+<div style={{
+  background: SURFACE.panel,                     // 或 strong / solid / subtle / app
+  border: `1px solid ${BORDER.panel}`,           // 或 soft / mid / strong / accent
+  borderRadius: RADIUS.xl,                        // sm:2 / md:4 / lg:6 / xl:8 / pill / full
+  boxShadow: ELEVATION.lg,                        // sm / md / lg / dock
+  padding: "12px 14px",
+}}>
+```
+
+### 9.2 文字
+
+```tsx
+import { COLORS, FONT_DATA, FONT_CJK, FONT_SIZE, FONT_WEIGHT } from "../styles/designTokens";
+
+<span style={{
+  fontFamily: FONT_DATA,                          // 數據/時間 → FONT_DATA；中文 → FONT_CJK
+  fontSize: FONT_SIZE.base,                       // xs:9 / sm:10 / base:11 / md:12 / lg:13 / xl:18 / xxl:22
+  fontWeight: FONT_WEIGHT.semibold,
+  color: COLORS.textDefault,                       // textStrong / textDefault / textMuted / textDim / textFaint / textGhost
+}}>
+```
+
+### 9.3 圖層分類色（layer-specific）
+
+```tsx
+import { LAYER_COLORS } from "./sidebar/layerCatalog";
+
+const color = LAYER_COLORS.flights;               // 95+ 個 layer key 已預定
+```
+
+### 9.4 圖示
+
+```tsx
+import { X } from "lucide-react";                  // 關閉鈕：統一 <X size={14} />
+```
+
+### 9.5 4 個禁忌（會被 review 退回）
+
+| ❌ 寫死 | ✅ 改用 |
+|---|---|
+| `background: "rgba(0,0,0,0.52)"` | `SURFACE.panel` |
+| `color: "rgba(255,255,255,0.5)"` | `COLORS.textMuted` |
+| `fontFamily: "monospace"` | `FONT_DATA` |
+| `borderRadius: 4` | `RADIUS.md` |
+| 純文字 `×` 關閉鈕 | `<X size={14} />` from lucide |
+
+### 9.6 圖層專屬規則（new layer 時加做）
+
+新增 layer 必過 CLAUDE.md §5a 四鐵則：透明度 slider / 圖例 / click popup / select dropdown。
+細節見 `docs/development-rules.md` §4a。
+
+## 10. 相關文件
 
 - `CLAUDE.md` §5 / §5a — 新增 layer 強制順序 + UX 四鐵則
 - `docs/development-rules.md` §4a — 四鐵則完整版

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -200,6 +200,7 @@ style={{ fontFamily: "monospace" }}          // 改用 FONT_DATA
 - ❌ 不一次大爆炸改全部元件 — 每 Phase 獨立 PR
 - ❌ 不在新元件 inline 寫死 hex / rgba / px font size
 - ❌ 不反向把 `intelTokens` 改成 re-export from `designTokens`（會 circular dep，見 §1）
+- ❌ **`SURFACE.*` 只給 panel 容器底**；button / select / segmented control 等**互動態背景不用 SURFACE**（即使數值相同 `rgba(0,0,0,0.4)`）。語意不同 — 互動態背景之後若要 token 化，會獨立開 `CONTROL.*` 群組。Phase 1 review 教訓。
 
 ## 8. 未納入 token 的範圍（未來題目，不在 Phase 0–6 scope）
 

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -1,0 +1,218 @@
+# Mini Taiwan Pulse — Design System
+
+> 視覺一致性規範與 token SSOT。新元件 / 重構元件**必讀**。
+
+## 0. 設計原則
+
+| | |
+|---|---|
+| **不引入 CSS 框架** | 維持 inline `style={{}}` + token import。Mapbox / Three.js / 動態 opacity 大量混在元件中，框架反而是負擔。 |
+| **token 為唯一 SSOT** | 顏色 / 字體 / 圓角 / 陰影一律從 `src/styles/designTokens.ts` import；禁止 inline 寫 hex / rgba。 |
+| **`LAYER_COLORS` 不動** | 圖層代表色由 `src/components/sidebar/layerCatalog.ts` SSOT，已被 `layerConsistency` 測試保護。 |
+| **業務元件不抽通用庫** | 不建 `Button` / `Card` 通用元件庫；業務元件深耦合 Mapbox / timeStore，抽出反而 over-abstract。 |
+| **每階段獨立 PR** | 大改不一次推；每 Phase 一個 PR，可獨立 review / merge / rollback。 |
+
+## 1. SSOT 結構
+
+| 檔案 | 角色 |
+|---|---|
+| `src/styles/designTokens.ts` | **全專案 token SSOT** — 新元件統一 import |
+| `src/components/intel/intelTokens.ts` | intel/satellite 歷史 token，被 designTokens **單向 re-export**（⚠️ 禁止反向 import，會造成 circular dep） |
+| `src/components/sidebar/layerCatalog.ts` | `LAYER_COLORS` / `SECTIONS` — 圖層代表色 + 分區 SSOT |
+| `src/components/LegendPanel.tsx` `LEGEND_REGISTRY` | layer → 圖例對接 SSOT |
+| `src/components/featureInfo/registry.tsx` `PANEL_REGISTRY` | layer → click popup 對接 SSOT |
+
+**遷移方向**：未來 intel/satellite 也改 import `designTokens`，`intelTokens.ts` 退役為**純常數定義檔（被動）**或直接刪除（把定義搬進 designTokens）。
+⚠️ **不可**把 `intelTokens.ts` 改成「re-export from designTokens」— designTokens 已 import intelTokens，反向 re-export 會立刻形成 circular dependency。正確順序：(a) 把常數從 intelTokens 搬到 designTokens；(b) intelTokens 改成 re-export from designTokens（單向，無 cycle）；(c) 待所有 import 都改完才刪 intelTokens.ts。
+
+## 2. Token 全表
+
+### 2.1 SURFACE — 面板背景五階
+
+| Token | 值 | 用途 |
+|---|---|---|
+| `SURFACE.app` | `#0a0a14` | App 底（地圖底色 / LoadingScreen） |
+| `SURFACE.subtle` | `rgba(0,0,0,0.40)` | narrow sidebar / 浮動 overlay |
+| `SURFACE.panel` | `rgba(0,0,0,0.52)` | **主面板預設**（IntelPanel / SatelliteConsole / Legend） |
+| `SURFACE.strong` | `rgba(10,10,20,0.88)` | 需高可讀性（FeatureInfo / DataCalendar） |
+| `SURFACE.solid` | `rgba(10,10,20,0.94)` | 全屏 / 模態 / LiveWall |
+
+### 2.2 COLORS — 文字 / 強調 / 狀態（沿用 intelTokens）
+
+| Token | 用途 |
+|---|---|
+| `COLORS.textStrong` `#f3f4f6` | 主標題 / 重點數據 |
+| `COLORS.textDefault` `#d8dce3` | 預設正文 |
+| `COLORS.textMuted` `#9ca3af` | 次要資訊 / 副標 |
+| `COLORS.textDim` `#6b7280` | label / placeholder |
+| `COLORS.textFaint` `#4b5560` | 提示性說明 |
+| `COLORS.textGhost` `#363b44` | 接近不可見的裝飾 |
+| `COLORS.accent` `#64aaff` | 互動 / 連結 / focus |
+| `COLORS.statusLive` `#22c55e` | live / online / OK |
+| `COLORS.statusWarn` `#ff9800` | warn / 警戒 |
+| `COLORS.statusErr` `#ef4444` | err / fail / critical |
+
+完整列表見 `designTokens.ts` 與 `intelTokens.ts`。
+
+### 2.3 BORDER
+
+| Token | 值 |
+|---|---|
+| `BORDER.soft` | `rgba(255,255,255,0.06)` |
+| `BORDER.panel` | `rgba(255,255,255,0.10)` — 主面板邊框預設 |
+| `BORDER.mid` | `rgba(255,255,255,0.14)` |
+| `BORDER.strong` | `rgba(255,255,255,0.22)` |
+| `BORDER.accent` | `rgba(100,170,255,0.55)` |
+
+### 2.4 RADIUS — 圓角 4 階尺寸 + 2 種 shape
+
+| Token | 值 | 用途 |
+|---|---|---|
+| `RADIUS.sm` | `2` | inline pill / tag |
+| `RADIUS.md` | `4` | **預設** badge / 小卡 |
+| `RADIUS.lg` | `6` | panel inner card |
+| `RADIUS.xl` | `8` | panel 外框 |
+| `RADIUS.pill` | `9999` | 完整 pill |
+| `RADIUS.full` | `"50%"` | 圓點 / 圓鈕（字串，非 number） |
+
+收斂規則：`3 → md(4)`，`5/7 → lg(6)`，`9/10 → xl(8)`。
+**罕用 12 / 16 / 24px（共 3 處）保留 inline 一次性數值**，不進 scale。
+
+### 2.5 FONT_SIZE — 字級七階
+
+| Token | 值 | audit 使用次數 | 用途 |
+|---|---|---|---|
+| `FONT_SIZE.xs` | `9` | 174 | 標籤 / pill / uppercase 標題 |
+| `FONT_SIZE.sm` | `10` | 157 | 副資訊 |
+| `FONT_SIZE.base` | `11` | 106 | **預設正文** |
+| `FONT_SIZE.md` | `12` | 66 | 強調副資訊 |
+| `FONT_SIZE.lg` | `13` | 82 | 強調正文 |
+| `FONT_SIZE.xl` | `18` | 11 | 卡片標題 |
+| `FONT_SIZE.xxl` | `22` | 8 | panel header |
+
+14px (13 use) → 就近 round 至 `md(12)` 或 `lg(13)`。
+16px (5 use) → `xl(18)` 或 inline。
+32 / 40px 各 1 use → **保留 inline** 一次性數值，不進 scale。
+
+### 2.6 FONT_WEIGHT
+
+`regular: 400` / `semibold: 600` / `bold: 700`。實務只用 600 / 700。
+
+### 2.7 ELEVATION — 主面板陰影
+
+| Token | 值 |
+|---|---|
+| `ELEVATION.sm` | `0 6px 20px rgba(0,0,0,0.50)` |
+| `ELEVATION.md` | `0 8px 32px rgba(0,0,0,0.55)` |
+| `ELEVATION.lg` | `0 12px 40px rgba(0,0,0,0.45)` |
+| `ELEVATION.dock` | `0 -16px 50px rgba(0,0,0,0.50)`（反向，MonitorPanel 從上緣散） |
+
+### 2.8 SPACING
+
+`xxs:2 / xs:4 / sm:6 / md:8 / lg:12 / xl:16 / xxl:24`。對應 gap / padding 大宗值。
+
+### 2.9 WHITE_ALPHA
+
+裝飾用半透白（軟分隔線、glow 底等）：`4 / 8 / 12 / 20 / 40 / 60`。文字色請用 `COLORS.text*`。
+
+### 2.10 FONT_FAMILY
+
+| Token | 值 |
+|---|---|
+| `FONT_CJK` | `"Noto Sans TC", "PingFang TC", ...` |
+| `FONT_DATA` | `"JetBrains Mono", "SF Mono", ui-monospace, ...`（**取代散落的 `"monospace"`**） |
+
+## 3. 災害 / 警示語意色
+
+**規則**：以 `LAYER_COLORS`（地圖色）為基準，`ALERT_GROUPS_DEF`（警示卡）對齊。
+
+理由：用戶第一眼接觸是地圖。同一語意在地圖、warning bar、popup 應該是同色。
+
+| 語意 | 基準（LAYER_COLORS） | 目前 ALERT_GROUPS_DEF | Phase 5 對齊後 |
+|---|---|---|---|
+| earthquake | `#ff3b30` | `#d946ef` | → `#ff3b30` |
+| flood / water | `#ef4444`（floodSensor） | `#2dd4bf` | → `#ef4444` |
+| fire | `#ff5722`（fireEvents） | safety `#fb7185` | safety 拆出 fire 用 `#ff5722` |
+| weather | （無 layer 對應） | `#38bdf8` | 沿用 |
+| transit | （無 layer 對應） | `#fb923c` | 沿用 |
+| lifeline | （無 layer 對應） | `#a3e635` | 沿用 |
+
+## 4. 使用守則
+
+### 4.1 何時 import 哪個
+
+```tsx
+// ✅ 新元件 / 重構元件 — 從 designTokens
+import { SURFACE, COLORS, RADIUS, FONT_SIZE, ELEVATION, FONT_DATA } from "../styles/designTokens";
+
+// ⚠️ intel / satellite 既有元件 — 沿用 intelTokens 路徑（不強制改，re-export 一致）
+import { COLORS, FONT_DATA } from "../intel/intelTokens";
+
+// ❌ 不要直接寫 hex / rgba 在 inline style
+style={{ background: "rgba(0,0,0,0.52)" }}  // 改用 SURFACE.panel
+style={{ fontFamily: "monospace" }}          // 改用 FONT_DATA
+```
+
+### 4.2 LAYER_COLORS 例外
+
+地圖 layer 代表色**永遠**從 `LAYER_COLORS[layerKey]` 讀，不收進 designTokens：
+
+- 已有 `layerConsistency` 測試保護
+- Mapbox paint property 吃字串，layer key 對應 cleanly
+- 95+ 動態色超出 token scale 設計目的
+
+### 4.3 LayerSidebar 雙 theme
+
+行動版 `LayerSidebar` 的 `isDarkTheme` 分支保留 — Phase 3 只套暗側 token，亮側暫不抽（流量低 + 未驗證）。未來題目。
+
+## 5. 圖層 UX 鐵則（CLAUDE.md §5a 延伸）
+
+任何新 layer 必過：
+
+1. 透明度 slider（`useTransportParams`）
+2. 分類 ≥ 2 → 寫圖例（`LEGEND_REGISTRY`，`layerConsistency` 測試擋）
+3. 可選取 → 接 click popup（`PANEL_REGISTRY`）
+4. options ≥ 4 → 原生 `<select>` dropdown
+
+**設計系統延伸**（Phase 0+）：
+
+5. **不引入新顏色** — 一律 `SURFACE` / `COLORS` / `LAYER_COLORS`
+6. **不引入新 radius / fontSize** — 一律 scale token
+7. **不重複寫 panel 外框** — 標準組合：`SURFACE.panel` + `border: 1px solid BORDER.panel` + `RADIUS.xl` + `ELEVATION.lg`
+
+## 6. 遷移狀態
+
+| Phase | 範圍 | 狀態 |
+|---|---|---|
+| 0 | 建 `designTokens.ts` + 本文件 | ✅ 完成 |
+| 1 | 統一面板背景 + 陰影（→ SURFACE / ELEVATION） | pending |
+| 2 | fontFamily 統一（`"monospace"` → `FONT_DATA`） | pending |
+| 3 | 文字色階梯統一（散落 rgba 白 → `COLORS.text*`） | pending |
+| 4 | borderRadius / fontSize 收斂 | pending |
+| 5 | 災害語意色對齊（以 `LAYER_COLORS` 為基準） | pending |
+| 6 | CloseButton / Loading 統一 | pending |
+
+## 7. KEEP OUT — 不做的事
+
+- ❌ 不引入 Tailwind / CSS Modules / styled-components
+- ❌ 不抽 `Button` / `Card` 通用元件庫
+- ❌ 不改 `LAYER_COLORS` 結構（已被測試保護）
+- ❌ 不一次大爆炸改全部元件 — 每 Phase 獨立 PR
+- ❌ 不在新元件 inline 寫死 hex / rgba / px font size
+- ❌ 不反向把 `intelTokens` 改成 re-export from `designTokens`（會 circular dep，見 §1）
+
+## 8. 未納入 token 的範圍（未來題目，不在 Phase 0–6 scope）
+
+下列項目雖有需求但暫不在現階段 token 化，待真實痛點出現再開：
+
+- **Z_INDEX scale** — Mapbox controls / panel / modal / loading 目前散布 inline，未集中。
+- **transition / duration / easing tokens** — 互動動畫多為一次性，未統一節奏。
+- **互動狀態色**（hover / focus-ring / disabled / pressed）— 現多用 opacity 切換，未抽 state vocabulary。
+- **Breakpoint tokens** — 桌機 / 手機分流目前用 JS `isMobile` 判斷，無 CSS breakpoint scale。
+- **Control sizing**（button height / icon size / hit-area）— Phase 6 統一 CloseButton 時順手定，但不擴展為通用 scale。
+
+## 9. 相關文件
+
+- `CLAUDE.md` §5 / §5a — 新增 layer 強制順序 + UX 四鐵則
+- `docs/development-rules.md` §4a — 四鐵則完整版
+- `docs/known-issues.md` — 歷史 bug + 診斷

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { COLORS, FONT_DATA } from "./styles/designTokens";
+import { COLORS, FONT_DATA, RADIUS, FONT_SIZE } from "./styles/designTokens";
 import type { Map as MapboxMap } from "mapbox-gl";
 import type { ViewMode, RenderMode, DisplayMode, Flight, ExpandableLayerKey, LayerVisibility, AppMode } from "./types";
 import type { StationPillarData } from "./three/StationPillarScene";
@@ -1220,14 +1220,14 @@ export default function App() {
               width: 32, height: 32, margin: "0 auto 12px",
               border: "3px solid rgba(255,255,255,0.15)",
               borderTop: "3px solid #64aaff",
-              borderRadius: "50%",
+              borderRadius: RADIUS.full,
               animation: "day-loading-spin 0.8s linear infinite",
             }} />
             <style>{`@keyframes day-loading-spin { to { transform: rotate(360deg); } }`}</style>
-            <div style={{ fontSize: 14, fontWeight: 600, marginBottom: 6 }}>
+            <div style={{ fontSize: FONT_SIZE.lg, fontWeight: 600, marginBottom: 6 }}>
               資料更新中
             </div>
-            <div style={{ fontSize: 12, opacity: 0.7 }}>
+            <div style={{ fontSize: FONT_SIZE.md, opacity: 0.7 }}>
               {[
                 shipsDayLoading && "船舶",
                 flightsDayLoading && "航班",
@@ -1285,7 +1285,7 @@ export default function App() {
             </div>
             <div
               style={{
-                fontSize: 18,
+                fontSize: FONT_SIZE.xl,
                 fontFamily: FONT_DATA,
                 fontWeight: 600,
                 color: COLORS.textDefault,
@@ -1298,7 +1298,7 @@ export default function App() {
             </div>
             <div
               style={{
-                fontSize: 14,
+                fontSize: FONT_SIZE.lg,
                 fontFamily: FONT_DATA,
                 color: COLORS.textDim,
                 letterSpacing: 1,
@@ -1318,7 +1318,7 @@ export default function App() {
             </div>
             <div
               style={{
-                fontSize: 14,
+                fontSize: FONT_SIZE.lg,
                 fontFamily: FONT_DATA,
                 color: COLORS.textDim,
                 letterSpacing: 1,
@@ -1342,7 +1342,7 @@ export default function App() {
               background: "rgba(0,0,0,0.4)",
               border: "1px solid rgba(255,255,255,0.2)",
               color: "#fff",
-              fontSize: 22,
+              fontSize: FONT_SIZE.xxl,
               cursor: "pointer",
               display: "flex",
               alignItems: "center",
@@ -1356,9 +1356,9 @@ export default function App() {
               padding: "4px 12px",
               background: "rgba(255,255,255,0.08)",
               border: "1px solid rgba(255,255,255,0.15)",
-              borderRadius: 4,
+              borderRadius: RADIUS.md,
               color: COLORS.textDim,
-              fontSize: 11,
+              fontSize: FONT_SIZE.base,
               fontFamily: FONT_DATA,
               cursor: "pointer",
             }}
@@ -1387,7 +1387,7 @@ export default function App() {
             <h1
               style={{
                 margin: 0,
-                fontSize: 18,
+                fontSize: FONT_SIZE.xl,
                 color: isDarkTheme ? "#fff" : "#333",
                 fontFamily: FONT_DATA,
                 letterSpacing: 2,
@@ -1403,7 +1403,7 @@ export default function App() {
             />
 
             {loading && (
-              <span style={{ color: isDarkTheme ? COLORS.textMuted : "rgba(0,0,0,0.45)", fontSize: 13 }}>
+              <span style={{ color: isDarkTheme ? COLORS.textMuted : "rgba(0,0,0,0.45)", fontSize: FONT_SIZE.lg }}>
                 Loading...
               </span>
             )}
@@ -1551,9 +1551,9 @@ export default function App() {
                 padding: "6px 14px",
                 background: isDarkTheme ? "rgba(255,255,255,0.1)" : "rgba(0,0,0,0.06)",
                 border: `1px solid ${isDarkTheme ? "rgba(255,255,255,0.2)" : "rgba(0,0,0,0.12)"}`,
-                borderRadius: 6,
+                borderRadius: RADIUS.lg,
                 color: isDarkTheme ? "#fff" : "#333",
-                fontSize: 12,
+                fontSize: FONT_SIZE.md,
                 fontFamily: FONT_DATA,
                 cursor: "pointer",
                 backdropFilter: "blur(8px)",
@@ -1580,9 +1580,9 @@ export default function App() {
                   ? "#64aaff"
                   : (isDarkTheme ? "rgba(80,140,255,0.25)" : "rgba(80,140,255,0.15)"),
                 border: `1px solid ${monitorOpen ? "#64aaff" : "rgba(80,140,255,0.5)"}`,
-                borderRadius: 6,
+                borderRadius: RADIUS.lg,
                 color: monitorOpen ? "#04121f" : (isDarkTheme ? "#fff" : "#333"),
-                fontSize: 12,
+                fontSize: FONT_SIZE.md,
                 fontFamily: FONT_DATA,
                 fontWeight: monitorOpen ? 700 : 400,
                 cursor: "pointer",
@@ -1605,12 +1605,12 @@ export default function App() {
                 style={{
                   marginLeft: 2,
                   padding: "1px 5px",
-                  borderRadius: 3,
+                  borderRadius: RADIUS.md,
                   background: monitorOpen
                     ? "rgba(4,18,31,0.18)"
                     : "rgba(255,152,0,0.18)",
                   border: `1px solid ${monitorOpen ? "rgba(4,18,31,0.35)" : "rgba(255,152,0,0.55)"}`,
-                  fontSize: 8,
+                  fontSize: FONT_SIZE.xs,
                   fontWeight: 700,
                   letterSpacing: 1,
                   color: monitorOpen ? "#04121f" : "#ff9800",
@@ -1639,9 +1639,9 @@ export default function App() {
                 padding: "6px 14px",
                 background: isDarkTheme ? "rgba(255,255,255,0.1)" : "rgba(0,0,0,0.06)",
                 border: `1px solid ${isDarkTheme ? "rgba(255,255,255,0.2)" : "rgba(0,0,0,0.12)"}`,
-                borderRadius: 6,
+                borderRadius: RADIUS.lg,
                 color: isDarkTheme ? "#fff" : "#333",
-                fontSize: 12,
+                fontSize: FONT_SIZE.md,
                 fontFamily: FONT_DATA,
                 cursor: "pointer",
                 backdropFilter: "blur(8px)",
@@ -1660,7 +1660,7 @@ export default function App() {
               right: 16,
               zIndex: 10,
               color: isDarkTheme ? COLORS.textFaint : "rgba(0,0,0,0.2)",
-              fontSize: 10,
+              fontSize: FONT_SIZE.sm,
               fontFamily: FONT_DATA,
               letterSpacing: 0.5,
               textAlign: "right",
@@ -1678,7 +1678,7 @@ export default function App() {
               zIndex: 10,
               background: isDarkTheme ? "rgba(0,0,0,0.35)" : "rgba(255,255,255,0.35)",
               backdropFilter: "blur(8px)",
-              borderRadius: 6,
+              borderRadius: RADIUS.lg,
               padding: "4px 10px",
               transition: "left 0.2s ease",
             }}
@@ -1686,7 +1686,7 @@ export default function App() {
             <div
               style={{
                 color: isDarkTheme ? COLORS.textDim : "rgba(0,0,0,0.45)",
-                fontSize: 11,
+                fontSize: FONT_SIZE.base,
                 fontFamily: FONT_DATA,
               }}
             >
@@ -1701,7 +1701,7 @@ export default function App() {
             <div
               style={{
                 color: isDarkTheme ? COLORS.textDim : "rgba(0,0,0,0.3)",
-                fontSize: 11,
+                fontSize: FONT_SIZE.base,
                 fontFamily: FONT_DATA,
               }}
             >
@@ -1733,14 +1733,14 @@ export default function App() {
               WebkitBackdropFilter: "blur(12px)",
             }}
           >
-            <span style={{ color: "#fff", fontSize: 14, fontFamily: FONT_DATA, fontWeight: 700, letterSpacing: 1 }}>
+            <span style={{ color: "#fff", fontSize: FONT_SIZE.lg, fontFamily: FONT_DATA, fontWeight: 700, letterSpacing: 1 }}>
               MTP
             </span>
 
             <div style={{ flex: 1 }} />
 
             {loading && (
-              <span style={{ color: COLORS.textMuted, fontSize: 11, fontFamily: FONT_DATA }}>
+              <span style={{ color: COLORS.textMuted, fontSize: FONT_SIZE.base, fontFamily: FONT_DATA }}>
                 Loading...
               </span>
             )}
@@ -1750,11 +1750,11 @@ export default function App() {
               style={{
                 width: 36,
                 height: 36,
-                borderRadius: 8,
+                borderRadius: RADIUS.xl,
                 background: "rgba(255,255,255,0.1)",
                 border: "1px solid rgba(255,255,255,0.2)",
                 color: "#fff",
-                fontSize: 12,
+                fontSize: FONT_SIZE.md,
                 fontFamily: FONT_DATA,
                 cursor: "pointer",
                 display: "flex",
@@ -1770,11 +1770,11 @@ export default function App() {
               style={{
                 height: 36,
                 padding: "0 10px",
-                borderRadius: 8,
+                borderRadius: RADIUS.xl,
                 background: "rgba(255,255,255,0.1)",
                 border: "1px solid rgba(255,255,255,0.2)",
                 color: "#fff",
-                fontSize: 12,
+                fontSize: FONT_SIZE.md,
                 fontFamily: FONT_DATA,
                 cursor: "pointer",
                 letterSpacing: 1,
@@ -1788,13 +1788,13 @@ export default function App() {
               style={{
                 height: 36,
                 padding: "0 10px",
-                borderRadius: 8,
+                borderRadius: RADIUS.xl,
                 background: renderMode === "3d"
                   ? "rgba(80,140,255,0.25)"
                   : "rgba(255,170,68,0.25)",
                 border: `1px solid ${renderMode === "3d" ? "rgba(80,140,255,0.5)" : "rgba(255,170,68,0.5)"}`,
                 color: "#fff",
-                fontSize: 12,
+                fontSize: FONT_SIZE.md,
                 fontFamily: FONT_DATA,
                 cursor: "pointer",
                 letterSpacing: 1,
@@ -1910,7 +1910,7 @@ export default function App() {
                 {level === "full" && (
                   <div style={{ marginTop: 12, display: "flex", flexDirection: "column", gap: 10 }}>
                     <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
-                      <span style={{ color: COLORS.textMuted, fontSize: 11, fontFamily: FONT_DATA }}>Style</span>
+                      <span style={{ color: COLORS.textMuted, fontSize: FONT_SIZE.base, fontFamily: FONT_DATA }}>Style</span>
                       <StyleSelector
                         selected={mapStyleId}
                         isDarkTheme={true}
@@ -1953,24 +1953,24 @@ export default function App() {
             background: "rgba(10,10,20,0.9)",
             backdropFilter: "blur(12px)",
             border: "1px solid rgba(100,170,255,0.4)",
-            borderRadius: 8,
+            borderRadius: RADIUS.xl,
             padding: "10px 14px",
             pointerEvents: "none",
             fontFamily: FONT_DATA,
             minWidth: 160,
           }}
         >
-          <div style={{ fontSize: 13, fontWeight: 700, color: "#fff", letterSpacing: 1 }}>
+          <div style={{ fontSize: FONT_SIZE.lg, fontWeight: 700, color: "#fff", letterSpacing: 1 }}>
             {tooltipInfo.flight.callsign}
           </div>
-          <div style={{ fontSize: 11, color: COLORS.textDefault, marginTop: 4 }}>
+          <div style={{ fontSize: FONT_SIZE.base, color: COLORS.textDefault, marginTop: 4 }}>
             {tooltipInfo.flight.origin_iata} → {tooltipInfo.flight.dest_iata}
           </div>
-          <div style={{ fontSize: 11, color: COLORS.textMuted, marginTop: 2 }}>
+          <div style={{ fontSize: FONT_SIZE.base, color: COLORS.textMuted, marginTop: 2 }}>
             {tooltipInfo.flight.aircraft_type}
             {tooltipInfo.altitude != null && ` · ${tooltipInfo.altitude}m`}
           </div>
-          <div style={{ fontSize: 10, color: "rgba(100,170,255,0.6)", marginTop: 4 }}>
+          <div style={{ fontSize: FONT_SIZE.sm, color: "rgba(100,170,255,0.6)", marginTop: 4 }}>
             double-click to track
           </div>
         </div>
@@ -1987,24 +1987,24 @@ export default function App() {
             background: "rgba(10,10,20,0.9)",
             backdropFilter: "blur(12px)",
             border: `1px solid ${trainTooltipInfo.train.color}66`,
-            borderRadius: 8,
+            borderRadius: RADIUS.xl,
             padding: "10px 14px",
             pointerEvents: "none",
             fontFamily: FONT_DATA,
             minWidth: 180,
           }}
         >
-          <div style={{ fontSize: 13, fontWeight: 700, color: trainTooltipInfo.train.color, letterSpacing: 1 }}>
+          <div style={{ fontSize: FONT_SIZE.lg, fontWeight: 700, color: trainTooltipInfo.train.color, letterSpacing: 1 }}>
             {trainTooltipInfo.train.trainId}
           </div>
-          <div style={{ fontSize: 11, color: COLORS.textDefault, marginTop: 4 }}>
+          <div style={{ fontSize: FONT_SIZE.base, color: COLORS.textDefault, marginTop: 4 }}>
             {trainTooltipInfo.train.systemId.toUpperCase()} · {trainTooltipInfo.train.trackId}
           </div>
-          <div style={{ fontSize: 11, color: COLORS.textMuted, marginTop: 2 }}>
+          <div style={{ fontSize: FONT_SIZE.base, color: COLORS.textMuted, marginTop: 2 }}>
             {trainTooltipInfo.train.status === "running" ? "行駛中" : "停靠中"}
             {trainTooltipInfo.train.trainTypeCode && ` · ${trainTooltipInfo.train.trainTypeCode}`}
           </div>
-          <div style={{ fontSize: 10, color: COLORS.textDim, marginTop: 2 }}>
+          <div style={{ fontSize: FONT_SIZE.sm, color: COLORS.textDim, marginTop: 2 }}>
             {trainTooltipInfo.train.position[0].toFixed(4)}, {trainTooltipInfo.train.position[1].toFixed(4)}
           </div>
         </div>
@@ -2021,24 +2021,24 @@ export default function App() {
             background: "rgba(10,10,20,0.9)",
             backdropFilter: "blur(12px)",
             border: `1px solid ${busTooltipInfo.bus.color}66`,
-            borderRadius: 8,
+            borderRadius: RADIUS.xl,
             padding: "10px 14px",
             pointerEvents: "none",
             fontFamily: FONT_DATA,
             minWidth: 180,
           }}
         >
-          <div style={{ fontSize: 13, fontWeight: 700, color: busTooltipInfo.bus.color, letterSpacing: 1 }}>
+          <div style={{ fontSize: FONT_SIZE.lg, fontWeight: 700, color: busTooltipInfo.bus.color, letterSpacing: 1 }}>
             {busTooltipInfo.bus.routeName}
           </div>
-          <div style={{ fontSize: 11, color: COLORS.textDefault, marginTop: 4 }}>
+          <div style={{ fontSize: FONT_SIZE.base, color: COLORS.textDefault, marginTop: 4 }}>
             {busTooltipInfo.bus.plateNumb} · {busTooltipInfo.bus.city}
           </div>
-          <div style={{ fontSize: 11, color: COLORS.textMuted, marginTop: 2 }}>
+          <div style={{ fontSize: FONT_SIZE.base, color: COLORS.textMuted, marginTop: 2 }}>
             {busTooltipInfo.bus.status === "running" ? "行駛中" : "停靠中"}
             {busTooltipInfo.bus.speed > 0 && ` · ${busTooltipInfo.bus.speed.toFixed(0)} km/h`}
           </div>
-          <div style={{ fontSize: 10, color: COLORS.textDim, marginTop: 2 }}>
+          <div style={{ fontSize: FONT_SIZE.sm, color: COLORS.textDim, marginTop: 2 }}>
             {busTooltipInfo.bus.position[1].toFixed(4)}, {busTooltipInfo.bus.position[0].toFixed(4)}
           </div>
         </div>
@@ -2073,7 +2073,7 @@ export default function App() {
               background: "rgba(10,10,20,0.92)",
               backdropFilter: "blur(12px)",
               border: "1px solid #a78bfa66",
-              borderRadius: 8,
+              borderRadius: RADIUS.xl,
               padding: "10px 14px",
               pointerEvents: "none",
               fontFamily: FONT_DATA,
@@ -2081,20 +2081,20 @@ export default function App() {
               maxWidth: 360,
             }}
           >
-            <div style={{ fontSize: 13, fontWeight: 700, color: "#a78bfa", letterSpacing: 1 }}>
+            <div style={{ fontSize: FONT_SIZE.lg, fontWeight: 700, color: "#a78bfa", letterSpacing: 1 }}>
               {frame.route.city} · {frame.route.routeName ?? frame.route.routeId}
             </div>
-            <div style={{ fontSize: 10, color: COLORS.textDim, marginTop: 2 }}>
+            <div style={{ fontSize: FONT_SIZE.sm, color: COLORS.textDim, marginTop: 2 }}>
               route_id: {frame.route.routeId} · {frame.totalStops} stops · {frame.route.vehicleType}
             </div>
 
             {frame.route.scheduleInferred && (
-              <div style={{ marginTop: 6, fontSize: 10, color: "#fbbf24", fontWeight: 600 }}>
+              <div style={{ marginTop: 6, fontSize: FONT_SIZE.sm, color: "#fbbf24", fontWeight: 600 }}>
                 ⚠ 此路線無精確時刻，時間為推算（直線距離×1.4 ÷ 15km/h + 每站停 3 min）
               </div>
             )}
 
-            <div style={{ marginTop: 8, fontSize: 11, display: "flex", gap: 6, alignItems: "center" }}>
+            <div style={{ marginTop: 8, fontSize: FONT_SIZE.base, display: "flex", gap: 6, alignItems: "center" }}>
               <span style={{ color: stateColor, fontWeight: 700 }}>
                 {frame.state === "moving" ? "● 移動中" :
                  frame.state === "waiting" ? "● 停留中" :
@@ -2104,17 +2104,17 @@ export default function App() {
             </div>
 
             {isTripBreak && (
-              <div style={{ marginTop: 6, fontSize: 11, color: "#ef4444", fontWeight: 700 }}>
+              <div style={{ marginTop: 6, fontSize: FONT_SIZE.base, color: "#ef4444", fontWeight: 700 }}>
                 ⚠ 班次切換 gap={fmtGap(frame.gapToNextSec)}（&gt; {Math.round(WASTE_SCHEDULE_TRIP_BREAK_S / 60)}min 應 invisible）
               </div>
             )}
 
-            <div style={{ marginTop: 8, paddingTop: 6, borderTop: "1px dashed rgba(255,255,255,0.15)", fontSize: 11, color: COLORS.textStrong }}>
-              <div style={{ color: COLORS.textMuted, fontSize: 10, marginBottom: 2 }}>
+            <div style={{ marginTop: 8, paddingTop: 6, borderTop: "1px dashed rgba(255,255,255,0.15)", fontSize: FONT_SIZE.base, color: COLORS.textStrong }}>
+              <div style={{ color: COLORS.textMuted, fontSize: FONT_SIZE.sm, marginBottom: 2 }}>
                 ↓ 上一站 (#{frame.prevStop.stopSeq}/{frame.totalStops})
               </div>
               <div>{frame.prevStop.stopName ?? "(no name)"}</div>
-              <div style={{ fontSize: 10, color: COLORS.textMuted, marginTop: 2 }}>
+              <div style={{ fontSize: FONT_SIZE.sm, color: COLORS.textMuted, marginTop: 2 }}>
                 arrival {fmt(frame.prevStop.arrivalSec)} · departure {fmt(frame.prevStop.departureSec)}
                 {frame.prevStop.departureSec > frame.prevStop.arrivalSec &&
                   ` · 停 ${fmtGap(frame.prevStop.departureSec - frame.prevStop.arrivalSec)}`}
@@ -2122,12 +2122,12 @@ export default function App() {
             </div>
 
             {frame.nextStop && (
-              <div style={{ marginTop: 6, fontSize: 11, color: COLORS.textStrong }}>
-                <div style={{ color: COLORS.textMuted, fontSize: 10, marginBottom: 2 }}>
+              <div style={{ marginTop: 6, fontSize: FONT_SIZE.base, color: COLORS.textStrong }}>
+                <div style={{ color: COLORS.textMuted, fontSize: FONT_SIZE.sm, marginBottom: 2 }}>
                   ↓ 下一站 (#{frame.nextStop.stopSeq}/{frame.totalStops})
                 </div>
                 <div>{frame.nextStop.stopName ?? "(no name)"}</div>
-                <div style={{ fontSize: 10, color: COLORS.textMuted, marginTop: 2 }}>
+                <div style={{ fontSize: FONT_SIZE.sm, color: COLORS.textMuted, marginTop: 2 }}>
                   arrival {fmt(frame.nextStop.arrivalSec)}
                   {" · gap "}
                   <span style={{ color: isTripBreak ? "#ef4444" : COLORS.textMuted }}>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { FONT_DATA } from "./styles/designTokens";
 import type { Map as MapboxMap } from "mapbox-gl";
 import type { ViewMode, RenderMode, DisplayMode, Flight, ExpandableLayerKey, LayerVisibility, AppMode } from "./types";
 import type { StationPillarData } from "./three/StationPillarScene";
@@ -1213,7 +1214,7 @@ export default function App() {
         }}>
           <div style={{
             background: "rgba(0,0,0,0.8)", borderRadius: 12, padding: "24px 36px",
-            color: "#fff", textAlign: "center", fontFamily: "monospace",
+            color: "#fff", textAlign: "center", fontFamily: FONT_DATA,
           }}>
             <div style={{
               width: 32, height: 32, margin: "0 auto 12px",
@@ -1273,7 +1274,7 @@ export default function App() {
             <div
               style={{
                 fontSize: isMobile ? 20 : 28,
-                fontFamily: "monospace",
+                fontFamily: FONT_DATA,
                 fontWeight: 700,
                 color: "#fff",
                 letterSpacing: isMobile ? 2 : 4,
@@ -1285,7 +1286,7 @@ export default function App() {
             <div
               style={{
                 fontSize: 18,
-                fontFamily: "monospace",
+                fontFamily: FONT_DATA,
                 fontWeight: 600,
                 color: "rgba(255,255,255,0.7)",
                 letterSpacing: 2,
@@ -1298,7 +1299,7 @@ export default function App() {
             <div
               style={{
                 fontSize: 14,
-                fontFamily: "monospace",
+                fontFamily: FONT_DATA,
                 color: "rgba(255,255,255,0.4)",
                 letterSpacing: 1,
                 marginTop: 4,
@@ -1318,7 +1319,7 @@ export default function App() {
             <div
               style={{
                 fontSize: 14,
-                fontFamily: "monospace",
+                fontFamily: FONT_DATA,
                 color: "rgba(255,255,255,0.3)",
                 letterSpacing: 1,
                 marginTop: 4,
@@ -1358,7 +1359,7 @@ export default function App() {
               borderRadius: 4,
               color: "rgba(255,255,255,0.4)",
               fontSize: 11,
-              fontFamily: "monospace",
+              fontFamily: FONT_DATA,
               cursor: "pointer",
             }}
           >
@@ -1388,7 +1389,7 @@ export default function App() {
                 margin: 0,
                 fontSize: 18,
                 color: isDarkTheme ? "#fff" : "#333",
-                fontFamily: "monospace",
+                fontFamily: FONT_DATA,
                 letterSpacing: 2,
               }}
             >
@@ -1553,7 +1554,7 @@ export default function App() {
                 borderRadius: 6,
                 color: isDarkTheme ? "#fff" : "#333",
                 fontSize: 12,
-                fontFamily: "monospace",
+                fontFamily: FONT_DATA,
                 cursor: "pointer",
                 backdropFilter: "blur(8px)",
                 letterSpacing: 1,
@@ -1582,7 +1583,7 @@ export default function App() {
                 borderRadius: 6,
                 color: monitorOpen ? "#04121f" : (isDarkTheme ? "#fff" : "#333"),
                 fontSize: 12,
-                fontFamily: "monospace",
+                fontFamily: FONT_DATA,
                 fontWeight: monitorOpen ? 700 : 400,
                 cursor: "pointer",
                 backdropFilter: "blur(8px)",
@@ -1641,7 +1642,7 @@ export default function App() {
                 borderRadius: 6,
                 color: isDarkTheme ? "#fff" : "#333",
                 fontSize: 12,
-                fontFamily: "monospace",
+                fontFamily: FONT_DATA,
                 cursor: "pointer",
                 backdropFilter: "blur(8px)",
                 letterSpacing: 1,
@@ -1660,7 +1661,7 @@ export default function App() {
               zIndex: 10,
               color: isDarkTheme ? "rgba(255,255,255,0.25)" : "rgba(0,0,0,0.2)",
               fontSize: 10,
-              fontFamily: "monospace",
+              fontFamily: FONT_DATA,
               letterSpacing: 0.5,
               textAlign: "right",
             }}
@@ -1686,7 +1687,7 @@ export default function App() {
               style={{
                 color: isDarkTheme ? "rgba(255,255,255,0.4)" : "rgba(0,0,0,0.45)",
                 fontSize: 11,
-                fontFamily: "monospace",
+                fontFamily: FONT_DATA,
               }}
             >
               {displayedFlights.length} flights
@@ -1701,7 +1702,7 @@ export default function App() {
               style={{
                 color: isDarkTheme ? "rgba(255,255,255,0.3)" : "rgba(0,0,0,0.3)",
                 fontSize: 11,
-                fontFamily: "monospace",
+                fontFamily: FONT_DATA,
               }}
             >
               {cameraInfo.lat}, {cameraInfo.lng} z{cameraInfo.zoom} pitch {cameraInfo.pitch} bearing {cameraInfo.bearing}
@@ -1732,14 +1733,14 @@ export default function App() {
               WebkitBackdropFilter: "blur(12px)",
             }}
           >
-            <span style={{ color: "#fff", fontSize: 14, fontFamily: "monospace", fontWeight: 700, letterSpacing: 1 }}>
+            <span style={{ color: "#fff", fontSize: 14, fontFamily: FONT_DATA, fontWeight: 700, letterSpacing: 1 }}>
               MTP
             </span>
 
             <div style={{ flex: 1 }} />
 
             {loading && (
-              <span style={{ color: "rgba(255,255,255,0.5)", fontSize: 11, fontFamily: "monospace" }}>
+              <span style={{ color: "rgba(255,255,255,0.5)", fontSize: 11, fontFamily: FONT_DATA }}>
                 Loading...
               </span>
             )}
@@ -1754,7 +1755,7 @@ export default function App() {
                 border: "1px solid rgba(255,255,255,0.2)",
                 color: "#fff",
                 fontSize: 12,
-                fontFamily: "monospace",
+                fontFamily: FONT_DATA,
                 cursor: "pointer",
                 display: "flex",
                 alignItems: "center",
@@ -1774,7 +1775,7 @@ export default function App() {
                 border: "1px solid rgba(255,255,255,0.2)",
                 color: "#fff",
                 fontSize: 12,
-                fontFamily: "monospace",
+                fontFamily: FONT_DATA,
                 cursor: "pointer",
                 letterSpacing: 1,
               }}
@@ -1794,7 +1795,7 @@ export default function App() {
                 border: `1px solid ${renderMode === "3d" ? "rgba(80,140,255,0.5)" : "rgba(255,170,68,0.5)"}`,
                 color: "#fff",
                 fontSize: 12,
-                fontFamily: "monospace",
+                fontFamily: FONT_DATA,
                 cursor: "pointer",
                 letterSpacing: 1,
               }}
@@ -1909,7 +1910,7 @@ export default function App() {
                 {level === "full" && (
                   <div style={{ marginTop: 12, display: "flex", flexDirection: "column", gap: 10 }}>
                     <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
-                      <span style={{ color: "rgba(255,255,255,0.5)", fontSize: 11, fontFamily: "monospace" }}>Style</span>
+                      <span style={{ color: "rgba(255,255,255,0.5)", fontSize: 11, fontFamily: FONT_DATA }}>Style</span>
                       <StyleSelector
                         selected={mapStyleId}
                         isDarkTheme={true}
@@ -1955,7 +1956,7 @@ export default function App() {
             borderRadius: 8,
             padding: "10px 14px",
             pointerEvents: "none",
-            fontFamily: "monospace",
+            fontFamily: FONT_DATA,
             minWidth: 160,
           }}
         >
@@ -1989,7 +1990,7 @@ export default function App() {
             borderRadius: 8,
             padding: "10px 14px",
             pointerEvents: "none",
-            fontFamily: "monospace",
+            fontFamily: FONT_DATA,
             minWidth: 180,
           }}
         >
@@ -2023,7 +2024,7 @@ export default function App() {
             borderRadius: 8,
             padding: "10px 14px",
             pointerEvents: "none",
-            fontFamily: "monospace",
+            fontFamily: FONT_DATA,
             minWidth: 180,
           }}
         >
@@ -2075,7 +2076,7 @@ export default function App() {
               borderRadius: 8,
               padding: "10px 14px",
               pointerEvents: "none",
-              fontFamily: "monospace",
+              fontFamily: FONT_DATA,
               minWidth: 280,
               maxWidth: 360,
             }}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { FONT_DATA } from "./styles/designTokens";
+import { COLORS, FONT_DATA } from "./styles/designTokens";
 import type { Map as MapboxMap } from "mapbox-gl";
 import type { ViewMode, RenderMode, DisplayMode, Flight, ExpandableLayerKey, LayerVisibility, AppMode } from "./types";
 import type { StationPillarData } from "./three/StationPillarScene";
@@ -1288,7 +1288,7 @@ export default function App() {
                 fontSize: 18,
                 fontFamily: FONT_DATA,
                 fontWeight: 600,
-                color: "rgba(255,255,255,0.7)",
+                color: COLORS.textDefault,
                 letterSpacing: 2,
                 marginTop: 6,
                 textShadow: "0 1px 8px rgba(0,0,0,0.5)",
@@ -1300,7 +1300,7 @@ export default function App() {
               style={{
                 fontSize: 14,
                 fontFamily: FONT_DATA,
-                color: "rgba(255,255,255,0.4)",
+                color: COLORS.textDim,
                 letterSpacing: 1,
                 marginTop: 4,
                 textShadow: "0 1px 6px rgba(0,0,0,0.5)",
@@ -1320,7 +1320,7 @@ export default function App() {
               style={{
                 fontSize: 14,
                 fontFamily: FONT_DATA,
-                color: "rgba(255,255,255,0.3)",
+                color: COLORS.textDim,
                 letterSpacing: 1,
                 marginTop: 4,
                 textShadow: "0 1px 6px rgba(0,0,0,0.5)",
@@ -1357,7 +1357,7 @@ export default function App() {
               background: "rgba(255,255,255,0.08)",
               border: "1px solid rgba(255,255,255,0.15)",
               borderRadius: 4,
-              color: "rgba(255,255,255,0.4)",
+              color: COLORS.textDim,
               fontSize: 11,
               fontFamily: FONT_DATA,
               cursor: "pointer",
@@ -1403,7 +1403,7 @@ export default function App() {
             />
 
             {loading && (
-              <span style={{ color: isDarkTheme ? "rgba(255,255,255,0.5)" : "rgba(0,0,0,0.45)", fontSize: 13 }}>
+              <span style={{ color: isDarkTheme ? COLORS.textMuted : "rgba(0,0,0,0.45)", fontSize: 13 }}>
                 Loading...
               </span>
             )}
@@ -1659,7 +1659,7 @@ export default function App() {
               top: 84,
               right: 16,
               zIndex: 10,
-              color: isDarkTheme ? "rgba(255,255,255,0.25)" : "rgba(0,0,0,0.2)",
+              color: isDarkTheme ? COLORS.textFaint : "rgba(0,0,0,0.2)",
               fontSize: 10,
               fontFamily: FONT_DATA,
               letterSpacing: 0.5,
@@ -1685,7 +1685,7 @@ export default function App() {
           >
             <div
               style={{
-                color: isDarkTheme ? "rgba(255,255,255,0.4)" : "rgba(0,0,0,0.45)",
+                color: isDarkTheme ? COLORS.textDim : "rgba(0,0,0,0.45)",
                 fontSize: 11,
                 fontFamily: FONT_DATA,
               }}
@@ -1700,7 +1700,7 @@ export default function App() {
             </div>
             <div
               style={{
-                color: isDarkTheme ? "rgba(255,255,255,0.3)" : "rgba(0,0,0,0.3)",
+                color: isDarkTheme ? COLORS.textDim : "rgba(0,0,0,0.3)",
                 fontSize: 11,
                 fontFamily: FONT_DATA,
               }}
@@ -1740,7 +1740,7 @@ export default function App() {
             <div style={{ flex: 1 }} />
 
             {loading && (
-              <span style={{ color: "rgba(255,255,255,0.5)", fontSize: 11, fontFamily: FONT_DATA }}>
+              <span style={{ color: COLORS.textMuted, fontSize: 11, fontFamily: FONT_DATA }}>
                 Loading...
               </span>
             )}
@@ -1910,7 +1910,7 @@ export default function App() {
                 {level === "full" && (
                   <div style={{ marginTop: 12, display: "flex", flexDirection: "column", gap: 10 }}>
                     <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
-                      <span style={{ color: "rgba(255,255,255,0.5)", fontSize: 11, fontFamily: FONT_DATA }}>Style</span>
+                      <span style={{ color: COLORS.textMuted, fontSize: 11, fontFamily: FONT_DATA }}>Style</span>
                       <StyleSelector
                         selected={mapStyleId}
                         isDarkTheme={true}
@@ -1963,10 +1963,10 @@ export default function App() {
           <div style={{ fontSize: 13, fontWeight: 700, color: "#fff", letterSpacing: 1 }}>
             {tooltipInfo.flight.callsign}
           </div>
-          <div style={{ fontSize: 11, color: "rgba(255,255,255,0.7)", marginTop: 4 }}>
+          <div style={{ fontSize: 11, color: COLORS.textDefault, marginTop: 4 }}>
             {tooltipInfo.flight.origin_iata} → {tooltipInfo.flight.dest_iata}
           </div>
-          <div style={{ fontSize: 11, color: "rgba(255,255,255,0.5)", marginTop: 2 }}>
+          <div style={{ fontSize: 11, color: COLORS.textMuted, marginTop: 2 }}>
             {tooltipInfo.flight.aircraft_type}
             {tooltipInfo.altitude != null && ` · ${tooltipInfo.altitude}m`}
           </div>
@@ -1997,14 +1997,14 @@ export default function App() {
           <div style={{ fontSize: 13, fontWeight: 700, color: trainTooltipInfo.train.color, letterSpacing: 1 }}>
             {trainTooltipInfo.train.trainId}
           </div>
-          <div style={{ fontSize: 11, color: "rgba(255,255,255,0.7)", marginTop: 4 }}>
+          <div style={{ fontSize: 11, color: COLORS.textDefault, marginTop: 4 }}>
             {trainTooltipInfo.train.systemId.toUpperCase()} · {trainTooltipInfo.train.trackId}
           </div>
-          <div style={{ fontSize: 11, color: "rgba(255,255,255,0.5)", marginTop: 2 }}>
+          <div style={{ fontSize: 11, color: COLORS.textMuted, marginTop: 2 }}>
             {trainTooltipInfo.train.status === "running" ? "行駛中" : "停靠中"}
             {trainTooltipInfo.train.trainTypeCode && ` · ${trainTooltipInfo.train.trainTypeCode}`}
           </div>
-          <div style={{ fontSize: 10, color: "rgba(255,255,255,0.35)", marginTop: 2 }}>
+          <div style={{ fontSize: 10, color: COLORS.textDim, marginTop: 2 }}>
             {trainTooltipInfo.train.position[0].toFixed(4)}, {trainTooltipInfo.train.position[1].toFixed(4)}
           </div>
         </div>
@@ -2031,14 +2031,14 @@ export default function App() {
           <div style={{ fontSize: 13, fontWeight: 700, color: busTooltipInfo.bus.color, letterSpacing: 1 }}>
             {busTooltipInfo.bus.routeName}
           </div>
-          <div style={{ fontSize: 11, color: "rgba(255,255,255,0.7)", marginTop: 4 }}>
+          <div style={{ fontSize: 11, color: COLORS.textDefault, marginTop: 4 }}>
             {busTooltipInfo.bus.plateNumb} · {busTooltipInfo.bus.city}
           </div>
-          <div style={{ fontSize: 11, color: "rgba(255,255,255,0.5)", marginTop: 2 }}>
+          <div style={{ fontSize: 11, color: COLORS.textMuted, marginTop: 2 }}>
             {busTooltipInfo.bus.status === "running" ? "行駛中" : "停靠中"}
             {busTooltipInfo.bus.speed > 0 && ` · ${busTooltipInfo.bus.speed.toFixed(0)} km/h`}
           </div>
-          <div style={{ fontSize: 10, color: "rgba(255,255,255,0.35)", marginTop: 2 }}>
+          <div style={{ fontSize: 10, color: COLORS.textDim, marginTop: 2 }}>
             {busTooltipInfo.bus.position[1].toFixed(4)}, {busTooltipInfo.bus.position[0].toFixed(4)}
           </div>
         </div>
@@ -2084,7 +2084,7 @@ export default function App() {
             <div style={{ fontSize: 13, fontWeight: 700, color: "#a78bfa", letterSpacing: 1 }}>
               {frame.route.city} · {frame.route.routeName ?? frame.route.routeId}
             </div>
-            <div style={{ fontSize: 10, color: "rgba(255,255,255,0.4)", marginTop: 2 }}>
+            <div style={{ fontSize: 10, color: COLORS.textDim, marginTop: 2 }}>
               route_id: {frame.route.routeId} · {frame.totalStops} stops · {frame.route.vehicleType}
             </div>
 
@@ -2100,7 +2100,7 @@ export default function App() {
                  frame.state === "waiting" ? "● 停留中" :
                  frame.state === "before-route" ? "○ 路線未開始" : "○ 路線已結束"}
               </span>
-              <span style={{ color: "rgba(255,255,255,0.5)" }}>now {fmt(frame.nowSec)}</span>
+              <span style={{ color: COLORS.textMuted }}>now {fmt(frame.nowSec)}</span>
             </div>
 
             {isTripBreak && (
@@ -2109,12 +2109,12 @@ export default function App() {
               </div>
             )}
 
-            <div style={{ marginTop: 8, paddingTop: 6, borderTop: "1px dashed rgba(255,255,255,0.15)", fontSize: 11, color: "rgba(255,255,255,0.85)" }}>
-              <div style={{ color: "rgba(255,255,255,0.5)", fontSize: 10, marginBottom: 2 }}>
+            <div style={{ marginTop: 8, paddingTop: 6, borderTop: "1px dashed rgba(255,255,255,0.15)", fontSize: 11, color: COLORS.textStrong }}>
+              <div style={{ color: COLORS.textMuted, fontSize: 10, marginBottom: 2 }}>
                 ↓ 上一站 (#{frame.prevStop.stopSeq}/{frame.totalStops})
               </div>
               <div>{frame.prevStop.stopName ?? "(no name)"}</div>
-              <div style={{ fontSize: 10, color: "rgba(255,255,255,0.55)", marginTop: 2 }}>
+              <div style={{ fontSize: 10, color: COLORS.textMuted, marginTop: 2 }}>
                 arrival {fmt(frame.prevStop.arrivalSec)} · departure {fmt(frame.prevStop.departureSec)}
                 {frame.prevStop.departureSec > frame.prevStop.arrivalSec &&
                   ` · 停 ${fmtGap(frame.prevStop.departureSec - frame.prevStop.arrivalSec)}`}
@@ -2122,15 +2122,15 @@ export default function App() {
             </div>
 
             {frame.nextStop && (
-              <div style={{ marginTop: 6, fontSize: 11, color: "rgba(255,255,255,0.85)" }}>
-                <div style={{ color: "rgba(255,255,255,0.5)", fontSize: 10, marginBottom: 2 }}>
+              <div style={{ marginTop: 6, fontSize: 11, color: COLORS.textStrong }}>
+                <div style={{ color: COLORS.textMuted, fontSize: 10, marginBottom: 2 }}>
                   ↓ 下一站 (#{frame.nextStop.stopSeq}/{frame.totalStops})
                 </div>
                 <div>{frame.nextStop.stopName ?? "(no name)"}</div>
-                <div style={{ fontSize: 10, color: "rgba(255,255,255,0.55)", marginTop: 2 }}>
+                <div style={{ fontSize: 10, color: COLORS.textMuted, marginTop: 2 }}>
                   arrival {fmt(frame.nextStop.arrivalSec)}
                   {" · gap "}
-                  <span style={{ color: isTripBreak ? "#ef4444" : "rgba(255,255,255,0.55)" }}>
+                  <span style={{ color: isTripBreak ? "#ef4444" : COLORS.textMuted }}>
                     {fmtGap(frame.gapToNextSec)}
                   </span>
                 </div>

--- a/src/components/AirportSelector.tsx
+++ b/src/components/AirportSelector.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import { ALL_PRESETS } from "../map/cameraPresets";
 import type { CameraPreset } from "../types";
+import { FONT_DATA } from "../styles/designTokens";
 
 interface Props {
   isDarkTheme?: boolean;
@@ -50,7 +51,7 @@ export function LocationJump({ isDarkTheme = true, onJump, currentId }: Props) {
     borderRadius: 4,
     padding: "4px 8px",
     fontSize: 14,
-    fontFamily: "monospace",
+    fontFamily: FONT_DATA,
     backdropFilter: "blur(8px)",
     cursor: "pointer",
   };
@@ -74,7 +75,7 @@ export function LocationJump({ isDarkTheme = true, onJump, currentId }: Props) {
             border: "1px solid rgba(255,255,255,0.12)",
             borderRadius: 8,
             padding: "12px 14px",
-            fontFamily: "monospace",
+            fontFamily: FONT_DATA,
           }}
         >
           {/* Overview */}
@@ -113,7 +114,7 @@ function SectionTitle({ children }: { children: React.ReactNode }) {
         fontSize: 11,
         letterSpacing: 2,
         marginBottom: 6,
-        fontFamily: "monospace",
+        fontFamily: FONT_DATA,
       }}
     >
       {children}
@@ -171,7 +172,7 @@ function Item({
             : "transparent",
         color: active ? "#64aaff" : "#fff",
         fontSize: compact ? 12 : 13,
-        fontFamily: "monospace",
+        fontFamily: FONT_DATA,
         cursor: "pointer",
         textAlign: "left",
         width: "100%",

--- a/src/components/AirportSelector.tsx
+++ b/src/components/AirportSelector.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import { ALL_PRESETS } from "../map/cameraPresets";
 import type { CameraPreset } from "../types";
-import { COLORS, FONT_DATA } from "../styles/designTokens";
+import { COLORS, FONT_DATA, RADIUS, FONT_SIZE } from "../styles/designTokens";
 
 interface Props {
   isDarkTheme?: boolean;
@@ -48,9 +48,9 @@ export function LocationJump({ isDarkTheme = true, onJump, currentId }: Props) {
     background: isDarkTheme ? "rgba(0,0,0,0.6)" : "rgba(255,255,255,0.85)",
     color: isDarkTheme ? "#fff" : "#333",
     border: `1px solid ${isDarkTheme ? "rgba(255,255,255,0.2)" : "rgba(0,0,0,0.12)"}`,
-    borderRadius: 4,
+    borderRadius: RADIUS.md,
     padding: "4px 8px",
-    fontSize: 14,
+    fontSize: FONT_SIZE.lg,
     fontFamily: FONT_DATA,
     backdropFilter: "blur(8px)",
     cursor: "pointer",
@@ -73,7 +73,7 @@ export function LocationJump({ isDarkTheme = true, onJump, currentId }: Props) {
             background: "rgba(14,14,22,0.95)",
             backdropFilter: "blur(16px)",
             border: "1px solid rgba(255,255,255,0.12)",
-            borderRadius: 8,
+            borderRadius: RADIUS.xl,
             padding: "12px 14px",
             fontFamily: FONT_DATA,
           }}
@@ -111,7 +111,7 @@ function SectionTitle({ children }: { children: React.ReactNode }) {
     <div
       style={{
         color: COLORS.textDim,
-        fontSize: 11,
+        fontSize: FONT_SIZE.base,
         letterSpacing: 2,
         marginBottom: 6,
         fontFamily: FONT_DATA,
@@ -163,7 +163,7 @@ function Item({
         alignItems: "center",
         gap: 6,
         padding: compact ? "5px 6px" : "5px 8px",
-        borderRadius: 4,
+        borderRadius: RADIUS.md,
         border: "none",
         background: active
           ? "rgba(100,170,255,0.15)"
@@ -171,19 +171,19 @@ function Item({
             ? "rgba(255,255,255,0.08)"
             : "transparent",
         color: active ? "#64aaff" : "#fff",
-        fontSize: compact ? 12 : 13,
+        fontSize: compact ? FONT_SIZE.md : FONT_SIZE.lg,
         fontFamily: FONT_DATA,
         cursor: "pointer",
         textAlign: "left",
         width: "100%",
       }}
     >
-      {active && <span style={{ fontSize: 8, lineHeight: 1 }}>●</span>}
+      {active && <span style={{ fontSize: FONT_SIZE.xs, lineHeight: 1 }}>●</span>}
       <span style={{ flex: 1, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
         {preset.name}
       </span>
       {airport && iata && (
-        <span style={{ color: COLORS.textDim, fontSize: 11 }}>{iata}</span>
+        <span style={{ color: COLORS.textDim, fontSize: FONT_SIZE.base }}>{iata}</span>
       )}
     </button>
   );

--- a/src/components/AirportSelector.tsx
+++ b/src/components/AirportSelector.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import { ALL_PRESETS } from "../map/cameraPresets";
 import type { CameraPreset } from "../types";
-import { FONT_DATA } from "../styles/designTokens";
+import { COLORS, FONT_DATA } from "../styles/designTokens";
 
 interface Props {
   isDarkTheme?: boolean;
@@ -110,7 +110,7 @@ function SectionTitle({ children }: { children: React.ReactNode }) {
   return (
     <div
       style={{
-        color: "rgba(255,255,255,0.4)",
+        color: COLORS.textDim,
         fontSize: 11,
         letterSpacing: 2,
         marginBottom: 6,
@@ -183,7 +183,7 @@ function Item({
         {preset.name}
       </span>
       {airport && iata && (
-        <span style={{ color: "rgba(255,255,255,0.35)", fontSize: 11 }}>{iata}</span>
+        <span style={{ color: COLORS.textDim, fontSize: 11 }}>{iata}</span>
       )}
     </button>
   );

--- a/src/components/AqiLegend.tsx
+++ b/src/components/AqiLegend.tsx
@@ -1,4 +1,4 @@
-import { FONT_DATA } from "../styles/designTokens";
+import { FONT_DATA, RADIUS, FONT_SIZE } from "../styles/designTokens";
 
 /**
  * AqiLegend — AQI 6 級色階圖例（橫條）
@@ -38,7 +38,7 @@ export function AqiLegend({ isDark, caption }: Props) {
         background: isDark ? "rgba(0,0,0,0.55)" : "rgba(255,255,255,0.7)",
         backdropFilter: "blur(12px)",
         WebkitBackdropFilter: "blur(12px)",
-        borderRadius: 8,
+        borderRadius: RADIUS.xl,
         fontFamily: FONT_DATA,
         color: isDark ? "#ddd" : "#222",
       }}
@@ -58,7 +58,7 @@ export function AqiLegend({ isDark, caption }: Props) {
       `}</style>
       <div
         style={{
-          fontSize: 10,
+          fontSize: FONT_SIZE.sm,
           marginBottom: 4,
           opacity: 0.75,
           display: "flex",
@@ -70,7 +70,7 @@ export function AqiLegend({ isDark, caption }: Props) {
         {loadingLabel && (
           <span style={{ marginLeft: "auto", display: "inline-flex", alignItems: "center", gap: 4, color: "#93c5fd" }}>
             <span className="aqi-spin" />
-            <span style={{ fontSize: 9 }}>載入中…</span>
+            <span style={{ fontSize: FONT_SIZE.xs }}>載入中…</span>
           </span>
         )}
       </div>
@@ -79,7 +79,7 @@ export function AqiLegend({ isDark, caption }: Props) {
           display: "flex",
           height: 12,
           width: 220,
-          borderRadius: 2,
+          borderRadius: RADIUS.sm,
           overflow: "hidden",
         }}
       >
@@ -95,7 +95,7 @@ export function AqiLegend({ isDark, caption }: Props) {
         style={{
           display: "flex",
           justifyContent: "space-between",
-          fontSize: 8,
+          fontSize: FONT_SIZE.xs,
           marginTop: 2,
           opacity: 0.75,
           width: 220,
@@ -106,7 +106,7 @@ export function AqiLegend({ isDark, caption }: Props) {
         ))}
       </div>
       {caption && (
-        <div style={{ fontSize: 9, marginTop: 3, opacity: 0.6 }}>{caption}</div>
+        <div style={{ fontSize: FONT_SIZE.xs, marginTop: 3, opacity: 0.6 }}>{caption}</div>
       )}
     </div>
   );

--- a/src/components/AqiLegend.tsx
+++ b/src/components/AqiLegend.tsx
@@ -1,3 +1,5 @@
+import { FONT_DATA } from "../styles/designTokens";
+
 /**
  * AqiLegend — AQI 6 級色階圖例（橫條）
  *
@@ -37,7 +39,7 @@ export function AqiLegend({ isDark, caption }: Props) {
         backdropFilter: "blur(12px)",
         WebkitBackdropFilter: "blur(12px)",
         borderRadius: 8,
-        fontFamily: "monospace",
+        fontFamily: FONT_DATA,
         color: isDark ? "#ddd" : "#222",
       }}
     >

--- a/src/components/AqiProductSwitcher.tsx
+++ b/src/components/AqiProductSwitcher.tsx
@@ -3,6 +3,7 @@
  *
  * 僅當 aqiImagery 圖層開啟時才由 App 掛上。
  */
+import { FONT_DATA } from "../styles/designTokens";
 
 import { AQI_PRODUCT_LABELS, type AqiProduct } from "../types";
 
@@ -25,7 +26,7 @@ export function AqiProductSwitcher({ current, onChange, isDark }: Props) {
         backdropFilter: "blur(12px)",
         WebkitBackdropFilter: "blur(12px)",
         borderRadius: 8,
-        fontFamily: "monospace",
+        fontFamily: FONT_DATA,
       }}
     >
       {PRODUCTS.map((p) => {
@@ -36,7 +37,7 @@ export function AqiProductSwitcher({ current, onChange, isDark }: Props) {
             onClick={() => onChange(p)}
             style={{
               fontSize: 10,
-              fontFamily: "monospace",
+              fontFamily: FONT_DATA,
               padding: "4px 8px",
               borderRadius: 4,
               border: "1px solid",

--- a/src/components/AqiProductSwitcher.tsx
+++ b/src/components/AqiProductSwitcher.tsx
@@ -3,7 +3,7 @@
  *
  * 僅當 aqiImagery 圖層開啟時才由 App 掛上。
  */
-import { FONT_DATA } from "../styles/designTokens";
+import { FONT_DATA, RADIUS, FONT_SIZE } from "../styles/designTokens";
 
 import { AQI_PRODUCT_LABELS, type AqiProduct } from "../types";
 
@@ -25,7 +25,7 @@ export function AqiProductSwitcher({ current, onChange, isDark }: Props) {
         background: isDark ? "rgba(0,0,0,0.55)" : "rgba(255,255,255,0.7)",
         backdropFilter: "blur(12px)",
         WebkitBackdropFilter: "blur(12px)",
-        borderRadius: 8,
+        borderRadius: RADIUS.xl,
         fontFamily: FONT_DATA,
       }}
     >
@@ -36,10 +36,10 @@ export function AqiProductSwitcher({ current, onChange, isDark }: Props) {
             key={p}
             onClick={() => onChange(p)}
             style={{
-              fontSize: 10,
+              fontSize: FONT_SIZE.sm,
               fontFamily: FONT_DATA,
               padding: "4px 8px",
-              borderRadius: 4,
+              borderRadius: RADIUS.md,
               border: "1px solid",
               borderColor: active
                 ? "rgba(139, 195, 74, 0.7)"

--- a/src/components/CctvStreamView.tsx
+++ b/src/components/CctvStreamView.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from "react";
+import { COLORS } from "../styles/designTokens";
 
 interface Props {
   /** VideoStreamURL — MJPEG 串流（freeway/highway/部分 city）或 HTML 播放頁（北市/桃園/台中等 city） */
@@ -143,7 +144,7 @@ export function CctvStreamView({ streamUrl, imageUrl, source, accentColor }: Pro
       <span
         style={{
           fontSize: 11,
-          color: "rgba(255,255,255,0.55)",
+          color: COLORS.textMuted,
           textAlign: "center",
           padding: "0 12px",
           lineHeight: 1.5,
@@ -203,7 +204,7 @@ export function CctvStreamView({ streamUrl, imageUrl, source, accentColor }: Pro
             style={{
               position: "absolute",
               fontSize: 11,
-              color: "rgba(255,255,255,0.4)",
+              color: COLORS.textDim,
             }}
           >
             載入中…

--- a/src/components/CctvStreamView.tsx
+++ b/src/components/CctvStreamView.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from "react";
-import { COLORS } from "../styles/designTokens";
+import { COLORS, RADIUS, FONT_SIZE } from "../styles/designTokens";
 
 interface Props {
   /** VideoStreamURL — MJPEG 串流（freeway/highway/部分 city）或 HTML 播放頁（北市/桃園/台中等 city） */
@@ -74,7 +74,7 @@ const BOX_STYLE: React.CSSProperties = {
   width: "100%",
   // CCTV 畫面多為 16:9，框用同比例隨寬度自適應，避免太扁造成上下裁切 / 左右黑邊
   aspectRatio: "16 / 9",
-  borderRadius: 4,
+  borderRadius: RADIUS.md,
   overflow: "hidden",
   background: "#0a0a0a",
   border: "1px solid rgba(255,255,255,0.08)",
@@ -130,7 +130,7 @@ export function CctvStreamView({ streamUrl, imageUrl, source, accentColor }: Pro
         display: "inline-block",
         marginTop: 6,
         color: accentColor,
-        fontSize: 11,
+        fontSize: FONT_SIZE.base,
         textDecoration: "underline",
         wordBreak: "break-all",
       }}
@@ -143,7 +143,7 @@ export function CctvStreamView({ streamUrl, imageUrl, source, accentColor }: Pro
     <div style={BOX_STYLE} data-cctv-source={source}>
       <span
         style={{
-          fontSize: 11,
+          fontSize: FONT_SIZE.base,
           color: COLORS.textMuted,
           textAlign: "center",
           padding: "0 12px",
@@ -203,7 +203,7 @@ export function CctvStreamView({ streamUrl, imageUrl, source, accentColor }: Pro
           <span
             style={{
               position: "absolute",
-              fontSize: 11,
+              fontSize: FONT_SIZE.base,
               color: COLORS.textDim,
             }}
           >

--- a/src/components/DataCalendarPanel.tsx
+++ b/src/components/DataCalendarPanel.tsx
@@ -1,5 +1,5 @@
 import { useState, useMemo } from "react";
-import { FONT_DATA } from "../styles/designTokens";
+import { COLORS, FONT_DATA } from "../styles/designTokens";
 import { ChevronLeft, ChevronRight, Navigation } from "lucide-react";
 import type { DataRegistry } from "../hooks/useDataRegistry";
 
@@ -256,7 +256,7 @@ export function DataCalendarPanel({ registry, selectedDate, onDateSelect }: Prop
                 <span style={{
                   fontSize: 10,
                   fontFamily: FONT_DATA,
-                  color: isSelected ? "#fff" : (sourcesOnDay.length > 0 ? "rgba(255,255,255,0.8)" : "rgba(255,255,255,0.25)"),
+                  color: isSelected ? "#fff" : (sourcesOnDay.length > 0 ? COLORS.textDefault : COLORS.textFaint),
                   fontWeight: isSelected ? 700 : 400,
                   lineHeight: 1,
                 }}>
@@ -292,7 +292,7 @@ export function DataCalendarPanel({ registry, selectedDate, onDateSelect }: Prop
                   <span style={{
                     fontSize: 7,
                     fontFamily: FONT_DATA,
-                    color: "rgba(255,255,255,0.5)",
+                    color: COLORS.textMuted,
                     lineHeight: 1,
                   }}>
                     {Math.round(coverage * 100)}%
@@ -356,7 +356,7 @@ export function DataCalendarPanel({ registry, selectedDate, onDateSelect }: Prop
                     padding: "1px 6px",
                     borderRadius: 3,
                     background: hasData ? "rgba(255,255,255,0.06)" : "transparent",
-                    color: hasData ? s.color : "rgba(255,255,255,0.2)",
+                    color: hasData ? s.color : COLORS.textFaint,
                     border: hasData ? `1px solid ${s.color}33` : "1px solid rgba(255,255,255,0.06)",
                   }}
                 >
@@ -388,7 +388,7 @@ export function DataCalendarPanel({ registry, selectedDate, onDateSelect }: Prop
                   borderRadius: 3,
                   border: isActive ? `1px solid ${s.color}` : "1px solid rgba(255,255,255,0.1)",
                   background: isActive ? `${s.color}22` : "transparent",
-                  color: isActive ? s.color : "rgba(255,255,255,0.5)",
+                  color: isActive ? s.color : COLORS.textMuted,
                   cursor: "pointer",
                   transition: "all 0.15s",
                 }}

--- a/src/components/DataCalendarPanel.tsx
+++ b/src/components/DataCalendarPanel.tsx
@@ -1,5 +1,5 @@
 import { useState, useMemo } from "react";
-import { COLORS, FONT_DATA } from "../styles/designTokens";
+import { COLORS, FONT_DATA, RADIUS, FONT_SIZE } from "../styles/designTokens";
 import { ChevronLeft, ChevronRight, Navigation } from "lucide-react";
 import type { DataRegistry } from "../hooks/useDataRegistry";
 
@@ -126,7 +126,7 @@ export function DataCalendarPanel({ registry, selectedDate, onDateSelect }: Prop
       {/* ── DAILY section ── */}
       {cyclicSources.length > 0 && (
         <div style={{ padding: "8px 12px" }}>
-          <div style={{ fontSize: 10, fontWeight: 600, letterSpacing: 1.5, color: DIM, fontFamily: FONT_DATA, marginBottom: 6 }}>
+          <div style={{ fontSize: FONT_SIZE.sm, fontWeight: 600, letterSpacing: 1.5, color: DIM, fontFamily: FONT_DATA, marginBottom: 6 }}>
             DAILY
           </div>
           <div style={{ display: "flex", gap: 6, flexWrap: "wrap" }}>
@@ -134,18 +134,18 @@ export function DataCalendarPanel({ registry, selectedDate, onDateSelect }: Prop
               <span
                 key={s.id}
                 style={{
-                  fontSize: 10,
+                  fontSize: FONT_SIZE.sm,
                   fontFamily: FONT_DATA,
                   color: s.color,
                   background: "rgba(255,255,255,0.05)",
-                  borderRadius: 3,
+                  borderRadius: RADIUS.md,
                   padding: "2px 6px",
                 }}
               >
                 {s.label}
               </span>
             ))}
-            <span style={{ fontSize: 10, fontFamily: FONT_DATA, color: DIM }}>always</span>
+            <span style={{ fontSize: FONT_SIZE.sm, fontFamily: FONT_DATA, color: DIM }}>always</span>
           </div>
         </div>
       )}
@@ -159,7 +159,7 @@ export function DataCalendarPanel({ registry, selectedDate, onDateSelect }: Prop
         <button onClick={() => shiftMonth(-1)} style={navBtnStyle}>
           <ChevronLeft size={14} />
         </button>
-        <span style={{ flex: 1, textAlign: "center", fontSize: 12, fontWeight: 600, color: "#fff", fontFamily: "Inter, system-ui, sans-serif" }}>
+        <span style={{ flex: 1, textAlign: "center", fontSize: FONT_SIZE.md, fontWeight: 600, color: "#fff", fontFamily: "Inter, system-ui, sans-serif" }}>
           {year}年{month + 1}月
         </span>
         <button onClick={() => shiftMonth(1)} style={navBtnStyle}>
@@ -173,10 +173,10 @@ export function DataCalendarPanel({ registry, selectedDate, onDateSelect }: Prop
               key={m}
               onClick={() => setMode(m)}
               style={{
-                fontSize: 9,
+                fontSize: FONT_SIZE.xs,
                 fontFamily: FONT_DATA,
                 padding: "2px 6px",
-                borderRadius: 3,
+                borderRadius: RADIUS.md,
                 border: mode === m ? "1px solid rgba(255,255,255,0.3)" : "1px solid transparent",
                 background: mode === m ? "rgba(255,255,255,0.1)" : "transparent",
                 color: mode === m ? "#fff" : DIM,
@@ -198,7 +198,7 @@ export function DataCalendarPanel({ registry, selectedDate, onDateSelect }: Prop
               key={wd}
               style={{
                 textAlign: "center",
-                fontSize: 9,
+                fontSize: FONT_SIZE.xs,
                 color: DIM,
                 fontFamily: FONT_DATA,
                 padding: "2px 0",
@@ -239,7 +239,7 @@ export function DataCalendarPanel({ registry, selectedDate, onDateSelect }: Prop
                     : isSelected
                       ? "1px solid rgba(255,255,255,0.3)"
                       : "1px solid transparent",
-                  borderRadius: 4,
+                  borderRadius: RADIUS.md,
                   background: mode === "heat"
                     ? `rgba(100, 200, 255, ${coverage * 0.35})`
                     : (isSelected ? "rgba(255,255,255,0.08)" : "transparent"),
@@ -254,7 +254,7 @@ export function DataCalendarPanel({ registry, selectedDate, onDateSelect }: Prop
               >
                 {/* Day number */}
                 <span style={{
-                  fontSize: 10,
+                  fontSize: FONT_SIZE.sm,
                   fontFamily: FONT_DATA,
                   color: isSelected ? "#fff" : (sourcesOnDay.length > 0 ? COLORS.textDefault : COLORS.textFaint),
                   fontWeight: isSelected ? 700 : 400,
@@ -278,7 +278,7 @@ export function DataCalendarPanel({ registry, selectedDate, onDateSelect }: Prop
                         style={{
                           width: 4,
                           height: 4,
-                          borderRadius: "50%",
+                          borderRadius: RADIUS.full,
                           background: SOURCE_COLORS[srcId] ?? "#888",
                           flexShrink: 0,
                         }}
@@ -290,7 +290,7 @@ export function DataCalendarPanel({ registry, selectedDate, onDateSelect }: Prop
                 {/* Heat mode: coverage % */}
                 {mode === "heat" && sourcesOnDay.length > 0 && (
                   <span style={{
-                    fontSize: 7,
+                    fontSize: FONT_SIZE.xs,
                     fontFamily: FONT_DATA,
                     color: COLORS.textMuted,
                     lineHeight: 1,
@@ -309,10 +309,10 @@ export function DataCalendarPanel({ registry, selectedDate, onDateSelect }: Prop
         <div style={{ padding: "4px 12px 8px" }}>
           <div style={{ height: 1, background: BORDER, marginBottom: 6 }} />
           <div style={{ display: "flex", alignItems: "center", gap: 6, marginBottom: 6 }}>
-            <span style={{ fontSize: 11, fontWeight: 600, color: "#fff", fontFamily: "Inter, system-ui, sans-serif" }}>
+            <span style={{ fontSize: FONT_SIZE.base, fontWeight: 600, color: "#fff", fontFamily: "Inter, system-ui, sans-serif" }}>
               {detailDate.getMonth() + 1}/{detailDate.getDate()} ({WEEKDAYS[detailDate.getDay()]})
             </span>
-            <span style={{ fontSize: 10, color: DIM, fontFamily: FONT_DATA }}>
+            <span style={{ fontSize: FONT_SIZE.sm, color: DIM, fontFamily: FONT_DATA }}>
               {(() => {
                 const sources = daySourceMap.get(detailDate.getDate()) ?? [];
                 return totalSources > 0
@@ -329,12 +329,12 @@ export function DataCalendarPanel({ registry, selectedDate, onDateSelect }: Prop
                 display: "flex",
                 alignItems: "center",
                 gap: 3,
-                fontSize: 10,
+                fontSize: FONT_SIZE.sm,
                 fontFamily: FONT_DATA,
                 color: "#64aaff",
                 background: "rgba(100,170,255,0.1)",
                 border: "1px solid rgba(100,170,255,0.3)",
-                borderRadius: 4,
+                borderRadius: RADIUS.md,
                 padding: "2px 8px",
                 cursor: "pointer",
               }}
@@ -351,10 +351,10 @@ export function DataCalendarPanel({ registry, selectedDate, onDateSelect }: Prop
                 <span
                   key={s.id}
                   style={{
-                    fontSize: 10,
+                    fontSize: FONT_SIZE.sm,
                     fontFamily: FONT_DATA,
                     padding: "1px 6px",
-                    borderRadius: 3,
+                    borderRadius: RADIUS.md,
                     background: hasData ? "rgba(255,255,255,0.06)" : "transparent",
                     color: hasData ? s.color : COLORS.textFaint,
                     border: hasData ? `1px solid ${s.color}33` : "1px solid rgba(255,255,255,0.06)",
@@ -371,7 +371,7 @@ export function DataCalendarPanel({ registry, selectedDate, onDateSelect }: Prop
       {/* ── Legend (click to filter) ── */}
       <div style={{ height: 1, background: BORDER, margin: "0 12px" }} />
       <div style={{ padding: "6px 12px 8px" }}>
-        <div style={{ fontSize: 9, color: DIM, fontFamily: FONT_DATA, marginBottom: 4, letterSpacing: 1 }}>
+        <div style={{ fontSize: FONT_SIZE.xs, color: DIM, fontFamily: FONT_DATA, marginBottom: 4, letterSpacing: 1 }}>
           FILTER (click to highlight)
         </div>
         <div style={{ display: "flex", flexWrap: "wrap", gap: 3 }}>
@@ -382,10 +382,10 @@ export function DataCalendarPanel({ registry, selectedDate, onDateSelect }: Prop
                 key={s.id}
                 onClick={() => setFilterSource(isActive ? null : s.id)}
                 style={{
-                  fontSize: 10,
+                  fontSize: FONT_SIZE.sm,
                   fontFamily: FONT_DATA,
                   padding: "2px 6px",
-                  borderRadius: 3,
+                  borderRadius: RADIUS.md,
                   border: isActive ? `1px solid ${s.color}` : "1px solid rgba(255,255,255,0.1)",
                   background: isActive ? `${s.color}22` : "transparent",
                   color: isActive ? s.color : COLORS.textMuted,
@@ -397,7 +397,7 @@ export function DataCalendarPanel({ registry, selectedDate, onDateSelect }: Prop
                   display: "inline-block",
                   width: 6,
                   height: 6,
-                  borderRadius: "50%",
+                  borderRadius: RADIUS.full,
                   background: s.color,
                   marginRight: 3,
                   verticalAlign: "middle",
@@ -410,10 +410,10 @@ export function DataCalendarPanel({ registry, selectedDate, onDateSelect }: Prop
             <button
               onClick={() => setFilterSource(null)}
               style={{
-                fontSize: 9,
+                fontSize: FONT_SIZE.xs,
                 fontFamily: FONT_DATA,
                 padding: "2px 6px",
-                borderRadius: 3,
+                borderRadius: RADIUS.md,
                 border: "1px solid rgba(255,255,255,0.15)",
                 background: "rgba(255,255,255,0.05)",
                 color: DIM,
@@ -434,7 +434,7 @@ export function DataCalendarPanel({ registry, selectedDate, onDateSelect }: Prop
 const navBtnStyle: React.CSSProperties = {
   width: 24,
   height: 24,
-  borderRadius: 4,
+  borderRadius: RADIUS.md,
   border: "none",
   background: "transparent",
   color: "#9CA3AF",

--- a/src/components/DataCalendarPanel.tsx
+++ b/src/components/DataCalendarPanel.tsx
@@ -1,4 +1,5 @@
 import { useState, useMemo } from "react";
+import { FONT_DATA } from "../styles/designTokens";
 import { ChevronLeft, ChevronRight, Navigation } from "lucide-react";
 import type { DataRegistry } from "../hooks/useDataRegistry";
 
@@ -125,7 +126,7 @@ export function DataCalendarPanel({ registry, selectedDate, onDateSelect }: Prop
       {/* ── DAILY section ── */}
       {cyclicSources.length > 0 && (
         <div style={{ padding: "8px 12px" }}>
-          <div style={{ fontSize: 10, fontWeight: 600, letterSpacing: 1.5, color: DIM, fontFamily: "monospace", marginBottom: 6 }}>
+          <div style={{ fontSize: 10, fontWeight: 600, letterSpacing: 1.5, color: DIM, fontFamily: FONT_DATA, marginBottom: 6 }}>
             DAILY
           </div>
           <div style={{ display: "flex", gap: 6, flexWrap: "wrap" }}>
@@ -134,7 +135,7 @@ export function DataCalendarPanel({ registry, selectedDate, onDateSelect }: Prop
                 key={s.id}
                 style={{
                   fontSize: 10,
-                  fontFamily: "monospace",
+                  fontFamily: FONT_DATA,
                   color: s.color,
                   background: "rgba(255,255,255,0.05)",
                   borderRadius: 3,
@@ -144,7 +145,7 @@ export function DataCalendarPanel({ registry, selectedDate, onDateSelect }: Prop
                 {s.label}
               </span>
             ))}
-            <span style={{ fontSize: 10, fontFamily: "monospace", color: DIM }}>always</span>
+            <span style={{ fontSize: 10, fontFamily: FONT_DATA, color: DIM }}>always</span>
           </div>
         </div>
       )}
@@ -173,7 +174,7 @@ export function DataCalendarPanel({ registry, selectedDate, onDateSelect }: Prop
               onClick={() => setMode(m)}
               style={{
                 fontSize: 9,
-                fontFamily: "monospace",
+                fontFamily: FONT_DATA,
                 padding: "2px 6px",
                 borderRadius: 3,
                 border: mode === m ? "1px solid rgba(255,255,255,0.3)" : "1px solid transparent",
@@ -199,7 +200,7 @@ export function DataCalendarPanel({ registry, selectedDate, onDateSelect }: Prop
                 textAlign: "center",
                 fontSize: 9,
                 color: DIM,
-                fontFamily: "monospace",
+                fontFamily: FONT_DATA,
                 padding: "2px 0",
               }}
             >
@@ -254,7 +255,7 @@ export function DataCalendarPanel({ registry, selectedDate, onDateSelect }: Prop
                 {/* Day number */}
                 <span style={{
                   fontSize: 10,
-                  fontFamily: "monospace",
+                  fontFamily: FONT_DATA,
                   color: isSelected ? "#fff" : (sourcesOnDay.length > 0 ? "rgba(255,255,255,0.8)" : "rgba(255,255,255,0.25)"),
                   fontWeight: isSelected ? 700 : 400,
                   lineHeight: 1,
@@ -290,7 +291,7 @@ export function DataCalendarPanel({ registry, selectedDate, onDateSelect }: Prop
                 {mode === "heat" && sourcesOnDay.length > 0 && (
                   <span style={{
                     fontSize: 7,
-                    fontFamily: "monospace",
+                    fontFamily: FONT_DATA,
                     color: "rgba(255,255,255,0.5)",
                     lineHeight: 1,
                   }}>
@@ -311,7 +312,7 @@ export function DataCalendarPanel({ registry, selectedDate, onDateSelect }: Prop
             <span style={{ fontSize: 11, fontWeight: 600, color: "#fff", fontFamily: "Inter, system-ui, sans-serif" }}>
               {detailDate.getMonth() + 1}/{detailDate.getDate()} ({WEEKDAYS[detailDate.getDay()]})
             </span>
-            <span style={{ fontSize: 10, color: DIM, fontFamily: "monospace" }}>
+            <span style={{ fontSize: 10, color: DIM, fontFamily: FONT_DATA }}>
               {(() => {
                 const sources = daySourceMap.get(detailDate.getDate()) ?? [];
                 return totalSources > 0
@@ -329,7 +330,7 @@ export function DataCalendarPanel({ registry, selectedDate, onDateSelect }: Prop
                 alignItems: "center",
                 gap: 3,
                 fontSize: 10,
-                fontFamily: "monospace",
+                fontFamily: FONT_DATA,
                 color: "#64aaff",
                 background: "rgba(100,170,255,0.1)",
                 border: "1px solid rgba(100,170,255,0.3)",
@@ -351,7 +352,7 @@ export function DataCalendarPanel({ registry, selectedDate, onDateSelect }: Prop
                   key={s.id}
                   style={{
                     fontSize: 10,
-                    fontFamily: "monospace",
+                    fontFamily: FONT_DATA,
                     padding: "1px 6px",
                     borderRadius: 3,
                     background: hasData ? "rgba(255,255,255,0.06)" : "transparent",
@@ -370,7 +371,7 @@ export function DataCalendarPanel({ registry, selectedDate, onDateSelect }: Prop
       {/* ── Legend (click to filter) ── */}
       <div style={{ height: 1, background: BORDER, margin: "0 12px" }} />
       <div style={{ padding: "6px 12px 8px" }}>
-        <div style={{ fontSize: 9, color: DIM, fontFamily: "monospace", marginBottom: 4, letterSpacing: 1 }}>
+        <div style={{ fontSize: 9, color: DIM, fontFamily: FONT_DATA, marginBottom: 4, letterSpacing: 1 }}>
           FILTER (click to highlight)
         </div>
         <div style={{ display: "flex", flexWrap: "wrap", gap: 3 }}>
@@ -382,7 +383,7 @@ export function DataCalendarPanel({ registry, selectedDate, onDateSelect }: Prop
                 onClick={() => setFilterSource(isActive ? null : s.id)}
                 style={{
                   fontSize: 10,
-                  fontFamily: "monospace",
+                  fontFamily: FONT_DATA,
                   padding: "2px 6px",
                   borderRadius: 3,
                   border: isActive ? `1px solid ${s.color}` : "1px solid rgba(255,255,255,0.1)",
@@ -410,7 +411,7 @@ export function DataCalendarPanel({ registry, selectedDate, onDateSelect }: Prop
               onClick={() => setFilterSource(null)}
               style={{
                 fontSize: 9,
-                fontFamily: "monospace",
+                fontFamily: FONT_DATA,
                 padding: "2px 6px",
                 borderRadius: 3,
                 border: "1px solid rgba(255,255,255,0.15)",

--- a/src/components/FeatureInfoPanel.tsx
+++ b/src/components/FeatureInfoPanel.tsx
@@ -4,7 +4,7 @@
 // layerType → 元件對應在 featureInfo/registry.tsx。新增 layer popup 只要：
 // 1) 對應 domain 檔寫 panel 元件  2) registry.tsx 加 PANEL_REGISTRY + HEADER_LABELS 各一行。
 import { X } from "lucide-react";
-import { COLORS, SURFACE, FONT_DATA } from "../styles/designTokens";
+import { COLORS, SURFACE, FONT_DATA, RADIUS, FONT_SIZE } from "../styles/designTokens";
 import type { FeatureInfo } from "../types";
 import type { ReservoirContext } from "../data/reservoirContextLoader";
 import { PANEL_REGISTRY, HEADER_LABELS } from "./featureInfo/registry";
@@ -46,7 +46,7 @@ export function FeatureInfoPanel({ feature, onClose, reservoirContext }: Props) 
         backdropFilter: "blur(14px)",
         WebkitBackdropFilter: "blur(14px)",
         border: "1px solid rgba(100, 170, 255, 0.25)",
-        borderRadius: 10,
+        borderRadius: RADIUS.xl,
         padding: "12px 14px",
         fontFamily: FONT_DATA,
       }}
@@ -72,7 +72,7 @@ export function FeatureInfoPanel({ feature, onClose, reservoirContext }: Props) 
       </button>
 
       {/* Header label */}
-      <div style={{ fontSize: 9, color: COLORS.textDim, letterSpacing: 1.5, textTransform: "uppercase", marginBottom: 6, flexShrink: 0 }}>
+      <div style={{ fontSize: FONT_SIZE.xs, color: COLORS.textDim, letterSpacing: 1.5, textTransform: "uppercase", marginBottom: 6, flexShrink: 0 }}>
         {HEADER_LABELS[feature.layerType]}
       </div>
 

--- a/src/components/FeatureInfoPanel.tsx
+++ b/src/components/FeatureInfoPanel.tsx
@@ -4,7 +4,7 @@
 // layerType → 元件對應在 featureInfo/registry.tsx。新增 layer popup 只要：
 // 1) 對應 domain 檔寫 panel 元件  2) registry.tsx 加 PANEL_REGISTRY + HEADER_LABELS 各一行。
 import { X } from "lucide-react";
-import { SURFACE } from "../styles/designTokens";
+import { SURFACE, FONT_DATA } from "../styles/designTokens";
 import type { FeatureInfo } from "../types";
 import type { ReservoirContext } from "../data/reservoirContextLoader";
 import { PANEL_REGISTRY, HEADER_LABELS } from "./featureInfo/registry";
@@ -48,7 +48,7 @@ export function FeatureInfoPanel({ feature, onClose, reservoirContext }: Props) 
         border: "1px solid rgba(100, 170, 255, 0.25)",
         borderRadius: 10,
         padding: "12px 14px",
-        fontFamily: "monospace",
+        fontFamily: FONT_DATA,
       }}
     >
       {/* Close button */}

--- a/src/components/FeatureInfoPanel.tsx
+++ b/src/components/FeatureInfoPanel.tsx
@@ -4,7 +4,7 @@
 // layerType → 元件對應在 featureInfo/registry.tsx。新增 layer popup 只要：
 // 1) 對應 domain 檔寫 panel 元件  2) registry.tsx 加 PANEL_REGISTRY + HEADER_LABELS 各一行。
 import { X } from "lucide-react";
-import { SURFACE, FONT_DATA } from "../styles/designTokens";
+import { COLORS, SURFACE, FONT_DATA } from "../styles/designTokens";
 import type { FeatureInfo } from "../types";
 import type { ReservoirContext } from "../data/reservoirContextLoader";
 import { PANEL_REGISTRY, HEADER_LABELS } from "./featureInfo/registry";
@@ -60,7 +60,7 @@ export function FeatureInfoPanel({ feature, onClose, reservoirContext }: Props) 
           right: 8,
           background: "none",
           border: "none",
-          color: "rgba(255,255,255,0.4)",
+          color: COLORS.textDim,
           cursor: "pointer",
           padding: 2,
           display: "flex",
@@ -72,7 +72,7 @@ export function FeatureInfoPanel({ feature, onClose, reservoirContext }: Props) 
       </button>
 
       {/* Header label */}
-      <div style={{ fontSize: 9, color: "rgba(255,255,255,0.3)", letterSpacing: 1.5, textTransform: "uppercase", marginBottom: 6, flexShrink: 0 }}>
+      <div style={{ fontSize: 9, color: COLORS.textDim, letterSpacing: 1.5, textTransform: "uppercase", marginBottom: 6, flexShrink: 0 }}>
         {HEADER_LABELS[feature.layerType]}
       </div>
 

--- a/src/components/FeatureInfoPanel.tsx
+++ b/src/components/FeatureInfoPanel.tsx
@@ -4,6 +4,7 @@
 // layerType → 元件對應在 featureInfo/registry.tsx。新增 layer popup 只要：
 // 1) 對應 domain 檔寫 panel 元件  2) registry.tsx 加 PANEL_REGISTRY + HEADER_LABELS 各一行。
 import { X } from "lucide-react";
+import { SURFACE } from "../styles/designTokens";
 import type { FeatureInfo } from "../types";
 import type { ReservoirContext } from "../data/reservoirContextLoader";
 import { PANEL_REGISTRY, HEADER_LABELS } from "./featureInfo/registry";
@@ -41,7 +42,7 @@ export function FeatureInfoPanel({ feature, onClose, reservoirContext }: Props) 
         maxHeight: "80vh",
         display: "flex",
         flexDirection: "column",
-        background: "rgba(10, 10, 20, 0.88)",
+        background: SURFACE.strong,
         backdropFilter: "blur(14px)",
         WebkitBackdropFilter: "blur(14px)",
         border: "1px solid rgba(100, 170, 255, 0.25)",

--- a/src/components/HistoricalTimeline.tsx
+++ b/src/components/HistoricalTimeline.tsx
@@ -1,4 +1,4 @@
-import { FONT_DATA } from "../styles/designTokens";
+import { FONT_DATA, RADIUS, FONT_SIZE } from "../styles/designTokens";
 
 export type HistoricalGranularity = "year" | "month" | "day";
 
@@ -27,9 +27,9 @@ const getBtnStyle = (dark: boolean): React.CSSProperties => ({
   background: dark ? "rgba(120,120,120,0.35)" : "rgba(255,255,255,0.9)",
   color: dark ? "rgba(220,220,220,0.9)" : "#555",
   border: `1px solid ${dark ? "rgba(255,255,255,0.12)" : "rgba(0,0,0,0.08)"}`,
-  borderRadius: 4,
+  borderRadius: RADIUS.md,
   padding: "4px 10px",
-  fontSize: 14,
+  fontSize: FONT_SIZE.lg,
   cursor: "pointer",
   fontFamily: FONT_DATA,
   backdropFilter: "blur(8px)",
@@ -39,9 +39,9 @@ const getSelectStyle = (dark: boolean): React.CSSProperties => ({
   background: dark ? "rgba(120,120,120,0.35)" : "rgba(255,255,255,0.9)",
   color: dark ? "rgba(220,220,220,0.9)" : "#555",
   border: `1px solid ${dark ? "rgba(255,255,255,0.12)" : "rgba(0,0,0,0.08)"}`,
-  borderRadius: 4,
+  borderRadius: RADIUS.md,
   padding: "4px 8px",
-  fontSize: 13,
+  fontSize: FONT_SIZE.lg,
   fontFamily: FONT_DATA,
 });
 
@@ -110,7 +110,7 @@ export function HistoricalTimeline({
     const active = g === granularity;
     return {
       ...getBtnStyle(dark),
-      fontSize: 12,
+      fontSize: FONT_SIZE.md,
       padding: "3px 10px",
       fontWeight: active ? 700 : 400,
       color: active ? "#4caf50" : dark ? "rgba(220,220,220,0.9)" : "#555",
@@ -144,7 +144,7 @@ export function HistoricalTimeline({
       <span
         style={{
           width: 26,
-          fontSize: 11,
+          fontSize: FONT_SIZE.base,
           color: dark ? "rgba(180,180,180,0.7)" : "rgba(0,0,0,0.55)",
           fontFamily: FONT_DATA,
           textAlign: "right",
@@ -165,7 +165,7 @@ export function HistoricalTimeline({
       <span
         style={{
           minWidth: 36,
-          fontSize: 11,
+          fontSize: FONT_SIZE.base,
           color: dark ? "rgba(220,220,220,0.85)" : "#444",
           fontFamily: FONT_DATA,
         }}
@@ -191,7 +191,7 @@ export function HistoricalTimeline({
         <span
           style={{
             marginLeft: "auto",
-            fontSize: 13,
+            fontSize: FONT_SIZE.lg,
             fontWeight: 600,
             color: dark ? "rgba(240,240,240,0.95)" : "#222",
             fontFamily: FONT_DATA,
@@ -208,7 +208,7 @@ export function HistoricalTimeline({
           style={{
             ...getBtnStyle(dark),
             ...(isMobile
-              ? { width: 44, height: 44, fontSize: 18, padding: 0, display: "flex", alignItems: "center", justifyContent: "center" }
+              ? { width: 44, height: 44, fontSize: FONT_SIZE.xl, padding: 0, display: "flex", alignItems: "center", justifyContent: "center" }
               : {}),
           }}
           title={playing ? "暫停" : `播放（依${granLabel[granularity]}推進）`}
@@ -229,7 +229,7 @@ export function HistoricalTimeline({
         </select>
         <span
           style={{
-            fontSize: 11,
+            fontSize: FONT_SIZE.base,
             color: dark ? "rgba(180,180,180,0.55)" : "rgba(0,0,0,0.5)",
             fontFamily: FONT_DATA,
           }}

--- a/src/components/HistoricalTimeline.tsx
+++ b/src/components/HistoricalTimeline.tsx
@@ -1,3 +1,5 @@
+import { FONT_DATA } from "../styles/designTokens";
+
 export type HistoricalGranularity = "year" | "month" | "day";
 
 interface Props {
@@ -29,7 +31,7 @@ const getBtnStyle = (dark: boolean): React.CSSProperties => ({
   padding: "4px 10px",
   fontSize: 14,
   cursor: "pointer",
-  fontFamily: "monospace",
+  fontFamily: FONT_DATA,
   backdropFilter: "blur(8px)",
 });
 
@@ -40,7 +42,7 @@ const getSelectStyle = (dark: boolean): React.CSSProperties => ({
   borderRadius: 4,
   padding: "4px 8px",
   fontSize: 13,
-  fontFamily: "monospace",
+  fontFamily: FONT_DATA,
 });
 
 const granLabel: Record<HistoricalGranularity, string> = {
@@ -144,7 +146,7 @@ export function HistoricalTimeline({
           width: 26,
           fontSize: 11,
           color: dark ? "rgba(180,180,180,0.7)" : "rgba(0,0,0,0.55)",
-          fontFamily: "monospace",
+          fontFamily: FONT_DATA,
           textAlign: "right",
         }}
       >
@@ -165,7 +167,7 @@ export function HistoricalTimeline({
           minWidth: 36,
           fontSize: 11,
           color: dark ? "rgba(220,220,220,0.85)" : "#444",
-          fontFamily: "monospace",
+          fontFamily: FONT_DATA,
         }}
       >
         {value}
@@ -192,7 +194,7 @@ export function HistoricalTimeline({
             fontSize: 13,
             fontWeight: 600,
             color: dark ? "rgba(240,240,240,0.95)" : "#222",
-            fontFamily: "monospace",
+            fontFamily: FONT_DATA,
           }}
         >
           {formatLabel(year, month, day, granularity)}
@@ -229,7 +231,7 @@ export function HistoricalTimeline({
           style={{
             fontSize: 11,
             color: dark ? "rgba(180,180,180,0.55)" : "rgba(0,0,0,0.5)",
-            fontFamily: "monospace",
+            fontFamily: FONT_DATA,
           }}
         >
           火災資料：111~113

--- a/src/components/IconRailSidebar.tsx
+++ b/src/components/IconRailSidebar.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useMemo, memo, type CSSProperties } from "react";
-import { FONT_DATA } from "../styles/designTokens";
+import { COLORS, FONT_DATA } from "../styles/designTokens";
 import {
   Activity, Layers, MapPin, CalendarDays, Settings, X,
   Plane, Ship, TrainFront, Bus, Bike, Route, Anchor, PlaneTakeoff,
@@ -728,7 +728,7 @@ function LayersPanel({
             background: "rgba(255,255,255,0.06)",
             border: "1px solid rgba(255,255,255,0.12)",
             borderRadius: 6,
-            color: "rgba(255,255,255,0.5)",
+            color: COLORS.textMuted,
             fontSize: 11,
             cursor: "pointer",
             fontFamily: "Inter, system-ui, sans-serif",
@@ -825,7 +825,7 @@ function ExpandedControls({
   const inactiveBtn: CSSProperties = {
     ...btnBase,
     background: "rgba(0,0,0,0.4)",
-    color: "rgba(255,255,255,0.5)",
+    color: COLORS.textMuted,
   };
 
   return (
@@ -870,7 +870,7 @@ function ExpandedControls({
                     key={ctrl.label}
                     style={{
                       display: "flex", alignItems: "center", gap: 4,
-                      color: "rgba(255,255,255,0.5)", fontSize: 10, fontFamily: FONT_DATA,
+                      color: COLORS.textMuted, fontSize: 10, fontFamily: FONT_DATA,
                     }}
                   >
                     <span style={{ minWidth: 50, flexShrink: 0 }}>{ctrl.label}</span>
@@ -898,7 +898,7 @@ function ExpandedControls({
                   key={ctrl.label}
                   style={{
                     display: "flex", alignItems: "center", gap: 4,
-                    color: "rgba(255,255,255,0.5)", fontSize: 10, fontFamily: FONT_DATA,
+                    color: COLORS.textMuted, fontSize: 10, fontFamily: FONT_DATA,
                   }}
                 >
                   <span style={{ minWidth: 50, flexShrink: 0 }}>{ctrl.label}</span>
@@ -916,7 +916,7 @@ function ExpandedControls({
                         border: ctrl.value === opt.value
                           ? "1px solid rgba(255,255,255,0.25)"
                           : "1px solid rgba(255,255,255,0.15)",
-                        color: ctrl.value === opt.value ? "#fff" : "rgba(255,255,255,0.4)",
+                        color: ctrl.value === opt.value ? "#fff" : COLORS.textDim,
                       }}
                     >
                       {opt.label}
@@ -932,7 +932,7 @@ function ExpandedControls({
                   key={ctrl.label}
                   style={{
                     display: "flex", alignItems: "center", gap: 4,
-                    color: "rgba(255,255,255,0.5)", fontSize: 10, fontFamily: FONT_DATA,
+                    color: COLORS.textMuted, fontSize: 10, fontFamily: FONT_DATA,
                   }}
                 >
                   <span style={{ minWidth: 50, flexShrink: 0 }}>{ctrl.label}</span>
@@ -946,7 +946,7 @@ function ExpandedControls({
                       border: ctrl.value
                         ? "1px solid rgba(255,255,255,0.25)"
                         : "1px solid rgba(255,255,255,0.15)",
-                      color: ctrl.value ? "#fff" : "rgba(255,255,255,0.4)",
+                      color: ctrl.value ? "#fff" : COLORS.textDim,
                     }}
                   >
                     {ctrl.value ? "ON" : "OFF"}
@@ -962,7 +962,7 @@ function ExpandedControls({
                 key={s.label}
                 style={{
                   display: "flex", alignItems: "center", gap: 4,
-                  color: "rgba(255,255,255,0.5)", fontSize: 10, fontFamily: FONT_DATA,
+                  color: COLORS.textMuted, fontSize: 10, fontFamily: FONT_DATA,
                 }}
               >
                 <span style={{ minWidth: 50, flexShrink: 0 }}>{s.label}</span>

--- a/src/components/IconRailSidebar.tsx
+++ b/src/components/IconRailSidebar.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useMemo, memo, type CSSProperties } from "react";
+import { FONT_DATA } from "../styles/designTokens";
 import {
   Activity, Layers, MapPin, CalendarDays, Settings, X,
   Plane, Ship, TrainFront, Bus, Bike, Route, Anchor, PlaneTakeoff,
@@ -563,7 +564,7 @@ function CategoryLabel({ children }: { children: string }) {
     <div
       style={{
         color: DIM,
-        fontFamily: "monospace",
+        fontFamily: FONT_DATA,
         fontSize: 10,
         fontWeight: 600,
         letterSpacing: 2,
@@ -690,7 +691,7 @@ const LayerRow = memo(function LayerRow({
       {count != null && count > 0 && (
         <span
           style={{
-            fontFamily: "monospace",
+            fontFamily: FONT_DATA,
             fontSize: 11,
             color: active ? color : INACTIVE_TEXT,
             marginRight: 4,
@@ -809,7 +810,7 @@ function ExpandedControls({
     fontSize: 9,
     padding: "2px 6px",
     borderRadius: 3,
-    fontFamily: "monospace",
+    fontFamily: FONT_DATA,
     cursor: "pointer",
     border: "1px solid transparent",
   };
@@ -869,7 +870,7 @@ function ExpandedControls({
                     key={ctrl.label}
                     style={{
                       display: "flex", alignItems: "center", gap: 4,
-                      color: "rgba(255,255,255,0.5)", fontSize: 10, fontFamily: "monospace",
+                      color: "rgba(255,255,255,0.5)", fontSize: 10, fontFamily: FONT_DATA,
                     }}
                   >
                     <span style={{ minWidth: 50, flexShrink: 0 }}>{ctrl.label}</span>
@@ -880,7 +881,7 @@ function ExpandedControls({
                         flex: 1, fontSize: 10, padding: "1px 6px",
                         background: "rgba(0,0,0,0.5)", color: "#fff",
                         border: "1px solid rgba(255,255,255,0.15)",
-                        borderRadius: 3, fontFamily: "monospace",
+                        borderRadius: 3, fontFamily: FONT_DATA,
                       }}
                     >
                       {ctrl.options.map((opt) => (
@@ -897,7 +898,7 @@ function ExpandedControls({
                   key={ctrl.label}
                   style={{
                     display: "flex", alignItems: "center", gap: 4,
-                    color: "rgba(255,255,255,0.5)", fontSize: 10, fontFamily: "monospace",
+                    color: "rgba(255,255,255,0.5)", fontSize: 10, fontFamily: FONT_DATA,
                   }}
                 >
                   <span style={{ minWidth: 50, flexShrink: 0 }}>{ctrl.label}</span>
@@ -931,7 +932,7 @@ function ExpandedControls({
                   key={ctrl.label}
                   style={{
                     display: "flex", alignItems: "center", gap: 4,
-                    color: "rgba(255,255,255,0.5)", fontSize: 10, fontFamily: "monospace",
+                    color: "rgba(255,255,255,0.5)", fontSize: 10, fontFamily: FONT_DATA,
                   }}
                 >
                   <span style={{ minWidth: 50, flexShrink: 0 }}>{ctrl.label}</span>
@@ -961,7 +962,7 @@ function ExpandedControls({
                 key={s.label}
                 style={{
                   display: "flex", alignItems: "center", gap: 4,
-                  color: "rgba(255,255,255,0.5)", fontSize: 10, fontFamily: "monospace",
+                  color: "rgba(255,255,255,0.5)", fontSize: 10, fontFamily: FONT_DATA,
                 }}
               >
                 <span style={{ minWidth: 50, flexShrink: 0 }}>{s.label}</span>
@@ -1029,7 +1030,7 @@ function CollapsibleSection({
         }}>
           {title}
         </span>
-        <span style={{ fontSize: 9, color: DIM, fontFamily: "monospace", marginLeft: 4 }}>
+        <span style={{ fontSize: 9, color: DIM, fontFamily: FONT_DATA, marginLeft: 4 }}>
           {count}
         </span>
       </div>
@@ -1196,7 +1197,7 @@ function LocationItem({
           style={{
             fontSize: 10,
             color: DIM,
-            fontFamily: "monospace",
+            fontFamily: FONT_DATA,
             whiteSpace: "nowrap",
             overflow: "hidden",
             textOverflow: "ellipsis",

--- a/src/components/IconRailSidebar.tsx
+++ b/src/components/IconRailSidebar.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useMemo, memo, type CSSProperties } from "react";
-import { COLORS, FONT_DATA } from "../styles/designTokens";
+import { COLORS, FONT_DATA, RADIUS, FONT_SIZE } from "../styles/designTokens";
 import {
   Activity, Layers, MapPin, CalendarDays, Settings, X,
   Plane, Ship, TrainFront, Bus, Bike, Route, Anchor, PlaneTakeoff,
@@ -403,9 +403,9 @@ export function IconRailSidebar({
             backdropFilter: "blur(8px)",
             WebkitBackdropFilter: "blur(8px)",
             border: `1px solid ${BORDER}`,
-            borderRadius: 8,
+            borderRadius: RADIUS.xl,
             color: ACCENT,
-            fontSize: 13,
+            fontSize: FONT_SIZE.lg,
             whiteSpace: "nowrap",
             zIndex: 5,
             pointerEvents: "none",
@@ -435,7 +435,7 @@ export function IconRailSidebar({
               background: BG_PANEL,
               backdropFilter: "blur(12px)",
               WebkitBackdropFilter: "blur(12px)",
-              borderRadius: 8,
+              borderRadius: RADIUS.xl,
               display: "flex",
               flexDirection: "column",
               overflow: "hidden",
@@ -495,7 +495,7 @@ function RailIcon({
       style={{
         width: 40,
         height: 40,
-        borderRadius: 8,
+        borderRadius: RADIUS.xl,
         border: "none",
         background: active ? "rgba(255,255,255,0.08)" : "transparent",
         color: active ? ACCENT : DIM,
@@ -531,7 +531,7 @@ function PanelHeader({
         flexShrink: 0,
       }}
     >
-      <span style={{ color: "#fff", fontSize: 13, fontWeight: 600, fontFamily: "Inter, system-ui, sans-serif" }}>
+      <span style={{ color: "#fff", fontSize: FONT_SIZE.lg, fontWeight: 600, fontFamily: "Inter, system-ui, sans-serif" }}>
         {title}
       </span>
       <div style={{ flex: 1 }} />
@@ -540,7 +540,7 @@ function PanelHeader({
         style={{
           width: 24,
           height: 24,
-          borderRadius: 4,
+          borderRadius: RADIUS.md,
           border: "none",
           background: "transparent",
           color: DIM,
@@ -565,7 +565,7 @@ function CategoryLabel({ children }: { children: string }) {
       style={{
         color: DIM,
         fontFamily: FONT_DATA,
-        fontSize: 10,
+        fontSize: FONT_SIZE.sm,
         fontWeight: 600,
         letterSpacing: 2,
         textTransform: "uppercase",
@@ -586,7 +586,7 @@ function ToggleSwitch({ on, onChange }: { on: boolean; onChange: () => void }) {
       style={{
         width: 28,
         height: 16,
-        borderRadius: 8,
+        borderRadius: RADIUS.xl,
         border: "none",
         background: on ? ACCENT_TOGGLE : "#4B5563",
         position: "relative",
@@ -600,7 +600,7 @@ function ToggleSwitch({ on, onChange }: { on: boolean; onChange: () => void }) {
         style={{
           width: 12,
           height: 12,
-          borderRadius: "50%",
+          borderRadius: RADIUS.full,
           background: on ? "#1a1a1a" : "#fff",
           position: "absolute",
           top: 2,
@@ -680,7 +680,7 @@ const LayerRow = memo(function LayerRow({
       <span
         style={{
           flex: 1,
-          fontSize: 12,
+          fontSize: FONT_SIZE.md,
           fontFamily: "Inter, system-ui, sans-serif",
           color: active ? "#fff" : INACTIVE_TEXT,
           transition: "color 0.15s",
@@ -692,7 +692,7 @@ const LayerRow = memo(function LayerRow({
         <span
           style={{
             fontFamily: FONT_DATA,
-            fontSize: 11,
+            fontSize: FONT_SIZE.base,
             color: active ? color : INACTIVE_TEXT,
             marginRight: 4,
           }}
@@ -727,9 +727,9 @@ function LayersPanel({
             padding: "5px 0",
             background: "rgba(255,255,255,0.06)",
             border: "1px solid rgba(255,255,255,0.12)",
-            borderRadius: 6,
+            borderRadius: RADIUS.lg,
             color: COLORS.textMuted,
-            fontSize: 11,
+            fontSize: FONT_SIZE.base,
             cursor: "pointer",
             fontFamily: "Inter, system-ui, sans-serif",
           }}
@@ -807,9 +807,9 @@ function ExpandedControls({
   onDisplayModeChange, onHide, controls,
 }: ExpandedControlsProps) {
   const btnBase: CSSProperties = {
-    fontSize: 9,
+    fontSize: FONT_SIZE.xs,
     padding: "2px 6px",
-    borderRadius: 3,
+    borderRadius: RADIUS.md,
     fontFamily: FONT_DATA,
     cursor: "pointer",
     border: "1px solid transparent",
@@ -870,7 +870,7 @@ function ExpandedControls({
                     key={ctrl.label}
                     style={{
                       display: "flex", alignItems: "center", gap: 4,
-                      color: COLORS.textMuted, fontSize: 10, fontFamily: FONT_DATA,
+                      color: COLORS.textMuted, fontSize: FONT_SIZE.sm, fontFamily: FONT_DATA,
                     }}
                   >
                     <span style={{ minWidth: 50, flexShrink: 0 }}>{ctrl.label}</span>
@@ -878,10 +878,10 @@ function ExpandedControls({
                       value={ctrl.value}
                       onChange={(e) => ctrl.onChange(e.target.value)}
                       style={{
-                        flex: 1, fontSize: 10, padding: "1px 6px",
+                        flex: 1, fontSize: FONT_SIZE.sm, padding: "1px 6px",
                         background: "rgba(0,0,0,0.5)", color: "#fff",
                         border: "1px solid rgba(255,255,255,0.15)",
-                        borderRadius: 3, fontFamily: FONT_DATA,
+                        borderRadius: RADIUS.md, fontFamily: FONT_DATA,
                       }}
                     >
                       {ctrl.options.map((opt) => (
@@ -898,7 +898,7 @@ function ExpandedControls({
                   key={ctrl.label}
                   style={{
                     display: "flex", alignItems: "center", gap: 4,
-                    color: COLORS.textMuted, fontSize: 10, fontFamily: FONT_DATA,
+                    color: COLORS.textMuted, fontSize: FONT_SIZE.sm, fontFamily: FONT_DATA,
                   }}
                 >
                   <span style={{ minWidth: 50, flexShrink: 0 }}>{ctrl.label}</span>
@@ -908,7 +908,7 @@ function ExpandedControls({
                       onClick={() => ctrl.onChange(opt.value)}
                       style={{
                         ...btnBase,
-                        fontSize: 9,
+                        fontSize: FONT_SIZE.xs,
                         padding: "1px 8px",
                         background: ctrl.value === opt.value
                           ? "rgba(255,255,255,0.12)"
@@ -932,7 +932,7 @@ function ExpandedControls({
                   key={ctrl.label}
                   style={{
                     display: "flex", alignItems: "center", gap: 4,
-                    color: COLORS.textMuted, fontSize: 10, fontFamily: FONT_DATA,
+                    color: COLORS.textMuted, fontSize: FONT_SIZE.sm, fontFamily: FONT_DATA,
                   }}
                 >
                   <span style={{ minWidth: 50, flexShrink: 0 }}>{ctrl.label}</span>
@@ -940,7 +940,7 @@ function ExpandedControls({
                     onClick={() => ctrl.onChange(!ctrl.value)}
                     style={{
                       ...btnBase,
-                      fontSize: 9,
+                      fontSize: FONT_SIZE.xs,
                       padding: "1px 8px",
                       background: ctrl.value ? "rgba(255,255,255,0.12)" : "rgba(0,0,0,0.4)",
                       border: ctrl.value
@@ -962,7 +962,7 @@ function ExpandedControls({
                 key={s.label}
                 style={{
                   display: "flex", alignItems: "center", gap: 4,
-                  color: COLORS.textMuted, fontSize: 10, fontFamily: FONT_DATA,
+                  color: COLORS.textMuted, fontSize: FONT_SIZE.sm, fontFamily: FONT_DATA,
                 }}
               >
                 <span style={{ minWidth: 50, flexShrink: 0 }}>{s.label}</span>
@@ -1025,12 +1025,12 @@ function CollapsibleSection({
           ? <ChevronDown size={12} color={DIM} />
           : <ChevronRight size={12} color={DIM} />}
         <span style={{
-          fontSize: 10, fontWeight: 700, letterSpacing: 1.5,
+          fontSize: FONT_SIZE.sm, fontWeight: 700, letterSpacing: 1.5,
           color: DIM, fontFamily: "Inter, system-ui, sans-serif",
         }}>
           {title}
         </span>
-        <span style={{ fontSize: 9, color: DIM, fontFamily: FONT_DATA, marginLeft: 4 }}>
+        <span style={{ fontSize: FONT_SIZE.xs, color: DIM, fontFamily: FONT_DATA, marginLeft: 4 }}>
           {count}
         </span>
       </div>
@@ -1055,7 +1055,7 @@ function LocationsPanel({
             alignItems: "center",
             gap: 6,
             background: "#1A1C20",
-            borderRadius: 6,
+            borderRadius: RADIUS.lg,
             padding: "6px 8px",
           }}
         >
@@ -1071,7 +1071,7 @@ function LocationsPanel({
               border: "none",
               outline: "none",
               color: "#fff",
-              fontSize: 12,
+              fontSize: FONT_SIZE.md,
               fontFamily: "Inter, system-ui, sans-serif",
             }}
           />
@@ -1182,7 +1182,7 @@ function LocationItem({
       <div style={{ flex: 1, minWidth: 0 }}>
         <div
           style={{
-            fontSize: 12,
+            fontSize: FONT_SIZE.md,
             fontWeight: 600,
             color: active ? "#fff" : INACTIVE_TEXT,
             fontFamily: "Inter, system-ui, sans-serif",
@@ -1195,7 +1195,7 @@ function LocationItem({
         </div>
         <div
           style={{
-            fontSize: 10,
+            fontSize: FONT_SIZE.sm,
             color: DIM,
             fontFamily: FONT_DATA,
             whiteSpace: "nowrap",
@@ -1211,7 +1211,7 @@ function LocationItem({
         style={{
           width: 24,
           height: 24,
-          borderRadius: 4,
+          borderRadius: RADIUS.md,
           border: "none",
           background: "transparent",
           color: active ? ACCENT : DIM,

--- a/src/components/InfoModal.tsx
+++ b/src/components/InfoModal.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { CHANGELOG } from "../data/changelog";
+import { RADIUS, FONT_SIZE } from "../styles/designTokens";
 
 type BottomTab = "guide" | "about" | "profile";
 type GuidePage = "getting-started" | "feature-legend" | "data-sources" | "daily-changelog";
@@ -33,7 +34,7 @@ const t = (obj: T, lang: Lang) => obj[lang];
 
 function SectionTitle({ children }: { children: React.ReactNode }) {
   return (
-    <h3 style={{ fontSize: 11, color: S.label, margin: "0 0 10px", letterSpacing: 1.5, textTransform: "uppercase" }}>
+    <h3 style={{ fontSize: FONT_SIZE.base, color: S.label, margin: "0 0 10px", letterSpacing: 1.5, textTransform: "uppercase" }}>
       {children}
     </h3>
   );
@@ -49,13 +50,13 @@ function Card({ title, children, accentColor, style }: {
     <div style={{
       background: S.cardBg,
       border: `1px solid ${S.cardBorder}`,
-      borderRadius: 8,
+      borderRadius: RADIUS.xl,
       padding: "12px 14px",
       borderLeft: accentColor ? `3px solid ${accentColor}` : undefined,
       ...style,
     }}>
-      {title && <div style={{ fontSize: 12, color: S.text, fontWeight: 600, marginBottom: 6 }}>{title}</div>}
-      <div style={{ fontSize: 12, lineHeight: 1.7, color: S.sub }}>{children}</div>
+      {title && <div style={{ fontSize: FONT_SIZE.md, color: S.text, fontWeight: 600, marginBottom: 6 }}>{title}</div>}
+      <div style={{ fontSize: FONT_SIZE.md, lineHeight: 1.7, color: S.sub }}>{children}</div>
     </div>
   );
 }
@@ -67,8 +68,8 @@ function Tag({ children }: { children: React.ReactNode }) {
       padding: "3px 10px",
       background: S.cardBg,
       border: `1px solid ${S.cardBorder}`,
-      borderRadius: 4,
-      fontSize: 11,
+      borderRadius: RADIUS.md,
+      fontSize: FONT_SIZE.base,
       color: S.sub,
     }}>
       {children}
@@ -83,8 +84,8 @@ function KeyBadge({ children }: { children: React.ReactNode }) {
       padding: "1px 6px",
       background: "rgba(255,255,255,0.08)",
       border: "1px solid rgba(255,255,255,0.15)",
-      borderRadius: 3,
-      fontSize: 11,
+      borderRadius: RADIUS.md,
+      fontSize: FONT_SIZE.base,
       fontFamily: S.font,
       color: S.text,
     }}>
@@ -95,7 +96,7 @@ function KeyBadge({ children }: { children: React.ReactNode }) {
 
 function ParamRow({ label, desc }: { label: string; desc: string }) {
   return (
-    <div style={{ display: "flex", gap: 8, fontSize: 12, lineHeight: 1.6, marginBottom: 4 }}>
+    <div style={{ display: "flex", gap: 8, fontSize: FONT_SIZE.md, lineHeight: 1.6, marginBottom: 4 }}>
       <span style={{ color: S.active, fontWeight: 600, minWidth: 80, flexShrink: 0 }}>{label}</span>
       <span style={{ color: S.sub }}>{desc}</span>
     </div>
@@ -105,7 +106,7 @@ function ParamRow({ label, desc }: { label: string; desc: string }) {
 function ExpandableParams({ lang, items }: { lang: Lang; items: { label: string; zh: string; en: string }[] }) {
   return (
     <div style={{ borderTop: `1px solid ${S.cardBorder}`, paddingTop: 8, marginTop: 4 }}>
-      <div style={{ fontSize: 11, color: S.label, marginBottom: 6 }}>
+      <div style={{ fontSize: FONT_SIZE.base, color: S.label, marginBottom: 6 }}>
         {lang === "zh" ? "▸ 展開可調整：" : "▸ Expandable parameters:"}
       </div>
       {items.map((p) => <ParamRow key={p.label} label={p.label} desc={t(p, lang)} />)}
@@ -119,7 +120,7 @@ function GettingStartedPage({ lang }: { lang: Lang }) {
   const L = lang === "zh";
   return (
     <div style={{ display: "flex", flexDirection: "column", gap: 18 }}>
-      <p style={{ fontSize: 13, lineHeight: 1.8, color: S.text, margin: 0 }}>
+      <p style={{ fontSize: FONT_SIZE.lg, lineHeight: 1.8, color: S.text, margin: 0 }}>
         {L
           ? <>歡迎使用 <b>Mini Taiwan Pulse</b> — 以 3D 呈現台灣航班、船舶、鐵道的即時動態視覺化。地圖預設以全台鳥瞰視角開啟，你可以自由旋轉、縮放來探索。</>
           : <>Welcome to <b>Mini Taiwan Pulse</b> — a real-time 3D visualization of Taiwan's flights, ships, and trains. The map opens with a bird's-eye view of Taiwan. Feel free to rotate and zoom to explore.</>
@@ -268,7 +269,7 @@ function FeatureLegendPage({ lang }: { lang: Lang }) {
 
   return (
     <div style={{ display: "flex", flexDirection: "column", gap: 18 }}>
-      <p style={{ fontSize: 13, lineHeight: 1.8, color: S.text, margin: 0 }}>
+      <p style={{ fontSize: FONT_SIZE.lg, lineHeight: 1.8, color: S.text, margin: 0 }}>
         {L
           ? <>左側面板包含 <b>23 個圖層</b>，分為 10 大分類。每個圖層有 <b>圓形開關</b> 控制可見性。帶 <b>▸ 三角形</b> 的圖層可展開參數面板，拖曳 slider 即時調整視覺效果。</>
           : <>The left panel contains <b>23 layers</b> organized into 10 categories. Each layer has a <b>circle toggle</b> for visibility. Layers with a <b>▸ triangle</b> can expand a parameter panel — drag sliders to adjust visuals in real-time.</>
@@ -279,7 +280,7 @@ function FeatureLegendPage({ lang }: { lang: Lang }) {
       <SectionTitle>MOVING — {L ? "動態運具" : "Moving Vehicles"}</SectionTitle>
       <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
         <Card title={L ? "航班 Flight" : "Flight"} accentColor="#64aaff">
-          <div style={{ marginBottom: 6, color: S.text, fontSize: 12 }}>
+          <div style={{ marginBottom: 6, color: S.text, fontSize: FONT_SIZE.md }}>
             {L
               ? <>3D 弧線 + 光球 + 彗尾光軌。支援 <b>Live Status</b>（只看光球）與 <b>Trails</b>（含完整軌跡線）兩種模式切換。</>
               : <>3D arcs + orbs + comet trails. Supports <b>Live Status</b> (orbs only) and <b>Trails</b> (with full flight paths) mode toggle.</>
@@ -289,14 +290,14 @@ function FeatureLegendPage({ lang }: { lang: Lang }) {
         </Card>
 
         <Card title={L ? "船舶 Ship" : "Ship"} accentColor="#1ad9e5">
-          <div style={{ marginBottom: 6, color: S.text, fontSize: 12 }}>
+          <div style={{ marginBottom: 6, color: S.text, fontSize: FONT_SIZE.md }}>
             {L ? "InstancedMesh 光球 + 拖尾線，顯示台灣周邊海域的船舶動態。" : "InstancedMesh orbs + trailing lines, showing ship movements around Taiwan's waters."}
           </div>
           <ExpandableParams lang={lang} items={shipParams} />
         </Card>
 
         <Card title={L ? "鐵道 Rail" : "Rail"} accentColor="#ee6c00">
-          <div style={{ marginBottom: 6, color: S.text, fontSize: 12 }}>
+          <div style={{ marginBottom: 6, color: S.text, fontSize: FONT_SIZE.md }}>
             {L
               ? "6 個軌道系統（台鐵 · 高鐵 · 台北/高雄/台中捷運 · 高雄輕軌）的列車即時位置。"
               : "Real-time train positions across 6 rail systems (TRA · THSR · Taipei/Kaohsiung/Taichung Metro · Kaohsiung LRT)."}
@@ -309,7 +310,7 @@ function FeatureLegendPage({ lang }: { lang: Lang }) {
       <SectionTitle>NEWS — {L ? "新聞" : "News"}</SectionTitle>
       <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
         <Card title={L ? "新聞事件 News" : "News Events"} accentColor="#ff9800">
-          <div style={{ color: S.text, fontSize: 12 }}>
+          <div style={{ color: S.text, fontSize: FONT_SIZE.md }}>
             {L
               ? "預設關閉。顯示中央通訊社 CNA RSS 新聞事件的地理標記，透過 Gemini API 自動地理編碼。主要新聞以較大橘色圓點顯示，次要新聞以較小灰色圓點顯示。點擊可查看新聞標題、摘要、分類與連結。"
               : "Off by default. Shows CNA RSS news events as geographic markers, auto-geocoded via Gemini API. Primary news shown as larger orange dots, secondary as smaller gray dots. Click to view title, summary, category, and link."}
@@ -321,7 +322,7 @@ function FeatureLegendPage({ lang }: { lang: Lang }) {
       <SectionTitle>STATION — {L ? "站點標記" : "Station Markers"}</SectionTitle>
       <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
         <Card title={L ? "高鐵站 / 台鐵站 / 捷運站" : "THSR / TRA / Metro Stations"}>
-          <div style={{ marginBottom: 6, color: S.text, fontSize: 12 }}>
+          <div style={{ marginBottom: 6, color: S.text, fontSize: FONT_SIZE.md }}>
             {L
               ? "三種車站各自獨立控制。大站以 Polygon 渲染邊界，小站以圓環標記。3D 模式下支援光柱效果，光柱高度代表該站每日停靠次數。"
               : "Three station types independently controlled. Large stations rendered as polygon boundaries, small ones as circle markers. 3D mode supports light pillars — pillar height represents daily stop count."}
@@ -330,7 +331,7 @@ function FeatureLegendPage({ lang }: { lang: Lang }) {
         </Card>
 
         <Card title={L ? "市區公車站 / 公路客運站" : "City Bus / Intercity Bus Stations"}>
-          <div style={{ marginBottom: 6, color: S.text, fontSize: 12 }}>
+          <div style={{ marginBottom: 6, color: S.text, fontSize: FONT_SIZE.md }}>
             {L ? "預設關閉。開啟後以小圓點顯示全台公車站點分佈。" : "Off by default. When enabled, shows bus stop distribution as small dots across Taiwan."}
           </div>
           <ExpandableParams lang={lang} items={[
@@ -339,7 +340,7 @@ function FeatureLegendPage({ lang }: { lang: Lang }) {
         </Card>
 
         <Card title={L ? "公共腳踏車 Bike" : "Public Bike"}>
-          <div style={{ marginBottom: 6, color: S.text, fontSize: 12 }}>
+          <div style={{ marginBottom: 6, color: S.text, fontSize: FONT_SIZE.md }}>
             {L ? "預設關閉。顯示全台 YouBike 等公共腳踏車站點位置。" : "Off by default. Shows YouBike and other public bike station locations across Taiwan."}
           </div>
           <ExpandableParams lang={lang} items={[
@@ -352,14 +353,14 @@ function FeatureLegendPage({ lang }: { lang: Lang }) {
       <SectionTitle>ROUTE — {L ? "路徑" : "Routes"}</SectionTitle>
       <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
         <Card title={L ? "國道 Highway / 省道 Prov.Road" : "Highway / Provincial Road"}>
-          <div style={{ color: S.text, fontSize: 12 }}>
+          <div style={{ color: S.text, fontSize: FONT_SIZE.md }}>
             {L
               ? "預設關閉。國道以紅色線條顯示，省道以橘色線條顯示，寬度隨 zoom 層級自動調整。純開關，無額外可調參數。"
               : "Off by default. Highways shown in red, provincial roads in orange. Line width auto-adjusts with zoom level. Toggle only, no adjustable parameters."}
           </div>
         </Card>
         <Card title={L ? "自行車道 Cycling" : "Cycling Routes"}>
-          <div style={{ marginBottom: 6, color: S.text, fontSize: 12 }}>
+          <div style={{ marginBottom: 6, color: S.text, fontSize: FONT_SIZE.md }}>
             {L ? "預設關閉。以綠色線條顯示全台自行車專用道。" : "Off by default. Shows cycling paths across Taiwan in green."}
           </div>
           <ExpandableParams lang={lang} items={[
@@ -372,14 +373,14 @@ function FeatureLegendPage({ lang }: { lang: Lang }) {
       <SectionTitle>INFRA — {L ? "基礎設施" : "Infrastructure"}</SectionTitle>
       <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
         <Card title={L ? "碼頭 Port / 機場 Airport" : "Port / Airport"}>
-          <div style={{ color: S.text, fontSize: 12 }}>
+          <div style={{ color: S.text, fontSize: FONT_SIZE.md }}>
             {L
               ? "港口與機場以 Polygon 邊界 + 光暈效果顯示。機場的透明度和光暈可透過航班面板的 APT / Glow 調整。碼頭為純開關。"
               : "Ports and airports rendered as polygon boundaries with glow effects. Airport opacity and glow are adjustable via the Flight panel's APT / Glow. Ports are toggle only."}
           </div>
         </Card>
         <Card title={L ? "燈塔 Lighthouse" : "Lighthouse"}>
-          <div style={{ marginBottom: 6, color: S.text, fontSize: 12 }}>
+          <div style={{ marginBottom: 6, color: S.text, fontSize: FONT_SIZE.md }}>
             {L
               ? <>全台 36 座燈塔位置，3D 模式下附帶<b>旋轉錐形光束</b>動畫效果。</>
               : <>All 36 lighthouses in Taiwan. In 3D mode, features an animated <b>rotating cone-shaped beam</b>.</>
@@ -392,7 +393,7 @@ function FeatureLegendPage({ lang }: { lang: Lang }) {
       {/* MONITOR */}
       <SectionTitle>MONITOR — {L ? "監測" : "Monitoring"}</SectionTitle>
       <Card title={L ? "國道壅塞 Congestion" : "Freeway Congestion"}>
-        <div style={{ marginBottom: 6, color: S.text, fontSize: 12 }}>
+        <div style={{ marginBottom: 6, color: S.text, fontSize: FONT_SIZE.md }}>
           {L
             ? "預設關閉。依 timeline 動態回放國道各路段壅塞程度，以色彩編碼顯示（順暢 / 壅塞 / 嚴重壅塞）。資料源：交通部 TDX → Supabase `realtime.freeway_congestion_daily`（pre-aggregate 每 20 分鐘 refresh）。"
             : "Off by default. Dynamically plays back freeway segment congestion levels along the timeline with color coding (free / congested / heavy). Source: MOTC TDX → Supabase `realtime.freeway_congestion_daily` (pre-aggregated, refreshed every 20 minutes)."}
@@ -406,14 +407,14 @@ function FeatureLegendPage({ lang }: { lang: Lang }) {
       <SectionTitle>HAZARD — {L ? "災害" : "Hazards"}</SectionTitle>
       <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
         <Card title={L ? "地震事件 Earthquake" : "Earthquake Events"}>
-          <div style={{ color: S.text, fontSize: 12 }}>
+          <div style={{ color: S.text, fontSize: FONT_SIZE.md }}>
             {L
               ? "預設開啟。依 timeline 當天累積顯示地震事件，圓圈大小對應規模、顏色對應深度，附 ripple 動畫。資料源：CWA 地震目錄 → Supabase `realtime.earthquake_events`。"
               : "Enabled by default. Accumulates earthquake events for the selected timeline date. Circle size scales with magnitude, color reflects depth, with ripple animation. Source: CWA earthquake catalog → Supabase `realtime.earthquake_events`."}
           </div>
         </Card>
         <Card title={L ? "災害示警 Disaster Alerts" : "Disaster Alerts"}>
-          <div style={{ color: S.text, fontSize: 12 }}>
+          <div style={{ color: S.text, fontSize: FONT_SIZE.md }}>
             {L
               ? "預設開啟。NCDR CAP feed 彙整颱風、豪雨、強風、枯旱、水庫放流等示警，依 timeline 動態顯示生效中範圍。幾何用鄉鎮/縣市 boundaries fallback 解析。資料源：NCDR CAP → Supabase `realtime.disaster_alerts`。"
               : "Enabled by default. Aggregates NCDR CAP alerts (typhoon, heavy rain, strong wind, drought, reservoir release, etc.), dynamically filtering active alerts by timeline. Geometry resolved via township/county boundaries fallback. Source: NCDR CAP → Supabase `realtime.disaster_alerts`."}
@@ -425,7 +426,7 @@ function FeatureLegendPage({ lang }: { lang: Lang }) {
       <SectionTitle>ANALYTICS — {L ? "分析" : "Analytics"}</SectionTitle>
       <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
         <Card title={L ? "人流模擬 Pop. Flow" : "Population Flow Simulation"}>
-          <div style={{ marginBottom: 6, color: S.text, fontSize: 12 }}>
+          <div style={{ marginBottom: 6, color: S.text, fontSize: FONT_SIZE.md }}>
             {L
               ? "預設關閉。以六角形網格顯示全台日間/夜間人流分布。色階：日間 Plasma（深靛→亮黃）、夜間 Viridis（深紫→亮黃），感知均勻、色盲友善。Zoom 自動切換網格精度。"
               : "Off by default. Displays day/night population flow distribution across Taiwan using hexagonal grids. Color scales: day = Plasma (indigo → yellow), night = Viridis (purple → yellow), perceptually uniform and colorblind-safe. Grid resolution auto-switches by zoom level."}
@@ -439,7 +440,7 @@ function FeatureLegendPage({ lang }: { lang: Lang }) {
           ]} />
         </Card>
         <Card title={L ? "人口數 Population" : "Population Count"}>
-          <div style={{ marginBottom: 6, color: S.text, fontSize: 12 }}>
+          <div style={{ marginBottom: 6, color: S.text, fontSize: FONT_SIZE.md }}>
             {L
               ? "預設關閉。以六角形網格顯示全台村里總人口密度。資料來源：SEGIS 社會經濟統計地理資訊網（114 年 6 月，7,748 村里）。色階：Inferno（深黑→紫紅→橘黃→亮黃白），log1p 正規化適合重尾分布。"
               : "Off by default. Displays village-level total population density using hexagonal grids. Source: SEGIS (2025/06, 7,748 villages). Color scale: Inferno (black → purple-red → orange → bright yellow-white), log1p normalization for heavy-tailed distribution."}
@@ -452,7 +453,7 @@ function FeatureLegendPage({ lang }: { lang: Lang }) {
           ]} />
         </Card>
         <Card title={L ? "人口指標 Indicators" : "Population Indicators"}>
-          <div style={{ marginBottom: 6, color: S.text, fontSize: 12 }}>
+          <div style={{ marginBottom: 6, color: S.text, fontSize: FONT_SIZE.md }}>
             {L
               ? "預設關閉。9 項村里人口衍生指標，分三類：數量（戶數/男/女）、結構（性別比/每戶人數）、負擔（扶養比/扶幼比/扶老比/老化指數）。數量指標 log 正規化，比率指標 linear 正規化。比率欄位以人口加權平均聚合至 H3 網格。"
               : "Off by default. 9 derived demographic indicators in 3 categories: Count (households/male/female), Structure (sex ratio/persons per household), Burden (dependency/child dependency/elderly dependency/aging index). Count metrics use log normalization, ratio metrics use linear normalization. Ratios are population-weighted when aggregated to H3 grids."}
@@ -467,12 +468,12 @@ function FeatureLegendPage({ lang }: { lang: Lang }) {
           ]} />
         </Card>
         <Card title={L ? "社經面貌 Socio-Econ" : "Socioeconomic Profile"}>
-          <div style={{ marginBottom: 6, color: S.text, fontSize: 12 }}>
+          <div style={{ marginBottom: 6, color: S.text, fontSize: FONT_SIZE.md }}>
             {L
               ? "預設關閉。以六角形網格顯示村里級社會經濟面貌。資料來源：SEGIS 社會經濟統計地理資訊網 + 財政部綜合所得稅統計（114 年，7,748 村里）。色階：Viridis（深紫→青綠→亮黃），感知均勻、色盲友善。分兩大類五項指標："
               : "Off by default. Displays village-level socioeconomic profiles using hexagonal grids. Source: SEGIS + Ministry of Finance income tax statistics (2025, 7,748 villages). Color scale: Viridis (purple → teal → yellow), perceptually uniform and colorblind-safe. Two categories, five indicators:"}
           </div>
-          <div style={{ marginBottom: 6, color: S.dim, fontSize: 11 }}>
+          <div style={{ marginBottom: 6, color: S.dim, fontSize: FONT_SIZE.base }}>
             {L
               ? "【收入 Income】Med — 所得中位數（萬元/年），反映當地一般收入水平；IQR — 四分位距比（Q3/Q1），數值越大代表貧富差距越懸殊；Sal% — 薪資佔比（薪資所得/總所得），越高代表該地區越依賴受薪工作。\n【社會 Social】Vital — 人口活力分數（出生率 40% + 社會增加 50% + 結婚淨率 10%，min-max 正規化後加權），衡量地區人口成長動能；Vuln — 脆弱度指數（低收入比 30% + 老年比 30% + 高風險比 20% + 無住宅比 20%），越高代表該地區越需要社會支持。"
               : "【Income】Med — Median income (¥10K/yr), reflects general income level; IQR — Interquartile ratio (Q3/Q1), higher = greater income inequality; Sal% — Salary share (salary income / total income), higher = more wage-dependent.\n【Social】Vital — Vitality score (birth rate 40% + social increase 50% + marriage net 10%, min-max normalized), measures population growth momentum; Vuln — Vulnerability index (low-income 30% + elderly 30% + high-risk 20% + no-housing 20%), higher = greater need for social support."}
@@ -487,12 +488,12 @@ function FeatureLegendPage({ lang }: { lang: Lang }) {
           ]} />
         </Card>
         <Card title={L ? "空間經濟 Spatial-Econ" : "Spatial Economy"}>
-          <div style={{ marginBottom: 6, color: S.text, fontSize: 12 }}>
+          <div style={{ marginBottom: 6, color: S.text, fontSize: FONT_SIZE.md }}>
             {L
               ? "預設關閉。以六角形網格顯示最小統計區級空間經濟指標。資料來源：SEGIS 最小統計區（157,933 區）+ 實價登錄 + 國土利用調查。色階：Magma（深黑→紫紅→橘→亮黃白）。分兩大類五項指標："
               : "Off by default. Displays minimal-statistical-area-level spatial economy indicators using hexagonal grids. Source: SEGIS minimal areas (157,933 zones) + actual price registry + national land use survey. Color scale: Magma (black → purple-red → orange → bright yellow-white). Two categories, five indicators:"}
           </div>
-          <div style={{ marginBottom: 6, color: S.dim, fontSize: 11 }}>
+          <div style={{ marginBottom: 6, color: S.dim, fontSize: FONT_SIZE.base }}>
             {L
               ? "【房市 Housing】Price — 房價中位數（萬元/坪），取自實價登錄、P99 封頂去極端值；Unit — 每坪單價（萬元），另一維度呈現房市行情；P/I — 房價所得比（房價中位數 ÷ 鄉鎮市區所得中位數），衡量購屋負擔壓力，數值越高代表當地居民越難負擔。\n【土地 Land】Amty — 便利設施密度（便利商店 + 學校等設施數 / 面積），反映生活機能；Mix — 土地混合度（Shannon 熵，9 類國土利用），越高代表土地使用越多元、都市機能越豐富。"
               : "【Housing】Price — Median housing price (¥10K/ping), from actual price registry with P99 cap; Unit — Unit price per ping (¥10K), another dimension of market conditions; P/I — Price-to-income ratio (median price ÷ town-level median income), measures housing affordability pressure.\n【Land】Amty — Amenity density (convenience stores + schools etc. / area), reflects livability; Mix — Land use mix (Shannon entropy over 9 national land use categories), higher = more diverse urban functions."}
@@ -512,7 +513,7 @@ function FeatureLegendPage({ lang }: { lang: Lang }) {
       <SectionTitle>ENVIRON — {L ? "環境" : "Environment"}</SectionTitle>
       <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
         <Card title={L ? "氣象站 Weather" : "Weather Stations"}>
-          <div style={{ marginBottom: 6, color: S.text, fontSize: 12 }}>
+          <div style={{ marginBottom: 6, color: S.text, fontSize: FONT_SIZE.md }}>
             {L ? "預設關閉。顯示全台氣象觀測站點位置。" : "Off by default. Shows weather observation station locations across Taiwan."}
           </div>
           <ExpandableParams lang={lang} items={[
@@ -520,14 +521,14 @@ function FeatureLegendPage({ lang }: { lang: Lang }) {
           ]} />
         </Card>
         <Card title={L ? "風場範圍 Wind Farm" : "Wind Farm"}>
-          <div style={{ color: S.text, fontSize: 12 }}>
+          <div style={{ color: S.text, fontSize: FONT_SIZE.md }}>
             {L
               ? "預設關閉。以半透明填充顯示台灣離岸風場規劃範圍。純開關，無額外可調參數。"
               : "Off by default. Shows Taiwan's offshore wind farm planning zones as translucent fills. Toggle only, no adjustable parameters."}
           </div>
         </Card>
         <Card title={L ? "溫度波浪 Temperature" : "Temperature Wave"}>
-          <div style={{ marginBottom: 6, color: S.text, fontSize: 12 }}>
+          <div style={{ marginBottom: 6, color: S.text, fontSize: FONT_SIZE.md }}>
             {L
               ? "預設關閉。以 3D 波浪曲面或 2D 色圖顯示台灣溫度場分佈，資料來自中央氣象署 0.03° 格點每小時快照。色盤使用 RdBu 發散色階（深藍→白→深紅），動畫以 vertex lerp 平滑過渡。"
               : "Off by default. Displays Taiwan's temperature field as a 3D wave surface or 2D color map, using hourly snapshots from CWA's 0.03° grid. Uses RdBu diverging color scale (blue → white → red), with smooth vertex lerp animation."}
@@ -541,14 +542,14 @@ function FeatureLegendPage({ lang }: { lang: Lang }) {
           ]} />
         </Card>
         <Card title={L ? "衛星雲圖 Cloud Imagery" : "Cloud Imagery"}>
-          <div style={{ color: S.text, fontSize: 12 }}>
+          <div style={{ color: S.text, fontSize: FONT_SIZE.md }}>
             {L
               ? "預設開啟。CWA 衛星雲圖 PNG frame 序列，依 timeline 回放最近 24 小時。資料源：CWA File API `O-C0042-*` → Supabase `realtime.cwa_imagery_frames`（透過 `get_cwa_imagery_frames_batch` 批次 RPC 一次載入所有 frame bytes）。"
               : "Enabled by default. CWA satellite cloud imagery PNG frame sequence, played back along the timeline over the last 24 hours. Source: CWA File API `O-C0042-*` → Supabase `realtime.cwa_imagery_frames` (loaded via `get_cwa_imagery_frames_batch` batch RPC)."}
           </div>
         </Card>
         <Card title={L ? "雷達回波 Radar Imagery" : "Radar Imagery"}>
-          <div style={{ color: S.text, fontSize: 12 }}>
+          <div style={{ color: S.text, fontSize: FONT_SIZE.md }}>
             {L
               ? "預設開啟。CWA 雷達回波合成圖 PNG frame，依 timeline 回放最近 24 小時。資料源：CWA File API `O-A0058-*` → Supabase `realtime.cwa_imagery_frames`。"
               : "Enabled by default. CWA composite radar echo PNG frames, played back along the timeline over the last 24 hours. Source: CWA File API `O-A0058-*` → Supabase `realtime.cwa_imagery_frames`."}
@@ -559,7 +560,7 @@ function FeatureLegendPage({ lang }: { lang: Lang }) {
       {/* 面板操作說明 */}
       <SectionTitle>{L ? "面板操作說明" : "PANEL USAGE"}</SectionTitle>
       <Card>
-        <div style={{ color: S.text, fontSize: 12, lineHeight: 1.8 }}>
+        <div style={{ color: S.text, fontSize: FONT_SIZE.md, lineHeight: 1.8 }}>
           {L ? (
             <>
               <b>收合/展開面板</b>：點擊面板左上角 ◀ 收合為窄條，點擊窄條展開。收合狀態下，彩色小點顯示各圖層啟用狀態。<br />
@@ -581,7 +582,7 @@ function FeatureLegendPage({ lang }: { lang: Lang }) {
       {/* 底部資訊列 */}
       <SectionTitle>{L ? "底部資訊列" : "BOTTOM STATUS BAR"}</SectionTitle>
       <Card>
-        <div style={{ color: S.text, fontSize: 12, lineHeight: 1.8 }}>
+        <div style={{ color: S.text, fontSize: FONT_SIZE.md, lineHeight: 1.8 }}>
           {L
             ? <>畫面底部顯示：即時運具數量（航班 / 船舶 / 列車各自計數）、以及相機參數 <b>Pitch</b>（俯仰角）· <b>Bearing</b>（方位角）· <b>Zoom</b>（縮放層級）。</>
             : <>The bottom bar displays: real-time vehicle counts (flights / ships / trains), and camera parameters <b>Pitch</b> · <b>Bearing</b> · <b>Zoom</b>.</>
@@ -695,16 +696,16 @@ function DataSourcesPage({ lang }: { lang: Lang }) {
 
   return (
     <div style={{ display: "flex", flexDirection: "column", gap: 10 }}>
-      <p style={{ fontSize: 13, lineHeight: 1.8, color: S.text, margin: "0 0 6px" }}>
+      <p style={{ fontSize: FONT_SIZE.lg, lineHeight: 1.8, color: S.text, margin: "0 0 6px" }}>
         {L
           ? "本專案整合多個即時與開放資料來源，所有資料經腳本擷取、轉換、過濾後呈現："
           : "This project integrates multiple real-time and open data sources, all processed through automated scripts:"}
       </p>
       {sources.map((s) => (
         <Card key={t(s.name, lang)} accentColor={s.color}>
-          <div style={{ fontSize: 12, fontWeight: 600, color: S.text, marginBottom: 4 }}>{t(s.name, lang)}</div>
-          <div style={{ fontSize: 11, color: S.active, marginBottom: 4 }}>{s.source}</div>
-          <div style={{ fontSize: 12, color: S.sub, lineHeight: 1.7 }}>{t(s.desc, lang)}</div>
+          <div style={{ fontSize: FONT_SIZE.md, fontWeight: 600, color: S.text, marginBottom: 4 }}>{t(s.name, lang)}</div>
+          <div style={{ fontSize: FONT_SIZE.base, color: S.active, marginBottom: 4 }}>{s.source}</div>
+          <div style={{ fontSize: FONT_SIZE.md, color: S.sub, lineHeight: 1.7 }}>{t(s.desc, lang)}</div>
         </Card>
       ))}
     </div>
@@ -748,11 +749,11 @@ function AboutPage({ lang }: { lang: Lang }) {
   return (
     <div style={{ display: "flex", flexDirection: "column", gap: 18 }}>
       <div>
-        <h2 style={{ fontSize: 18, color: S.text, margin: "0 0 10px", letterSpacing: 1 }}>Mini Taiwan Pulse</h2>
-        <p style={{ fontSize: 13, lineHeight: 1.9, color: S.text, margin: 0 }}>
+        <h2 style={{ fontSize: FONT_SIZE.xl, color: S.text, margin: "0 0 10px", letterSpacing: 1 }}>Mini Taiwan Pulse</h2>
+        <p style={{ fontSize: FONT_SIZE.lg, lineHeight: 1.9, color: S.text, margin: 0 }}>
           {L ? "用開放資料，感受台灣的脈動。" : "Feel Taiwan's pulse through open data."}
         </p>
-        <p style={{ fontSize: 13, lineHeight: 1.9, color: S.sub, margin: "8px 0 0" }}>
+        <p style={{ fontSize: FONT_SIZE.lg, lineHeight: 1.9, color: S.sub, margin: "8px 0 0" }}>
           {L
             ? "天空中的航班劃出弧線、海面上的船舶穿梭往返、軌道上的列車準時奔馳 — 這座島嶼每一刻都在呼吸。Mini Taiwan Pulse 將這些交通運輸的即時動態，以 3D 光球、光軌、拖尾線呈現在同一張地圖上，讓你看見台灣的脈搏。"
             : "Flights tracing arcs across the sky, ships navigating coastal waters, trains running on time along their tracks — this island breathes every moment. Mini Taiwan Pulse renders all this transportation activity as 3D orbs, light trails, and glowing paths on a single interactive map, letting you see Taiwan's heartbeat."}
@@ -763,11 +764,11 @@ function AboutPage({ lang }: { lang: Lang }) {
       <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fill, minmax(140px, 1fr))", gap: 10 }}>
         {stats.map((item) => (
           <div key={t(item.label, lang)} style={{
-            background: S.cardBg, border: `1px solid ${S.cardBorder}`, borderRadius: 8,
+            background: S.cardBg, border: `1px solid ${S.cardBorder}`, borderRadius: RADIUS.xl,
             padding: "12px 14px", textAlign: "center",
           }}>
-            <div style={{ fontSize: 20, fontWeight: 700, color: S.active }}>{item.num}</div>
-            <div style={{ fontSize: 11, color: S.sub, marginTop: 2 }}>{t(item.label, lang)}</div>
+            <div style={{ fontSize: FONT_SIZE.xxl, fontWeight: 700, color: S.active }}>{item.num}</div>
+            <div style={{ fontSize: FONT_SIZE.base, color: S.sub, marginTop: 2 }}>{t(item.label, lang)}</div>
           </div>
         ))}
       </div>
@@ -818,7 +819,7 @@ function ProjectCard({ name, desc, screenshot, site, github }: {
 }) {
   return (
     <div style={{
-      background: S.cardBg, border: `1px solid ${S.cardBorder}`, borderRadius: 8,
+      background: S.cardBg, border: `1px solid ${S.cardBorder}`, borderRadius: RADIUS.xl,
       overflow: "hidden",
     }}>
       {screenshot && (
@@ -828,17 +829,17 @@ function ProjectCard({ name, desc, screenshot, site, github }: {
         </div>
       )}
       <div style={{ padding: "10px 14px" }}>
-        <div style={{ fontSize: 13, fontWeight: 600, color: S.text, marginBottom: 4 }}>{name}</div>
-        <div style={{ fontSize: 11, color: S.sub, marginBottom: 8, lineHeight: 1.5 }}>{desc}</div>
+        <div style={{ fontSize: FONT_SIZE.lg, fontWeight: 600, color: S.text, marginBottom: 4 }}>{name}</div>
+        <div style={{ fontSize: FONT_SIZE.base, color: S.sub, marginBottom: 8, lineHeight: 1.5 }}>{desc}</div>
         <div style={{ display: "flex", gap: 8 }}>
           {site && (
             <a href={site} target="_blank" rel="noopener noreferrer"
-              style={{ fontSize: 11, color: S.active, textDecoration: "none" }}>
+              style={{ fontSize: FONT_SIZE.base, color: S.active, textDecoration: "none" }}>
               Live
             </a>
           )}
           <a href={github} target="_blank" rel="noopener noreferrer"
-            style={{ fontSize: 11, color: S.sub, textDecoration: "none" }}>
+            style={{ fontSize: FONT_SIZE.base, color: S.sub, textDecoration: "none" }}>
             GitHub
           </a>
         </div>
@@ -884,10 +885,10 @@ function ProfilePage({ lang }: { lang: Lang }) {
       {/* Avatar + Name */}
       <div style={{ display: "flex", alignItems: "center", gap: 14 }}>
         <img src="./screenshots/頭貼.jpg" alt="Migu"
-          style={{ width: 48, height: 48, borderRadius: "50%", objectFit: "cover" }} />
+          style={{ width: 48, height: 48, borderRadius: RADIUS.full, objectFit: "cover" }} />
         <div>
-          <div style={{ fontSize: 16, fontWeight: 600, color: S.text }}>Migu</div>
-          <div style={{ fontSize: 12, color: S.sub }}>Senior Data Analyst / GIS</div>
+          <div style={{ fontSize: FONT_SIZE.xl, fontWeight: 600, color: S.text }}>Migu</div>
+          <div style={{ fontSize: FONT_SIZE.md, color: S.sub }}>Senior Data Analyst / GIS</div>
         </div>
       </div>
 
@@ -895,12 +896,12 @@ function ProfilePage({ lang }: { lang: Lang }) {
       <SectionTitle>{L ? "社群連結" : "SOCIAL LINKS"}</SectionTitle>
       <div style={{ display: "flex", gap: 10, flexWrap: "wrap" }}>
         <a href="https://github.com/ianlkl11234s" target="_blank" rel="noopener noreferrer"
-          style={{ display: "flex", alignItems: "center", gap: 8, padding: "8px 14px", background: S.cardBg, border: `1px solid ${S.cardBorder}`, borderRadius: 8, textDecoration: "none", color: S.text, fontSize: 12 }}>
+          style={{ display: "flex", alignItems: "center", gap: 8, padding: "8px 14px", background: S.cardBg, border: `1px solid ${S.cardBorder}`, borderRadius: RADIUS.xl, textDecoration: "none", color: S.text, fontSize: FONT_SIZE.md }}>
           <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
           GitHub
         </a>
         <a href="https://www.threads.com/@ianlkl1314" target="_blank" rel="noopener noreferrer"
-          style={{ display: "flex", alignItems: "center", gap: 8, padding: "8px 14px", background: S.cardBg, border: `1px solid ${S.cardBorder}`, borderRadius: 8, textDecoration: "none", color: S.text, fontSize: 12 }}>
+          style={{ display: "flex", alignItems: "center", gap: 8, padding: "8px 14px", background: S.cardBg, border: `1px solid ${S.cardBorder}`, borderRadius: RADIUS.xl, textDecoration: "none", color: S.text, fontSize: FONT_SIZE.md }}>
           <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor"><path d="M12.186 24h-.007c-3.581-.024-6.334-1.205-8.184-3.509C2.35 18.44 1.5 15.586 1.472 12.01v-.017c.03-3.579.879-6.43 2.525-8.482C5.845 1.205 8.6.024 12.18 0h.014c2.746.02 5.043.725 6.826 2.098 1.677 1.29 2.858 3.13 3.509 5.467l-2.04.569c-1.104-3.96-3.898-5.984-8.304-6.015-2.91.022-5.11.936-6.54 2.717C4.307 6.504 3.616 8.914 3.59 12c.025 3.086.718 5.496 2.057 7.164 1.432 1.784 3.631 2.698 6.54 2.717 2.623-.02 4.358-.631 5.8-2.045 1.647-1.613 1.618-3.593 1.09-4.798-.346-.789-.96-1.42-1.744-1.838.164 3.1-1.063 5.453-3.693 5.453-1.602 0-2.97-.767-3.652-2.048-.585-1.098-.63-2.545.013-3.878.926-1.916 3.083-2.878 5.29-2.472.1-.612.133-1.266.08-1.952l2.036-.244c.083.87.06 1.693-.06 2.455 1.038.497 1.892 1.2 2.494 2.1.864 1.29 1.196 2.86.96 4.539-.32 2.28-1.462 4.1-3.298 5.272C15.692 23.347 13.718 24 12.186 24zm.512-7.17c.828 0 1.474-.31 1.858-.892.532-.806.56-2.04-.02-2.834-.328-.21-.702-.382-1.126-.506-.078 1.072-.29 2.089-.648 2.983-.137.343-.5 1.25.064 1.25h-.128z"/></svg>
           Threads
         </a>
@@ -975,7 +976,7 @@ export function InfoModal({ open, onClose, isMobile }: InfoModalProps) {
         padding: "20px 0",
       }}>
         <div style={{ padding: "0 16px" }}>
-          <div style={{ fontSize: 11, color: S.label, letterSpacing: 1.5, marginBottom: 14, textTransform: "uppercase" }}>
+          <div style={{ fontSize: FONT_SIZE.base, color: S.label, letterSpacing: 1.5, marginBottom: 14, textTransform: "uppercase" }}>
             {lang === "zh" ? "使用指南" : "User Guide"}
           </div>
           {activeTab === "guide" && (
@@ -984,9 +985,9 @@ export function InfoModal({ open, onClose, isMobile }: InfoModalProps) {
                 <button key={item.key} onClick={() => setGuidePage(item.key)}
                   style={{
                     background: guidePage === item.key ? "rgba(100,170,255,0.12)" : "transparent",
-                    border: "none", borderRadius: 6, padding: "8px 12px", textAlign: "left",
+                    border: "none", borderRadius: RADIUS.lg, padding: "8px 12px", textAlign: "left",
                     color: guidePage === item.key ? S.active : S.sub,
-                    fontSize: 12, fontFamily: S.font, cursor: "pointer", transition: "all 0.15s",
+                    fontSize: FONT_SIZE.md, fontFamily: S.font, cursor: "pointer", transition: "all 0.15s",
                   }}>
                   {item.label[lang]}
                 </button>
@@ -999,9 +1000,9 @@ export function InfoModal({ open, onClose, isMobile }: InfoModalProps) {
             <button key={tab.key} onClick={() => setActiveTab(tab.key)}
               style={{
                 background: activeTab === tab.key ? "rgba(100,170,255,0.12)" : "transparent",
-                border: "none", borderRadius: 6, padding: "8px 12px", textAlign: "left",
+                border: "none", borderRadius: RADIUS.lg, padding: "8px 12px", textAlign: "left",
                 color: activeTab === tab.key ? S.active : S.sub,
-                fontSize: 12, fontFamily: S.font, cursor: "pointer",
+                fontSize: FONT_SIZE.md, fontFamily: S.font, cursor: "pointer",
                 fontWeight: activeTab === tab.key ? 600 : 400, transition: "all 0.15s",
               }}>
               {tab.label[lang]}
@@ -1022,7 +1023,7 @@ export function InfoModal({ open, onClose, isMobile }: InfoModalProps) {
                 flex: 1, background: "transparent", border: "none",
                 borderBottom: activeTab === tab.key ? `2px solid ${S.active}` : "2px solid transparent",
                 padding: "8px 0", color: activeTab === tab.key ? S.active : S.sub,
-                fontSize: 12, fontFamily: S.font, cursor: "pointer",
+                fontSize: FONT_SIZE.md, fontFamily: S.font, cursor: "pointer",
                 fontWeight: activeTab === tab.key ? 600 : 400,
               }}>
               {tab.label[lang]}
@@ -1037,7 +1038,7 @@ export function InfoModal({ open, onClose, isMobile }: InfoModalProps) {
                   flex: 1, background: "transparent", border: "none",
                   borderBottom: guidePage === item.key ? `2px solid ${S.active}` : "2px solid transparent",
                   padding: "6px 0", color: guidePage === item.key ? S.active : S.sub,
-                  fontSize: 11, fontFamily: S.font, cursor: "pointer",
+                  fontSize: FONT_SIZE.base, fontFamily: S.font, cursor: "pointer",
                 }}>
                 {item.label[lang]}
               </button>
@@ -1074,16 +1075,16 @@ export function InfoModal({ open, onClose, isMobile }: InfoModalProps) {
             padding: isMobile ? "14px 16px" : "20px 28px",
             borderBottom: `1px solid ${S.border}`, flexShrink: 0,
           }}>
-            <h2 style={{ margin: 0, fontSize: isMobile ? 16 : 18, letterSpacing: 1, color: S.text }}>{title}</h2>
+            <h2 style={{ margin: 0, fontSize: isMobile ? FONT_SIZE.xl : FONT_SIZE.xl, letterSpacing: 1, color: S.text }}>{title}</h2>
             <div style={{ display: "flex", alignItems: "center", gap: 12 }}>
-              <div style={{ display: "flex", borderRadius: 6, overflow: "hidden", border: `1px solid ${S.border}` }}>
+              <div style={{ display: "flex", borderRadius: RADIUS.lg, overflow: "hidden", border: `1px solid ${S.border}` }}>
                 {(["zh", "en"] as Lang[]).map((l) => (
                   <button key={l} onClick={() => setLang(l)}
                     style={{
                       background: lang === l ? "rgba(100,170,255,0.15)" : "transparent",
                       border: "none", padding: "3px 10px",
                       color: lang === l ? S.active : S.sub,
-                      fontSize: 11, fontFamily: S.font, cursor: "pointer",
+                      fontSize: FONT_SIZE.base, fontFamily: S.font, cursor: "pointer",
                     }}>
                     {l.toUpperCase()}
                   </button>
@@ -1091,9 +1092,9 @@ export function InfoModal({ open, onClose, isMobile }: InfoModalProps) {
               </div>
               <button onClick={onClose}
                 style={{
-                  width: 28, height: 28, borderRadius: "50%",
+                  width: 28, height: 28, borderRadius: RADIUS.full,
                   background: "rgba(255,255,255,0.08)", border: "none", color: S.sub,
-                  fontSize: 16, cursor: "pointer",
+                  fontSize: FONT_SIZE.xl, cursor: "pointer",
                   display: "flex", alignItems: "center", justifyContent: "center",
                 }}>
                 ✕

--- a/src/components/LayerSidebar.tsx
+++ b/src/components/LayerSidebar.tsx
@@ -3,7 +3,7 @@ import type { LayerVisibility, ExpandableLayerKey, ViewMode, DisplayMode } from 
 import type { ParamControl } from "../hooks/useTransportParams";
 // 圖層目錄常數單一真實來源（與 IconRailSidebar 共用，消除漂移）
 import { LAYER_COLORS, TRANSPORT_LABELS, SECTIONS } from "./sidebar/layerCatalog";
-import { SURFACE, FONT_DATA } from "../styles/designTokens";
+import { SURFACE, FONT_DATA, RADIUS, FONT_SIZE } from "../styles/designTokens";
 
 // ── Props ──
 
@@ -87,14 +87,14 @@ export function LayerSidebar({
           background: isDarkTheme ? SURFACE.subtle : "rgba(255,255,255,0.5)",
           backdropFilter: "blur(12px)",
           WebkitBackdropFilter: "blur(12px)",
-          borderRadius: 8,
+          borderRadius: RADIUS.xl,
           padding: "8px 0",
           cursor: "pointer",
           transition: "width 0.2s ease",
         }}
       >
         {/* 展開箭頭 */}
-        <span style={{ fontSize: 9, color: dimColor, userSelect: "none" }}>&#x25B6;</span>
+        <span style={{ fontSize: FONT_SIZE.xs, color: dimColor, userSelect: "none" }}>&#x25B6;</span>
         {/* 活躍圖層色點 */}
         {allLayers.map(({ key }) => {
           const active = visibility[key];
@@ -105,7 +105,7 @@ export function LayerSidebar({
               style={{
                 width: 8,
                 height: 8,
-                borderRadius: "50%",
+                borderRadius: RADIUS.full,
                 background: active ? color : "transparent",
                 border: `1px solid ${active ? color : (isDarkTheme ? "rgba(255,255,255,0.15)" : "rgba(0,0,0,0.1)")}`,
                 transition: "all 0.15s",
@@ -131,11 +131,11 @@ export function LayerSidebar({
           zIndex: 1,
           width: 18,
           height: 18,
-          borderRadius: 3,
+          borderRadius: RADIUS.md,
           border: "none",
           background: isDarkTheme ? "rgba(255,255,255,0.08)" : "rgba(0,0,0,0.06)",
           color: dimColor,
-          fontSize: 8,
+          fontSize: FONT_SIZE.xs,
           cursor: "pointer",
           display: "flex",
           alignItems: "center",
@@ -195,7 +195,7 @@ function SidebarContent({
         background: isDarkTheme ? SURFACE.subtle : "rgba(255,255,255,0.5)",
         backdropFilter: "blur(12px)",
         WebkitBackdropFilter: "blur(12px)",
-        borderRadius: 8,
+        borderRadius: RADIUS.xl,
         padding: "8px 0",
         fontFamily: FONT_DATA,
       }}
@@ -214,7 +214,7 @@ function SidebarContent({
 
           <div
             style={{
-              fontSize: 9,
+              fontSize: FONT_SIZE.xs,
               fontWeight: 700,
               letterSpacing: 2,
               color: dimColor,
@@ -254,7 +254,7 @@ function SidebarContent({
                     style={{
                       width: 14,
                       height: 14,
-                      borderRadius: "50%",
+                      borderRadius: RADIUS.full,
                       background: active ? color : "transparent",
                       border: `1.5px solid ${active ? color : (isDarkTheme ? "rgba(255,255,255,0.25)" : "rgba(0,0,0,0.2)")}`,
                       cursor: "pointer",
@@ -286,7 +286,7 @@ function SidebarContent({
                     <span
                       onClick={() => onLayerClick(key)}
                       style={{
-                        fontSize: 10,
+                        fontSize: FONT_SIZE.sm,
                         color: dimColor,
                         transform: isExpanded ? "rotate(90deg)" : "rotate(0deg)",
                         transition: "transform 0.2s",
@@ -348,9 +348,9 @@ function ExpandedPanel({
   controls,
 }: ExpandedPanelProps) {
   const btnBase: React.CSSProperties = {
-    fontSize: 9,
+    fontSize: FONT_SIZE.xs,
     padding: "2px 6px",
-    borderRadius: 3,
+    borderRadius: RADIUS.md,
     fontFamily: FONT_DATA,
     cursor: "pointer",
     border: "1px solid transparent",
@@ -424,7 +424,7 @@ function ExpandedPanel({
                       alignItems: "center",
                       gap: 4,
                       color: isDarkTheme ? "rgba(255,255,255,0.5)" : "rgba(0,0,0,0.5)",
-                      fontSize: 10,
+                      fontSize: FONT_SIZE.sm,
                       fontFamily: FONT_DATA,
                     }}
                   >
@@ -434,12 +434,12 @@ function ExpandedPanel({
                       onChange={(e) => ctrl.onChange(e.target.value)}
                       style={{
                         flex: 1,
-                        fontSize: 10,
+                        fontSize: FONT_SIZE.sm,
                         padding: "1px 6px",
                         background: isDarkTheme ? "rgba(0,0,0,0.5)" : "rgba(255,255,255,0.8)",
                         color: isDarkTheme ? "#fff" : "#000",
                         border: `1px solid ${isDarkTheme ? "rgba(255,255,255,0.15)" : "rgba(0,0,0,0.15)"}`,
-                        borderRadius: 3,
+                        borderRadius: RADIUS.md,
                         fontFamily: FONT_DATA,
                       }}
                     >
@@ -458,7 +458,7 @@ function ExpandedPanel({
                     alignItems: "center",
                     gap: 4,
                     color: isDarkTheme ? "rgba(255,255,255,0.5)" : "rgba(0,0,0,0.5)",
-                    fontSize: 10,
+                    fontSize: FONT_SIZE.sm,
                     fontFamily: FONT_DATA,
                   }}
                 >
@@ -469,7 +469,7 @@ function ExpandedPanel({
                       onClick={() => ctrl.onChange(opt.value)}
                       style={{
                         ...btnBase,
-                        fontSize: 9,
+                        fontSize: FONT_SIZE.xs,
                         padding: "1px 8px",
                         background: ctrl.value === opt.value
                           ? (isDarkTheme ? "rgba(100,170,255,0.3)" : "rgba(100,170,255,0.2)")
@@ -498,7 +498,7 @@ function ExpandedPanel({
                     alignItems: "center",
                     gap: 4,
                     color: isDarkTheme ? "rgba(255,255,255,0.5)" : "rgba(0,0,0,0.5)",
-                    fontSize: 10,
+                    fontSize: FONT_SIZE.sm,
                     fontFamily: FONT_DATA,
                   }}
                 >
@@ -507,7 +507,7 @@ function ExpandedPanel({
                     onClick={() => ctrl.onChange(!ctrl.value)}
                     style={{
                       ...btnBase,
-                      fontSize: 9,
+                      fontSize: FONT_SIZE.xs,
                       padding: "1px 8px",
                       background: ctrl.value
                         ? (isDarkTheme ? "rgba(100,170,255,0.3)" : "rgba(100,170,255,0.2)")
@@ -536,7 +536,7 @@ function ExpandedPanel({
                   alignItems: "center",
                   gap: 4,
                   color: isDarkTheme ? "rgba(255,255,255,0.5)" : "rgba(0,0,0,0.5)",
-                  fontSize: 10,
+                  fontSize: FONT_SIZE.sm,
                   fontFamily: FONT_DATA,
                 }}
               >

--- a/src/components/LayerSidebar.tsx
+++ b/src/components/LayerSidebar.tsx
@@ -3,7 +3,7 @@ import type { LayerVisibility, ExpandableLayerKey, ViewMode, DisplayMode } from 
 import type { ParamControl } from "../hooks/useTransportParams";
 // 圖層目錄常數單一真實來源（與 IconRailSidebar 共用，消除漂移）
 import { LAYER_COLORS, TRANSPORT_LABELS, SECTIONS } from "./sidebar/layerCatalog";
-import { SURFACE } from "../styles/designTokens";
+import { SURFACE, FONT_DATA } from "../styles/designTokens";
 
 // ── Props ──
 
@@ -197,7 +197,7 @@ function SidebarContent({
         WebkitBackdropFilter: "blur(12px)",
         borderRadius: 8,
         padding: "8px 0",
-        fontFamily: "monospace",
+        fontFamily: FONT_DATA,
       }}
     >
       {SECTIONS.map((section, sIdx) => (
@@ -351,7 +351,7 @@ function ExpandedPanel({
     fontSize: 9,
     padding: "2px 6px",
     borderRadius: 3,
-    fontFamily: "monospace",
+    fontFamily: FONT_DATA,
     cursor: "pointer",
     border: "1px solid transparent",
   };
@@ -425,7 +425,7 @@ function ExpandedPanel({
                       gap: 4,
                       color: isDarkTheme ? "rgba(255,255,255,0.5)" : "rgba(0,0,0,0.5)",
                       fontSize: 10,
-                      fontFamily: "monospace",
+                      fontFamily: FONT_DATA,
                     }}
                   >
                     <span style={{ minWidth: isMobile ? 60 : 50, flexShrink: 0 }}>{ctrl.label}</span>
@@ -440,7 +440,7 @@ function ExpandedPanel({
                         color: isDarkTheme ? "#fff" : "#000",
                         border: `1px solid ${isDarkTheme ? "rgba(255,255,255,0.15)" : "rgba(0,0,0,0.15)"}`,
                         borderRadius: 3,
-                        fontFamily: "monospace",
+                        fontFamily: FONT_DATA,
                       }}
                     >
                       {ctrl.options.map((opt) => (
@@ -459,7 +459,7 @@ function ExpandedPanel({
                     gap: 4,
                     color: isDarkTheme ? "rgba(255,255,255,0.5)" : "rgba(0,0,0,0.5)",
                     fontSize: 10,
-                    fontFamily: "monospace",
+                    fontFamily: FONT_DATA,
                   }}
                 >
                   <span style={{ minWidth: isMobile ? 60 : 50, flexShrink: 0 }}>{ctrl.label}</span>
@@ -499,7 +499,7 @@ function ExpandedPanel({
                     gap: 4,
                     color: isDarkTheme ? "rgba(255,255,255,0.5)" : "rgba(0,0,0,0.5)",
                     fontSize: 10,
-                    fontFamily: "monospace",
+                    fontFamily: FONT_DATA,
                   }}
                 >
                   <span style={{ minWidth: isMobile ? 60 : 50, flexShrink: 0 }}>{ctrl.label}</span>
@@ -537,7 +537,7 @@ function ExpandedPanel({
                   gap: 4,
                   color: isDarkTheme ? "rgba(255,255,255,0.5)" : "rgba(0,0,0,0.5)",
                   fontSize: 10,
-                  fontFamily: "monospace",
+                  fontFamily: FONT_DATA,
                 }}
               >
                 <span style={{ minWidth: isMobile ? 60 : 50, flexShrink: 0 }}>{s.label}</span>

--- a/src/components/LayerSidebar.tsx
+++ b/src/components/LayerSidebar.tsx
@@ -3,6 +3,7 @@ import type { LayerVisibility, ExpandableLayerKey, ViewMode, DisplayMode } from 
 import type { ParamControl } from "../hooks/useTransportParams";
 // 圖層目錄常數單一真實來源（與 IconRailSidebar 共用，消除漂移）
 import { LAYER_COLORS, TRANSPORT_LABELS, SECTIONS } from "./sidebar/layerCatalog";
+import { SURFACE } from "../styles/designTokens";
 
 // ── Props ──
 
@@ -83,7 +84,7 @@ export function LayerSidebar({
           alignItems: "center",
           gap: 6,
           width: 28,
-          background: isDarkTheme ? "rgba(0,0,0,0.45)" : "rgba(255,255,255,0.5)",
+          background: isDarkTheme ? SURFACE.subtle : "rgba(255,255,255,0.5)",
           backdropFilter: "blur(12px)",
           WebkitBackdropFilter: "blur(12px)",
           borderRadius: 8,
@@ -191,7 +192,7 @@ function SidebarContent({
         width: isMobile ? "100%" : 240,
         maxHeight: isMobile ? undefined : "70vh",
         overflowY: isMobile ? undefined : "auto",
-        background: isDarkTheme ? "rgba(0,0,0,0.45)" : "rgba(255,255,255,0.5)",
+        background: isDarkTheme ? SURFACE.subtle : "rgba(255,255,255,0.5)",
         backdropFilter: "blur(12px)",
         WebkitBackdropFilter: "blur(12px)",
         borderRadius: 8,

--- a/src/components/LegendPanel.tsx
+++ b/src/components/LegendPanel.tsx
@@ -1,5 +1,6 @@
 import { Fragment, useState } from "react";
 import { ChevronDown, ChevronRight } from "lucide-react";
+import { SURFACE } from "../styles/designTokens";
 import type { LayerVisibility } from "../types";
 import { CROP_SUITABILITY_CROPS } from "../data/cropSuitabilityCrops";
 import { AGRI_POI_TYPES } from "../data/agriPOITypes";
@@ -135,7 +136,7 @@ export function LegendPanel({ visibility, overlayParams }: LegendPanelProps) {
     <div
       style={{
         width: 200,
-        background: "rgba(10, 10, 20, 0.88)",
+        background: SURFACE.strong,
         backdropFilter: "blur(14px)",
         WebkitBackdropFilter: "blur(14px)",
         border: "1px solid rgba(100, 170, 255, 0.15)",

--- a/src/components/LegendPanel.tsx
+++ b/src/components/LegendPanel.tsx
@@ -1,6 +1,6 @@
 import { Fragment, useState } from "react";
 import { ChevronDown, ChevronRight } from "lucide-react";
-import { COLORS, SURFACE, FONT_DATA } from "../styles/designTokens";
+import { COLORS, SURFACE, FONT_DATA, RADIUS, FONT_SIZE } from "../styles/designTokens";
 import type { LayerVisibility } from "../types";
 import { CROP_SUITABILITY_CROPS } from "../data/cropSuitabilityCrops";
 import { AGRI_POI_TYPES } from "../data/agriPOITypes";
@@ -140,7 +140,7 @@ export function LegendPanel({ visibility, overlayParams }: LegendPanelProps) {
         backdropFilter: "blur(14px)",
         WebkitBackdropFilter: "blur(14px)",
         border: "1px solid rgba(100, 170, 255, 0.15)",
-        borderRadius: 8,
+        borderRadius: RADIUS.xl,
         fontFamily: FONT_DATA,
         overflow: "hidden",
         transition: "all 0.2s ease",
@@ -159,7 +159,7 @@ export function LegendPanel({ visibility, overlayParams }: LegendPanelProps) {
           border: "none",
           cursor: "pointer",
           color: COLORS.textMuted,
-          fontSize: 10,
+          fontSize: FONT_SIZE.sm,
           fontFamily: FONT_DATA,
           letterSpacing: 1,
         }}
@@ -193,12 +193,12 @@ function FireCatRows({ cats, square }: { cats: { color: string; label: string }[
         <div key={c.label} style={{ display: "flex", alignItems: "center", gap: 6 }}>
           <div
             style={{
-              width: 10, height: 10, borderRadius: square ? 2 : "50%",
+              width: 10, height: 10, borderRadius: square ? RADIUS.sm : RADIUS.full,
               background: c.color, opacity: 0.9, flexShrink: 0,
               border: "1px solid rgba(255,255,255,0.6)", boxSizing: "border-box",
             }}
           />
-          <span style={{ fontSize: 9, color: COLORS.textMuted }}>{c.label}</span>
+          <span style={{ fontSize: FONT_SIZE.xs, color: COLORS.textMuted }}>{c.label}</span>
         </div>
       ))}
     </div>
@@ -216,7 +216,7 @@ const FLOOD_SENSOR_CATS = [
 function FloodSensorLegend() {
   return (
     <div>
-      <div style={{ fontSize: 9, color: COLORS.textDim, letterSpacing: 1, marginBottom: 4 }}>
+      <div style={{ fontSize: FONT_SIZE.xs, color: COLORS.textDim, letterSpacing: 1, marginBottom: 4 }}>
         都市淹水 USWG
       </div>
       <FireCatRows cats={FLOOD_SENSOR_CATS} />
@@ -227,7 +227,7 @@ function FloodSensorLegend() {
 function FireEventLegend() {
   return (
     <div>
-      <div style={{ fontSize: 9, color: COLORS.textDim, letterSpacing: 1, marginBottom: 4 }}>
+      <div style={{ fontSize: FONT_SIZE.xs, color: COLORS.textDim, letterSpacing: 1, marginBottom: 4 }}>
         FIRE 火災歷史
       </div>
       <FireCatRows cats={FIRE_EVENT_CATS} />
@@ -238,7 +238,7 @@ function FireEventLegend() {
 function FireStationLegend() {
   return (
     <div>
-      <div style={{ fontSize: 9, color: COLORS.textDim, letterSpacing: 1, marginBottom: 4 }}>
+      <div style={{ fontSize: FONT_SIZE.xs, color: COLORS.textDim, letterSpacing: 1, marginBottom: 4 }}>
         消防分隊 STATIONS
       </div>
       <FireCatRows cats={FIRE_STATION_CATS} />
@@ -249,11 +249,11 @@ function FireStationLegend() {
 function FireHydrantLegend() {
   return (
     <div>
-      <div style={{ fontSize: 9, color: COLORS.textDim, letterSpacing: 1, marginBottom: 4 }}>
+      <div style={{ fontSize: FONT_SIZE.xs, color: COLORS.textDim, letterSpacing: 1, marginBottom: 4 }}>
         消防栓 HYDRANTS
       </div>
       <FireCatRows cats={FIRE_HYDRANT_CATS} square />
-      <div style={{ fontSize: 8, color: "rgba(255,180,80,0.7)", marginTop: 4, lineHeight: 1.3 }}>
+      <div style={{ fontSize: FONT_SIZE.xs, color: "rgba(255,180,80,0.7)", marginTop: 4, lineHeight: 1.3 }}>
         ⚠️ {FIRE_HYDRANT_COVERAGE_NOTE}
       </div>
     </div>
@@ -263,14 +263,14 @@ function FireHydrantLegend() {
 function FireIsochroneLegend() {
   return (
     <div>
-      <div style={{ fontSize: 9, color: COLORS.textDim, letterSpacing: 1, marginBottom: 4 }}>
+      <div style={{ fontSize: FONT_SIZE.xs, color: COLORS.textDim, letterSpacing: 1, marginBottom: 4 }}>
         救援等時圈 ISOCHRONE
       </div>
       <FireCatRows
         cats={FIRE_ISOCHRONE_BANDS.map((b) => ({ color: b.color, label: b.label }))}
         square
       />
-      <div style={{ fontSize: 8, color: "rgba(255,180,80,0.7)", marginTop: 4, lineHeight: 1.3 }}>
+      <div style={{ fontSize: FONT_SIZE.xs, color: "rgba(255,180,80,0.7)", marginTop: 4, lineHeight: 1.3 }}>
         ⚠️ {FIRE_ISOCHRONE_NOTE}
       </div>
     </div>
@@ -280,14 +280,14 @@ function FireIsochroneLegend() {
 function EcoNetworkZonesLegend() {
   return (
     <div>
-      <div style={{ fontSize: 9, color: COLORS.textDim, letterSpacing: 1, marginBottom: 4 }}>
+      <div style={{ fontSize: FONT_SIZE.xs, color: COLORS.textDim, letterSpacing: 1, marginBottom: 4 }}>
         國土綠網分區 ECO NETWORK
       </div>
       <div style={{ display: "flex", flexDirection: "column", gap: 2 }}>
         {ECO_NETWORK_ZONE_TYPES.map((z) => (
           <div key={z.zone} style={{ display: "flex", alignItems: "center", gap: 6 }}>
-            <div style={{ width: 9, height: 9, borderRadius: 1, background: z.color, flexShrink: 0 }} />
-            <span style={{ fontSize: 9, color: COLORS.textDefault }}>{z.label}</span>
+            <div style={{ width: 9, height: 9, borderRadius: RADIUS.sm, background: z.color, flexShrink: 0 }} />
+            <span style={{ fontSize: FONT_SIZE.xs, color: COLORS.textDefault }}>{z.label}</span>
           </div>
         ))}
       </div>
@@ -325,12 +325,12 @@ const HIKING_TRAIL_SOURCES: { color: string; label: string }[] = [
 function HikingTrailsSourcesLegend() {
   return (
     <div style={{ marginTop: 4, paddingLeft: 8, borderLeft: "1px solid rgba(255,255,255,0.12)" }}>
-      <div style={{ fontSize: 8, color: COLORS.textDim, marginBottom: 2 }}>步道來源 source</div>
+      <div style={{ fontSize: FONT_SIZE.xs, color: COLORS.textDim, marginBottom: 2 }}>步道來源 source</div>
       <div style={{ display: "flex", flexDirection: "column", gap: 1 }}>
         {HIKING_TRAIL_SOURCES.map((t) => (
           <div key={t.label} style={{ display: "flex", alignItems: "center", gap: 5 }}>
             <div style={{ width: 12, height: 2, background: t.color, flexShrink: 0 }} />
-            <span style={{ fontSize: 8, color: COLORS.textMuted }}>{t.label}</span>
+            <span style={{ fontSize: FONT_SIZE.xs, color: COLORS.textMuted }}>{t.label}</span>
           </div>
         ))}
       </div>
@@ -341,12 +341,12 @@ function HikingTrailsSourcesLegend() {
 function ForestReserveTypesLegend() {
   return (
     <div style={{ marginTop: 4, paddingLeft: 8, borderLeft: "1px solid rgba(255,255,255,0.12)" }}>
-      <div style={{ fontSize: 8, color: COLORS.textDim, marginBottom: 2 }}>保安林種類</div>
+      <div style={{ fontSize: FONT_SIZE.xs, color: COLORS.textDim, marginBottom: 2 }}>保安林種類</div>
       <div style={{ display: "flex", flexDirection: "column", gap: 1 }}>
         {FOREST_RESERVE_TYPES.map((t) => (
           <div key={t.key} style={{ display: "flex", alignItems: "center", gap: 5 }}>
-            <div style={{ width: 8, height: 8, borderRadius: 1, background: t.color, flexShrink: 0 }} />
-            <span style={{ fontSize: 8, color: COLORS.textMuted }}>{t.label}</span>
+            <div style={{ width: 8, height: 8, borderRadius: RADIUS.sm, background: t.color, flexShrink: 0 }} />
+            <span style={{ fontSize: FONT_SIZE.xs, color: COLORS.textMuted }}>{t.label}</span>
           </div>
         ))}
       </div>
@@ -359,7 +359,7 @@ function ForestryLegend({ visibility }: { visibility: LayerVisibility }) {
   if (rows.length === 0) return null;
   return (
     <div>
-      <div style={{ fontSize: 9, color: COLORS.textDim, letterSpacing: 1, marginBottom: 4 }}>
+      <div style={{ fontSize: FONT_SIZE.xs, color: COLORS.textDim, letterSpacing: 1, marginBottom: 4 }}>
         FORESTRY 林業
       </div>
       <div style={{ display: "flex", flexDirection: "column", gap: 2 }}>
@@ -369,7 +369,7 @@ function ForestryLegend({ visibility }: { visibility: LayerVisibility }) {
               style={{
                 width: r.shape === "line" ? 14 : 10,
                 height: r.shape === "line" ? 2 : 10,
-                borderRadius: r.shape === "circle" ? "50%" : 1,
+                borderRadius: r.shape === "circle" ? RADIUS.full : RADIUS.sm,
                 background: r.color,
                 opacity: 0.9,
                 flexShrink: 0,
@@ -377,7 +377,7 @@ function ForestryLegend({ visibility }: { visibility: LayerVisibility }) {
                 boxSizing: "border-box",
               }}
             />
-            <span style={{ fontSize: 9, color: COLORS.textMuted }}>{r.label}</span>
+            <span style={{ fontSize: FONT_SIZE.xs, color: COLORS.textMuted }}>{r.label}</span>
           </div>
         ))}
       </div>
@@ -394,10 +394,10 @@ function SoilFertilityLegend({ metricIdx }: { metricIdx: number }) {
   const meta = SOIL_FERTILITY_METRICS[metricId];
   return (
     <div>
-      <div style={{ fontSize: 9, color: COLORS.textDim, letterSpacing: 1, marginBottom: 4 }}>
+      <div style={{ fontSize: FONT_SIZE.xs, color: COLORS.textDim, letterSpacing: 1, marginBottom: 4 }}>
         SOIL FERTILITY
       </div>
-      <div style={{ fontSize: 9, color: COLORS.textMuted, marginBottom: 4 }}>
+      <div style={{ fontSize: FONT_SIZE.xs, color: COLORS.textMuted, marginBottom: 4 }}>
         {meta.label}{meta.unit ? ` (${meta.unit})` : ""}
       </div>
       <div style={{ display: "flex", flexDirection: "column", gap: 2 }}>
@@ -405,11 +405,11 @@ function SoilFertilityLegend({ metricIdx }: { metricIdx: number }) {
           <div key={`${s.color}-${s.label}`} style={{ display: "flex", alignItems: "center", gap: 6 }}>
             <div
               style={{
-                width: 10, height: 10, borderRadius: 2,
+                width: 10, height: 10, borderRadius: RADIUS.sm,
                 background: s.color, opacity: 0.9, flexShrink: 0,
               }}
             />
-            <span style={{ fontSize: 9, color: COLORS.textMuted }}>{s.label}</span>
+            <span style={{ fontSize: FONT_SIZE.xs, color: COLORS.textMuted }}>{s.label}</span>
           </div>
         ))}
       </div>
@@ -422,7 +422,7 @@ function SoilFertilityLegend({ metricIdx }: { metricIdx: number }) {
 function AgriPOILegend() {
   return (
     <div>
-      <div style={{ fontSize: 9, color: COLORS.textDim, letterSpacing: 1, marginBottom: 4 }}>
+      <div style={{ fontSize: FONT_SIZE.xs, color: COLORS.textDim, letterSpacing: 1, marginBottom: 4 }}>
         AGRICULTURE POI
       </div>
       <div style={{ display: "flex", flexDirection: "column", gap: 2 }}>
@@ -432,7 +432,7 @@ function AgriPOILegend() {
               style={{
                 width: 10,
                 height: 10,
-                borderRadius: "50%",
+                borderRadius: RADIUS.full,
                 background: t.color,
                 opacity: 0.9,
                 border: "1px solid #fff",
@@ -440,7 +440,7 @@ function AgriPOILegend() {
                 flexShrink: 0,
               }}
             />
-            <span style={{ fontSize: 9, color: COLORS.textMuted }}>
+            <span style={{ fontSize: FONT_SIZE.xs, color: COLORS.textMuted }}>
               {t.labelZh}
               <span style={{ color: COLORS.textDim, marginLeft: 4 }}>{t.labelEn}</span>
             </span>
@@ -454,14 +454,14 @@ function AgriPOILegend() {
 function MedicalIsochroneLegend() {
   return (
     <div>
-      <div style={{ fontSize: 9, color: COLORS.textDim, letterSpacing: 1, marginBottom: 4 }}>
+      <div style={{ fontSize: FONT_SIZE.xs, color: COLORS.textDim, letterSpacing: 1, marginBottom: 4 }}>
         醫療等時圈 MEDICAL ISOCHRONE
       </div>
       <FireCatRows
         cats={MEDICAL_ISOCHRONE_BANDS.map((b) => ({ color: b.color, label: b.label }))}
         square
       />
-      <div style={{ fontSize: 8, color: "rgba(255,180,80,0.7)", marginTop: 4, lineHeight: 1.3 }}>
+      <div style={{ fontSize: FONT_SIZE.xs, color: "rgba(255,180,80,0.7)", marginTop: 4, lineHeight: 1.3 }}>
         ⚠️ {MEDICAL_ISOCHRONE_NOTE}
       </div>
     </div>
@@ -474,7 +474,7 @@ function MedicalLegend({ visibility }: { visibility: LayerVisibility }) {
   if (shown.length === 0) return null;
   return (
     <div>
-      <div style={{ fontSize: 9, color: COLORS.textDim, letterSpacing: 1, marginBottom: 4 }}>
+      <div style={{ fontSize: FONT_SIZE.xs, color: COLORS.textDim, letterSpacing: 1, marginBottom: 4 }}>
         MEDICAL 醫療據點
       </div>
       <div style={{ display: "flex", flexDirection: "column", gap: 2 }}>
@@ -484,7 +484,7 @@ function MedicalLegend({ visibility }: { visibility: LayerVisibility }) {
               style={{
                 width: 10,
                 height: 10,
-                borderRadius: "50%",
+                borderRadius: RADIUS.full,
                 background: t.color,
                 opacity: 0.9,
                 border: "1px solid #fff",
@@ -492,7 +492,7 @@ function MedicalLegend({ visibility }: { visibility: LayerVisibility }) {
                 flexShrink: 0,
               }}
             />
-            <span style={{ fontSize: 9, color: COLORS.textMuted }}>
+            <span style={{ fontSize: FONT_SIZE.xs, color: COLORS.textMuted }}>
               {t.labelZh}
               <span style={{ color: COLORS.textDim, marginLeft: 4 }}>{t.labelEn}</span>
             </span>
@@ -507,7 +507,7 @@ function AgriCompanyLegend({ visibility }: { visibility: LayerVisibility }) {
   const rows = AGRI_COMPANY_TYPES.filter((t) => visibility[t.key]);
   return (
     <div>
-      <div style={{ fontSize: 9, color: COLORS.textDim, letterSpacing: 1, marginBottom: 4 }}>
+      <div style={{ fontSize: FONT_SIZE.xs, color: COLORS.textDim, letterSpacing: 1, marginBottom: 4 }}>
         農企業登記 AGRI BUSINESS
       </div>
       <div style={{ display: "flex", flexDirection: "column", gap: 2 }}>
@@ -517,7 +517,7 @@ function AgriCompanyLegend({ visibility }: { visibility: LayerVisibility }) {
               style={{
                 width: 10,
                 height: 10,
-                borderRadius: "50%",
+                borderRadius: RADIUS.full,
                 background: t.color,
                 opacity: 0.9,
                 border: "1px solid rgba(255,255,255,0.6)",
@@ -525,7 +525,7 @@ function AgriCompanyLegend({ visibility }: { visibility: LayerVisibility }) {
                 flexShrink: 0,
               }}
             />
-            <span style={{ fontSize: 9, color: COLORS.textMuted }}>
+            <span style={{ fontSize: FONT_SIZE.xs, color: COLORS.textMuted }}>
               {t.labelZh}
               <span style={{ color: COLORS.textDim, marginLeft: 4 }}>{t.labelEn}</span>
             </span>
@@ -543,10 +543,10 @@ function CropSuitabilityLegend({ cropId }: { cropId: number }) {
   const cropLabel = crop ? `${crop.nameZh} (${crop.nameEn})` : `#${cropId}`;
   return (
     <div>
-      <div style={{ fontSize: 9, color: COLORS.textDim, letterSpacing: 1, marginBottom: 4 }}>
+      <div style={{ fontSize: FONT_SIZE.xs, color: COLORS.textDim, letterSpacing: 1, marginBottom: 4 }}>
         CROP SUITABILITY
       </div>
-      <div style={{ fontSize: 9, color: COLORS.textMuted, marginBottom: 4 }}>
+      <div style={{ fontSize: FONT_SIZE.xs, color: COLORS.textMuted, marginBottom: 4 }}>
         {cropLabel}
       </div>
       <div style={{ display: "flex", flexDirection: "column", gap: 2 }}>
@@ -556,13 +556,13 @@ function CropSuitabilityLegend({ cropId }: { cropId: number }) {
               style={{
                 width: 10,
                 height: 10,
-                borderRadius: 2,
+                borderRadius: RADIUS.sm,
                 background: s.color,
                 opacity: 0.85,
                 flexShrink: 0,
               }}
             />
-            <span style={{ fontSize: 9, color: COLORS.textMuted }}>{s.label}</span>
+            <span style={{ fontSize: FONT_SIZE.xs, color: COLORS.textMuted }}>{s.label}</span>
           </div>
         ))}
       </div>
@@ -575,25 +575,25 @@ function CropSuitabilityLegend({ cropId }: { cropId: number }) {
 function EarthquakeLegend() {
   return (
     <div>
-      <div style={{ fontSize: 9, color: COLORS.textDim, letterSpacing: 1, marginBottom: 4 }}>
+      <div style={{ fontSize: FONT_SIZE.xs, color: COLORS.textDim, letterSpacing: 1, marginBottom: 4 }}>
         EARTHQUAKE
       </div>
 
       {/* Depth color bar */}
       <div style={{ marginBottom: 4 }}>
-        <div style={{ fontSize: 9, color: COLORS.textMuted, marginBottom: 2 }}>
+        <div style={{ fontSize: FONT_SIZE.xs, color: COLORS.textMuted, marginBottom: 2 }}>
           Depth (km)
         </div>
         <div
           style={{
             height: 8,
-            borderRadius: 4,
+            borderRadius: RADIUS.md,
             background: `linear-gradient(to right, ${EQ_DEPTH_STOPS.map((s) => s.color).join(", ")})`,
           }}
         />
         <div style={{ display: "flex", justifyContent: "space-between", marginTop: 1 }}>
           {EQ_DEPTH_STOPS.map((s) => (
-            <span key={s.depth} style={{ fontSize: 8, color: COLORS.textDim }}>
+            <span key={s.depth} style={{ fontSize: FONT_SIZE.xs, color: COLORS.textDim }}>
               {s.label}
             </span>
           ))}
@@ -602,7 +602,7 @@ function EarthquakeLegend() {
 
       {/* Magnitude size reference */}
       <div>
-        <div style={{ fontSize: 9, color: COLORS.textMuted, marginBottom: 3 }}>
+        <div style={{ fontSize: FONT_SIZE.xs, color: COLORS.textMuted, marginBottom: 3 }}>
           Magnitude
         </div>
         <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
@@ -614,13 +614,13 @@ function EarthquakeLegend() {
                   style={{
                     width: Math.min(r, 16),
                     height: Math.min(r, 16),
-                    borderRadius: "50%",
+                    borderRadius: RADIUS.full,
                     background: "rgba(255, 59, 48, 0.4)",
                     border: "1px solid rgba(255, 59, 48, 0.7)",
                     flexShrink: 0,
                   }}
                 />
-                <span style={{ fontSize: 8, color: COLORS.textDim }}>M{m}</span>
+                <span style={{ fontSize: FONT_SIZE.xs, color: COLORS.textDim }}>M{m}</span>
               </div>
             );
           })}
@@ -635,7 +635,7 @@ function EarthquakeLegend() {
 function RoadEventsLegend() {
   return (
     <div>
-      <div style={{ fontSize: 9, color: COLORS.textDim, letterSpacing: 1, marginBottom: 4 }}>
+      <div style={{ fontSize: FONT_SIZE.xs, color: COLORS.textDim, letterSpacing: 1, marginBottom: 4 }}>
         ROAD EVENTS
       </div>
       <div style={{ display: "flex", flexDirection: "column", gap: 2 }}>
@@ -645,17 +645,17 @@ function RoadEventsLegend() {
               style={{
                 width: 10,
                 height: 10,
-                borderRadius: "50%",
+                borderRadius: RADIUS.full,
                 background: item.color,
                 opacity: 0.85,
                 flexShrink: 0,
               }}
             />
-            <span style={{ fontSize: 9, color: COLORS.textMuted }}>{item.label}</span>
+            <span style={{ fontSize: FONT_SIZE.xs, color: COLORS.textMuted }}>{item.label}</span>
           </div>
         ))}
       </div>
-      <div style={{ fontSize: 8, color: COLORS.textFaint, marginTop: 4 }}>
+      <div style={{ fontSize: FONT_SIZE.xs, color: COLORS.textFaint, marginTop: 4 }}>
         ⚠ live_city 偏基隆；高雄缺 TDX 來源
       </div>
     </div>
@@ -666,12 +666,12 @@ function DisasterAlertLegend({ visibility }: { visibility: LayerVisibility }) {
   const groups = ALERT_GROUP_KEYS.filter((k) => visibility[k]);
   return (
     <div>
-      <div style={{ fontSize: 9, color: COLORS.textDim, letterSpacing: 1, marginBottom: 4 }}>
+      <div style={{ fontSize: FONT_SIZE.xs, color: COLORS.textDim, letterSpacing: 1, marginBottom: 4 }}>
         NCDR 示警 ALERTS
       </div>
       {groups.map((g) => (
         <div key={g} style={{ marginBottom: 4 }}>
-          <div style={{ fontSize: 8, color: COLORS.textDim, marginBottom: 2 }}>
+          <div style={{ fontSize: FONT_SIZE.xs, color: COLORS.textDim, marginBottom: 2 }}>
             {ALERT_GROUPS[g].label}
           </div>
           <div style={{ display: "flex", flexDirection: "column", gap: 2 }}>
@@ -681,19 +681,19 @@ function DisasterAlertLegend({ visibility }: { visibility: LayerVisibility }) {
                   style={{
                     width: 10,
                     height: 10,
-                    borderRadius: 2,
+                    borderRadius: RADIUS.sm,
                     background: color,
                     opacity: 0.8,
                     flexShrink: 0,
                   }}
                 />
-                <span style={{ fontSize: 9, color: COLORS.textMuted }}>{term}</span>
+                <span style={{ fontSize: FONT_SIZE.xs, color: COLORS.textMuted }}>{term}</span>
               </div>
             ))}
           </div>
         </div>
       ))}
-      <div style={{ fontSize: 8, color: COLORS.textFaint, marginTop: 2 }}>
+      <div style={{ fontSize: FONT_SIZE.xs, color: COLORS.textFaint, marginTop: 2 }}>
         填色深淺 = 嚴重度（Extreme→Minor）
       </div>
     </div>
@@ -705,7 +705,7 @@ function DisasterAlertLegend({ visibility }: { visibility: LayerVisibility }) {
 function NewsEventsLegend() {
   return (
     <div>
-      <div style={{ fontSize: 9, color: COLORS.textDim, letterSpacing: 1, marginBottom: 4 }}>
+      <div style={{ fontSize: FONT_SIZE.xs, color: COLORS.textDim, letterSpacing: 1, marginBottom: 4 }}>
         NEWS EVENTS
       </div>
       <div style={{ display: "flex", flexDirection: "column", gap: 2 }}>
@@ -715,17 +715,17 @@ function NewsEventsLegend() {
               style={{
                 width: 10,
                 height: 10,
-                borderRadius: "50%",
+                borderRadius: RADIUS.full,
                 background: cat.color,
                 opacity: cat.key === "other" ? 0.4 : 0.9,
                 flexShrink: 0,
               }}
             />
-            <span style={{ fontSize: 9, color: COLORS.textMuted }}>{cat.label}</span>
+            <span style={{ fontSize: FONT_SIZE.xs, color: COLORS.textMuted }}>{cat.label}</span>
           </div>
         ))}
       </div>
-      <div style={{ fontSize: 8, color: COLORS.textFaint, marginTop: 4 }}>
+      <div style={{ fontSize: FONT_SIZE.xs, color: COLORS.textFaint, marginTop: 4 }}>
         座標 = 鄉鎮代表點（非事件位置）
       </div>
     </div>
@@ -737,32 +737,32 @@ function NewsEventsLegend() {
 function IotRiverLegend() {
   return (
     <div>
-      <div style={{ fontSize: 9, color: COLORS.textDim, letterSpacing: 1, marginBottom: 4 }}>
+      <div style={{ fontSize: FONT_SIZE.xs, color: COLORS.textDim, letterSpacing: 1, marginBottom: 4 }}>
         IOT 河川（補強）
       </div>
       <div style={{ marginBottom: 4 }}>
-        <div style={{ fontSize: 9, color: COLORS.textMuted, marginBottom: 2 }}>
+        <div style={{ fontSize: FONT_SIZE.xs, color: COLORS.textMuted, marginBottom: 2 }}>
           當日水位變化
         </div>
         <div
           style={{
             height: 8,
-            borderRadius: 4,
+            borderRadius: RADIUS.md,
             background: `linear-gradient(to right, ${IOT_RIVER_DELTA_STOPS.map((s) => s.color).join(", ")})`,
           }}
         />
         <div style={{ display: "flex", justifyContent: "space-between", marginTop: 1 }}>
-          <span style={{ fontSize: 8, color: COLORS.textDim }}>下降</span>
-          <span style={{ fontSize: 8, color: COLORS.textDim }}>持平</span>
-          <span style={{ fontSize: 8, color: COLORS.textDim }}>上升</span>
+          <span style={{ fontSize: FONT_SIZE.xs, color: COLORS.textDim }}>下降</span>
+          <span style={{ fontSize: FONT_SIZE.xs, color: COLORS.textDim }}>持平</span>
+          <span style={{ fontSize: FONT_SIZE.xs, color: COLORS.textDim }}>上升</span>
         </div>
         <div style={{ display: "flex", justifyContent: "space-between", marginTop: 1 }}>
-          <span style={{ fontSize: 8, color: COLORS.textDim }}>-1m</span>
-          <span style={{ fontSize: 8, color: COLORS.textDim }}>0</span>
-          <span style={{ fontSize: 8, color: COLORS.textDim }}>+1m</span>
+          <span style={{ fontSize: FONT_SIZE.xs, color: COLORS.textDim }}>-1m</span>
+          <span style={{ fontSize: FONT_SIZE.xs, color: COLORS.textDim }}>0</span>
+          <span style={{ fontSize: FONT_SIZE.xs, color: COLORS.textDim }}>+1m</span>
         </div>
       </div>
-      <div style={{ fontSize: 8, color: COLORS.textDim, lineHeight: 1.4 }}>
+      <div style={{ fontSize: FONT_SIZE.xs, color: COLORS.textDim, lineHeight: 1.4 }}>
         圈大小 = 變化幅度
       </div>
     </div>
@@ -782,7 +782,7 @@ const WATER_CANAL_ITEMS = [
 function WaterCanalLegend() {
   return (
     <div>
-      <div style={{ fontSize: 9, color: COLORS.textDim, letterSpacing: 1, marginBottom: 4 }}>
+      <div style={{ fontSize: FONT_SIZE.xs, color: COLORS.textDim, letterSpacing: 1, marginBottom: 4 }}>
         灌排渠道 CANAL
       </div>
       <div style={{ display: "flex", flexDirection: "column", gap: 2 }}>
@@ -790,11 +790,11 @@ function WaterCanalLegend() {
           <div key={c.label} style={{ display: "flex", alignItems: "center", gap: 6 }}>
             <div
               style={{
-                width: 16, height: 3, borderRadius: 1,
+                width: 16, height: 3, borderRadius: RADIUS.sm,
                 background: c.color, opacity: 0.9, flexShrink: 0,
               }}
             />
-            <span style={{ fontSize: 9, color: COLORS.textMuted }}>{c.label}</span>
+            <span style={{ fontSize: FONT_SIZE.xs, color: COLORS.textMuted }}>{c.label}</span>
           </div>
         ))}
       </div>
@@ -805,7 +805,7 @@ function WaterCanalLegend() {
 function IotStructureLegend() {
   return (
     <div>
-      <div style={{ fontSize: 9, color: COLORS.textDim, letterSpacing: 1, marginBottom: 4 }}>
+      <div style={{ fontSize: FONT_SIZE.xs, color: COLORS.textDim, letterSpacing: 1, marginBottom: 4 }}>
         IOT 水工結構
       </div>
       <div style={{ display: "flex", flexDirection: "column", gap: 3 }}>
@@ -815,7 +815,7 @@ function IotStructureLegend() {
               style={{
                 width: 8,
                 height: 8,
-                borderRadius: "50%",
+                borderRadius: RADIUS.full,
                 background: s.color,
                 opacity: 0.9,
                 flexShrink: 0,
@@ -823,8 +823,8 @@ function IotStructureLegend() {
               }}
             />
             <div style={{ display: "flex", flexDirection: "column", lineHeight: 1.2 }}>
-              <span style={{ fontSize: 9, color: COLORS.textMuted }}>{s.label}</span>
-              <span style={{ fontSize: 8, color: COLORS.textDim }}>{s.measure}</span>
+              <span style={{ fontSize: FONT_SIZE.xs, color: COLORS.textMuted }}>{s.label}</span>
+              <span style={{ fontSize: FONT_SIZE.xs, color: COLORS.textDim }}>{s.measure}</span>
             </div>
           </div>
         ))}
@@ -856,16 +856,16 @@ function SatelliteLegend({ visibility }: { visibility: LayerVisibility }) {
   if (!active.length) return null;
   return (
     <div>
-      <div style={{ fontSize: 9, color: COLORS.textDim, letterSpacing: 1, marginBottom: 4 }}>
+      <div style={{ fontSize: FONT_SIZE.xs, color: COLORS.textDim, letterSpacing: 1, marginBottom: 4 }}>
         衛星 SATELLITES
       </div>
       {active.map((i) => (
         <div key={i.key} style={{ display: "flex", alignItems: "center", gap: 6, marginTop: 3 }}>
-          <span style={{ width: 12, height: 12, borderRadius: "50%", background: SATELLITE_COLORS[i.cat], display: "inline-block" }} />
-          <span style={{ fontSize: 10, color: COLORS.textDefault }}>{SATELLITE_LABELS[i.cat]}</span>
+          <span style={{ width: 12, height: 12, borderRadius: RADIUS.full, background: SATELLITE_COLORS[i.cat], display: "inline-block" }} />
+          <span style={{ fontSize: FONT_SIZE.sm, color: COLORS.textDefault }}>{SATELLITE_LABELS[i.cat]}</span>
         </div>
       ))}
-      <div style={{ marginTop: 6, fontSize: 8, lineHeight: 1.35, color: COLORS.textDim }}>
+      <div style={{ marginTop: 6, fontSize: FONT_SIZE.xs, lineHeight: 1.35, color: COLORS.textDim }}>
         ● 即時點 = 子衛星正下方<br />
         ● 內圓 50 km swath（成像範圍示意）<br />
         ● 虛線外圓 1,500 km（仰角 ≥ 10° 可見 cone）<br />

--- a/src/components/LegendPanel.tsx
+++ b/src/components/LegendPanel.tsx
@@ -1,6 +1,6 @@
 import { Fragment, useState } from "react";
 import { ChevronDown, ChevronRight } from "lucide-react";
-import { SURFACE } from "../styles/designTokens";
+import { SURFACE, FONT_DATA } from "../styles/designTokens";
 import type { LayerVisibility } from "../types";
 import { CROP_SUITABILITY_CROPS } from "../data/cropSuitabilityCrops";
 import { AGRI_POI_TYPES } from "../data/agriPOITypes";
@@ -141,7 +141,7 @@ export function LegendPanel({ visibility, overlayParams }: LegendPanelProps) {
         WebkitBackdropFilter: "blur(14px)",
         border: "1px solid rgba(100, 170, 255, 0.15)",
         borderRadius: 8,
-        fontFamily: "monospace",
+        fontFamily: FONT_DATA,
         overflow: "hidden",
         transition: "all 0.2s ease",
       }}
@@ -160,7 +160,7 @@ export function LegendPanel({ visibility, overlayParams }: LegendPanelProps) {
           cursor: "pointer",
           color: "rgba(255,255,255,0.5)",
           fontSize: 10,
-          fontFamily: "monospace",
+          fontFamily: FONT_DATA,
           letterSpacing: 1,
         }}
       >

--- a/src/components/LegendPanel.tsx
+++ b/src/components/LegendPanel.tsx
@@ -1,6 +1,6 @@
 import { Fragment, useState } from "react";
 import { ChevronDown, ChevronRight } from "lucide-react";
-import { SURFACE, FONT_DATA } from "../styles/designTokens";
+import { COLORS, SURFACE, FONT_DATA } from "../styles/designTokens";
 import type { LayerVisibility } from "../types";
 import { CROP_SUITABILITY_CROPS } from "../data/cropSuitabilityCrops";
 import { AGRI_POI_TYPES } from "../data/agriPOITypes";
@@ -158,7 +158,7 @@ export function LegendPanel({ visibility, overlayParams }: LegendPanelProps) {
           background: "none",
           border: "none",
           cursor: "pointer",
-          color: "rgba(255,255,255,0.5)",
+          color: COLORS.textMuted,
           fontSize: 10,
           fontFamily: FONT_DATA,
           letterSpacing: 1,
@@ -198,7 +198,7 @@ function FireCatRows({ cats, square }: { cats: { color: string; label: string }[
               border: "1px solid rgba(255,255,255,0.6)", boxSizing: "border-box",
             }}
           />
-          <span style={{ fontSize: 9, color: "rgba(255,255,255,0.5)" }}>{c.label}</span>
+          <span style={{ fontSize: 9, color: COLORS.textMuted }}>{c.label}</span>
         </div>
       ))}
     </div>
@@ -216,7 +216,7 @@ const FLOOD_SENSOR_CATS = [
 function FloodSensorLegend() {
   return (
     <div>
-      <div style={{ fontSize: 9, color: "rgba(255,255,255,0.35)", letterSpacing: 1, marginBottom: 4 }}>
+      <div style={{ fontSize: 9, color: COLORS.textDim, letterSpacing: 1, marginBottom: 4 }}>
         都市淹水 USWG
       </div>
       <FireCatRows cats={FLOOD_SENSOR_CATS} />
@@ -227,7 +227,7 @@ function FloodSensorLegend() {
 function FireEventLegend() {
   return (
     <div>
-      <div style={{ fontSize: 9, color: "rgba(255,255,255,0.35)", letterSpacing: 1, marginBottom: 4 }}>
+      <div style={{ fontSize: 9, color: COLORS.textDim, letterSpacing: 1, marginBottom: 4 }}>
         FIRE 火災歷史
       </div>
       <FireCatRows cats={FIRE_EVENT_CATS} />
@@ -238,7 +238,7 @@ function FireEventLegend() {
 function FireStationLegend() {
   return (
     <div>
-      <div style={{ fontSize: 9, color: "rgba(255,255,255,0.35)", letterSpacing: 1, marginBottom: 4 }}>
+      <div style={{ fontSize: 9, color: COLORS.textDim, letterSpacing: 1, marginBottom: 4 }}>
         消防分隊 STATIONS
       </div>
       <FireCatRows cats={FIRE_STATION_CATS} />
@@ -249,7 +249,7 @@ function FireStationLegend() {
 function FireHydrantLegend() {
   return (
     <div>
-      <div style={{ fontSize: 9, color: "rgba(255,255,255,0.35)", letterSpacing: 1, marginBottom: 4 }}>
+      <div style={{ fontSize: 9, color: COLORS.textDim, letterSpacing: 1, marginBottom: 4 }}>
         消防栓 HYDRANTS
       </div>
       <FireCatRows cats={FIRE_HYDRANT_CATS} square />
@@ -263,7 +263,7 @@ function FireHydrantLegend() {
 function FireIsochroneLegend() {
   return (
     <div>
-      <div style={{ fontSize: 9, color: "rgba(255,255,255,0.35)", letterSpacing: 1, marginBottom: 4 }}>
+      <div style={{ fontSize: 9, color: COLORS.textDim, letterSpacing: 1, marginBottom: 4 }}>
         救援等時圈 ISOCHRONE
       </div>
       <FireCatRows
@@ -280,14 +280,14 @@ function FireIsochroneLegend() {
 function EcoNetworkZonesLegend() {
   return (
     <div>
-      <div style={{ fontSize: 9, color: "rgba(255,255,255,0.35)", letterSpacing: 1, marginBottom: 4 }}>
+      <div style={{ fontSize: 9, color: COLORS.textDim, letterSpacing: 1, marginBottom: 4 }}>
         國土綠網分區 ECO NETWORK
       </div>
       <div style={{ display: "flex", flexDirection: "column", gap: 2 }}>
         {ECO_NETWORK_ZONE_TYPES.map((z) => (
           <div key={z.zone} style={{ display: "flex", alignItems: "center", gap: 6 }}>
             <div style={{ width: 9, height: 9, borderRadius: 1, background: z.color, flexShrink: 0 }} />
-            <span style={{ fontSize: 9, color: "rgba(255,255,255,0.7)" }}>{z.label}</span>
+            <span style={{ fontSize: 9, color: COLORS.textDefault }}>{z.label}</span>
           </div>
         ))}
       </div>
@@ -325,12 +325,12 @@ const HIKING_TRAIL_SOURCES: { color: string; label: string }[] = [
 function HikingTrailsSourcesLegend() {
   return (
     <div style={{ marginTop: 4, paddingLeft: 8, borderLeft: "1px solid rgba(255,255,255,0.12)" }}>
-      <div style={{ fontSize: 8, color: "rgba(255,255,255,0.4)", marginBottom: 2 }}>步道來源 source</div>
+      <div style={{ fontSize: 8, color: COLORS.textDim, marginBottom: 2 }}>步道來源 source</div>
       <div style={{ display: "flex", flexDirection: "column", gap: 1 }}>
         {HIKING_TRAIL_SOURCES.map((t) => (
           <div key={t.label} style={{ display: "flex", alignItems: "center", gap: 5 }}>
             <div style={{ width: 12, height: 2, background: t.color, flexShrink: 0 }} />
-            <span style={{ fontSize: 8, color: "rgba(255,255,255,0.55)" }}>{t.label}</span>
+            <span style={{ fontSize: 8, color: COLORS.textMuted }}>{t.label}</span>
           </div>
         ))}
       </div>
@@ -341,12 +341,12 @@ function HikingTrailsSourcesLegend() {
 function ForestReserveTypesLegend() {
   return (
     <div style={{ marginTop: 4, paddingLeft: 8, borderLeft: "1px solid rgba(255,255,255,0.12)" }}>
-      <div style={{ fontSize: 8, color: "rgba(255,255,255,0.4)", marginBottom: 2 }}>保安林種類</div>
+      <div style={{ fontSize: 8, color: COLORS.textDim, marginBottom: 2 }}>保安林種類</div>
       <div style={{ display: "flex", flexDirection: "column", gap: 1 }}>
         {FOREST_RESERVE_TYPES.map((t) => (
           <div key={t.key} style={{ display: "flex", alignItems: "center", gap: 5 }}>
             <div style={{ width: 8, height: 8, borderRadius: 1, background: t.color, flexShrink: 0 }} />
-            <span style={{ fontSize: 8, color: "rgba(255,255,255,0.55)" }}>{t.label}</span>
+            <span style={{ fontSize: 8, color: COLORS.textMuted }}>{t.label}</span>
           </div>
         ))}
       </div>
@@ -359,7 +359,7 @@ function ForestryLegend({ visibility }: { visibility: LayerVisibility }) {
   if (rows.length === 0) return null;
   return (
     <div>
-      <div style={{ fontSize: 9, color: "rgba(255,255,255,0.35)", letterSpacing: 1, marginBottom: 4 }}>
+      <div style={{ fontSize: 9, color: COLORS.textDim, letterSpacing: 1, marginBottom: 4 }}>
         FORESTRY 林業
       </div>
       <div style={{ display: "flex", flexDirection: "column", gap: 2 }}>
@@ -377,7 +377,7 @@ function ForestryLegend({ visibility }: { visibility: LayerVisibility }) {
                 boxSizing: "border-box",
               }}
             />
-            <span style={{ fontSize: 9, color: "rgba(255,255,255,0.55)" }}>{r.label}</span>
+            <span style={{ fontSize: 9, color: COLORS.textMuted }}>{r.label}</span>
           </div>
         ))}
       </div>
@@ -394,10 +394,10 @@ function SoilFertilityLegend({ metricIdx }: { metricIdx: number }) {
   const meta = SOIL_FERTILITY_METRICS[metricId];
   return (
     <div>
-      <div style={{ fontSize: 9, color: "rgba(255,255,255,0.35)", letterSpacing: 1, marginBottom: 4 }}>
+      <div style={{ fontSize: 9, color: COLORS.textDim, letterSpacing: 1, marginBottom: 4 }}>
         SOIL FERTILITY
       </div>
-      <div style={{ fontSize: 9, color: "rgba(255,255,255,0.55)", marginBottom: 4 }}>
+      <div style={{ fontSize: 9, color: COLORS.textMuted, marginBottom: 4 }}>
         {meta.label}{meta.unit ? ` (${meta.unit})` : ""}
       </div>
       <div style={{ display: "flex", flexDirection: "column", gap: 2 }}>
@@ -409,7 +409,7 @@ function SoilFertilityLegend({ metricIdx }: { metricIdx: number }) {
                 background: s.color, opacity: 0.9, flexShrink: 0,
               }}
             />
-            <span style={{ fontSize: 9, color: "rgba(255,255,255,0.5)" }}>{s.label}</span>
+            <span style={{ fontSize: 9, color: COLORS.textMuted }}>{s.label}</span>
           </div>
         ))}
       </div>
@@ -422,7 +422,7 @@ function SoilFertilityLegend({ metricIdx }: { metricIdx: number }) {
 function AgriPOILegend() {
   return (
     <div>
-      <div style={{ fontSize: 9, color: "rgba(255,255,255,0.35)", letterSpacing: 1, marginBottom: 4 }}>
+      <div style={{ fontSize: 9, color: COLORS.textDim, letterSpacing: 1, marginBottom: 4 }}>
         AGRICULTURE POI
       </div>
       <div style={{ display: "flex", flexDirection: "column", gap: 2 }}>
@@ -440,9 +440,9 @@ function AgriPOILegend() {
                 flexShrink: 0,
               }}
             />
-            <span style={{ fontSize: 9, color: "rgba(255,255,255,0.5)" }}>
+            <span style={{ fontSize: 9, color: COLORS.textMuted }}>
               {t.labelZh}
-              <span style={{ color: "rgba(255,255,255,0.3)", marginLeft: 4 }}>{t.labelEn}</span>
+              <span style={{ color: COLORS.textDim, marginLeft: 4 }}>{t.labelEn}</span>
             </span>
           </div>
         ))}
@@ -454,7 +454,7 @@ function AgriPOILegend() {
 function MedicalIsochroneLegend() {
   return (
     <div>
-      <div style={{ fontSize: 9, color: "rgba(255,255,255,0.35)", letterSpacing: 1, marginBottom: 4 }}>
+      <div style={{ fontSize: 9, color: COLORS.textDim, letterSpacing: 1, marginBottom: 4 }}>
         醫療等時圈 MEDICAL ISOCHRONE
       </div>
       <FireCatRows
@@ -474,7 +474,7 @@ function MedicalLegend({ visibility }: { visibility: LayerVisibility }) {
   if (shown.length === 0) return null;
   return (
     <div>
-      <div style={{ fontSize: 9, color: "rgba(255,255,255,0.35)", letterSpacing: 1, marginBottom: 4 }}>
+      <div style={{ fontSize: 9, color: COLORS.textDim, letterSpacing: 1, marginBottom: 4 }}>
         MEDICAL 醫療據點
       </div>
       <div style={{ display: "flex", flexDirection: "column", gap: 2 }}>
@@ -492,9 +492,9 @@ function MedicalLegend({ visibility }: { visibility: LayerVisibility }) {
                 flexShrink: 0,
               }}
             />
-            <span style={{ fontSize: 9, color: "rgba(255,255,255,0.5)" }}>
+            <span style={{ fontSize: 9, color: COLORS.textMuted }}>
               {t.labelZh}
-              <span style={{ color: "rgba(255,255,255,0.3)", marginLeft: 4 }}>{t.labelEn}</span>
+              <span style={{ color: COLORS.textDim, marginLeft: 4 }}>{t.labelEn}</span>
             </span>
           </div>
         ))}
@@ -507,7 +507,7 @@ function AgriCompanyLegend({ visibility }: { visibility: LayerVisibility }) {
   const rows = AGRI_COMPANY_TYPES.filter((t) => visibility[t.key]);
   return (
     <div>
-      <div style={{ fontSize: 9, color: "rgba(255,255,255,0.35)", letterSpacing: 1, marginBottom: 4 }}>
+      <div style={{ fontSize: 9, color: COLORS.textDim, letterSpacing: 1, marginBottom: 4 }}>
         農企業登記 AGRI BUSINESS
       </div>
       <div style={{ display: "flex", flexDirection: "column", gap: 2 }}>
@@ -525,9 +525,9 @@ function AgriCompanyLegend({ visibility }: { visibility: LayerVisibility }) {
                 flexShrink: 0,
               }}
             />
-            <span style={{ fontSize: 9, color: "rgba(255,255,255,0.5)" }}>
+            <span style={{ fontSize: 9, color: COLORS.textMuted }}>
               {t.labelZh}
-              <span style={{ color: "rgba(255,255,255,0.3)", marginLeft: 4 }}>{t.labelEn}</span>
+              <span style={{ color: COLORS.textDim, marginLeft: 4 }}>{t.labelEn}</span>
             </span>
           </div>
         ))}
@@ -543,10 +543,10 @@ function CropSuitabilityLegend({ cropId }: { cropId: number }) {
   const cropLabel = crop ? `${crop.nameZh} (${crop.nameEn})` : `#${cropId}`;
   return (
     <div>
-      <div style={{ fontSize: 9, color: "rgba(255,255,255,0.35)", letterSpacing: 1, marginBottom: 4 }}>
+      <div style={{ fontSize: 9, color: COLORS.textDim, letterSpacing: 1, marginBottom: 4 }}>
         CROP SUITABILITY
       </div>
-      <div style={{ fontSize: 9, color: "rgba(255,255,255,0.55)", marginBottom: 4 }}>
+      <div style={{ fontSize: 9, color: COLORS.textMuted, marginBottom: 4 }}>
         {cropLabel}
       </div>
       <div style={{ display: "flex", flexDirection: "column", gap: 2 }}>
@@ -562,7 +562,7 @@ function CropSuitabilityLegend({ cropId }: { cropId: number }) {
                 flexShrink: 0,
               }}
             />
-            <span style={{ fontSize: 9, color: "rgba(255,255,255,0.5)" }}>{s.label}</span>
+            <span style={{ fontSize: 9, color: COLORS.textMuted }}>{s.label}</span>
           </div>
         ))}
       </div>
@@ -575,13 +575,13 @@ function CropSuitabilityLegend({ cropId }: { cropId: number }) {
 function EarthquakeLegend() {
   return (
     <div>
-      <div style={{ fontSize: 9, color: "rgba(255,255,255,0.35)", letterSpacing: 1, marginBottom: 4 }}>
+      <div style={{ fontSize: 9, color: COLORS.textDim, letterSpacing: 1, marginBottom: 4 }}>
         EARTHQUAKE
       </div>
 
       {/* Depth color bar */}
       <div style={{ marginBottom: 4 }}>
-        <div style={{ fontSize: 9, color: "rgba(255,255,255,0.45)", marginBottom: 2 }}>
+        <div style={{ fontSize: 9, color: COLORS.textMuted, marginBottom: 2 }}>
           Depth (km)
         </div>
         <div
@@ -593,7 +593,7 @@ function EarthquakeLegend() {
         />
         <div style={{ display: "flex", justifyContent: "space-between", marginTop: 1 }}>
           {EQ_DEPTH_STOPS.map((s) => (
-            <span key={s.depth} style={{ fontSize: 8, color: "rgba(255,255,255,0.35)" }}>
+            <span key={s.depth} style={{ fontSize: 8, color: COLORS.textDim }}>
               {s.label}
             </span>
           ))}
@@ -602,7 +602,7 @@ function EarthquakeLegend() {
 
       {/* Magnitude size reference */}
       <div>
-        <div style={{ fontSize: 9, color: "rgba(255,255,255,0.45)", marginBottom: 3 }}>
+        <div style={{ fontSize: 9, color: COLORS.textMuted, marginBottom: 3 }}>
           Magnitude
         </div>
         <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
@@ -620,7 +620,7 @@ function EarthquakeLegend() {
                     flexShrink: 0,
                   }}
                 />
-                <span style={{ fontSize: 8, color: "rgba(255,255,255,0.4)" }}>M{m}</span>
+                <span style={{ fontSize: 8, color: COLORS.textDim }}>M{m}</span>
               </div>
             );
           })}
@@ -635,7 +635,7 @@ function EarthquakeLegend() {
 function RoadEventsLegend() {
   return (
     <div>
-      <div style={{ fontSize: 9, color: "rgba(255,255,255,0.35)", letterSpacing: 1, marginBottom: 4 }}>
+      <div style={{ fontSize: 9, color: COLORS.textDim, letterSpacing: 1, marginBottom: 4 }}>
         ROAD EVENTS
       </div>
       <div style={{ display: "flex", flexDirection: "column", gap: 2 }}>
@@ -651,11 +651,11 @@ function RoadEventsLegend() {
                 flexShrink: 0,
               }}
             />
-            <span style={{ fontSize: 9, color: "rgba(255,255,255,0.5)" }}>{item.label}</span>
+            <span style={{ fontSize: 9, color: COLORS.textMuted }}>{item.label}</span>
           </div>
         ))}
       </div>
-      <div style={{ fontSize: 8, color: "rgba(255,255,255,0.25)", marginTop: 4 }}>
+      <div style={{ fontSize: 8, color: COLORS.textFaint, marginTop: 4 }}>
         ⚠ live_city 偏基隆；高雄缺 TDX 來源
       </div>
     </div>
@@ -666,12 +666,12 @@ function DisasterAlertLegend({ visibility }: { visibility: LayerVisibility }) {
   const groups = ALERT_GROUP_KEYS.filter((k) => visibility[k]);
   return (
     <div>
-      <div style={{ fontSize: 9, color: "rgba(255,255,255,0.35)", letterSpacing: 1, marginBottom: 4 }}>
+      <div style={{ fontSize: 9, color: COLORS.textDim, letterSpacing: 1, marginBottom: 4 }}>
         NCDR 示警 ALERTS
       </div>
       {groups.map((g) => (
         <div key={g} style={{ marginBottom: 4 }}>
-          <div style={{ fontSize: 8, color: "rgba(255,255,255,0.3)", marginBottom: 2 }}>
+          <div style={{ fontSize: 8, color: COLORS.textDim, marginBottom: 2 }}>
             {ALERT_GROUPS[g].label}
           </div>
           <div style={{ display: "flex", flexDirection: "column", gap: 2 }}>
@@ -687,13 +687,13 @@ function DisasterAlertLegend({ visibility }: { visibility: LayerVisibility }) {
                     flexShrink: 0,
                   }}
                 />
-                <span style={{ fontSize: 9, color: "rgba(255,255,255,0.5)" }}>{term}</span>
+                <span style={{ fontSize: 9, color: COLORS.textMuted }}>{term}</span>
               </div>
             ))}
           </div>
         </div>
       ))}
-      <div style={{ fontSize: 8, color: "rgba(255,255,255,0.25)", marginTop: 2 }}>
+      <div style={{ fontSize: 8, color: COLORS.textFaint, marginTop: 2 }}>
         填色深淺 = 嚴重度（Extreme→Minor）
       </div>
     </div>
@@ -705,7 +705,7 @@ function DisasterAlertLegend({ visibility }: { visibility: LayerVisibility }) {
 function NewsEventsLegend() {
   return (
     <div>
-      <div style={{ fontSize: 9, color: "rgba(255,255,255,0.35)", letterSpacing: 1, marginBottom: 4 }}>
+      <div style={{ fontSize: 9, color: COLORS.textDim, letterSpacing: 1, marginBottom: 4 }}>
         NEWS EVENTS
       </div>
       <div style={{ display: "flex", flexDirection: "column", gap: 2 }}>
@@ -721,11 +721,11 @@ function NewsEventsLegend() {
                 flexShrink: 0,
               }}
             />
-            <span style={{ fontSize: 9, color: "rgba(255,255,255,0.5)" }}>{cat.label}</span>
+            <span style={{ fontSize: 9, color: COLORS.textMuted }}>{cat.label}</span>
           </div>
         ))}
       </div>
-      <div style={{ fontSize: 8, color: "rgba(255,255,255,0.25)", marginTop: 4 }}>
+      <div style={{ fontSize: 8, color: COLORS.textFaint, marginTop: 4 }}>
         座標 = 鄉鎮代表點（非事件位置）
       </div>
     </div>
@@ -737,11 +737,11 @@ function NewsEventsLegend() {
 function IotRiverLegend() {
   return (
     <div>
-      <div style={{ fontSize: 9, color: "rgba(255,255,255,0.35)", letterSpacing: 1, marginBottom: 4 }}>
+      <div style={{ fontSize: 9, color: COLORS.textDim, letterSpacing: 1, marginBottom: 4 }}>
         IOT 河川（補強）
       </div>
       <div style={{ marginBottom: 4 }}>
-        <div style={{ fontSize: 9, color: "rgba(255,255,255,0.45)", marginBottom: 2 }}>
+        <div style={{ fontSize: 9, color: COLORS.textMuted, marginBottom: 2 }}>
           當日水位變化
         </div>
         <div
@@ -752,17 +752,17 @@ function IotRiverLegend() {
           }}
         />
         <div style={{ display: "flex", justifyContent: "space-between", marginTop: 1 }}>
-          <span style={{ fontSize: 8, color: "rgba(255,255,255,0.35)" }}>下降</span>
-          <span style={{ fontSize: 8, color: "rgba(255,255,255,0.35)" }}>持平</span>
-          <span style={{ fontSize: 8, color: "rgba(255,255,255,0.35)" }}>上升</span>
+          <span style={{ fontSize: 8, color: COLORS.textDim }}>下降</span>
+          <span style={{ fontSize: 8, color: COLORS.textDim }}>持平</span>
+          <span style={{ fontSize: 8, color: COLORS.textDim }}>上升</span>
         </div>
         <div style={{ display: "flex", justifyContent: "space-between", marginTop: 1 }}>
-          <span style={{ fontSize: 8, color: "rgba(255,255,255,0.35)" }}>-1m</span>
-          <span style={{ fontSize: 8, color: "rgba(255,255,255,0.35)" }}>0</span>
-          <span style={{ fontSize: 8, color: "rgba(255,255,255,0.35)" }}>+1m</span>
+          <span style={{ fontSize: 8, color: COLORS.textDim }}>-1m</span>
+          <span style={{ fontSize: 8, color: COLORS.textDim }}>0</span>
+          <span style={{ fontSize: 8, color: COLORS.textDim }}>+1m</span>
         </div>
       </div>
-      <div style={{ fontSize: 8, color: "rgba(255,255,255,0.4)", lineHeight: 1.4 }}>
+      <div style={{ fontSize: 8, color: COLORS.textDim, lineHeight: 1.4 }}>
         圈大小 = 變化幅度
       </div>
     </div>
@@ -782,7 +782,7 @@ const WATER_CANAL_ITEMS = [
 function WaterCanalLegend() {
   return (
     <div>
-      <div style={{ fontSize: 9, color: "rgba(255,255,255,0.35)", letterSpacing: 1, marginBottom: 4 }}>
+      <div style={{ fontSize: 9, color: COLORS.textDim, letterSpacing: 1, marginBottom: 4 }}>
         灌排渠道 CANAL
       </div>
       <div style={{ display: "flex", flexDirection: "column", gap: 2 }}>
@@ -794,7 +794,7 @@ function WaterCanalLegend() {
                 background: c.color, opacity: 0.9, flexShrink: 0,
               }}
             />
-            <span style={{ fontSize: 9, color: "rgba(255,255,255,0.5)" }}>{c.label}</span>
+            <span style={{ fontSize: 9, color: COLORS.textMuted }}>{c.label}</span>
           </div>
         ))}
       </div>
@@ -805,7 +805,7 @@ function WaterCanalLegend() {
 function IotStructureLegend() {
   return (
     <div>
-      <div style={{ fontSize: 9, color: "rgba(255,255,255,0.35)", letterSpacing: 1, marginBottom: 4 }}>
+      <div style={{ fontSize: 9, color: COLORS.textDim, letterSpacing: 1, marginBottom: 4 }}>
         IOT 水工結構
       </div>
       <div style={{ display: "flex", flexDirection: "column", gap: 3 }}>
@@ -823,8 +823,8 @@ function IotStructureLegend() {
               }}
             />
             <div style={{ display: "flex", flexDirection: "column", lineHeight: 1.2 }}>
-              <span style={{ fontSize: 9, color: "rgba(255,255,255,0.5)" }}>{s.label}</span>
-              <span style={{ fontSize: 8, color: "rgba(255,255,255,0.3)" }}>{s.measure}</span>
+              <span style={{ fontSize: 9, color: COLORS.textMuted }}>{s.label}</span>
+              <span style={{ fontSize: 8, color: COLORS.textDim }}>{s.measure}</span>
             </div>
           </div>
         ))}
@@ -856,16 +856,16 @@ function SatelliteLegend({ visibility }: { visibility: LayerVisibility }) {
   if (!active.length) return null;
   return (
     <div>
-      <div style={{ fontSize: 9, color: "rgba(255,255,255,0.35)", letterSpacing: 1, marginBottom: 4 }}>
+      <div style={{ fontSize: 9, color: COLORS.textDim, letterSpacing: 1, marginBottom: 4 }}>
         衛星 SATELLITES
       </div>
       {active.map((i) => (
         <div key={i.key} style={{ display: "flex", alignItems: "center", gap: 6, marginTop: 3 }}>
           <span style={{ width: 12, height: 12, borderRadius: "50%", background: SATELLITE_COLORS[i.cat], display: "inline-block" }} />
-          <span style={{ fontSize: 10, color: "rgba(255,255,255,0.7)" }}>{SATELLITE_LABELS[i.cat]}</span>
+          <span style={{ fontSize: 10, color: COLORS.textDefault }}>{SATELLITE_LABELS[i.cat]}</span>
         </div>
       ))}
-      <div style={{ marginTop: 6, fontSize: 8, lineHeight: 1.35, color: "rgba(255,255,255,0.4)" }}>
+      <div style={{ marginTop: 6, fontSize: 8, lineHeight: 1.35, color: COLORS.textDim }}>
         ● 即時點 = 子衛星正下方<br />
         ● 內圓 50 km swath（成像範圍示意）<br />
         ● 虛線外圓 1,500 km（仰角 ≥ 10° 可見 cone）<br />

--- a/src/components/LoadingScreen.tsx
+++ b/src/components/LoadingScreen.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from "react";
-import { COLORS, FONT_DATA } from "../styles/designTokens";
+import { COLORS, FONT_DATA, RADIUS, FONT_SIZE } from "../styles/designTokens";
 
 interface LoadingStep {
   label: string;
@@ -126,10 +126,10 @@ export function LoadingScreen({ steps }: LoadingScreenProps) {
       }}
     >
       {/* title */}
-      <div style={{ fontSize: 22, letterSpacing: 4, fontWeight: 700, marginBottom: 2 }}>
+      <div style={{ fontSize: FONT_SIZE.xxl, letterSpacing: 4, fontWeight: 700, marginBottom: 2 }}>
         Mini Taiwan Pulse
       </div>
-      <div style={{ fontSize: 10, color: COLORS.textDim, letterSpacing: 1, marginBottom: 4 }}>
+      <div style={{ fontSize: FONT_SIZE.sm, color: COLORS.textDim, letterSpacing: 1, marginBottom: 4 }}>
         Supabase Realtime
       </div>
 
@@ -146,7 +146,7 @@ export function LoadingScreen({ steps }: LoadingScreenProps) {
                 display: "flex",
                 alignItems: "center",
                 gap: 10,
-                fontSize: 13,
+                fontSize: FONT_SIZE.lg,
                 color: isDone
                   ? CAT_COLOR[stepToCat(step.label)]
                   : isActive
@@ -169,7 +169,7 @@ export function LoadingScreen({ steps }: LoadingScreenProps) {
                 ) : "○"}
               </span>
               <span style={{ minWidth: 160 }}>{step.label}</span>
-              <span style={{ fontSize: 11, opacity: 0.7 }}>
+              <span style={{ fontSize: FONT_SIZE.base, opacity: 0.7 }}>
                 {isDone && step.count != null
                   ? step.count.toLocaleString()
                   : isActive
@@ -183,7 +183,7 @@ export function LoadingScreen({ steps }: LoadingScreenProps) {
 
       {/* progress bar */}
       <div style={{ display: "flex", flexDirection: "column", alignItems: "center", gap: 6, marginTop: 4 }}>
-        <div style={{ fontSize: 11, color: COLORS.textDim, letterSpacing: 0.5 }}>
+        <div style={{ fontSize: FONT_SIZE.base, color: COLORS.textDim, letterSpacing: 0.5 }}>
           {allDone ? "載入完成" : `載入中... ${doneCount}/${steps.length}`}
         </div>
         <div
@@ -191,7 +191,7 @@ export function LoadingScreen({ steps }: LoadingScreenProps) {
             width: 280,
             height: 4,
             background: "rgba(255,255,255,0.08)",
-            borderRadius: 2,
+            borderRadius: RADIUS.sm,
             overflow: "hidden",
             position: "relative",
           }}
@@ -201,13 +201,13 @@ export function LoadingScreen({ steps }: LoadingScreenProps) {
               width: `${progress * 100}%`,
               height: "100%",
               background: "linear-gradient(90deg, #64aaff, #4ecdc4)",
-              borderRadius: 2,
+              borderRadius: RADIUS.sm,
               transition: "width 0.5s ease",
               boxShadow: "0 0 12px rgba(100,170,255,0.5), 0 0 4px rgba(100,170,255,0.8)",
             }}
           />
         </div>
-        <div style={{ fontSize: 10, color: COLORS.textFaint }}>
+        <div style={{ fontSize: FONT_SIZE.sm, color: COLORS.textFaint }}>
           {Math.round(progress * 100)}%
         </div>
       </div>
@@ -220,7 +220,7 @@ export function LoadingScreen({ steps }: LoadingScreenProps) {
           marginTop: 8,
           background: "rgba(255,255,255,0.03)",
           border: "1px solid rgba(255,255,255,0.06)",
-          borderRadius: 6,
+          borderRadius: RADIUS.lg,
           padding: "8px 12px",
           overflow: "hidden",
           display: "flex",
@@ -229,7 +229,7 @@ export function LoadingScreen({ steps }: LoadingScreenProps) {
         }}
       >
         {lines.length === 0 && !allDone && (
-          <div style={{ fontSize: 11, color: COLORS.textFaint, lineHeight: "20px" }}>
+          <div style={{ fontSize: FONT_SIZE.base, color: COLORS.textFaint, lineHeight: "20px" }}>
             Connecting to Supabase...
           </div>
         )}
@@ -239,7 +239,7 @@ export function LoadingScreen({ steps }: LoadingScreenProps) {
             <div
               key={line.id}
               style={{
-                fontSize: 11,
+                fontSize: FONT_SIZE.base,
                 lineHeight: "20px",
                 whiteSpace: "nowrap",
                 overflow: "hidden",

--- a/src/components/LoadingScreen.tsx
+++ b/src/components/LoadingScreen.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from "react";
-import { COLORS, FONT_DATA, RADIUS, FONT_SIZE } from "../styles/designTokens";
+import { COLORS, FONT_DATA, RADIUS, FONT_SIZE, SURFACE } from "../styles/designTokens";
 
 interface LoadingStep {
   label: string;
@@ -112,7 +112,7 @@ export function LoadingScreen({ steps }: LoadingScreenProps) {
       style={{
         position: "fixed",
         inset: 0,
-        background: "#0a0a14",
+        background: SURFACE.app,
         display: "flex",
         flexDirection: "column",
         alignItems: "center",

--- a/src/components/LoadingScreen.tsx
+++ b/src/components/LoadingScreen.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from "react";
+import { FONT_DATA } from "../styles/designTokens";
 
 interface LoadingStep {
   label: string;
@@ -117,7 +118,7 @@ export function LoadingScreen({ steps }: LoadingScreenProps) {
         alignItems: "center",
         justifyContent: "center",
         gap: 16,
-        fontFamily: "monospace",
+        fontFamily: FONT_DATA,
         color: "#fff",
         zIndex: 9999,
         opacity: fading ? 0 : 1,

--- a/src/components/LoadingScreen.tsx
+++ b/src/components/LoadingScreen.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from "react";
-import { FONT_DATA } from "../styles/designTokens";
+import { COLORS, FONT_DATA } from "../styles/designTokens";
 
 interface LoadingStep {
   label: string;
@@ -129,7 +129,7 @@ export function LoadingScreen({ steps }: LoadingScreenProps) {
       <div style={{ fontSize: 22, letterSpacing: 4, fontWeight: 700, marginBottom: 2 }}>
         Mini Taiwan Pulse
       </div>
-      <div style={{ fontSize: 10, color: "rgba(255,255,255,0.3)", letterSpacing: 1, marginBottom: 4 }}>
+      <div style={{ fontSize: 10, color: COLORS.textDim, letterSpacing: 1, marginBottom: 4 }}>
         Supabase Realtime
       </div>
 
@@ -150,8 +150,8 @@ export function LoadingScreen({ steps }: LoadingScreenProps) {
                 color: isDone
                   ? CAT_COLOR[stepToCat(step.label)]
                   : isActive
-                    ? "rgba(255,255,255,0.7)"
-                    : "rgba(255,255,255,0.2)",
+                    ? COLORS.textDefault
+                    : COLORS.textFaint,
                 transition: "color 0.3s",
               }}
             >
@@ -183,7 +183,7 @@ export function LoadingScreen({ steps }: LoadingScreenProps) {
 
       {/* progress bar */}
       <div style={{ display: "flex", flexDirection: "column", alignItems: "center", gap: 6, marginTop: 4 }}>
-        <div style={{ fontSize: 11, color: "rgba(255,255,255,0.35)", letterSpacing: 0.5 }}>
+        <div style={{ fontSize: 11, color: COLORS.textDim, letterSpacing: 0.5 }}>
           {allDone ? "載入完成" : `載入中... ${doneCount}/${steps.length}`}
         </div>
         <div
@@ -207,7 +207,7 @@ export function LoadingScreen({ steps }: LoadingScreenProps) {
             }}
           />
         </div>
-        <div style={{ fontSize: 10, color: "rgba(255,255,255,0.25)" }}>
+        <div style={{ fontSize: 10, color: COLORS.textFaint }}>
           {Math.round(progress * 100)}%
         </div>
       </div>
@@ -229,7 +229,7 @@ export function LoadingScreen({ steps }: LoadingScreenProps) {
         }}
       >
         {lines.length === 0 && !allDone && (
-          <div style={{ fontSize: 11, color: "rgba(255,255,255,0.2)", lineHeight: "20px" }}>
+          <div style={{ fontSize: 11, color: COLORS.textFaint, lineHeight: "20px" }}>
             Connecting to Supabase...
           </div>
         )}

--- a/src/components/MobileBottomSheet.tsx
+++ b/src/components/MobileBottomSheet.tsx
@@ -1,4 +1,5 @@
 import { useState, useCallback } from "react";
+import { RADIUS } from "../styles/designTokens";
 
 type SheetLevel = "collapsed" | "half" | "full";
 
@@ -73,7 +74,7 @@ export function MobileBottomSheet({ isLandscape, children }: Props) {
           style={{
             width: 36,
             height: 4,
-            borderRadius: 2,
+            borderRadius: RADIUS.sm,
             background: "rgba(255,255,255,0.3)",
           }}
         />

--- a/src/components/ModeToggle.tsx
+++ b/src/components/ModeToggle.tsx
@@ -1,5 +1,5 @@
 import type { AppMode } from "../types";
-import { FONT_DATA } from "../styles/designTokens";
+import { FONT_DATA, RADIUS, FONT_SIZE } from "../styles/designTokens";
 
 interface Props {
   appMode: AppMode;
@@ -21,18 +21,18 @@ export function ModeToggle({
     padding: 4,
     background: dark ? "rgba(30,30,30,0.85)" : "rgba(255,255,255,0.92)",
     border: `1px solid ${dark ? "rgba(255,255,255,0.12)" : "rgba(0,0,0,0.08)"}`,
-    borderRadius: 6,
+    borderRadius: RADIUS.lg,
     backdropFilter: "blur(8px)",
     fontFamily: FONT_DATA,
   };
 
   const tab = (active: boolean): React.CSSProperties => ({
     padding: "4px 12px",
-    fontSize: 12,
+    fontSize: FONT_SIZE.md,
     fontWeight: active ? 700 : 400,
     cursor: "pointer",
     border: "none",
-    borderRadius: 4,
+    borderRadius: RADIUS.md,
     color: active ? "#4caf50" : dark ? "rgba(220,220,220,0.85)" : "#555",
     background: active
       ? "rgba(76,175,80,0.18)"

--- a/src/components/ModeToggle.tsx
+++ b/src/components/ModeToggle.tsx
@@ -1,4 +1,5 @@
 import type { AppMode } from "../types";
+import { FONT_DATA } from "../styles/designTokens";
 
 interface Props {
   appMode: AppMode;
@@ -22,7 +23,7 @@ export function ModeToggle({
     border: `1px solid ${dark ? "rgba(255,255,255,0.12)" : "rgba(0,0,0,0.08)"}`,
     borderRadius: 6,
     backdropFilter: "blur(8px)",
-    fontFamily: "monospace",
+    fontFamily: FONT_DATA,
   };
 
   const tab = (active: boolean): React.CSSProperties => ({

--- a/src/components/StyleSelector.tsx
+++ b/src/components/StyleSelector.tsx
@@ -1,5 +1,5 @@
 import type { MapStyle } from "../types";
-import { FONT_DATA } from "../styles/designTokens";
+import { FONT_DATA, RADIUS, FONT_SIZE } from "../styles/designTokens";
 
 export const MAP_STYLES: MapStyle[] = [
   { id: "dark", name: "Dark", url: "mapbox://styles/mapbox/dark-v11" },
@@ -20,9 +20,9 @@ const getStyle = (dark: boolean): React.CSSProperties => ({
   background: dark ? "rgba(0,0,0,0.6)" : "rgba(255,255,255,0.85)",
   color: dark ? "#fff" : "#333",
   border: `1px solid ${dark ? "rgba(255,255,255,0.2)" : "rgba(0,0,0,0.12)"}`,
-  borderRadius: 4,
+  borderRadius: RADIUS.md,
   padding: "4px 8px",
-  fontSize: 12,
+  fontSize: FONT_SIZE.md,
   fontFamily: FONT_DATA,
   backdropFilter: "blur(8px)",
 });

--- a/src/components/StyleSelector.tsx
+++ b/src/components/StyleSelector.tsx
@@ -1,4 +1,5 @@
 import type { MapStyle } from "../types";
+import { FONT_DATA } from "../styles/designTokens";
 
 export const MAP_STYLES: MapStyle[] = [
   { id: "dark", name: "Dark", url: "mapbox://styles/mapbox/dark-v11" },
@@ -22,7 +23,7 @@ const getStyle = (dark: boolean): React.CSSProperties => ({
   borderRadius: 4,
   padding: "4px 8px",
   fontSize: 12,
-  fontFamily: "monospace",
+  fontFamily: FONT_DATA,
   backdropFilter: "blur(8px)",
 });
 

--- a/src/components/TimelineControls.tsx
+++ b/src/components/TimelineControls.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import type { TimeMode } from "../types";
-import { FONT_DATA } from "../styles/designTokens";
+import { FONT_DATA, RADIUS, FONT_SIZE } from "../styles/designTokens";
 
 interface Props {
   playing: boolean;
@@ -30,9 +30,9 @@ const getBtnStyle = (dark: boolean): React.CSSProperties => ({
   background: dark ? "rgba(120,120,120,0.35)" : "rgba(255,255,255,0.9)",
   color: dark ? "rgba(220,220,220,0.9)" : "#555",
   border: `1px solid ${dark ? "rgba(255,255,255,0.12)" : "rgba(0,0,0,0.08)"}`,
-  borderRadius: 4,
+  borderRadius: RADIUS.md,
   padding: "4px 10px",
-  fontSize: 14,
+  fontSize: FONT_SIZE.lg,
   cursor: "pointer",
   fontFamily: FONT_DATA,
   backdropFilter: "blur(8px)",
@@ -42,9 +42,9 @@ const getSelectStyle = (dark: boolean): React.CSSProperties => ({
   background: dark ? "rgba(120,120,120,0.35)" : "rgba(255,255,255,0.9)",
   color: dark ? "rgba(220,220,220,0.9)" : "#555",
   border: `1px solid ${dark ? "rgba(255,255,255,0.12)" : "rgba(0,0,0,0.08)"}`,
-  borderRadius: 4,
+  borderRadius: RADIUS.md,
   padding: "4px 8px",
-  fontSize: 13,
+  fontSize: FONT_SIZE.lg,
   fontFamily: FONT_DATA,
   backdropFilter: "blur(8px)",
 });
@@ -113,7 +113,7 @@ export function TimelineControls({
   const arrowBtn: React.CSSProperties = {
     ...getBtnStyle(dark),
     padding: "2px 8px",
-    fontSize: 12,
+    fontSize: FONT_SIZE.md,
     lineHeight: 1,
   };
 
@@ -143,7 +143,7 @@ export function TimelineControls({
           onClick={() => setShowDatePicker((v) => !v)}
           style={{
             ...getBtnStyle(dark),
-            fontSize: 13,
+            fontSize: FONT_SIZE.lg,
             fontWeight: 600,
             padding: "3px 10px",
             minWidth: 110,
@@ -167,7 +167,7 @@ export function TimelineControls({
           }}
           style={{
             ...getBtnStyle(dark),
-            fontSize: 11,
+            fontSize: FONT_SIZE.base,
             padding: "3px 8px",
             fontWeight: isLive ? 700 : 400,
             letterSpacing: isLive ? 1 : 0,
@@ -187,7 +187,7 @@ export function TimelineControls({
         <select
           value={rangeDays}
           onChange={(e) => onRangeDaysChange(Number(e.target.value))}
-          style={{ ...getSelectStyle(dark), fontSize: 11, padding: "3px 4px" }}
+          style={{ ...getSelectStyle(dark), fontSize: FONT_SIZE.base, padding: "3px 4px" }}
           title="顯示天數"
         >
           <option value={1}>1d</option>
@@ -212,7 +212,7 @@ export function TimelineControls({
             style={{
               ...getSelectStyle(dark),
               width: "100%",
-              fontSize: 14,
+              fontSize: FONT_SIZE.lg,
               padding: "6px 8px",
             }}
           />
@@ -231,7 +231,7 @@ export function TimelineControls({
         >
           <button onClick={onToggle} style={{
             ...getBtnStyle(dark),
-            ...(isMobile ? { width: 44, height: 44, fontSize: 18, padding: 0, display: "flex", alignItems: "center", justifyContent: "center" } : {}),
+            ...(isMobile ? { width: 44, height: 44, fontSize: FONT_SIZE.xl, padding: 0, display: "flex", alignItems: "center", justifyContent: "center" } : {}),
           }}>
             {playing ? "\u23F8" : "\u25B6"}
           </button>
@@ -253,7 +253,7 @@ export function TimelineControls({
           <span
             style={{
               color: isFuture ? "#ff9800" : (dark ? "rgba(200,200,200,0.7)" : "rgba(0,0,0,0.5)"),
-              fontSize: 14,
+              fontSize: FONT_SIZE.lg,
               fontFamily: FONT_DATA,
               fontWeight: 600,
             }}
@@ -264,11 +264,11 @@ export function TimelineControls({
             <span
               title="此時間尚未到達，沒有最新資料"
               style={{
-                fontSize: 11,
+                fontSize: FONT_SIZE.base,
                 color: "#ff9800",
                 background: "rgba(255,152,0,0.12)",
                 border: "1px solid rgba(255,152,0,0.4)",
-                borderRadius: 4,
+                borderRadius: RADIUS.md,
                 padding: "2px 6px",
                 fontFamily: FONT_DATA,
               }}
@@ -282,7 +282,7 @@ export function TimelineControls({
       {/* Live mode: show current time */}
       {isLive && (
         <div style={{
-          fontSize: 14,
+          fontSize: FONT_SIZE.lg,
           fontFamily: FONT_DATA,
           fontWeight: 600,
           color: "#4caf50",
@@ -309,7 +309,7 @@ export function TimelineControls({
               display: "flex",
               justifyContent: "space-between",
               color: dark ? "rgba(180,180,180,0.4)" : "rgba(0,0,0,0.3)",
-              fontSize: 10,
+              fontSize: FONT_SIZE.sm,
               fontFamily: FONT_DATA,
               marginTop: 2,
             }}

--- a/src/components/TimelineControls.tsx
+++ b/src/components/TimelineControls.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import type { TimeMode } from "../types";
+import { FONT_DATA } from "../styles/designTokens";
 
 interface Props {
   playing: boolean;
@@ -33,7 +34,7 @@ const getBtnStyle = (dark: boolean): React.CSSProperties => ({
   padding: "4px 10px",
   fontSize: 14,
   cursor: "pointer",
-  fontFamily: "monospace",
+  fontFamily: FONT_DATA,
   backdropFilter: "blur(8px)",
 });
 
@@ -44,7 +45,7 @@ const getSelectStyle = (dark: boolean): React.CSSProperties => ({
   borderRadius: 4,
   padding: "4px 8px",
   fontSize: 13,
-  fontFamily: "monospace",
+  fontFamily: FONT_DATA,
   backdropFilter: "blur(8px)",
 });
 
@@ -253,7 +254,7 @@ export function TimelineControls({
             style={{
               color: isFuture ? "#ff9800" : (dark ? "rgba(200,200,200,0.7)" : "rgba(0,0,0,0.5)"),
               fontSize: 14,
-              fontFamily: "monospace",
+              fontFamily: FONT_DATA,
               fontWeight: 600,
             }}
           >
@@ -269,7 +270,7 @@ export function TimelineControls({
                 border: "1px solid rgba(255,152,0,0.4)",
                 borderRadius: 4,
                 padding: "2px 6px",
-                fontFamily: "monospace",
+                fontFamily: FONT_DATA,
               }}
             >
               ⚠ 尚無資料
@@ -282,7 +283,7 @@ export function TimelineControls({
       {isLive && (
         <div style={{
           fontSize: 14,
-          fontFamily: "monospace",
+          fontFamily: FONT_DATA,
           fontWeight: 600,
           color: "#4caf50",
           marginBottom: 6,
@@ -309,7 +310,7 @@ export function TimelineControls({
               justifyContent: "space-between",
               color: dark ? "rgba(180,180,180,0.4)" : "rgba(0,0,0,0.3)",
               fontSize: 10,
-              fontFamily: "monospace",
+              fontFamily: FONT_DATA,
               marginTop: 2,
             }}
           >

--- a/src/components/TimeseriesSparkline.tsx
+++ b/src/components/TimeseriesSparkline.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from "react";
-import { COLORS } from "../styles/designTokens";
+import { COLORS, FONT_SIZE } from "../styles/designTokens";
 
 /**
  * 24h SVG sparkline — Y 軸刻度 + 警戒線 + X 軸 6/12/18h tick
@@ -118,7 +118,7 @@ export function TimeseriesSparkline({
     return (
       <div
         style={{
-          fontSize: 10,
+          fontSize: FONT_SIZE.sm,
           color: COLORS.textDim,
           padding: "8px 4px",
           textAlign: "center",

--- a/src/components/TimeseriesSparkline.tsx
+++ b/src/components/TimeseriesSparkline.tsx
@@ -1,4 +1,5 @@
 import { useMemo } from "react";
+import { COLORS } from "../styles/designTokens";
 
 /**
  * 24h SVG sparkline — Y 軸刻度 + 警戒線 + X 軸 6/12/18h tick
@@ -118,7 +119,7 @@ export function TimeseriesSparkline({
       <div
         style={{
           fontSize: 10,
-          color: "rgba(255,255,255,0.4)",
+          color: COLORS.textDim,
           padding: "8px 4px",
           textAlign: "center",
         }}

--- a/src/components/featureInfo/agriPanels.tsx
+++ b/src/components/featureInfo/agriPanels.tsx
@@ -1,3 +1,4 @@
+import { COLORS } from "../../styles/designTokens";
 import { AGRI_POI_TYPES } from "../../data/agriPOITypes";
 import { AGRI_COMPANY_TYPES } from "../../data/agriCompanyTypes";
 import { ECO_NETWORK_ZONE_TYPES } from "../../data/ecoNetworkZoneTypes";
@@ -69,7 +70,7 @@ export function AgriSoilFertilityPanel({ props }: { props: Record<string, unknow
       <Row label="CEC" value={cec.text} color={cec.color} />
       <Row label="Mehlich-3 P" value={m3p.text} color={m3p.color} />
       <Row label="Mehlich-3 K" value={m3k.text} color={m3k.color} />
-      <div style={{ fontSize: 8, color: "rgba(255,255,255,0.35)", marginTop: 6, lineHeight: 1.5 }}>
+      <div style={{ fontSize: 8, color: COLORS.textDim, marginTop: 6, lineHeight: 1.5 }}>
         ※ 0 值表示該項未測（多數網格只測 pH / OM）
       </div>
     </>

--- a/src/components/featureInfo/agriPanels.tsx
+++ b/src/components/featureInfo/agriPanels.tsx
@@ -1,4 +1,4 @@
-import { COLORS } from "../../styles/designTokens";
+import { COLORS, RADIUS, FONT_SIZE } from "../../styles/designTokens";
 import { AGRI_POI_TYPES } from "../../data/agriPOITypes";
 import { AGRI_COMPANY_TYPES } from "../../data/agriCompanyTypes";
 import { ECO_NETWORK_ZONE_TYPES } from "../../data/ecoNetworkZoneTypes";
@@ -18,8 +18,8 @@ export function AgriSoilPanel({ props }: { props: Record<string, unknown> }) {
   return (
     <>
       <div style={{ display: "flex", alignItems: "center", gap: 6, marginBottom: 6 }}>
-        <div style={{ width: 10, height: 10, borderRadius: 2, background: "#8d6e63", flexShrink: 0 }} />
-        <div style={{ fontSize: 13, fontWeight: 700, color: "#fff", letterSpacing: 0.5 }}>
+        <div style={{ width: 10, height: 10, borderRadius: RADIUS.sm, background: "#8d6e63", flexShrink: 0 }} />
+        <div style={{ fontSize: FONT_SIZE.lg, fontWeight: 700, color: "#fff", letterSpacing: 0.5 }}>
           {soilType || soilClass || "土壤分類"}
         </div>
       </div>
@@ -60,8 +60,8 @@ export function AgriSoilFertilityPanel({ props }: { props: Record<string, unknow
   return (
     <>
       <div style={{ display: "flex", alignItems: "center", gap: 6, marginBottom: 6 }}>
-        <div style={{ width: 10, height: 10, borderRadius: 2, background: "#00897b", flexShrink: 0 }} />
-        <div style={{ fontSize: 13, fontWeight: 700, color: "#fff", letterSpacing: 0.5 }}>
+        <div style={{ width: 10, height: 10, borderRadius: RADIUS.sm, background: "#00897b", flexShrink: 0 }} />
+        <div style={{ fontSize: FONT_SIZE.lg, fontWeight: 700, color: "#fff", letterSpacing: 0.5 }}>
           土壤肥力 250m 網格
         </div>
       </div>
@@ -70,7 +70,7 @@ export function AgriSoilFertilityPanel({ props }: { props: Record<string, unknow
       <Row label="CEC" value={cec.text} color={cec.color} />
       <Row label="Mehlich-3 P" value={m3p.text} color={m3p.color} />
       <Row label="Mehlich-3 K" value={m3k.text} color={m3k.color} />
-      <div style={{ fontSize: 8, color: COLORS.textDim, marginTop: 6, lineHeight: 1.5 }}>
+      <div style={{ fontSize: FONT_SIZE.xs, color: COLORS.textDim, marginTop: 6, lineHeight: 1.5 }}>
         ※ 0 值表示該項未測（多數網格只測 pH / OM）
       </div>
     </>
@@ -86,8 +86,8 @@ export function AgriLeisureFarmZonesPanel({ props }: { props: Record<string, unk
   return (
     <>
       <div style={{ display: "flex", alignItems: "center", gap: 6, marginBottom: 6 }}>
-        <div style={{ width: 10, height: 10, borderRadius: 2, background: "#66bb6a", flexShrink: 0 }} />
-        <div style={{ fontSize: 13, fontWeight: 700, color: "#fff", letterSpacing: 0.5 }}>
+        <div style={{ width: 10, height: 10, borderRadius: RADIUS.sm, background: "#66bb6a", flexShrink: 0 }} />
+        <div style={{ fontSize: FONT_SIZE.lg, fontWeight: 700, color: "#fff", letterSpacing: 0.5 }}>
           {name || "休閒農業區"}
         </div>
       </div>
@@ -116,8 +116,8 @@ export function AgriCropSuitabilityPanel({ props }: { props: Record<string, unkn
   return (
     <>
       <div style={{ display: "flex", alignItems: "center", gap: 6, marginBottom: 6 }}>
-        <div style={{ width: 10, height: 10, borderRadius: 2, background: kindInfo.color, flexShrink: 0 }} />
-        <div style={{ fontSize: 13, fontWeight: 700, color: "#fff", letterSpacing: 0.5 }}>
+        <div style={{ width: 10, height: 10, borderRadius: RADIUS.sm, background: kindInfo.color, flexShrink: 0 }} />
+        <div style={{ fontSize: FONT_SIZE.lg, fontWeight: 700, color: "#fff", letterSpacing: 0.5 }}>
           {cropNameZh || cropNameEn || "作物適栽"}
         </div>
       </div>
@@ -141,8 +141,8 @@ export function AgriRuralRegenPanel({ props }: { props: Record<string, unknown> 
   return (
     <>
       <div style={{ display: "flex", alignItems: "center", gap: 6, marginBottom: 6 }}>
-        <div style={{ width: 10, height: 10, borderRadius: 2, background: "#ffb74d", flexShrink: 0 }} />
-        <div style={{ fontSize: 13, fontWeight: 700, color: "#fff", letterSpacing: 0.5 }}>
+        <div style={{ width: 10, height: 10, borderRadius: RADIUS.sm, background: "#ffb74d", flexShrink: 0 }} />
+        <div style={{ fontSize: FONT_SIZE.lg, fontWeight: 700, color: "#fff", letterSpacing: 0.5 }}>
           {community || "農村再生社區"}
         </div>
       </div>
@@ -164,8 +164,8 @@ export function AgriPOIPanel({ props }: { props: Record<string, unknown> }) {
   return (
     <>
       <div style={{ display: "flex", alignItems: "center", gap: 6, marginBottom: 6 }}>
-        <div style={{ width: 10, height: 10, borderRadius: "50%", background: meta.color, flexShrink: 0 }} />
-        <div style={{ fontSize: 13, fontWeight: 700, color: "#fff", letterSpacing: 0.5 }}>
+        <div style={{ width: 10, height: 10, borderRadius: RADIUS.full, background: meta.color, flexShrink: 0 }} />
+        <div style={{ fontSize: FONT_SIZE.lg, fontWeight: 700, color: "#fff", letterSpacing: 0.5 }}>
           {String(props.poi_name ?? "Unknown")}
         </div>
       </div>
@@ -186,8 +186,8 @@ export function AgriCompanyPanel({ props }: { props: Record<string, unknown> }) 
   return (
     <>
       <div style={{ display: "flex", alignItems: "center", gap: 6, marginBottom: 6 }}>
-        <div style={{ width: 10, height: 10, borderRadius: "50%", background: meta.color, flexShrink: 0 }} />
-        <div style={{ fontSize: 13, fontWeight: 700, color: "#fff", letterSpacing: 0.5 }}>
+        <div style={{ width: 10, height: 10, borderRadius: RADIUS.full, background: meta.color, flexShrink: 0 }} />
+        <div style={{ fontSize: FONT_SIZE.lg, fontWeight: 700, color: "#fff", letterSpacing: 0.5 }}>
           {String(props["公司名稱"] ?? "Unknown")}
         </div>
       </div>
@@ -206,8 +206,8 @@ export function FarmRoadsPanel({ props }: { props: Record<string, unknown> }) {
   return (
     <>
       <div style={{ display: "flex", alignItems: "center", gap: 6, marginBottom: 6 }}>
-        <div style={{ width: 12, height: 2, borderRadius: 1, background: "#7a8670", flexShrink: 0 }} />
-        <div style={{ fontSize: 13, fontWeight: 700, color: "#fff", letterSpacing: 0.5 }}>
+        <div style={{ width: 12, height: 2, borderRadius: RADIUS.sm, background: "#7a8670", flexShrink: 0 }} />
+        <div style={{ fontSize: FONT_SIZE.lg, fontWeight: 700, color: "#fff", letterSpacing: 0.5 }}>
           {String(props.NAME ?? "農路")}
         </div>
       </div>
@@ -226,8 +226,8 @@ export function EcoNetworkZonesPanel({ props }: { props: Record<string, unknown>
   return (
     <>
       <div style={{ display: "flex", alignItems: "center", gap: 6, marginBottom: 6 }}>
-        <div style={{ width: 10, height: 10, borderRadius: 2, background: color, flexShrink: 0 }} />
-        <div style={{ fontSize: 13, fontWeight: 700, color: "#fff", letterSpacing: 0.5 }}>
+        <div style={{ width: 10, height: 10, borderRadius: RADIUS.sm, background: color, flexShrink: 0 }} />
+        <div style={{ fontSize: FONT_SIZE.lg, fontWeight: 700, color: "#fff", letterSpacing: 0.5 }}>
           {zone || "國土綠網分區"}
         </div>
       </div>

--- a/src/components/featureInfo/airPanels.tsx
+++ b/src/components/featureInfo/airPanels.tsx
@@ -1,5 +1,5 @@
 import { aqiToColor } from "../../map/aqiColorScale";
-import { COLORS } from "../../styles/designTokens";
+import { COLORS, RADIUS, FONT_SIZE } from "../../styles/designTokens";
 import { Row, numOrNull, formatNum } from "./shared";
 
 export function AqiStationPanel({ props }: { props: Record<string, unknown> }) {
@@ -9,8 +9,8 @@ export function AqiStationPanel({ props }: { props: Record<string, unknown> }) {
   return (
     <>
       <div style={{ display: "flex", alignItems: "center", gap: 6, marginBottom: 6 }}>
-        <div style={{ width: 10, height: 10, borderRadius: 2, background: color, flexShrink: 0 }} />
-        <div style={{ fontSize: 13, fontWeight: 700, color: "#fff", letterSpacing: 0.5 }}>
+        <div style={{ width: 10, height: 10, borderRadius: RADIUS.sm, background: color, flexShrink: 0 }} />
+        <div style={{ fontSize: FONT_SIZE.lg, fontWeight: 700, color: "#fff", letterSpacing: 0.5 }}>
           {String(props.stationName ?? "Unknown")}
         </div>
       </div>
@@ -22,13 +22,13 @@ export function AqiStationPanel({ props }: { props: Record<string, unknown> }) {
           marginTop: 4,
           padding: "6px 8px",
           background: "rgba(255,255,255,0.04)",
-          borderRadius: 4,
+          borderRadius: RADIUS.md,
         }}
       >
         <span style={{ fontSize: 24, fontWeight: 700, color }}>
           {aqi ?? "—"}
         </span>
-        <span style={{ fontSize: 11, color: COLORS.textDefault }}>
+        <span style={{ fontSize: FONT_SIZE.base, color: COLORS.textDefault }}>
           AQI {String(props.status ?? "")}
         </span>
       </div>
@@ -55,8 +55,8 @@ export function MicroSensorPanel({ props }: { props: Record<string, unknown> }) 
   return (
     <>
       <div style={{ display: "flex", alignItems: "center", gap: 6, marginBottom: 6 }}>
-        <div style={{ width: 10, height: 10, borderRadius: 2, background: color, flexShrink: 0 }} />
-        <div style={{ fontSize: 13, fontWeight: 700, color: "#fff", letterSpacing: 0.5 }}>
+        <div style={{ width: 10, height: 10, borderRadius: RADIUS.sm, background: color, flexShrink: 0 }} />
+        <div style={{ fontSize: FONT_SIZE.lg, fontWeight: 700, color: "#fff", letterSpacing: 0.5 }}>
           {String(props.deviceId ?? "LASS Device")}
         </div>
       </div>
@@ -68,13 +68,13 @@ export function MicroSensorPanel({ props }: { props: Record<string, unknown> }) 
           marginTop: 4,
           padding: "6px 8px",
           background: "rgba(255,255,255,0.04)",
-          borderRadius: 4,
+          borderRadius: RADIUS.md,
         }}
       >
-        <span style={{ fontSize: 20, fontWeight: 700, color }}>
+        <span style={{ fontSize: FONT_SIZE.xxl, fontWeight: 700, color }}>
           {pm25 != null ? pm25.toFixed(1) : "—"}
         </span>
-        <span style={{ fontSize: 10, color: COLORS.textDefault }}>PM2.5 µg/m³</span>
+        <span style={{ fontSize: FONT_SIZE.sm, color: COLORS.textDefault }}>PM2.5 µg/m³</span>
       </div>
       <Row label="來源" value={String(props.source ?? "")} />
       <Row label="裝置" value={String(props.app ?? "")} />

--- a/src/components/featureInfo/airPanels.tsx
+++ b/src/components/featureInfo/airPanels.tsx
@@ -1,4 +1,5 @@
 import { aqiToColor } from "../../map/aqiColorScale";
+import { COLORS } from "../../styles/designTokens";
 import { Row, numOrNull, formatNum } from "./shared";
 
 export function AqiStationPanel({ props }: { props: Record<string, unknown> }) {
@@ -27,7 +28,7 @@ export function AqiStationPanel({ props }: { props: Record<string, unknown> }) {
         <span style={{ fontSize: 24, fontWeight: 700, color }}>
           {aqi ?? "—"}
         </span>
-        <span style={{ fontSize: 11, color: "rgba(255,255,255,0.7)" }}>
+        <span style={{ fontSize: 11, color: COLORS.textDefault }}>
           AQI {String(props.status ?? "")}
         </span>
       </div>
@@ -73,7 +74,7 @@ export function MicroSensorPanel({ props }: { props: Record<string, unknown> }) 
         <span style={{ fontSize: 20, fontWeight: 700, color }}>
           {pm25 != null ? pm25.toFixed(1) : "—"}
         </span>
-        <span style={{ fontSize: 10, color: "rgba(255,255,255,0.7)" }}>PM2.5 µg/m³</span>
+        <span style={{ fontSize: 10, color: COLORS.textDefault }}>PM2.5 µg/m³</span>
       </div>
       <Row label="來源" value={String(props.source ?? "")} />
       <Row label="裝置" value={String(props.app ?? "")} />

--- a/src/components/featureInfo/eventPanels.tsx
+++ b/src/components/featureInfo/eventPanels.tsx
@@ -1,7 +1,7 @@
 import { Row } from "./shared";
 import { getNewsCategoryDef } from "../../data/newsEventTypes";
 import type { ClusterEvent } from "../../data/newsEventsLoader";
-import { FONT_DATA } from "../../styles/designTokens";
+import { COLORS, FONT_DATA } from "../../styles/designTokens";
 
 function parseEvents(raw: unknown): ClusterEvent[] {
   if (typeof raw !== "string" || !raw) return [];
@@ -71,7 +71,7 @@ export function NewsEventPanel({ props }: { props: Record<string, unknown> }) {
         </div>
         <div style={{
           marginLeft: "auto", fontSize: 10, padding: "1px 6px", borderRadius: 3,
-          background: "rgba(255,255,255,0.12)", color: "rgba(255,255,255,0.9)", fontWeight: 600,
+          background: "rgba(255,255,255,0.12)", color: COLORS.textStrong, fontWeight: 600,
         }}>
           {eventCount} 則
         </div>
@@ -94,14 +94,14 @@ export function NewsEventPanel({ props }: { props: Record<string, unknown> }) {
                   target="_blank"
                   rel="noopener noreferrer"
                   style={{
-                    color: "rgba(255,255,255,0.92)", fontSize: 11.5, fontWeight: 600,
+                    color: COLORS.textStrong, fontSize: 11.5, fontWeight: 600,
                     textDecoration: "none", lineHeight: 1.4, display: "block",
                   }}
                 >
                   {e.title}
                 </a>
                 <div style={{
-                  fontSize: 10, color: "rgba(255,255,255,0.4)", marginTop: 2,
+                  fontSize: 10, color: COLORS.textDim, marginTop: 2,
                   display: "flex", gap: 6, flexWrap: "wrap",
                 }}>
                   <span style={{ color: cat.color }}>{cat.label}</span>
@@ -151,10 +151,10 @@ export function DisasterAlertPanel({ props }: { props: Record<string, unknown> }
       {headline && <Row label="標題" value={headline} />}
       {areaDesc && (
         <div style={{ display: "flex", gap: 8, marginTop: 4, fontSize: 11, lineHeight: 1.5 }}>
-          <span style={{ color: "rgba(255,255,255,0.45)", flexShrink: 0, minWidth: 56 }}>影響區域</span>
+          <span style={{ color: COLORS.textMuted, flexShrink: 0, minWidth: 56 }}>影響區域</span>
           <div
             style={{
-              color: "rgba(255,255,255,0.85)",
+              color: COLORS.textStrong,
               wordBreak: "break-word",
               maxHeight: 20 * 16.5, // 11px × 1.5 line-height × 20 lines
               overflowY: "auto",

--- a/src/components/featureInfo/eventPanels.tsx
+++ b/src/components/featureInfo/eventPanels.tsx
@@ -1,6 +1,7 @@
 import { Row } from "./shared";
 import { getNewsCategoryDef } from "../../data/newsEventTypes";
 import type { ClusterEvent } from "../../data/newsEventsLoader";
+import { FONT_DATA } from "../../styles/designTokens";
 
 function parseEvents(raw: unknown): ClusterEvent[] {
   if (typeof raw !== "string" || !raw) return [];
@@ -47,7 +48,7 @@ export function NewsEventPanel({ props }: { props: Record<string, unknown> }) {
               href={link}
               target="_blank"
               rel="noopener noreferrer"
-              style={{ color: cat.color, fontSize: 11, fontFamily: "monospace", textDecoration: "underline" }}
+              style={{ color: cat.color, fontSize: 11, fontFamily: FONT_DATA, textDecoration: "underline" }}
             >
               原文連結
             </a>

--- a/src/components/featureInfo/eventPanels.tsx
+++ b/src/components/featureInfo/eventPanels.tsx
@@ -1,7 +1,7 @@
 import { Row } from "./shared";
 import { getNewsCategoryDef } from "../../data/newsEventTypes";
 import type { ClusterEvent } from "../../data/newsEventsLoader";
-import { COLORS, FONT_DATA } from "../../styles/designTokens";
+import { COLORS, FONT_DATA, RADIUS, FONT_SIZE } from "../../styles/designTokens";
 
 function parseEvents(raw: unknown): ClusterEvent[] {
   if (typeof raw !== "string" || !raw) return [];
@@ -33,8 +33,8 @@ export function NewsEventPanel({ props }: { props: Record<string, unknown> }) {
     return (
       <>
         <div style={{ display: "flex", alignItems: "center", gap: 6, marginBottom: 6 }}>
-          <div style={{ width: 10, height: 10, borderRadius: "50%", background: cat.color, flexShrink: 0 }} />
-          <div style={{ fontSize: 13, fontWeight: 700, color: "#fff", letterSpacing: 0.5, lineHeight: 1.4 }}>
+          <div style={{ width: 10, height: 10, borderRadius: RADIUS.full, background: cat.color, flexShrink: 0 }} />
+          <div style={{ fontSize: FONT_SIZE.lg, fontWeight: 700, color: "#fff", letterSpacing: 0.5, lineHeight: 1.4 }}>
             {String(props.title ?? "Unknown Event")}
           </div>
         </div>
@@ -48,7 +48,7 @@ export function NewsEventPanel({ props }: { props: Record<string, unknown> }) {
               href={link}
               target="_blank"
               rel="noopener noreferrer"
-              style={{ color: cat.color, fontSize: 11, fontFamily: FONT_DATA, textDecoration: "underline" }}
+              style={{ color: cat.color, fontSize: FONT_SIZE.base, fontFamily: FONT_DATA, textDecoration: "underline" }}
             >
               原文連結
             </a>
@@ -65,12 +65,12 @@ export function NewsEventPanel({ props }: { props: Record<string, unknown> }) {
         display: "flex", alignItems: "center", gap: 6, marginBottom: 8,
         paddingBottom: 6, borderBottom: "1px solid rgba(255,255,255,0.1)",
       }}>
-        <div style={{ fontSize: 14, lineHeight: 1 }}>📰</div>
-        <div style={{ fontSize: 13, fontWeight: 700, color: "#fff", letterSpacing: 0.5, lineHeight: 1.4 }}>
+        <div style={{ fontSize: FONT_SIZE.lg, lineHeight: 1 }}>📰</div>
+        <div style={{ fontSize: FONT_SIZE.lg, fontWeight: 700, color: "#fff", letterSpacing: 0.5, lineHeight: 1.4 }}>
           {location}
         </div>
         <div style={{
-          marginLeft: "auto", fontSize: 10, padding: "1px 6px", borderRadius: 3,
+          marginLeft: "auto", fontSize: FONT_SIZE.sm, padding: "1px 6px", borderRadius: RADIUS.md,
           background: "rgba(255,255,255,0.12)", color: COLORS.textStrong, fontWeight: 600,
         }}>
           {eventCount} 則
@@ -85,7 +85,7 @@ export function NewsEventPanel({ props }: { props: Record<string, unknown> }) {
           return (
             <div key={e.id} style={{ display: "flex", gap: 6, alignItems: "flex-start" }}>
               <div style={{
-                width: 8, height: 8, borderRadius: "50%",
+                width: 8, height: 8, borderRadius: RADIUS.full,
                 background: cat.color, marginTop: 5, flexShrink: 0,
               }} />
               <div style={{ flex: 1, minWidth: 0 }}>
@@ -101,7 +101,7 @@ export function NewsEventPanel({ props }: { props: Record<string, unknown> }) {
                   {e.title}
                 </a>
                 <div style={{
-                  fontSize: 10, color: COLORS.textDim, marginTop: 2,
+                  fontSize: FONT_SIZE.sm, color: COLORS.textDim, marginTop: 2,
                   display: "flex", gap: 6, flexWrap: "wrap",
                 }}>
                   <span style={{ color: cat.color }}>{cat.label}</span>
@@ -137,12 +137,12 @@ export function DisasterAlertPanel({ props }: { props: Record<string, unknown> }
   return (
     <>
       <div style={{ display: "flex", alignItems: "center", gap: 6, marginBottom: 6 }}>
-        <div style={{ width: 10, height: 10, borderRadius: 2, background: color, flexShrink: 0 }} />
-        <div style={{ fontSize: 13, fontWeight: 700, color: "#fff", letterSpacing: 0.5 }}>
+        <div style={{ width: 10, height: 10, borderRadius: RADIUS.sm, background: color, flexShrink: 0 }} />
+        <div style={{ fontSize: FONT_SIZE.lg, fontWeight: 700, color: "#fff", letterSpacing: 0.5 }}>
           {event}
         </div>
         <div style={{
-          marginLeft: "auto", fontSize: 10, padding: "1px 6px", borderRadius: 3,
+          marginLeft: "auto", fontSize: FONT_SIZE.sm, padding: "1px 6px", borderRadius: RADIUS.md,
           background: color, color: "#fff", fontWeight: 600,
         }}>
           {sevLabel[severity] ?? severity}
@@ -150,7 +150,7 @@ export function DisasterAlertPanel({ props }: { props: Record<string, unknown> }
       </div>
       {headline && <Row label="標題" value={headline} />}
       {areaDesc && (
-        <div style={{ display: "flex", gap: 8, marginTop: 4, fontSize: 11, lineHeight: 1.5 }}>
+        <div style={{ display: "flex", gap: 8, marginTop: 4, fontSize: FONT_SIZE.base, lineHeight: 1.5 }}>
           <span style={{ color: COLORS.textMuted, flexShrink: 0, minWidth: 56 }}>影響區域</span>
           <div
             style={{
@@ -201,11 +201,11 @@ export function RoadEventPanel({ props }: { props: Record<string, unknown> }) {
   return (
     <>
       <div style={{ display: "flex", alignItems: "center", gap: 6, marginBottom: 6 }}>
-        <div style={{ width: 10, height: 10, borderRadius: "50%", background: color, flexShrink: 0 }} />
-        <div style={{ fontSize: 13, fontWeight: 700, color: "#fff", letterSpacing: 0.5, flex: 1, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+        <div style={{ width: 10, height: 10, borderRadius: RADIUS.full, background: color, flexShrink: 0 }} />
+        <div style={{ fontSize: FONT_SIZE.lg, fontWeight: 700, color: "#fff", letterSpacing: 0.5, flex: 1, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
           {title || (EVENT_TYPE_LABELS[eventType] ?? "路況事件")}
         </div>
-        <div style={{ fontSize: 10, padding: "1px 6px", borderRadius: 3, background: color, color: "#fff", fontWeight: 600, flexShrink: 0 }}>
+        <div style={{ fontSize: FONT_SIZE.sm, padding: "1px 6px", borderRadius: RADIUS.md, background: color, color: "#fff", fontWeight: 600, flexShrink: 0 }}>
           {EVENT_TYPE_LABELS[eventType] ?? "其他"}
         </div>
       </div>
@@ -225,8 +225,8 @@ export function ActiveFaultPanel({ props }: { props: Record<string, unknown> }) 
   return (
     <>
       <div style={{ display: "flex", alignItems: "center", gap: 6, marginBottom: 6 }}>
-        <div style={{ width: 10, height: 10, borderRadius: 2, background: "#ef5350", flexShrink: 0 }} />
-        <div style={{ fontSize: 13, fontWeight: 700, color: "#fff", letterSpacing: 0.5 }}>
+        <div style={{ width: 10, height: 10, borderRadius: RADIUS.sm, background: "#ef5350", flexShrink: 0 }} />
+        <div style={{ fontSize: FONT_SIZE.lg, fontWeight: 700, color: "#fff", letterSpacing: 0.5 }}>
           {String(props.fault_name ?? "Unknown Fault")}
         </div>
       </div>

--- a/src/components/featureInfo/firePanels.tsx
+++ b/src/components/featureInfo/firePanels.tsx
@@ -1,3 +1,4 @@
+import { RADIUS, FONT_SIZE } from "../../styles/designTokens";
 import { fireStationColor, fireHydrantColor, fireIsochroneColor, fireIsochroneLabel } from "../../data/fireTypes";
 import { Row } from "./shared";
 
@@ -17,8 +18,8 @@ export function FireEventPanel({ props }: { props: Record<string, unknown> }) {
   return (
     <>
       <div style={{ display: "flex", alignItems: "center", gap: 6, marginBottom: 6 }}>
-        <div style={{ width: 10, height: 10, borderRadius: "50%", background: accentColor, flexShrink: 0 }} />
-        <div style={{ fontSize: 13, fontWeight: 700, color: "#fff", letterSpacing: 0.5 }}>
+        <div style={{ width: 10, height: 10, borderRadius: RADIUS.full, background: accentColor, flexShrink: 0 }} />
+        <div style={{ fontSize: FONT_SIZE.lg, fontWeight: 700, color: "#fff", letterSpacing: 0.5 }}>
           {loc || "火災事件"}
         </div>
       </div>
@@ -36,8 +37,8 @@ export function FireStationPanel({ props }: { props: Record<string, unknown> }) 
   return (
     <>
       <div style={{ display: "flex", alignItems: "center", gap: 6, marginBottom: 6 }}>
-        <div style={{ width: 10, height: 10, borderRadius: "50%", background: accentColor, flexShrink: 0 }} />
-        <div style={{ fontSize: 13, fontWeight: 700, color: "#fff", letterSpacing: 0.5 }}>
+        <div style={{ width: 10, height: 10, borderRadius: RADIUS.full, background: accentColor, flexShrink: 0 }} />
+        <div style={{ fontSize: FONT_SIZE.lg, fontWeight: 700, color: "#fff", letterSpacing: 0.5 }}>
           {String(props.name ?? "消防分隊")}
         </div>
       </div>
@@ -56,8 +57,8 @@ export function FireHydrantPanel({ props }: { props: Record<string, unknown> }) 
   return (
     <>
       <div style={{ display: "flex", alignItems: "center", gap: 6, marginBottom: 6 }}>
-        <div style={{ width: 10, height: 10, borderRadius: 2, background: accentColor, flexShrink: 0 }} />
-        <div style={{ fontSize: 13, fontWeight: 700, color: "#fff", letterSpacing: 0.5 }}>
+        <div style={{ width: 10, height: 10, borderRadius: RADIUS.sm, background: accentColor, flexShrink: 0 }} />
+        <div style={{ fontSize: FONT_SIZE.lg, fontWeight: 700, color: "#fff", letterSpacing: 0.5 }}>
           消防栓
         </div>
       </div>
@@ -77,8 +78,8 @@ export function FireIsochronePanel({ props }: { props: Record<string, unknown> }
   return (
     <>
       <div style={{ display: "flex", alignItems: "center", gap: 6, marginBottom: 6 }}>
-        <div style={{ width: 10, height: 10, borderRadius: 2, background: accentColor, flexShrink: 0 }} />
-        <div style={{ fontSize: 13, fontWeight: 700, color: "#fff", letterSpacing: 0.5 }}>
+        <div style={{ width: 10, height: 10, borderRadius: RADIUS.sm, background: accentColor, flexShrink: 0 }} />
+        <div style={{ fontSize: FONT_SIZE.lg, fontWeight: 700, color: "#fff", letterSpacing: 0.5 }}>
           {fireIsochroneLabel(minutes)}
         </div>
       </div>
@@ -86,7 +87,7 @@ export function FireIsochronePanel({ props }: { props: Record<string, unknown> }
       <Row label="可達時間" value={`${minutes} 分鐘內`} color={accentColor} />
       <Row label="累積可達面積" value={cumulative} />
       <Row label="本級環帶面積" value={ring} />
-      <div style={{ fontSize: 9, color: "rgba(255,180,80,0.7)", marginTop: 6, lineHeight: 1.4 }}>
+      <div style={{ fontSize: FONT_SIZE.xs, color: "rgba(255,180,80,0.7)", marginTop: 6, lineHeight: 1.4 }}>
         ⚠️ driving 路網保守估計，未計消防車優先路權
       </div>
     </>

--- a/src/components/featureInfo/forestryPanels.tsx
+++ b/src/components/featureInfo/forestryPanels.tsx
@@ -1,4 +1,5 @@
 import { Row } from "./shared";
+import { COLORS } from "../../styles/designTokens";
 
 const HIKING_TRAIL_SOURCE_INFO: Record<string, { color: string; label: string }> = {
   A_forest: { color: "#d62728", label: "A 林業署國家步道（KML）" },
@@ -56,7 +57,7 @@ export function ForestryGenericPanel({ props }: { props: Record<string, unknown>
   return (
     <>
       {entries.length === 0 && (
-        <div style={{ fontSize: 10, color: "rgba(255,255,255,0.4)" }}>無屬性資料</div>
+        <div style={{ fontSize: 10, color: COLORS.textDim }}>無屬性資料</div>
       )}
       {entries.map(([k, v]) => {
         const label = FORESTRY_PROP_LABELS[k] ?? k;

--- a/src/components/featureInfo/forestryPanels.tsx
+++ b/src/components/featureInfo/forestryPanels.tsx
@@ -1,5 +1,5 @@
 import { Row } from "./shared";
-import { COLORS } from "../../styles/designTokens";
+import { COLORS, FONT_SIZE } from "../../styles/designTokens";
 
 const HIKING_TRAIL_SOURCE_INFO: Record<string, { color: string; label: string }> = {
   A_forest: { color: "#d62728", label: "A 林業署國家步道（KML）" },
@@ -22,7 +22,7 @@ export function HikingTrailsPanel({ props }: { props: Record<string, unknown> })
     <>
       <div style={{ display: "flex", alignItems: "center", gap: 6, marginBottom: 6 }}>
         <div style={{ width: 14, height: 2, background: info.color, flexShrink: 0 }} />
-        <div style={{ fontSize: 13, fontWeight: 700, color: "#fff", letterSpacing: 0.5 }}>{name}</div>
+        <div style={{ fontSize: FONT_SIZE.lg, fontWeight: 700, color: "#fff", letterSpacing: 0.5 }}>{name}</div>
       </div>
       <Row label="來源" value={info.label} color={info.color} />
       {region ? <Row label="管理單位" value={region} /> : null}
@@ -30,7 +30,7 @@ export function HikingTrailsPanel({ props }: { props: Record<string, unknown> })
       {dup ? <Row label="備註" value="與 A 林業署路線重疊" /> : null}
       {url ? (
         <div style={{ marginTop: 4 }}>
-          <a href={url} target="_blank" rel="noreferrer" style={{ color: "#7ec4ff", textDecoration: "underline", fontSize: 11 }}>
+          <a href={url} target="_blank" rel="noreferrer" style={{ color: "#7ec4ff", textDecoration: "underline", fontSize: FONT_SIZE.base }}>
             原始連結 ↗
           </a>
         </div>
@@ -57,7 +57,7 @@ export function ForestryGenericPanel({ props }: { props: Record<string, unknown>
   return (
     <>
       {entries.length === 0 && (
-        <div style={{ fontSize: 10, color: COLORS.textDim }}>無屬性資料</div>
+        <div style={{ fontSize: FONT_SIZE.sm, color: COLORS.textDim }}>無屬性資料</div>
       )}
       {entries.map(([k, v]) => {
         const label = FORESTRY_PROP_LABELS[k] ?? k;

--- a/src/components/featureInfo/infraPanels.tsx
+++ b/src/components/featureInfo/infraPanels.tsx
@@ -1,6 +1,6 @@
 import { CctvStreamView } from "../CctvStreamView";
 import { Row } from "./shared";
-import { COLORS } from "../../styles/designTokens";
+import { COLORS, RADIUS, FONT_SIZE } from "../../styles/designTokens";
 
 /** 海纜 cable_type 對應色 */
 const CABLE_TYPE_COLORS: Record<string, string> = {
@@ -66,8 +66,8 @@ export function SubmarineCablePanel({ props }: { props: Record<string, unknown> 
   return (
     <>
       <div style={{ display: "flex", alignItems: "center", gap: 6, marginBottom: 6 }}>
-        <div style={{ width: 10, height: 10, borderRadius: 2, background: accentColor, flexShrink: 0 }} />
-        <div style={{ fontSize: 13, fontWeight: 700, color: "#fff", letterSpacing: 0.5 }}>
+        <div style={{ width: 10, height: 10, borderRadius: RADIUS.sm, background: accentColor, flexShrink: 0 }} />
+        <div style={{ fontSize: FONT_SIZE.lg, fontWeight: 700, color: "#fff", letterSpacing: 0.5 }}>
           {String(props.name ?? "Unknown Cable")}
         </div>
       </div>
@@ -90,8 +90,8 @@ export function LandingStationPanel({ props }: { props: Record<string, unknown> 
   return (
     <>
       <div style={{ display: "flex", alignItems: "center", gap: 6, marginBottom: 6 }}>
-        <div style={{ width: 10, height: 10, borderRadius: "50%", background: accentColor, flexShrink: 0 }} />
-        <div style={{ fontSize: 13, fontWeight: 700, color: "#fff", letterSpacing: 0.5 }}>
+        <div style={{ width: 10, height: 10, borderRadius: RADIUS.full, background: accentColor, flexShrink: 0 }} />
+        <div style={{ fontSize: FONT_SIZE.lg, fontWeight: 700, color: "#fff", letterSpacing: 0.5 }}>
           {String(props.name ?? "Unknown Station")}
         </div>
       </div>
@@ -111,8 +111,8 @@ export function SchoolPanel({ props }: { props: Record<string, unknown> }) {
   return (
     <>
       <div style={{ display: "flex", alignItems: "center", gap: 6, marginBottom: 6 }}>
-        <div style={{ width: 10, height: 10, borderRadius: "50%", background: accentColor, flexShrink: 0 }} />
-        <div style={{ fontSize: 13, fontWeight: 700, color: "#fff", letterSpacing: 0.5 }}>
+        <div style={{ width: 10, height: 10, borderRadius: RADIUS.full, background: accentColor, flexShrink: 0 }} />
+        <div style={{ fontSize: FONT_SIZE.lg, fontWeight: 700, color: "#fff", letterSpacing: 0.5 }}>
           {String(props.school_name ?? "Unknown School")}
         </div>
       </div>
@@ -133,8 +133,8 @@ export function ConvenienceStorePanel({ props }: { props: Record<string, unknown
   return (
     <>
       <div style={{ display: "flex", alignItems: "center", gap: 6, marginBottom: 6 }}>
-        <div style={{ width: 10, height: 10, borderRadius: 2, background: accentColor, flexShrink: 0 }} />
-        <div style={{ fontSize: 13, fontWeight: 700, color: "#fff", letterSpacing: 0.5 }}>
+        <div style={{ width: 10, height: 10, borderRadius: RADIUS.sm, background: accentColor, flexShrink: 0 }} />
+        <div style={{ fontSize: FONT_SIZE.lg, fontWeight: 700, color: "#fff", letterSpacing: 0.5 }}>
           {String(props.name ?? "Unknown Store")}
         </div>
       </div>
@@ -148,8 +148,8 @@ export function LighthousePanel({ props }: { props: Record<string, unknown> }) {
   return (
     <>
       <div style={{ display: "flex", alignItems: "center", gap: 6, marginBottom: 6 }}>
-        <div style={{ width: 10, height: 10, borderRadius: "50%", background: "#ffd700", flexShrink: 0 }} />
-        <div style={{ fontSize: 13, fontWeight: 700, color: "#fff", letterSpacing: 0.5 }}>
+        <div style={{ width: 10, height: 10, borderRadius: RADIUS.full, background: "#ffd700", flexShrink: 0 }} />
+        <div style={{ fontSize: FONT_SIZE.lg, fontWeight: 700, color: "#fff", letterSpacing: 0.5 }}>
           {String(props.Name ?? "Unknown Lighthouse")}
         </div>
       </div>
@@ -166,8 +166,8 @@ export function PortPanel({ props }: { props: Record<string, unknown> }) {
   return (
     <>
       <div style={{ display: "flex", alignItems: "center", gap: 6, marginBottom: 6 }}>
-        <div style={{ width: 10, height: 10, borderRadius: 2, background: accentColor, flexShrink: 0 }} />
-        <div style={{ fontSize: 13, fontWeight: 700, color: "#fff", letterSpacing: 0.5 }}>
+        <div style={{ width: 10, height: 10, borderRadius: RADIUS.sm, background: accentColor, flexShrink: 0 }} />
+        <div style={{ fontSize: FONT_SIZE.lg, fontWeight: 700, color: "#fff", letterSpacing: 0.5 }}>
           {String(props.name ?? "Unknown Port")}
         </div>
       </div>
@@ -182,8 +182,8 @@ export function AirportPanel({ props }: { props: Record<string, unknown> }) {
   return (
     <>
       <div style={{ display: "flex", alignItems: "center", gap: 6, marginBottom: 6 }}>
-        <div style={{ width: 10, height: 10, borderRadius: "50%", background: "#daa520", flexShrink: 0 }} />
-        <div style={{ fontSize: 13, fontWeight: 700, color: "#fff", letterSpacing: 0.5 }}>
+        <div style={{ width: 10, height: 10, borderRadius: RADIUS.full, background: "#daa520", flexShrink: 0 }} />
+        <div style={{ fontSize: FONT_SIZE.lg, fontWeight: 700, color: "#fff", letterSpacing: 0.5 }}>
           {String(props.name ?? "Unknown Airport")}
         </div>
       </div>
@@ -205,8 +205,8 @@ export function CctvPanel({ props }: { props: Record<string, unknown> }) {
   return (
     <>
       <div style={{ display: "flex", alignItems: "center", gap: 6, marginBottom: 6 }}>
-        <div style={{ width: 10, height: 10, borderRadius: "50%", background: info.color, flexShrink: 0 }} />
-        <div style={{ fontSize: 13, fontWeight: 700, color: "#fff", letterSpacing: 0.5 }}>
+        <div style={{ width: 10, height: 10, borderRadius: RADIUS.full, background: info.color, flexShrink: 0 }} />
+        <div style={{ fontSize: FONT_SIZE.lg, fontWeight: 700, color: "#fff", letterSpacing: 0.5 }}>
           {String(props.RoadName ?? props.CCTVID ?? "CCTV")}
         </div>
       </div>
@@ -222,7 +222,7 @@ export function CctvPanel({ props }: { props: Record<string, unknown> }) {
           accentColor={info.color}
         />
       ) : (
-        <div style={{ marginTop: 8, fontSize: 11, color: COLORS.textMuted }}>
+        <div style={{ marginTop: 8, fontSize: FONT_SIZE.base, color: COLORS.textMuted }}>
           此攝影機未提供串流網址
         </div>
       )}
@@ -239,8 +239,8 @@ export function EtcGantryPanel({ props }: { props: Record<string, unknown> }) {
   return (
     <>
       <div style={{ display: "flex", alignItems: "center", gap: 6, marginBottom: 6 }}>
-        <div style={{ width: 10, height: 10, borderRadius: 2, background: accentColor, flexShrink: 0 }} />
-        <div style={{ fontSize: 13, fontWeight: 700, color: "#fff", letterSpacing: 0.5 }}>
+        <div style={{ width: 10, height: 10, borderRadius: RADIUS.sm, background: accentColor, flexShrink: 0 }} />
+        <div style={{ fontSize: FONT_SIZE.lg, fontWeight: 700, color: "#fff", letterSpacing: 0.5 }}>
           {String(props.GantryID ?? "ETC Gantry")}
         </div>
       </div>
@@ -258,8 +258,8 @@ export function ServiceAreaPanel({ props }: { props: Record<string, unknown> }) 
   return (
     <>
       <div style={{ display: "flex", alignItems: "center", gap: 6, marginBottom: 6 }}>
-        <div style={{ width: 10, height: 10, borderRadius: "50%", background: accentColor, flexShrink: 0 }} />
-        <div style={{ fontSize: 13, fontWeight: 700, color: "#fff", letterSpacing: 0.5 }}>
+        <div style={{ width: 10, height: 10, borderRadius: RADIUS.full, background: accentColor, flexShrink: 0 }} />
+        <div style={{ fontSize: FONT_SIZE.lg, fontWeight: 700, color: "#fff", letterSpacing: 0.5 }}>
           {String(props.Name ?? "Service Area")}
         </div>
       </div>
@@ -281,8 +281,8 @@ export function ServiceAreaPolygonPanel({ props }: { props: Record<string, unkno
   return (
     <>
       <div style={{ display: "flex", alignItems: "center", gap: 6, marginBottom: 6 }}>
-        <div style={{ width: 10, height: 10, borderRadius: 2, background: accentColor, flexShrink: 0 }} />
-        <div style={{ fontSize: 13, fontWeight: 700, color: "#fff", letterSpacing: 0.5 }}>
+        <div style={{ width: 10, height: 10, borderRadius: RADIUS.sm, background: accentColor, flexShrink: 0 }} />
+        <div style={{ fontSize: FONT_SIZE.lg, fontWeight: 700, color: "#fff", letterSpacing: 0.5 }}>
           {String(props.Name ?? "Service Area")}
         </div>
       </div>
@@ -299,8 +299,8 @@ export function TaxiStandPanel({ props }: { props: Record<string, unknown> }) {
   return (
     <>
       <div style={{ display: "flex", alignItems: "center", gap: 6, marginBottom: 6 }}>
-        <div style={{ width: 10, height: 10, borderRadius: "50%", background: accentColor, flexShrink: 0 }} />
-        <div style={{ fontSize: 13, fontWeight: 700, color: "#fff", letterSpacing: 0.5 }}>
+        <div style={{ width: 10, height: 10, borderRadius: RADIUS.full, background: accentColor, flexShrink: 0 }} />
+        <div style={{ fontSize: FONT_SIZE.lg, fontWeight: 700, color: "#fff", letterSpacing: 0.5 }}>
           {String(props.Name ?? "Taxi Stand")}
         </div>
       </div>

--- a/src/components/featureInfo/infraPanels.tsx
+++ b/src/components/featureInfo/infraPanels.tsx
@@ -1,5 +1,6 @@
 import { CctvStreamView } from "../CctvStreamView";
 import { Row } from "./shared";
+import { COLORS } from "../../styles/designTokens";
 
 /** 海纜 cable_type 對應色 */
 const CABLE_TYPE_COLORS: Record<string, string> = {
@@ -221,7 +222,7 @@ export function CctvPanel({ props }: { props: Record<string, unknown> }) {
           accentColor={info.color}
         />
       ) : (
-        <div style={{ marginTop: 8, fontSize: 11, color: "rgba(255,255,255,0.55)" }}>
+        <div style={{ marginTop: 8, fontSize: 11, color: COLORS.textMuted }}>
           此攝影機未提供串流網址
         </div>
       )}

--- a/src/components/featureInfo/medicalPanels.tsx
+++ b/src/components/featureInfo/medicalPanels.tsx
@@ -1,3 +1,4 @@
+import { RADIUS, FONT_SIZE } from "../../styles/designTokens";
 import { medIsochroneColor, medIsochroneLabel, MEDICAL_ISOCHRONE_NOTE } from "../../data/medicalIsochroneTypes";
 import { medicalColorByCat } from "../../data/medicalPOITypes";
 import { Row } from "./shared";
@@ -19,8 +20,8 @@ export function MedicalPOIPanel({ props }: { props: Record<string, unknown> }) {
   return (
     <>
       <div style={{ display: "flex", alignItems: "center", gap: 6, marginBottom: 6 }}>
-        <div style={{ width: 10, height: 10, borderRadius: "50%", background: color, flexShrink: 0 }} />
-        <div style={{ fontSize: 13, fontWeight: 700, color: "#fff", letterSpacing: 0.5 }}>{title}</div>
+        <div style={{ width: 10, height: 10, borderRadius: RADIUS.full, background: color, flexShrink: 0 }} />
+        <div style={{ fontSize: FONT_SIZE.lg, fontWeight: 700, color: "#fff", letterSpacing: 0.5 }}>{title}</div>
       </div>
       {medCat === "hospital" || medCat === "clinic" || medCat === "other_medical" ? (
         <>
@@ -83,15 +84,15 @@ export function MedicalIsochronePanel({ props }: { props: Record<string, unknown
   return (
     <>
       <div style={{ display: "flex", alignItems: "center", gap: 6, marginBottom: 6 }}>
-        <div style={{ width: 10, height: 10, borderRadius: 2, background: accentColor, flexShrink: 0 }} />
-        <div style={{ fontSize: 13, fontWeight: 700, color: "#fff", letterSpacing: 0.5 }}>
+        <div style={{ width: 10, height: 10, borderRadius: RADIUS.sm, background: accentColor, flexShrink: 0 }} />
+        <div style={{ fontSize: FONT_SIZE.lg, fontWeight: 700, color: "#fff", letterSpacing: 0.5 }}>
           {medIsochroneLabel(level)}
         </div>
       </div>
       {minutes != null && <Row label="最近大醫院車程" value={`${minutes.toFixed(1)} 分鐘`} color={accentColor} />}
       {nearest && <Row label="最近醫院" value={nearest} />}
       {nearestCat && <Row label="醫院層級" value={nearestCat.replace("hospital_", "").replace("_", " ")} />}
-      <div style={{ fontSize: 9, color: "rgba(255,180,80,0.7)", marginTop: 6, lineHeight: 1.4 }}>
+      <div style={{ fontSize: FONT_SIZE.xs, color: "rgba(255,180,80,0.7)", marginTop: 6, lineHeight: 1.4 }}>
         ⚠️ {MEDICAL_ISOCHRONE_NOTE}
       </div>
     </>

--- a/src/components/featureInfo/satellitePanels.tsx
+++ b/src/components/featureInfo/satellitePanels.tsx
@@ -1,4 +1,5 @@
 import { Row } from "./shared";
+import { COLORS } from "../../styles/designTokens";
 import { SATELLITE_COLORS, SATELLITE_LABELS, type SatelliteCategory } from "../../data/satelliteTypes";
 
 export function SatellitePanel({ props }: { props: Record<string, unknown> }) {
@@ -14,7 +15,7 @@ export function SatellitePanel({ props }: { props: Record<string, unknown> }) {
       <Row label="類別" value={catLabel} color={color} />
       <Row label="NORAD" value={norad} />
       <Row label="高度" value={Number.isFinite(altKm) ? `${altKm.toLocaleString()} km` : ""} />
-      <div style={{ marginTop: 6, fontSize: 10, color: "rgba(255,255,255,0.4)" }}>
+      <div style={{ marginTop: 6, fontSize: 10, color: COLORS.textDim }}>
         足跡：內圈 50 km swath / 外圈 1,500 km elevation ≥10° cone
       </div>
     </div>

--- a/src/components/featureInfo/satellitePanels.tsx
+++ b/src/components/featureInfo/satellitePanels.tsx
@@ -1,5 +1,5 @@
 import { Row } from "./shared";
-import { COLORS } from "../../styles/designTokens";
+import { COLORS, FONT_SIZE } from "../../styles/designTokens";
 import { SATELLITE_COLORS, SATELLITE_LABELS, type SatelliteCategory } from "../../data/satelliteTypes";
 
 export function SatellitePanel({ props }: { props: Record<string, unknown> }) {
@@ -11,11 +11,11 @@ export function SatellitePanel({ props }: { props: Record<string, unknown> }) {
   const catLabel = SATELLITE_LABELS[cat] ?? cat;
   return (
     <div>
-      <div style={{ fontWeight: 700, color, fontSize: 13 }}>{name || "Satellite"}</div>
+      <div style={{ fontWeight: 700, color, fontSize: FONT_SIZE.lg }}>{name || "Satellite"}</div>
       <Row label="類別" value={catLabel} color={color} />
       <Row label="NORAD" value={norad} />
       <Row label="高度" value={Number.isFinite(altKm) ? `${altKm.toLocaleString()} km` : ""} />
-      <div style={{ marginTop: 6, fontSize: 10, color: COLORS.textDim }}>
+      <div style={{ marginTop: 6, fontSize: FONT_SIZE.sm, color: COLORS.textDim }}>
         足跡：內圈 50 km swath / 外圈 1,500 km elevation ≥10° cone
       </div>
     </div>

--- a/src/components/featureInfo/shared.tsx
+++ b/src/components/featureInfo/shared.tsx
@@ -1,3 +1,5 @@
+import { COLORS } from "../../styles/designTokens";
+
 export function formatTaiwanTime(iso: string | null): string {
   if (!iso) return "";
   try {
@@ -14,8 +16,8 @@ export function Row({ label, value, color }: { label: string; value: string; col
   if (!value || value === "null" || value === "undefined") return null;
   return (
     <div style={{ display: "flex", gap: 8, marginTop: 4, fontSize: 11, lineHeight: 1.5 }}>
-      <span style={{ color: "rgba(255,255,255,0.45)", flexShrink: 0, minWidth: 56 }}>{label}</span>
-      <span style={{ color: color ?? "rgba(255,255,255,0.85)", wordBreak: "break-word" }}>{value}</span>
+      <span style={{ color: COLORS.textMuted, flexShrink: 0, minWidth: 56 }}>{label}</span>
+      <span style={{ color: color ?? COLORS.textStrong, wordBreak: "break-word" }}>{value}</span>
     </div>
   );
 }
@@ -27,7 +29,7 @@ export function Badge({ label, on, color }: { label: string; on: boolean; color:
       padding: "1px 5px",
       borderRadius: 2,
       background: on ? color : "rgba(255,255,255,0.08)",
-      color: on ? "#fff" : "rgba(255,255,255,0.4)",
+      color: on ? "#fff" : COLORS.textDim,
       fontWeight: on ? 700 : 400,
     }}>
       {label}

--- a/src/components/featureInfo/shared.tsx
+++ b/src/components/featureInfo/shared.tsx
@@ -1,4 +1,4 @@
-import { COLORS } from "../../styles/designTokens";
+import { COLORS, RADIUS, FONT_SIZE } from "../../styles/designTokens";
 
 export function formatTaiwanTime(iso: string | null): string {
   if (!iso) return "";
@@ -15,7 +15,7 @@ export function formatTaiwanTime(iso: string | null): string {
 export function Row({ label, value, color }: { label: string; value: string; color?: string }) {
   if (!value || value === "null" || value === "undefined") return null;
   return (
-    <div style={{ display: "flex", gap: 8, marginTop: 4, fontSize: 11, lineHeight: 1.5 }}>
+    <div style={{ display: "flex", gap: 8, marginTop: 4, fontSize: FONT_SIZE.base, lineHeight: 1.5 }}>
       <span style={{ color: COLORS.textMuted, flexShrink: 0, minWidth: 56 }}>{label}</span>
       <span style={{ color: color ?? COLORS.textStrong, wordBreak: "break-word" }}>{value}</span>
     </div>
@@ -25,9 +25,9 @@ export function Row({ label, value, color }: { label: string; value: string; col
 export function Badge({ label, on, color }: { label: string; on: boolean; color: string }) {
   return (
     <span style={{
-      fontSize: 10,
+      fontSize: FONT_SIZE.sm,
       padding: "1px 5px",
-      borderRadius: 2,
+      borderRadius: RADIUS.sm,
       background: on ? color : "rgba(255,255,255,0.08)",
       color: on ? "#fff" : COLORS.textDim,
       fontWeight: on ? 700 : 400,

--- a/src/components/featureInfo/taipeiWicPanels.tsx
+++ b/src/components/featureInfo/taipeiWicPanels.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { COLORS } from "../../styles/designTokens";
 import { Waves, DoorOpen, Droplets } from "lucide-react";
 import { TimeseriesSparkline, type SparklinePoint } from "../TimeseriesSparkline";
 import {
@@ -61,14 +62,14 @@ export function TaipeiSewerPanel({ props }: { props: Record<string, unknown> }) 
       </div>
       <div style={{ display: "flex", gap: 6, marginTop: 4 }}>
         <div style={{ flex: 1, padding: "6px 8px", background: `${color}1a`, borderRadius: 4 }}>
-          <div style={{ fontSize: 9, color: "rgba(255,255,255,0.6)" }}>距地面 ground_far</div>
+          <div style={{ fontSize: 9, color: COLORS.textMuted }}>距地面 ground_far</div>
           <div style={{ fontSize: 18, fontWeight: 700, color }}>
             {groundFar != null ? groundFar.toFixed(2) : "—"}
             <span style={{ fontSize: 10, opacity: 0.7, marginLeft: 4 }}>m</span>
           </div>
         </div>
         <div style={{ flex: 1, padding: "6px 8px", background: "rgba(255,255,255,0.05)", borderRadius: 4 }}>
-          <div style={{ fontSize: 9, color: "rgba(255,255,255,0.6)" }}>絕對水位 level_out</div>
+          <div style={{ fontSize: 9, color: COLORS.textMuted }}>絕對水位 level_out</div>
           <div style={{ fontSize: 18, fontWeight: 700, color: "#fff" }}>
             {levelOut != null ? levelOut.toFixed(2) : "—"}
             <span style={{ fontSize: 10, opacity: 0.7, marginLeft: 4 }}>m</span>
@@ -76,11 +77,11 @@ export function TaipeiSewerPanel({ props }: { props: Record<string, unknown> }) 
         </div>
       </div>
       {obs && <Row label="觀測時間" value={formatTaiwanTime(obs).slice(0, 16)} />}
-      <div style={{ marginTop: 8, fontSize: 9, color: "rgba(255,255,255,0.5)", letterSpacing: 0.5 }}>
+      <div style={{ marginTop: 8, fontSize: 9, color: COLORS.textMuted, letterSpacing: 0.5 }}>
         24h 水位高程趨勢
       </div>
       {loadingTs ? (
-        <div style={{ fontSize: 10, color: "rgba(255,255,255,0.4)", padding: "8px 4px", textAlign: "center" }}>載入中…</div>
+        <div style={{ fontSize: 10, color: COLORS.textDim, padding: "8px 4px", textAlign: "center" }}>載入中…</div>
       ) : (
         <TimeseriesSparkline data={series} unit="m" lineColor={color} height={120} />
       )}
@@ -140,14 +141,14 @@ export function TaipeiPumbPanel({ props }: { props: Record<string, unknown> }) {
       </div>
       <div style={{ display: "flex", gap: 6, marginTop: 4 }}>
         <div style={{ flex: 1, padding: "6px 8px", background: `${color}1a`, borderRadius: 4 }}>
-          <div style={{ fontSize: 9, color: "rgba(255,255,255,0.6)" }}>內池水位 inner</div>
+          <div style={{ fontSize: 9, color: COLORS.textMuted }}>內池水位 inner</div>
           <div style={{ fontSize: 18, fontWeight: 700, color }}>
             {inner != null ? inner.toFixed(2) : "—"}
             <span style={{ fontSize: 10, opacity: 0.7, marginLeft: 4 }}>m</span>
           </div>
         </div>
         <div style={{ flex: 1, padding: "6px 8px", background: "rgba(255,255,255,0.05)", borderRadius: 4 }}>
-          <div style={{ fontSize: 9, color: "rgba(255,255,255,0.6)" }}>外池水位 outer</div>
+          <div style={{ fontSize: 9, color: COLORS.textMuted }}>外池水位 outer</div>
           <div style={{ fontSize: 18, fontWeight: 700, color: "#fff" }}>
             {outer != null ? outer.toFixed(2) : "—"}
             <span style={{ fontSize: 10, opacity: 0.7, marginLeft: 4 }}>m</span>
@@ -158,11 +159,11 @@ export function TaipeiPumbPanel({ props }: { props: Record<string, unknown> }) {
       <Row label="抽水機" value={pumbStatus || "—"} color={pumbStatus === "運轉" ? "#22d3ee" : undefined} />
       <Row label="閘門" value={doorStatus || "—"} />
       {obs && <Row label="觀測時間" value={formatTaiwanTime(obs).slice(0, 16)} />}
-      <div style={{ marginTop: 8, fontSize: 9, color: "rgba(255,255,255,0.5)", letterSpacing: 0.5 }}>
+      <div style={{ marginTop: 8, fontSize: 9, color: COLORS.textMuted, letterSpacing: 0.5 }}>
         24h 內池水位趨勢
       </div>
       {loadingTs ? (
-        <div style={{ fontSize: 10, color: "rgba(255,255,255,0.4)", padding: "8px 4px", textAlign: "center" }}>載入中…</div>
+        <div style={{ fontSize: 10, color: COLORS.textDim, padding: "8px 4px", textAlign: "center" }}>載入中…</div>
       ) : (
         <TimeseriesSparkline
           data={series}
@@ -194,7 +195,7 @@ export function TaipeiEvacuatePanel({ props }: { props: Record<string, unknown> 
     if (fo === "" && fc === "" && flt === "") return null;
     return (
       <div key={idx} style={{ display: "flex", gap: 4, alignItems: "center", fontSize: 11, padding: "3px 6px", background: "rgba(255,255,255,0.04)", borderRadius: 4 }}>
-        <span style={{ color: "rgba(255,255,255,0.6)", marginRight: 4 }}>門 {idx}</span>
+        <span style={{ color: COLORS.textMuted, marginRight: 4 }}>門 {idx}</span>
         <Badge label="開" on={fo === "+"} color="#22c55e" />
         <Badge label="閉" on={fc === "+"} color="#ef4444" />
         <Badge label="障" on={flt === "+"} color="#fbbf24" />
@@ -251,13 +252,13 @@ export function TaipeiEvacuatePanel({ props }: { props: Record<string, unknown> 
         {gateNum >= 2 && renderGate(2)}
       </div>
       {obs && <Row label="觀測時間" value={formatTaiwanTime(obs).slice(0, 16)} />}
-      <div style={{ marginTop: 8, fontSize: 9, color: "rgba(255,255,255,0.5)", letterSpacing: 0.5 }}>
+      <div style={{ marginTop: 8, fontSize: 9, color: COLORS.textMuted, letterSpacing: 0.5 }}>
         24h 狀態變化
       </div>
       {loadingTs ? (
-        <div style={{ fontSize: 10, color: "rgba(255,255,255,0.4)", padding: "8px 4px", textAlign: "center" }}>載入中…</div>
+        <div style={{ fontSize: 10, color: COLORS.textDim, padding: "8px 4px", textAlign: "center" }}>載入中…</div>
       ) : history.length === 0 ? (
-        <div style={{ fontSize: 10, color: "rgba(255,255,255,0.4)", padding: "8px 4px", textAlign: "center" }}>24h 內無狀態變化</div>
+        <div style={{ fontSize: 10, color: COLORS.textDim, padding: "8px 4px", textAlign: "center" }}>24h 內無狀態變化</div>
       ) : (
         <div style={{ display: "flex", flexDirection: "column", gap: 2, maxHeight: 140, overflowY: "auto" }}>
           {history.slice().reverse().map((h, i) => {
@@ -265,7 +266,7 @@ export function TaipeiEvacuatePanel({ props }: { props: Record<string, unknown> 
             const lbl = h.state === "closed" ? "閉" : h.state === "faulted" ? "障" : h.state === "open" ? "開" : "?";
             return (
               <div key={i} style={{ display: "flex", alignItems: "center", gap: 6, fontSize: 10, padding: "2px 4px" }}>
-                <span style={{ color: "rgba(255,255,255,0.5)" }}>{formatTaiwanTime(h.t).slice(5, 16)}</span>
+                <span style={{ color: COLORS.textMuted }}>{formatTaiwanTime(h.t).slice(5, 16)}</span>
                 <span style={{ background: c, color: "#fff", padding: "0 4px", borderRadius: 2, fontWeight: 600 }}>{lbl}</span>
               </div>
             );

--- a/src/components/featureInfo/taipeiWicPanels.tsx
+++ b/src/components/featureInfo/taipeiWicPanels.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { COLORS } from "../../styles/designTokens";
+import { COLORS, RADIUS, FONT_SIZE } from "../../styles/designTokens";
 import { Waves, DoorOpen, Droplets } from "lucide-react";
 import { TimeseriesSparkline, type SparklinePoint } from "../TimeseriesSparkline";
 import {
@@ -51,37 +51,37 @@ export function TaipeiSewerPanel({ props }: { props: Record<string, unknown> }) 
     <>
       <div style={{ display: "flex", alignItems: "center", gap: 6, marginBottom: 6 }}>
         <Waves size={14} color={color} strokeWidth={2.4} />
-        <div style={{ fontSize: 13, fontWeight: 700, color: "#fff", flex: 1, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+        <div style={{ fontSize: FONT_SIZE.lg, fontWeight: 700, color: "#fff", flex: 1, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
           {name} <span style={{ opacity: 0.5, fontWeight: 400 }}>#{stationNo}</span>
         </div>
         {groundFar != null && (
-          <div style={{ fontSize: 10, padding: "1px 6px", borderRadius: 3, background: color, color: "#fff", fontWeight: 600 }}>
+          <div style={{ fontSize: FONT_SIZE.sm, padding: "1px 6px", borderRadius: RADIUS.md, background: color, color: "#fff", fontWeight: 600 }}>
             {level}
           </div>
         )}
       </div>
       <div style={{ display: "flex", gap: 6, marginTop: 4 }}>
-        <div style={{ flex: 1, padding: "6px 8px", background: `${color}1a`, borderRadius: 4 }}>
-          <div style={{ fontSize: 9, color: COLORS.textMuted }}>距地面 ground_far</div>
-          <div style={{ fontSize: 18, fontWeight: 700, color }}>
+        <div style={{ flex: 1, padding: "6px 8px", background: `${color}1a`, borderRadius: RADIUS.md }}>
+          <div style={{ fontSize: FONT_SIZE.xs, color: COLORS.textMuted }}>距地面 ground_far</div>
+          <div style={{ fontSize: FONT_SIZE.xl, fontWeight: 700, color }}>
             {groundFar != null ? groundFar.toFixed(2) : "—"}
-            <span style={{ fontSize: 10, opacity: 0.7, marginLeft: 4 }}>m</span>
+            <span style={{ fontSize: FONT_SIZE.sm, opacity: 0.7, marginLeft: 4 }}>m</span>
           </div>
         </div>
-        <div style={{ flex: 1, padding: "6px 8px", background: "rgba(255,255,255,0.05)", borderRadius: 4 }}>
-          <div style={{ fontSize: 9, color: COLORS.textMuted }}>絕對水位 level_out</div>
-          <div style={{ fontSize: 18, fontWeight: 700, color: "#fff" }}>
+        <div style={{ flex: 1, padding: "6px 8px", background: "rgba(255,255,255,0.05)", borderRadius: RADIUS.md }}>
+          <div style={{ fontSize: FONT_SIZE.xs, color: COLORS.textMuted }}>絕對水位 level_out</div>
+          <div style={{ fontSize: FONT_SIZE.xl, fontWeight: 700, color: "#fff" }}>
             {levelOut != null ? levelOut.toFixed(2) : "—"}
-            <span style={{ fontSize: 10, opacity: 0.7, marginLeft: 4 }}>m</span>
+            <span style={{ fontSize: FONT_SIZE.sm, opacity: 0.7, marginLeft: 4 }}>m</span>
           </div>
         </div>
       </div>
       {obs && <Row label="觀測時間" value={formatTaiwanTime(obs).slice(0, 16)} />}
-      <div style={{ marginTop: 8, fontSize: 9, color: COLORS.textMuted, letterSpacing: 0.5 }}>
+      <div style={{ marginTop: 8, fontSize: FONT_SIZE.xs, color: COLORS.textMuted, letterSpacing: 0.5 }}>
         24h 水位高程趨勢
       </div>
       {loadingTs ? (
-        <div style={{ fontSize: 10, color: COLORS.textDim, padding: "8px 4px", textAlign: "center" }}>載入中…</div>
+        <div style={{ fontSize: FONT_SIZE.sm, color: COLORS.textDim, padding: "8px 4px", textAlign: "center" }}>載入中…</div>
       ) : (
         <TimeseriesSparkline data={series} unit="m" lineColor={color} height={120} />
       )}
@@ -130,28 +130,28 @@ export function TaipeiPumbPanel({ props }: { props: Record<string, unknown> }) {
     <>
       <div style={{ display: "flex", alignItems: "center", gap: 6, marginBottom: 6 }}>
         <Droplets size={14} color={color} strokeWidth={2.4} />
-        <div style={{ fontSize: 13, fontWeight: 700, color: "#fff", flex: 1, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+        <div style={{ fontSize: FONT_SIZE.lg, fontWeight: 700, color: "#fff", flex: 1, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
           {name} <span style={{ opacity: 0.5, fontWeight: 400 }}>#{stnId}</span>
         </div>
         {risk != null && (
-          <div style={{ fontSize: 10, padding: "1px 6px", borderRadius: 3, background: color, color: "#fff", fontWeight: 600 }}>
+          <div style={{ fontSize: FONT_SIZE.sm, padding: "1px 6px", borderRadius: RADIUS.md, background: color, color: "#fff", fontWeight: 600 }}>
             {level}
           </div>
         )}
       </div>
       <div style={{ display: "flex", gap: 6, marginTop: 4 }}>
-        <div style={{ flex: 1, padding: "6px 8px", background: `${color}1a`, borderRadius: 4 }}>
-          <div style={{ fontSize: 9, color: COLORS.textMuted }}>內池水位 inner</div>
-          <div style={{ fontSize: 18, fontWeight: 700, color }}>
+        <div style={{ flex: 1, padding: "6px 8px", background: `${color}1a`, borderRadius: RADIUS.md }}>
+          <div style={{ fontSize: FONT_SIZE.xs, color: COLORS.textMuted }}>內池水位 inner</div>
+          <div style={{ fontSize: FONT_SIZE.xl, fontWeight: 700, color }}>
             {inner != null ? inner.toFixed(2) : "—"}
-            <span style={{ fontSize: 10, opacity: 0.7, marginLeft: 4 }}>m</span>
+            <span style={{ fontSize: FONT_SIZE.sm, opacity: 0.7, marginLeft: 4 }}>m</span>
           </div>
         </div>
-        <div style={{ flex: 1, padding: "6px 8px", background: "rgba(255,255,255,0.05)", borderRadius: 4 }}>
-          <div style={{ fontSize: 9, color: COLORS.textMuted }}>外池水位 outer</div>
-          <div style={{ fontSize: 18, fontWeight: 700, color: "#fff" }}>
+        <div style={{ flex: 1, padding: "6px 8px", background: "rgba(255,255,255,0.05)", borderRadius: RADIUS.md }}>
+          <div style={{ fontSize: FONT_SIZE.xs, color: COLORS.textMuted }}>外池水位 outer</div>
+          <div style={{ fontSize: FONT_SIZE.xl, fontWeight: 700, color: "#fff" }}>
             {outer != null ? outer.toFixed(2) : "—"}
-            <span style={{ fontSize: 10, opacity: 0.7, marginLeft: 4 }}>m</span>
+            <span style={{ fontSize: FONT_SIZE.sm, opacity: 0.7, marginLeft: 4 }}>m</span>
           </div>
         </div>
       </div>
@@ -159,11 +159,11 @@ export function TaipeiPumbPanel({ props }: { props: Record<string, unknown> }) {
       <Row label="抽水機" value={pumbStatus || "—"} color={pumbStatus === "運轉" ? "#22d3ee" : undefined} />
       <Row label="閘門" value={doorStatus || "—"} />
       {obs && <Row label="觀測時間" value={formatTaiwanTime(obs).slice(0, 16)} />}
-      <div style={{ marginTop: 8, fontSize: 9, color: COLORS.textMuted, letterSpacing: 0.5 }}>
+      <div style={{ marginTop: 8, fontSize: FONT_SIZE.xs, color: COLORS.textMuted, letterSpacing: 0.5 }}>
         24h 內池水位趨勢
       </div>
       {loadingTs ? (
-        <div style={{ fontSize: 10, color: COLORS.textDim, padding: "8px 4px", textAlign: "center" }}>載入中…</div>
+        <div style={{ fontSize: FONT_SIZE.sm, color: COLORS.textDim, padding: "8px 4px", textAlign: "center" }}>載入中…</div>
       ) : (
         <TimeseriesSparkline
           data={series}
@@ -194,7 +194,7 @@ export function TaipeiEvacuatePanel({ props }: { props: Record<string, unknown> 
     const flt = String(props[`flt0${idx}`] ?? "");
     if (fo === "" && fc === "" && flt === "") return null;
     return (
-      <div key={idx} style={{ display: "flex", gap: 4, alignItems: "center", fontSize: 11, padding: "3px 6px", background: "rgba(255,255,255,0.04)", borderRadius: 4 }}>
+      <div key={idx} style={{ display: "flex", gap: 4, alignItems: "center", fontSize: FONT_SIZE.base, padding: "3px 6px", background: "rgba(255,255,255,0.04)", borderRadius: RADIUS.md }}>
         <span style={{ color: COLORS.textMuted, marginRight: 4 }}>門 {idx}</span>
         <Badge label="開" on={fo === "+"} color="#22c55e" />
         <Badge label="閉" on={fc === "+"} color="#ef4444" />
@@ -239,10 +239,10 @@ export function TaipeiEvacuatePanel({ props }: { props: Record<string, unknown> 
     <>
       <div style={{ display: "flex", alignItems: "center", gap: 6, marginBottom: 6 }}>
         <DoorOpen size={14} color={stateColor} strokeWidth={2.4} />
-        <div style={{ fontSize: 13, fontWeight: 700, color: "#fff", flex: 1, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+        <div style={{ fontSize: FONT_SIZE.lg, fontWeight: 700, color: "#fff", flex: 1, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
           {name} <span style={{ opacity: 0.5, fontWeight: 400 }}>#{stationNo}</span>
         </div>
-        <div style={{ fontSize: 10, padding: "1px 6px", borderRadius: 3, background: stateColor, color: "#fff", fontWeight: 600 }}>
+        <div style={{ fontSize: FONT_SIZE.sm, padding: "1px 6px", borderRadius: RADIUS.md, background: stateColor, color: "#fff", fontWeight: 600 }}>
           {stateLabel}
         </div>
       </div>
@@ -252,22 +252,22 @@ export function TaipeiEvacuatePanel({ props }: { props: Record<string, unknown> 
         {gateNum >= 2 && renderGate(2)}
       </div>
       {obs && <Row label="觀測時間" value={formatTaiwanTime(obs).slice(0, 16)} />}
-      <div style={{ marginTop: 8, fontSize: 9, color: COLORS.textMuted, letterSpacing: 0.5 }}>
+      <div style={{ marginTop: 8, fontSize: FONT_SIZE.xs, color: COLORS.textMuted, letterSpacing: 0.5 }}>
         24h 狀態變化
       </div>
       {loadingTs ? (
-        <div style={{ fontSize: 10, color: COLORS.textDim, padding: "8px 4px", textAlign: "center" }}>載入中…</div>
+        <div style={{ fontSize: FONT_SIZE.sm, color: COLORS.textDim, padding: "8px 4px", textAlign: "center" }}>載入中…</div>
       ) : history.length === 0 ? (
-        <div style={{ fontSize: 10, color: COLORS.textDim, padding: "8px 4px", textAlign: "center" }}>24h 內無狀態變化</div>
+        <div style={{ fontSize: FONT_SIZE.sm, color: COLORS.textDim, padding: "8px 4px", textAlign: "center" }}>24h 內無狀態變化</div>
       ) : (
         <div style={{ display: "flex", flexDirection: "column", gap: 2, maxHeight: 140, overflowY: "auto" }}>
           {history.slice().reverse().map((h, i) => {
             const c = h.state === "closed" ? "#ef4444" : h.state === "faulted" ? "#fbbf24" : h.state === "open" ? "#22c55e" : "#6b7280";
             const lbl = h.state === "closed" ? "閉" : h.state === "faulted" ? "障" : h.state === "open" ? "開" : "?";
             return (
-              <div key={i} style={{ display: "flex", alignItems: "center", gap: 6, fontSize: 10, padding: "2px 4px" }}>
+              <div key={i} style={{ display: "flex", alignItems: "center", gap: 6, fontSize: FONT_SIZE.sm, padding: "2px 4px" }}>
                 <span style={{ color: COLORS.textMuted }}>{formatTaiwanTime(h.t).slice(5, 16)}</span>
-                <span style={{ background: c, color: "#fff", padding: "0 4px", borderRadius: 2, fontWeight: 600 }}>{lbl}</span>
+                <span style={{ background: c, color: "#fff", padding: "0 4px", borderRadius: RADIUS.sm, fontWeight: 600 }}>{lbl}</span>
               </div>
             );
           })}

--- a/src/components/featureInfo/transportPanels.tsx
+++ b/src/components/featureInfo/transportPanels.tsx
@@ -1,3 +1,4 @@
+import { RADIUS, FONT_SIZE } from "../../styles/designTokens";
 import { Row } from "./shared";
 
 /** 氣象站類型對應色 */
@@ -35,8 +36,8 @@ export function WeatherStationPanel({ props }: { props: Record<string, unknown> 
   return (
     <>
       <div style={{ display: "flex", alignItems: "center", gap: 6, marginBottom: 6 }}>
-        <div style={{ width: 10, height: 10, borderRadius: "50%", background: accentColor, flexShrink: 0 }} />
-        <div style={{ fontSize: 13, fontWeight: 700, color: "#fff", letterSpacing: 0.5 }}>
+        <div style={{ width: 10, height: 10, borderRadius: RADIUS.full, background: accentColor, flexShrink: 0 }} />
+        <div style={{ fontSize: FONT_SIZE.lg, fontWeight: 700, color: "#fff", letterSpacing: 0.5 }}>
           {String(props.station_name ?? "Unknown Station")}
         </div>
       </div>
@@ -58,8 +59,8 @@ export function BikeStationPanel({ props }: { props: Record<string, unknown> }) 
   return (
     <>
       <div style={{ display: "flex", alignItems: "center", gap: 6, marginBottom: 6 }}>
-        <div style={{ width: 10, height: 10, borderRadius: "50%", background: accentColor, flexShrink: 0 }} />
-        <div style={{ fontSize: 13, fontWeight: 700, color: "#fff", letterSpacing: 0.5 }}>
+        <div style={{ width: 10, height: 10, borderRadius: RADIUS.full, background: accentColor, flexShrink: 0 }} />
+        <div style={{ fontSize: FONT_SIZE.lg, fontWeight: 700, color: "#fff", letterSpacing: 0.5 }}>
           {String(props.StationName ?? "Unknown Station")}
         </div>
       </div>
@@ -79,8 +80,8 @@ export function BusStationPanel({ props }: { props: Record<string, unknown> }) {
   return (
     <>
       <div style={{ display: "flex", alignItems: "center", gap: 6, marginBottom: 6 }}>
-        <div style={{ width: 10, height: 10, borderRadius: "50%", background: accentColor, flexShrink: 0 }} />
-        <div style={{ fontSize: 13, fontWeight: 700, color: "#fff", letterSpacing: 0.5 }}>
+        <div style={{ width: 10, height: 10, borderRadius: RADIUS.full, background: accentColor, flexShrink: 0 }} />
+        <div style={{ fontSize: FONT_SIZE.lg, fontWeight: 700, color: "#fff", letterSpacing: 0.5 }}>
           {String(props.StationName ?? "Unknown Station")}
         </div>
       </div>
@@ -100,8 +101,8 @@ export function RailStationPanel({ props }: { props: Record<string, unknown> }) 
   return (
     <>
       <div style={{ display: "flex", alignItems: "center", gap: 6, marginBottom: 6 }}>
-        <div style={{ width: 10, height: 10, borderRadius: "50%", background: accentColor, flexShrink: 0 }} />
-        <div style={{ fontSize: 13, fontWeight: 700, color: "#fff", letterSpacing: 0.5 }}>
+        <div style={{ width: 10, height: 10, borderRadius: RADIUS.full, background: accentColor, flexShrink: 0 }} />
+        <div style={{ fontSize: FONT_SIZE.lg, fontWeight: 700, color: "#fff", letterSpacing: 0.5 }}>
           {String(props.name ?? "Unknown Station")}
         </div>
       </div>

--- a/src/components/featureInfo/wastePanels.tsx
+++ b/src/components/featureInfo/wastePanels.tsx
@@ -1,3 +1,4 @@
+import { COLORS } from "../../styles/designTokens";
 import {
   WASTE_FACILITY_COLORS, WASTE_FACILITY_LABELS,
   WASTE_DISPOSAL_COLORS, WASTE_DISPOSAL_LABELS,
@@ -79,7 +80,7 @@ export function WasteDisposalPointPanel({ props }: { props: Record<string, unkno
 
       {/* 來源權威度 badge */}
       <div style={{ marginTop: 8, display: "flex", alignItems: "center", gap: 6 }}>
-        <span style={{ color: "rgba(255,255,255,0.45)", fontSize: 11, minWidth: 56 }}>來源</span>
+        <span style={{ color: COLORS.textMuted, fontSize: 11, minWidth: 56 }}>來源</span>
         <span
           style={{
             fontSize: 10,
@@ -98,7 +99,7 @@ export function WasteDisposalPointPanel({ props }: { props: Record<string, unkno
       {/* 可投放類別 chips */}
       {categories.length > 0 && (
         <div style={{ marginTop: 8 }}>
-          <div style={{ color: "rgba(255,255,255,0.45)", fontSize: 11, marginBottom: 4 }}>
+          <div style={{ color: COLORS.textMuted, fontSize: 11, marginBottom: 4 }}>
             可投放
           </div>
           <div style={{ display: "flex", flexWrap: "wrap", gap: 4 }}>
@@ -110,7 +111,7 @@ export function WasteDisposalPointPanel({ props }: { props: Record<string, unkno
                   padding: "1px 7px",
                   borderRadius: 8,
                   background: "rgba(255,255,255,0.06)",
-                  color: "rgba(255,255,255,0.75)",
+                  color: COLORS.textDefault,
                   border: "1px solid rgba(255,255,255,0.10)",
                 }}
               >

--- a/src/components/featureInfo/wastePanels.tsx
+++ b/src/components/featureInfo/wastePanels.tsx
@@ -1,4 +1,4 @@
-import { COLORS } from "../../styles/designTokens";
+import { COLORS, RADIUS, FONT_SIZE } from "../../styles/designTokens";
 import {
   WASTE_FACILITY_COLORS, WASTE_FACILITY_LABELS,
   WASTE_DISPOSAL_COLORS, WASTE_DISPOSAL_LABELS,
@@ -15,8 +15,8 @@ export function WasteFacilityPanel({ props }: { props: Record<string, unknown> }
   return (
     <>
       <div style={{ display: "flex", alignItems: "center", gap: 6, marginBottom: 6 }}>
-        <div style={{ width: 10, height: 10, borderRadius: "50%", background: color, flexShrink: 0 }} />
-        <div style={{ fontSize: 13, fontWeight: 700, color: "#fff", letterSpacing: 0.5 }}>
+        <div style={{ width: 10, height: 10, borderRadius: RADIUS.full, background: color, flexShrink: 0 }} />
+        <div style={{ fontSize: FONT_SIZE.lg, fontWeight: 700, color: "#fff", letterSpacing: 0.5 }}>
           {String(props.facility_name ?? "(未命名設施)")}
         </div>
       </div>
@@ -34,7 +34,7 @@ export function WasteFacilityPanel({ props }: { props: Record<string, unknown> }
             target="_blank"
             rel="noopener noreferrer"
             style={{
-              fontSize: 10,
+              fontSize: FONT_SIZE.sm,
               color: "#60a5fa",
               textDecoration: "underline",
               wordBreak: "break-all",
@@ -67,8 +67,8 @@ export function WasteDisposalPointPanel({ props }: { props: Record<string, unkno
   return (
     <>
       <div style={{ display: "flex", alignItems: "center", gap: 6, marginBottom: 6 }}>
-        <div style={{ width: 10, height: 10, borderRadius: "50%", background: color, flexShrink: 0 }} />
-        <div style={{ fontSize: 13, fontWeight: 700, color: "#fff", letterSpacing: 0.5 }}>
+        <div style={{ width: 10, height: 10, borderRadius: RADIUS.full, background: color, flexShrink: 0 }} />
+        <div style={{ fontSize: FONT_SIZE.lg, fontWeight: 700, color: "#fff", letterSpacing: 0.5 }}>
           {String(props.point_name ?? label)}
         </div>
       </div>
@@ -80,12 +80,12 @@ export function WasteDisposalPointPanel({ props }: { props: Record<string, unkno
 
       {/* 來源權威度 badge */}
       <div style={{ marginTop: 8, display: "flex", alignItems: "center", gap: 6 }}>
-        <span style={{ color: COLORS.textMuted, fontSize: 11, minWidth: 56 }}>來源</span>
+        <span style={{ color: COLORS.textMuted, fontSize: FONT_SIZE.base, minWidth: 56 }}>來源</span>
         <span
           style={{
-            fontSize: 10,
+            fontSize: FONT_SIZE.sm,
             padding: "2px 8px",
-            borderRadius: 10,
+            borderRadius: RADIUS.xl,
             background: badge.bg,
             color: badge.fg,
             border: `1px solid ${badge.fg}55`,
@@ -99,7 +99,7 @@ export function WasteDisposalPointPanel({ props }: { props: Record<string, unkno
       {/* 可投放類別 chips */}
       {categories.length > 0 && (
         <div style={{ marginTop: 8 }}>
-          <div style={{ color: COLORS.textMuted, fontSize: 11, marginBottom: 4 }}>
+          <div style={{ color: COLORS.textMuted, fontSize: FONT_SIZE.base, marginBottom: 4 }}>
             可投放
           </div>
           <div style={{ display: "flex", flexWrap: "wrap", gap: 4 }}>
@@ -107,9 +107,9 @@ export function WasteDisposalPointPanel({ props }: { props: Record<string, unkno
               <span
                 key={c}
                 style={{
-                  fontSize: 10,
+                  fontSize: FONT_SIZE.sm,
                   padding: "1px 7px",
-                  borderRadius: 8,
+                  borderRadius: RADIUS.xl,
                   background: "rgba(255,255,255,0.06)",
                   color: COLORS.textDefault,
                   border: "1px solid rgba(255,255,255,0.10)",
@@ -129,7 +129,7 @@ export function WasteDisposalPointPanel({ props }: { props: Record<string, unkno
             target="_blank"
             rel="noopener noreferrer"
             style={{
-              fontSize: 10,
+              fontSize: FONT_SIZE.sm,
               color: "#60a5fa",
               textDecoration: "underline",
               wordBreak: "break-all",

--- a/src/components/featureInfo/waterPanels.tsx
+++ b/src/components/featureInfo/waterPanels.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { TimeseriesSparkline, type SparklinePoint } from "../TimeseriesSparkline";
+import { FONT_DATA } from "../../styles/designTokens";
 import { fetchFloodSensorTimeseries } from "../../data/floodSensorLoader";
 import { fetchRiverLevelTimeseries } from "../../data/riverLevelLoader";
 import { fetchGroundwaterTimeseries } from "../../data/groundwaterLoader";
@@ -525,7 +526,7 @@ export function WaterReservoirContextPanel({ ctx }: { ctx: ReservoirContext }) {
             style={{
               marginLeft: "auto",
               fontSize: 9,
-              fontFamily: "monospace",
+              fontFamily: FONT_DATA,
               color: "rgba(255,255,255,0.3)",
             }}
           >

--- a/src/components/featureInfo/waterPanels.tsx
+++ b/src/components/featureInfo/waterPanels.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { TimeseriesSparkline, type SparklinePoint } from "../TimeseriesSparkline";
-import { FONT_DATA } from "../../styles/designTokens";
+import { COLORS, FONT_DATA } from "../../styles/designTokens";
 import { fetchFloodSensorTimeseries } from "../../data/floodSensorLoader";
 import { fetchRiverLevelTimeseries } from "../../data/riverLevelLoader";
 import { fetchGroundwaterTimeseries } from "../../data/groundwaterLoader";
@@ -217,17 +217,17 @@ export function RiverLevelPanel({ props }: { props: Record<string, unknown> }) {
         <span style={{ fontSize: 22, fontWeight: 700, color }}>
           {level.toFixed(2)}
         </span>
-        <span style={{ fontSize: 10, color: "rgba(255,255,255,0.7)" }}>m 水位</span>
+        <span style={{ fontSize: 10, color: COLORS.textDefault }}>m 水位</span>
       </div>
       <Row label="縣市" value={String(props.county ?? "")} />
       {obs && <Row label="觀測時間" value={formatTaiwanTime(obs).slice(0, 16)} />}
       <Row label="站號" value={String(props.station_id ?? "")} color="rgba(255,255,255,0.35)" />
 
-      <div style={{ marginTop: 8, fontSize: 9, color: "rgba(255,255,255,0.5)", letterSpacing: 0.5 }}>
+      <div style={{ marginTop: 8, fontSize: 9, color: COLORS.textMuted, letterSpacing: 0.5 }}>
         24h 趨勢
       </div>
       {loadingTs ? (
-        <div style={{ fontSize: 10, color: "rgba(255,255,255,0.4)", padding: "8px 4px", textAlign: "center" }}>
+        <div style={{ fontSize: 10, color: COLORS.textDim, padding: "8px 4px", textAlign: "center" }}>
           載入中…
         </div>
       ) : (
@@ -288,16 +288,16 @@ export function GroundwaterPanel({ props }: { props: Record<string, unknown> }) 
         <span style={{ fontSize: 22, fontWeight: 700, color: "#38bdf8" }}>
           {level != null ? level.toFixed(2) : "—"}
         </span>
-        <span style={{ fontSize: 10, color: "rgba(255,255,255,0.7)" }}>m 地下水位（海拔）</span>
+        <span style={{ fontSize: 10, color: COLORS.textDefault }}>m 地下水位（海拔）</span>
       </div>
       {obs && <Row label="觀測時間" value={formatTaiwanTime(obs).slice(0, 16)} />}
       <Row label="井號" value={String(props.station_id ?? "")} color="rgba(255,255,255,0.35)" />
 
-      <div style={{ marginTop: 8, fontSize: 9, color: "rgba(255,255,255,0.5)", letterSpacing: 0.5 }}>
+      <div style={{ marginTop: 8, fontSize: 9, color: COLORS.textMuted, letterSpacing: 0.5 }}>
         24h 趨勢
       </div>
       {loadingTs ? (
-        <div style={{ fontSize: 10, color: "rgba(255,255,255,0.4)", padding: "8px 4px", textAlign: "center" }}>
+        <div style={{ fontSize: 10, color: COLORS.textDim, padding: "8px 4px", textAlign: "center" }}>
           載入中…
         </div>
       ) : (
@@ -366,17 +366,17 @@ export function FloodSensorPanel({ props }: { props: Record<string, unknown> }) 
         <span style={{ fontSize: 22, fontWeight: 700, color }}>
           {depthCm.toFixed(1)}
         </span>
-        <span style={{ fontSize: 10, color: "rgba(255,255,255,0.7)" }}>{unit} 淹水深度</span>
+        <span style={{ fontSize: 10, color: COLORS.textDefault }}>{unit} 淹水深度</span>
       </div>
       {(county || town) && <Row label="區域" value={[county, town].filter(Boolean).join(" / ")} />}
       {admin && <Row label="管理單位" value={admin} />}
       {obs && <Row label="觀測時間" value={formatTaiwanTime(obs).slice(0, 16)} />}
 
-      <div style={{ marginTop: 8, fontSize: 9, color: "rgba(255,255,255,0.5)", letterSpacing: 0.5 }}>
+      <div style={{ marginTop: 8, fontSize: 9, color: COLORS.textMuted, letterSpacing: 0.5 }}>
         24h 趨勢
       </div>
       {loadingTs ? (
-        <div style={{ fontSize: 10, color: "rgba(255,255,255,0.4)", padding: "8px 4px", textAlign: "center" }}>
+        <div style={{ fontSize: 10, color: COLORS.textDim, padding: "8px 4px", textAlign: "center" }}>
           載入中…
         </div>
       ) : (
@@ -466,7 +466,7 @@ export function RainGaugePanel({ props }: { props: Record<string, unknown> }) {
         <span style={{ fontSize: 22, fontWeight: 700, color: level.color }}>
           {p10.toFixed(1)}
         </span>
-        <span style={{ fontSize: 10, color: "rgba(255,255,255,0.7)" }}>mm / 10 min</span>
+        <span style={{ fontSize: 10, color: COLORS.textDefault }}>mm / 10 min</span>
       </div>
       <Row label="1 小時累積" value={`${p1.toFixed(1)} mm`} />
       <Row label="3 小時累積" value={`${p3.toFixed(1)} mm`} />
@@ -475,11 +475,11 @@ export function RainGaugePanel({ props }: { props: Record<string, unknown> }) {
       {obs && <Row label="觀測時間" value={formatTaiwanTime(obs).slice(0, 16)} />}
       <Row label="站號" value={String(props.station_id ?? "")} color="rgba(255,255,255,0.35)" />
 
-      <div style={{ marginTop: 8, fontSize: 9, color: "rgba(255,255,255,0.5)", letterSpacing: 0.5 }}>
+      <div style={{ marginTop: 8, fontSize: 9, color: COLORS.textMuted, letterSpacing: 0.5 }}>
         24h 1 小時累積雨量
       </div>
       {loadingTs ? (
-        <div style={{ fontSize: 10, color: "rgba(255,255,255,0.4)", padding: "8px 4px", textAlign: "center" }}>
+        <div style={{ fontSize: 10, color: COLORS.textDim, padding: "8px 4px", textAlign: "center" }}>
           載入中…
         </div>
       ) : (
@@ -527,7 +527,7 @@ export function WaterReservoirContextPanel({ ctx }: { ctx: ReservoirContext }) {
               marginLeft: "auto",
               fontSize: 9,
               fontFamily: FONT_DATA,
-              color: "rgba(255,255,255,0.3)",
+              color: COLORS.textDim,
             }}
           >
             #{r.compare_id}
@@ -551,7 +551,7 @@ export function WaterReservoirContextPanel({ ctx }: { ctx: ReservoirContext }) {
           <span style={{ fontSize: 26, fontWeight: 700, color: accent, lineHeight: 1 }}>
             {storageRatio.toFixed(1)}
           </span>
-          <span style={{ fontSize: 11, color: "rgba(255,255,255,0.7)" }}>% 蓄水率</span>
+          <span style={{ fontSize: 11, color: COLORS.textDefault }}>% 蓄水率</span>
           {alert && (
             <span
               style={{

--- a/src/components/featureInfo/waterPanels.tsx
+++ b/src/components/featureInfo/waterPanels.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { TimeseriesSparkline, type SparklinePoint } from "../TimeseriesSparkline";
-import { COLORS, FONT_DATA } from "../../styles/designTokens";
+import { COLORS, FONT_DATA, RADIUS, FONT_SIZE } from "../../styles/designTokens";
 import { fetchFloodSensorTimeseries } from "../../data/floodSensorLoader";
 import { fetchRiverLevelTimeseries } from "../../data/riverLevelLoader";
 import { fetchGroundwaterTimeseries } from "../../data/groundwaterLoader";
@@ -44,8 +44,8 @@ export function WaterFacilityPanel({ props }: { props: Record<string, unknown> }
   return (
     <>
       <div style={{ display: "flex", alignItems: "center", gap: 6, marginBottom: 6 }}>
-        <div style={{ width: 10, height: 10, borderRadius: "50%", background: meta.color, flexShrink: 0 }} />
-        <div style={{ fontSize: 13, fontWeight: 700, color: "#fff", letterSpacing: 0.5 }}>
+        <div style={{ width: 10, height: 10, borderRadius: RADIUS.full, background: meta.color, flexShrink: 0 }} />
+        <div style={{ fontSize: FONT_SIZE.lg, fontWeight: 700, color: "#fff", letterSpacing: 0.5 }}>
           {String(props.name ?? "(未命名設施)")}
         </div>
       </div>
@@ -64,8 +64,8 @@ export function WaterMonitorPanel({ props }: { props: Record<string, unknown> })
   return (
     <>
       <div style={{ display: "flex", alignItems: "center", gap: 6, marginBottom: 6 }}>
-        <div style={{ width: 10, height: 10, borderRadius: "50%", background: meta.color, flexShrink: 0 }} />
-        <div style={{ fontSize: 13, fontWeight: 700, color: "#fff", letterSpacing: 0.5 }}>
+        <div style={{ width: 10, height: 10, borderRadius: RADIUS.full, background: meta.color, flexShrink: 0 }} />
+        <div style={{ fontSize: FONT_SIZE.lg, fontWeight: 700, color: "#fff", letterSpacing: 0.5 }}>
           {String(props.name ?? "(未命名站)")}
         </div>
       </div>
@@ -91,8 +91,8 @@ export function WaterDetentionBasinPanel({ props }: { props: Record<string, unkn
   return (
     <>
       <div style={{ display: "flex", alignItems: "center", gap: 6, marginBottom: 6 }}>
-        <div style={{ width: 10, height: 10, borderRadius: "50%", background: "#0284c7", flexShrink: 0 }} />
-        <div style={{ fontSize: 13, fontWeight: 700, color: "#fff", letterSpacing: 0.5 }}>
+        <div style={{ width: 10, height: 10, borderRadius: RADIUS.full, background: "#0284c7", flexShrink: 0 }} />
+        <div style={{ fontSize: FONT_SIZE.lg, fontWeight: 700, color: "#fff", letterSpacing: 0.5 }}>
           {String(props.name ?? "(未命名滯洪池)")}
         </div>
       </div>
@@ -133,8 +133,8 @@ export function WaterDamPanel({ props }: { props: Record<string, unknown> }) {
   return (
     <>
       <div style={{ display: "flex", alignItems: "center", gap: 6, marginBottom: 6 }}>
-        <div style={{ width: 10, height: 10, borderRadius: 2, background: accentColor, flexShrink: 0 }} />
-        <div style={{ fontSize: 13, fontWeight: 700, color: "#fff", letterSpacing: 0.5 }}>
+        <div style={{ width: 10, height: 10, borderRadius: RADIUS.sm, background: accentColor, flexShrink: 0 }} />
+        <div style={{ fontSize: FONT_SIZE.lg, fontWeight: 700, color: "#fff", letterSpacing: 0.5 }}>
           {String(props.name ?? "(未命名)")}
         </div>
       </div>
@@ -145,7 +145,7 @@ export function WaterDamPanel({ props }: { props: Record<string, unknown> }) {
       <Row label="壩高" value={props.dam_height_m ? `${props.dam_height_m} m` : ""} />
       <Row label="容量" value={capacityStr} />
       {isDam && (
-        <div style={{ marginTop: 8, fontSize: 10, color: hintColor, lineHeight: 1.5 }}>
+        <div style={{ marginTop: 8, fontSize: FONT_SIZE.sm, color: hintColor, lineHeight: 1.5 }}>
           ⓘ 此為壩體工程位置（壩牆出水口），與水庫水面中心點不重合屬正常
         </div>
       )}
@@ -183,17 +183,17 @@ export function RiverLevelPanel({ props }: { props: Record<string, unknown> }) {
   return (
     <>
       <div style={{ display: "flex", alignItems: "center", gap: 6, marginBottom: 6 }}>
-        <div style={{ width: 10, height: 10, borderRadius: "50%", background: color, flexShrink: 0 }} />
-        <div style={{ fontSize: 13, fontWeight: 700, color: "#fff", letterSpacing: 0.5 }}>
+        <div style={{ width: 10, height: 10, borderRadius: RADIUS.full, background: color, flexShrink: 0 }} />
+        <div style={{ fontSize: FONT_SIZE.lg, fontWeight: 700, color: "#fff", letterSpacing: 0.5 }}>
           {String(props.station_name ?? "(未命名站)")}
         </div>
         {abnormal && (
           <div
             style={{
               marginLeft: "auto",
-              fontSize: 10,
+              fontSize: FONT_SIZE.sm,
               padding: "2px 8px",
-              borderRadius: 3,
+              borderRadius: RADIUS.md,
               background: color,
               color: "#fff",
               fontWeight: 600,
@@ -211,30 +211,30 @@ export function RiverLevelPanel({ props }: { props: Record<string, unknown> }) {
           marginTop: 4,
           padding: "6px 8px",
           background: "rgba(34,211,238,0.08)",
-          borderRadius: 4,
+          borderRadius: RADIUS.md,
         }}
       >
-        <span style={{ fontSize: 22, fontWeight: 700, color }}>
+        <span style={{ fontSize: FONT_SIZE.xxl, fontWeight: 700, color }}>
           {level.toFixed(2)}
         </span>
-        <span style={{ fontSize: 10, color: COLORS.textDefault }}>m 水位</span>
+        <span style={{ fontSize: FONT_SIZE.sm, color: COLORS.textDefault }}>m 水位</span>
       </div>
       <Row label="縣市" value={String(props.county ?? "")} />
       {obs && <Row label="觀測時間" value={formatTaiwanTime(obs).slice(0, 16)} />}
       <Row label="站號" value={String(props.station_id ?? "")} color="rgba(255,255,255,0.35)" />
 
-      <div style={{ marginTop: 8, fontSize: 9, color: COLORS.textMuted, letterSpacing: 0.5 }}>
+      <div style={{ marginTop: 8, fontSize: FONT_SIZE.xs, color: COLORS.textMuted, letterSpacing: 0.5 }}>
         24h 趨勢
       </div>
       {loadingTs ? (
-        <div style={{ fontSize: 10, color: COLORS.textDim, padding: "8px 4px", textAlign: "center" }}>
+        <div style={{ fontSize: FONT_SIZE.sm, color: COLORS.textDim, padding: "8px 4px", textAlign: "center" }}>
           載入中…
         </div>
       ) : (
         <TimeseriesSparkline data={series} unit="m" lineColor={color} height={120} />
       )}
 
-      <div style={{ marginTop: 8, fontSize: 10, color: "rgba(150,200,255,0.6)", lineHeight: 1.5 }}>
+      <div style={{ marginTop: 8, fontSize: FONT_SIZE.sm, color: "rgba(150,200,255,0.6)", lineHeight: 1.5 }}>
         ⓘ 警戒水位資料（三級警戒）待上游 seed 補齊後加入
       </div>
     </>
@@ -269,8 +269,8 @@ export function GroundwaterPanel({ props }: { props: Record<string, unknown> }) 
   return (
     <>
       <div style={{ display: "flex", alignItems: "center", gap: 6, marginBottom: 6 }}>
-        <div style={{ width: 10, height: 10, borderRadius: "50%", background: "#0ea5e9", flexShrink: 0 }} />
-        <div style={{ fontSize: 13, fontWeight: 700, color: "#fff", letterSpacing: 0.5 }}>
+        <div style={{ width: 10, height: 10, borderRadius: RADIUS.full, background: "#0ea5e9", flexShrink: 0 }} />
+        <div style={{ fontSize: FONT_SIZE.lg, fontWeight: 700, color: "#fff", letterSpacing: 0.5 }}>
           {String(props.well_name ?? "(未命名井)")}
         </div>
       </div>
@@ -282,22 +282,22 @@ export function GroundwaterPanel({ props }: { props: Record<string, unknown> }) 
           marginTop: 4,
           padding: "6px 8px",
           background: "rgba(14,165,233,0.1)",
-          borderRadius: 4,
+          borderRadius: RADIUS.md,
         }}
       >
-        <span style={{ fontSize: 22, fontWeight: 700, color: "#38bdf8" }}>
+        <span style={{ fontSize: FONT_SIZE.xxl, fontWeight: 700, color: "#38bdf8" }}>
           {level != null ? level.toFixed(2) : "—"}
         </span>
-        <span style={{ fontSize: 10, color: COLORS.textDefault }}>m 地下水位（海拔）</span>
+        <span style={{ fontSize: FONT_SIZE.sm, color: COLORS.textDefault }}>m 地下水位（海拔）</span>
       </div>
       {obs && <Row label="觀測時間" value={formatTaiwanTime(obs).slice(0, 16)} />}
       <Row label="井號" value={String(props.station_id ?? "")} color="rgba(255,255,255,0.35)" />
 
-      <div style={{ marginTop: 8, fontSize: 9, color: COLORS.textMuted, letterSpacing: 0.5 }}>
+      <div style={{ marginTop: 8, fontSize: FONT_SIZE.xs, color: COLORS.textMuted, letterSpacing: 0.5 }}>
         24h 趨勢
       </div>
       {loadingTs ? (
-        <div style={{ fontSize: 10, color: COLORS.textDim, padding: "8px 4px", textAlign: "center" }}>
+        <div style={{ fontSize: FONT_SIZE.sm, color: COLORS.textDim, padding: "8px 4px", textAlign: "center" }}>
           載入中…
         </div>
       ) : (
@@ -344,13 +344,13 @@ export function FloodSensorPanel({ props }: { props: Record<string, unknown> }) 
   return (
     <>
       <div style={{ display: "flex", alignItems: "center", gap: 6, marginBottom: 6 }}>
-        <div style={{ width: 10, height: 10, borderRadius: "50%", background: color, flexShrink: 0 }} />
-        <div style={{ fontSize: 13, fontWeight: 700, color: "#fff", letterSpacing: 0.5, flex: 1, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+        <div style={{ width: 10, height: 10, borderRadius: RADIUS.full, background: color, flexShrink: 0 }} />
+        <div style={{ fontSize: FONT_SIZE.lg, fontWeight: 700, color: "#fff", letterSpacing: 0.5, flex: 1, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
           {name}
         </div>
         {depthCm > 0 && (
           <div style={{
-            marginLeft: "auto", fontSize: 10, padding: "1px 6px", borderRadius: 3,
+            marginLeft: "auto", fontSize: FONT_SIZE.sm, padding: "1px 6px", borderRadius: RADIUS.md,
             background: color, color: "#fff", fontWeight: 600,
           }}>
             {level}
@@ -360,23 +360,23 @@ export function FloodSensorPanel({ props }: { props: Record<string, unknown> }) 
       <div
         style={{
           display: "flex", alignItems: "baseline", gap: 8, marginTop: 4,
-          padding: "6px 8px", background: `${color}1a`, borderRadius: 4,
+          padding: "6px 8px", background: `${color}1a`, borderRadius: RADIUS.md,
         }}
       >
-        <span style={{ fontSize: 22, fontWeight: 700, color }}>
+        <span style={{ fontSize: FONT_SIZE.xxl, fontWeight: 700, color }}>
           {depthCm.toFixed(1)}
         </span>
-        <span style={{ fontSize: 10, color: COLORS.textDefault }}>{unit} 淹水深度</span>
+        <span style={{ fontSize: FONT_SIZE.sm, color: COLORS.textDefault }}>{unit} 淹水深度</span>
       </div>
       {(county || town) && <Row label="區域" value={[county, town].filter(Boolean).join(" / ")} />}
       {admin && <Row label="管理單位" value={admin} />}
       {obs && <Row label="觀測時間" value={formatTaiwanTime(obs).slice(0, 16)} />}
 
-      <div style={{ marginTop: 8, fontSize: 9, color: COLORS.textMuted, letterSpacing: 0.5 }}>
+      <div style={{ marginTop: 8, fontSize: FONT_SIZE.xs, color: COLORS.textMuted, letterSpacing: 0.5 }}>
         24h 趨勢
       </div>
       {loadingTs ? (
-        <div style={{ fontSize: 10, color: COLORS.textDim, padding: "8px 4px", textAlign: "center" }}>
+        <div style={{ fontSize: FONT_SIZE.sm, color: COLORS.textDim, padding: "8px 4px", textAlign: "center" }}>
           載入中…
         </div>
       ) : (
@@ -434,16 +434,16 @@ export function RainGaugePanel({ props }: { props: Record<string, unknown> }) {
   return (
     <>
       <div style={{ display: "flex", alignItems: "center", gap: 6, marginBottom: 6 }}>
-        <div style={{ width: 10, height: 10, borderRadius: "50%", background: level.color, flexShrink: 0 }} />
-        <div style={{ fontSize: 13, fontWeight: 700, color: "#fff", letterSpacing: 0.5 }}>
+        <div style={{ width: 10, height: 10, borderRadius: RADIUS.full, background: level.color, flexShrink: 0 }} />
+        <div style={{ fontSize: FONT_SIZE.lg, fontWeight: 700, color: "#fff", letterSpacing: 0.5 }}>
           {String(props.station_name ?? "(未命名站)")}
         </div>
         <div
           style={{
             marginLeft: "auto",
-            fontSize: 10,
+            fontSize: FONT_SIZE.sm,
             padding: "2px 8px",
-            borderRadius: 3,
+            borderRadius: RADIUS.md,
             background: level.color,
             color: "#fff",
             fontWeight: 600,
@@ -460,13 +460,13 @@ export function RainGaugePanel({ props }: { props: Record<string, unknown> }) {
           marginTop: 4,
           padding: "6px 8px",
           background: "rgba(59,130,246,0.08)",
-          borderRadius: 4,
+          borderRadius: RADIUS.md,
         }}
       >
-        <span style={{ fontSize: 22, fontWeight: 700, color: level.color }}>
+        <span style={{ fontSize: FONT_SIZE.xxl, fontWeight: 700, color: level.color }}>
           {p10.toFixed(1)}
         </span>
-        <span style={{ fontSize: 10, color: COLORS.textDefault }}>mm / 10 min</span>
+        <span style={{ fontSize: FONT_SIZE.sm, color: COLORS.textDefault }}>mm / 10 min</span>
       </div>
       <Row label="1 小時累積" value={`${p1.toFixed(1)} mm`} />
       <Row label="3 小時累積" value={`${p3.toFixed(1)} mm`} />
@@ -475,11 +475,11 @@ export function RainGaugePanel({ props }: { props: Record<string, unknown> }) {
       {obs && <Row label="觀測時間" value={formatTaiwanTime(obs).slice(0, 16)} />}
       <Row label="站號" value={String(props.station_id ?? "")} color="rgba(255,255,255,0.35)" />
 
-      <div style={{ marginTop: 8, fontSize: 9, color: COLORS.textMuted, letterSpacing: 0.5 }}>
+      <div style={{ marginTop: 8, fontSize: FONT_SIZE.xs, color: COLORS.textMuted, letterSpacing: 0.5 }}>
         24h 1 小時累積雨量
       </div>
       {loadingTs ? (
-        <div style={{ fontSize: 10, color: COLORS.textDim, padding: "8px 4px", textAlign: "center" }}>
+        <div style={{ fontSize: FONT_SIZE.sm, color: COLORS.textDim, padding: "8px 4px", textAlign: "center" }}>
           載入中…
         </div>
       ) : (
@@ -517,15 +517,15 @@ export function WaterReservoirContextPanel({ ctx }: { ctx: ReservoirContext }) {
   return (
     <>
       <div style={{ display: "flex", alignItems: "center", gap: 6, marginBottom: 8 }}>
-        <div style={{ width: 10, height: 10, borderRadius: 2, background: accent, flexShrink: 0 }} />
-        <div style={{ fontSize: 13, fontWeight: 700, color: "#fff", letterSpacing: 0.5 }}>
+        <div style={{ width: 10, height: 10, borderRadius: RADIUS.sm, background: accent, flexShrink: 0 }} />
+        <div style={{ fontSize: FONT_SIZE.lg, fontWeight: 700, color: "#fff", letterSpacing: 0.5 }}>
           {r?.res_name ?? "(未命名水庫)"}
         </div>
         {r?.compare_id != null && (
           <div
             style={{
               marginLeft: "auto",
-              fontSize: 9,
+              fontSize: FONT_SIZE.xs,
               fontFamily: FONT_DATA,
               color: COLORS.textDim,
             }}
@@ -544,21 +544,21 @@ export function WaterReservoirContextPanel({ ctx }: { ctx: ReservoirContext }) {
             marginBottom: 6,
             padding: "8px 10px",
             background: "rgba(34,211,238,0.08)",
-            borderRadius: 4,
+            borderRadius: RADIUS.md,
             border: "1px solid rgba(34,211,238,0.2)",
           }}
         >
           <span style={{ fontSize: 26, fontWeight: 700, color: accent, lineHeight: 1 }}>
             {storageRatio.toFixed(1)}
           </span>
-          <span style={{ fontSize: 11, color: COLORS.textDefault }}>% 蓄水率</span>
+          <span style={{ fontSize: FONT_SIZE.base, color: COLORS.textDefault }}>% 蓄水率</span>
           {alert && (
             <span
               style={{
                 marginLeft: "auto",
-                fontSize: 10,
+                fontSize: FONT_SIZE.sm,
                 padding: "2px 8px",
-                borderRadius: 3,
+                borderRadius: RADIUS.md,
                 background: alertColor,
                 color: "#fff",
                 fontWeight: 600,
@@ -639,14 +639,14 @@ export function WaterReservoirPolyPanel({ props }: { props: Record<string, unkno
   return (
     <>
       <div style={{ display: "flex", alignItems: "center", gap: 6, marginBottom: 6 }}>
-        <div style={{ width: 10, height: 10, borderRadius: 2, background: accent, flexShrink: 0 }} />
-        <div style={{ fontSize: 13, fontWeight: 700, color: "#fff", letterSpacing: 0.5 }}>
+        <div style={{ width: 10, height: 10, borderRadius: RADIUS.sm, background: accent, flexShrink: 0 }} />
+        <div style={{ fontSize: FONT_SIZE.lg, fontWeight: 700, color: "#fff", letterSpacing: 0.5 }}>
           {name}
         </div>
       </div>
       <Row label="類別" value="蓄水水面範圍" color={accent} />
       <Row label="資料源" value="WRA GIC reservoir_storage" />
-      <div style={{ marginTop: 8, fontSize: 10, color: "rgba(150,200,255,0.6)", lineHeight: 1.5 }}>
+      <div style={{ marginTop: 8, fontSize: FONT_SIZE.sm, color: "rgba(150,200,255,0.6)", lineHeight: 1.5 }}>
         ⓘ 此為水庫實際水面輪廓，部分水庫（如台電管的明潭、明湖下池）僅有面、無單獨點位
       </div>
     </>

--- a/src/components/intel/IntelCard.tsx
+++ b/src/components/intel/IntelCard.tsx
@@ -1,6 +1,7 @@
 import type { CSSProperties } from "react";
 import { IntelIcon, ICON } from "./IntelIcon";
 import { COLORS, FONT_CJK, FONT_DATA, GIS_LEVELS, SEV_LEVELS, relTime, clockTime } from "./intelTokens";
+import { RADIUS, FONT_SIZE } from "../../styles/designTokens";
 import { getNewsCategoryDef } from "../../data/newsEventTypes";
 import type { ClusterEvent } from "../../data/newsEventsLoader";
 import { useWallClock } from "../../hooks/useWallClock";
@@ -31,7 +32,7 @@ const btnGhost: CSSProperties = {
   alignItems: "center",
   gap: 5,
   padding: "5px 10px",
-  borderRadius: 4,
+  borderRadius: RADIUS.md,
   whiteSpace: "nowrap",
   background: "rgba(255,255,255,0.04)",
   border: `1px solid ${COLORS.borderMid}`,
@@ -71,7 +72,7 @@ export function IntelCard({ e, selected, expanded, trending, onSelect, onToggle,
           top: 14,
           width: 11,
           height: 11,
-          borderRadius: "50%",
+          borderRadius: RADIUS.full,
           background: cat.color,
           border: "2px solid #0a0a14",
           zIndex: 1,
@@ -82,7 +83,7 @@ export function IntelCard({ e, selected, expanded, trending, onSelect, onToggle,
         onClick={handleClick}
         style={{
           cursor: "pointer",
-          borderRadius: 8,
+          borderRadius: RADIUS.xl,
           padding: "11px 13px",
           background: selected ? "rgba(100,170,255,0.08)" : "rgba(255,255,255,0.022)",
           border: `1px solid ${selected ? COLORS.borderAccent : COLORS.borderSoft}`,
@@ -98,13 +99,13 @@ export function IntelCard({ e, selected, expanded, trending, onSelect, onToggle,
               gap: 4,
               padding: "1px 7px",
               whiteSpace: "nowrap",
-              borderRadius: 3,
+              borderRadius: RADIUS.md,
               background: `${cat.color}22`,
               border: `1px solid ${cat.color}66`,
             }}
           >
-            <span style={{ width: 6, height: 6, borderRadius: "50%", background: cat.color }} />
-            <span style={{ fontFamily: FONT_CJK, fontSize: 10, color: cat.color, fontWeight: 600 }}>
+            <span style={{ width: 6, height: 6, borderRadius: RADIUS.full, background: cat.color }} />
+            <span style={{ fontFamily: FONT_CJK, fontSize: FONT_SIZE.sm, color: cat.color, fontWeight: 600 }}>
               {cat.label}
             </span>
           </span>
@@ -119,7 +120,7 @@ export function IntelCard({ e, selected, expanded, trending, onSelect, onToggle,
                 color: COLORS.surge,
                 whiteSpace: "nowrap",
                 padding: "1px 6px",
-                borderRadius: 3,
+                borderRadius: RADIUS.md,
                 background: "rgba(255,152,0,0.14)",
                 border: "1px solid rgba(255,152,0,0.4)",
               }}
@@ -135,7 +136,7 @@ export function IntelCard({ e, selected, expanded, trending, onSelect, onToggle,
                 color: COLORS.statusWarn,
                 whiteSpace: "nowrap",
                 padding: "1px 6px",
-                borderRadius: 3,
+                borderRadius: RADIUS.md,
                 background: "rgba(255,152,0,0.12)",
                 border: "1px solid rgba(255,152,0,0.35)",
               }}
@@ -151,7 +152,7 @@ export function IntelCard({ e, selected, expanded, trending, onSelect, onToggle,
                 color: COLORS.textDim,
                 whiteSpace: "nowrap",
                 padding: "1px 6px",
-                borderRadius: 3,
+                borderRadius: RADIUS.md,
                 background: "rgba(255,255,255,0.04)",
                 border: `1px solid ${COLORS.borderSoft}`,
               }}
@@ -198,7 +199,7 @@ export function IntelCard({ e, selected, expanded, trending, onSelect, onToggle,
               marginBottom: 5,
               whiteSpace: "nowrap",
               fontFamily: FONT_DATA,
-              fontSize: 10,
+              fontSize: FONT_SIZE.sm,
               color: COLORS.textDim,
             }}
           >
@@ -221,7 +222,7 @@ export function IntelCard({ e, selected, expanded, trending, onSelect, onToggle,
           <div
             style={{
               fontFamily: FONT_CJK,
-              fontSize: 11,
+              fontSize: FONT_SIZE.base,
               color: COLORS.textDefault,
               lineHeight: 1.55,
               display: expanded ? "block" : "-webkit-box",
@@ -270,7 +271,7 @@ export function IntelCard({ e, selected, expanded, trending, onSelect, onToggle,
               style={{
                 marginLeft: "auto",
                 fontFamily: FONT_DATA,
-                fontSize: 9,
+                fontSize: FONT_SIZE.xs,
                 color: COLORS.textFaint,
               }}
             >
@@ -298,7 +299,7 @@ export function IntelCard({ e, selected, expanded, trending, onSelect, onToggle,
                 gridTemplateColumns: "auto 1fr",
                 gap: "3px 10px",
                 fontFamily: FONT_DATA,
-                fontSize: 10,
+                fontSize: FONT_SIZE.sm,
               }}
             >
               {e.county && (
@@ -353,7 +354,7 @@ export function IntelCard({ e, selected, expanded, trending, onSelect, onToggle,
                     alignItems: "center",
                     gap: 5,
                     padding: "5px 10px",
-                    borderRadius: 4,
+                    borderRadius: RADIUS.md,
                     whiteSpace: "nowrap",
                     background: `${cat.color}22`,
                     border: `1px solid ${cat.color}55`,

--- a/src/components/intel/IntelFilters.tsx
+++ b/src/components/intel/IntelFilters.tsx
@@ -1,5 +1,6 @@
 import type { CSSProperties } from "react";
 import { COLORS, FONT_CJK, FONT_DATA, COUNTY_OPTIONS } from "./intelTokens";
+import { RADIUS, FONT_SIZE } from "../../styles/designTokens";
 import { NEWS_CATEGORIES, type NewsCategory } from "../../data/newsEventTypes";
 
 export type TimeRange = "1h" | "6h" | "24h";
@@ -31,10 +32,10 @@ function chip(active: boolean): CSSProperties {
     display: "inline-flex",
     alignItems: "center",
     padding: "3px 9px",
-    borderRadius: 4,
+    borderRadius: RADIUS.md,
     cursor: "pointer",
     fontFamily: FONT_CJK,
-    fontSize: 11,
+    fontSize: FONT_SIZE.base,
     whiteSpace: "nowrap",
     background: active ? "rgba(255,255,255,0.12)" : "rgba(255,255,255,0.03)",
     border: `1px solid ${active ? COLORS.borderStrong : COLORS.borderSoft}`,
@@ -46,7 +47,7 @@ function chip(active: boolean): CSSProperties {
 function segBtn(active: boolean): CSSProperties {
   return {
     padding: "3px 10px",
-    borderRadius: 4,
+    borderRadius: RADIUS.md,
     border: "none",
     cursor: "pointer",
     whiteSpace: "nowrap",
@@ -92,10 +93,10 @@ export function IntelFilters({
                 alignItems: "center",
                 gap: 5,
                 padding: "3px 9px",
-                borderRadius: 4,
+                borderRadius: RADIUS.md,
                 cursor: "pointer",
                 fontFamily: FONT_CJK,
-                fontSize: 11,
+                fontSize: FONT_SIZE.base,
                 whiteSpace: "nowrap",
                 background: on ? `${c.color}26` : "rgba(255,255,255,0.03)",
                 border: `1px solid ${on ? c.color : COLORS.borderSoft}`,
@@ -107,7 +108,7 @@ export function IntelFilters({
                 style={{
                   width: 7,
                   height: 7,
-                  borderRadius: "50%",
+                  borderRadius: RADIUS.full,
                   background: c.color,
                   opacity: on ? 1 : 0.5,
                 }}
@@ -120,13 +121,13 @@ export function IntelFilters({
 
       {/* time range + 相關度（同一橫排） */}
       <div style={{ display: "flex", alignItems: "center", gap: 6, flexWrap: "wrap" }}>
-        <span style={{ fontFamily: FONT_CJK, fontSize: 10, color: COLORS.textFaint }}>近</span>
+        <span style={{ fontFamily: FONT_CJK, fontSize: FONT_SIZE.sm, color: COLORS.textFaint }}>近</span>
         <div
           style={{
             display: "flex",
             background: "rgba(0,0,0,0.4)",
             border: `1px solid ${COLORS.borderSoft}`,
-            borderRadius: 6,
+            borderRadius: RADIUS.lg,
             padding: 2,
             gap: 2,
           }}
@@ -137,7 +138,7 @@ export function IntelFilters({
             </button>
           ))}
         </div>
-        <span style={{ fontFamily: FONT_CJK, fontSize: 10, color: COLORS.textFaint, marginLeft: 6 }}>
+        <span style={{ fontFamily: FONT_CJK, fontSize: FONT_SIZE.sm, color: COLORS.textFaint, marginLeft: 6 }}>
           相關度
         </span>
         <div
@@ -145,7 +146,7 @@ export function IntelFilters({
             display: "flex",
             background: "rgba(0,0,0,0.4)",
             border: `1px solid ${COLORS.borderSoft}`,
-            borderRadius: 6,
+            borderRadius: RADIUS.lg,
             padding: 2,
             gap: 2,
           }}
@@ -171,7 +172,7 @@ export function IntelFilters({
             fontFamily: FONT_CJK,
             fontSize: 10.5,
             padding: "4px 10px",
-            borderRadius: 6,
+            borderRadius: RADIUS.lg,
             background: "rgba(0,0,0,0.45)",
             color: county === "全部" ? COLORS.textMuted : "#fff",
             border: `1px solid ${COLORS.borderMid}`,
@@ -193,7 +194,7 @@ export function IntelFilters({
             alignItems: "center",
             gap: 5,
             padding: "3px 9px",
-            borderRadius: 5,
+            borderRadius: RADIUS.lg,
             cursor: "pointer",
             fontFamily: FONT_CJK,
             fontSize: 10.5,
@@ -208,14 +209,14 @@ export function IntelFilters({
             style={{
               width: 12,
               height: 12,
-              borderRadius: 3,
+              borderRadius: RADIUS.md,
               display: "flex",
               alignItems: "center",
               justifyContent: "center",
               border: eventsOnly ? "none" : `1px solid ${COLORS.borderStrong}`,
               background: eventsOnly ? COLORS.accent : "transparent",
               color: "#04121f",
-              fontSize: 9,
+              fontSize: FONT_SIZE.xs,
               fontWeight: 700,
               fontFamily: FONT_DATA,
             }}

--- a/src/components/intel/IntelHeader.tsx
+++ b/src/components/intel/IntelHeader.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { IntelIcon, ICON } from "./IntelIcon";
 import { COLORS, FONT_CJK, FONT_DATA, clockTime, fmtCountdown } from "./intelTokens";
+import { RADIUS, FONT_SIZE } from "../../styles/designTokens";
 import type { SourceHealthSummary, SourceStatus } from "../../data/intelLoaders";
 
 interface Props {
@@ -50,7 +51,7 @@ export function IntelHeader({ totalCount, lastUpdateTs, countdownSec, sourceHeal
           <span style={{ fontFamily: FONT_CJK, fontSize: 13.5, fontWeight: 700, color: COLORS.textStrong }}>
             即時情報
           </span>
-          <span style={{ fontFamily: FONT_DATA, fontSize: 9, letterSpacing: "2.5px", color: COLORS.textDim }}>
+          <span style={{ fontFamily: FONT_DATA, fontSize: FONT_SIZE.xs, letterSpacing: "2.5px", color: COLORS.textDim }}>
             INTEL
           </span>
         </div>
@@ -61,7 +62,7 @@ export function IntelHeader({ totalCount, lastUpdateTs, countdownSec, sourceHeal
             gap: 5,
             marginLeft: 6,
             padding: "2px 8px",
-            borderRadius: 4,
+            borderRadius: RADIUS.md,
             background: COLORS.statusLiveSoft,
             border: `1px solid ${COLORS.statusLiveBorder}`,
           }}
@@ -70,13 +71,13 @@ export function IntelHeader({ totalCount, lastUpdateTs, countdownSec, sourceHeal
             style={{
               width: 6,
               height: 6,
-              borderRadius: "50%",
+              borderRadius: RADIUS.full,
               background: COLORS.statusLive,
               boxShadow: `0 0 6px ${COLORS.statusLive}`,
               animation: "intelRing 1.6s ease-in-out infinite",
             }}
           />
-          <span style={{ fontFamily: FONT_DATA, fontSize: 10, fontWeight: 700, color: COLORS.statusLive }}>
+          <span style={{ fontFamily: FONT_DATA, fontSize: FONT_SIZE.sm, fontWeight: 700, color: COLORS.statusLive }}>
             LIVE
           </span>
         </span>
@@ -87,7 +88,7 @@ export function IntelHeader({ totalCount, lastUpdateTs, countdownSec, sourceHeal
           style={{
             width: 24,
             height: 24,
-            borderRadius: 4,
+            borderRadius: RADIUS.md,
             border: "none",
             background: "transparent",
             color: COLORS.textDim,
@@ -112,7 +113,7 @@ export function IntelHeader({ totalCount, lastUpdateTs, countdownSec, sourceHeal
           gap: 10,
           whiteSpace: "nowrap",
           fontFamily: FONT_DATA,
-          fontSize: 10,
+          fontSize: FONT_SIZE.sm,
         }}
       >
         <span style={{ color: COLORS.textMuted }}>更新 {clockTime(lastUpdateTs)}</span>
@@ -126,7 +127,7 @@ export function IntelHeader({ totalCount, lastUpdateTs, countdownSec, sourceHeal
             gap: 5,
             marginLeft: "auto",
             padding: "2px 7px",
-            borderRadius: 4,
+            borderRadius: RADIUS.md,
             background: "rgba(255,255,255,0.04)",
             border: `1px solid ${COLORS.borderSoft}`,
             cursor: "pointer",
@@ -139,7 +140,7 @@ export function IntelHeader({ totalCount, lastUpdateTs, countdownSec, sourceHeal
             style={{
               width: 6,
               height: 6,
-              borderRadius: "50%",
+              borderRadius: RADIUS.full,
               background: degraded ? COLORS.statusWarn : COLORS.statusLive,
             }}
           />
@@ -166,7 +167,7 @@ export function IntelHeader({ totalCount, lastUpdateTs, countdownSec, sourceHeal
           <div
             style={{
               fontFamily: FONT_DATA,
-              fontSize: 9,
+              fontSize: FONT_SIZE.xs,
               letterSpacing: "1.5px",
               color: COLORS.textFaint,
               marginBottom: 6,
@@ -175,7 +176,7 @@ export function IntelHeader({ totalCount, lastUpdateTs, countdownSec, sourceHeal
             來源管線 PIPELINE · RSS×{total} → Gemini 地理編碼
           </div>
           {total === 0 ? (
-            <div style={{ fontFamily: FONT_CJK, fontSize: 10, color: COLORS.textFaint }}>
+            <div style={{ fontFamily: FONT_CJK, fontSize: FONT_SIZE.sm, color: COLORS.textFaint }}>
               尚無資料（collector 還沒回報過）
             </div>
           ) : (
@@ -187,7 +188,7 @@ export function IntelHeader({ totalCount, lastUpdateTs, countdownSec, sourceHeal
                       style={{
                         width: 5,
                         height: 5,
-                        borderRadius: "50%",
+                        borderRadius: RADIUS.full,
                         flexShrink: 0,
                         background: STATUS_COLOR[f.status],
                       }}
@@ -196,7 +197,7 @@ export function IntelHeader({ totalCount, lastUpdateTs, countdownSec, sourceHeal
                       title={f.feed_url}
                       style={{
                         fontFamily: FONT_CJK,
-                        fontSize: 10,
+                        fontSize: FONT_SIZE.sm,
                         color: COLORS.textDefault,
                         whiteSpace: "nowrap",
                         overflow: "hidden",
@@ -209,7 +210,7 @@ export function IntelHeader({ totalCount, lastUpdateTs, countdownSec, sourceHeal
                       style={{
                         marginLeft: "auto",
                         fontFamily: FONT_DATA,
-                        fontSize: 9,
+                        fontSize: FONT_SIZE.xs,
                         color: f.status === "ok" ? COLORS.textFaint : STATUS_COLOR[f.status],
                       }}
                     >

--- a/src/components/intel/IntelPanel.tsx
+++ b/src/components/intel/IntelPanel.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { COLORS, FONT_CJK, FONT_DATA, type AlertGroupShort } from "./intelTokens";
+import { ELEVATION } from "../../styles/designTokens";
 import { IntelIcon, ICON } from "./IntelIcon";
 import { IntelHeader } from "./IntelHeader";
 import { IntelReplay } from "./IntelReplay";
@@ -322,7 +323,7 @@ export function IntelPanel({
         flexDirection: "column",
         overflow: "hidden",
         pointerEvents: "auto",
-        boxShadow: "0 12px 40px rgba(0,0,0,0.45)",
+        boxShadow: ELEVATION.lg,
         animation: "intelPanelFadeIn .25s ease-out",
         color: COLORS.textDefault,
       }}

--- a/src/components/intel/IntelPanel.tsx
+++ b/src/components/intel/IntelPanel.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { COLORS, FONT_CJK, FONT_DATA, type AlertGroupShort } from "./intelTokens";
-import { ELEVATION } from "../../styles/designTokens";
+import { ELEVATION, RADIUS, FONT_SIZE } from "../../styles/designTokens";
 import { IntelIcon, ICON } from "./IntelIcon";
 import { IntelHeader } from "./IntelHeader";
 import { IntelReplay } from "./IntelReplay";
@@ -317,7 +317,7 @@ export function IntelPanel({
         backdropFilter: "blur(16px)",
         WebkitBackdropFilter: "blur(16px)",
         border: `1px solid ${COLORS.panelBorder}`,
-        borderRadius: 10,
+        borderRadius: RADIUS.xl,
         zIndex: 30,
         display: "flex",
         flexDirection: "column",
@@ -378,7 +378,7 @@ export function IntelPanel({
         >
           <span
             style={{
-              fontFamily: FONT_DATA, fontSize: 9, letterSpacing: "1.5px",
+              fontFamily: FONT_DATA, fontSize: FONT_SIZE.xs, letterSpacing: "1.5px",
               color: COLORS.textFaint, marginRight: 4,
             }}
           >
@@ -392,7 +392,7 @@ export function IntelPanel({
                 key={lv}
                 onClick={() => setSeverityMin(lv)}
                 style={{
-                  padding: "3px 9px", borderRadius: 4,
+                  padding: "3px 9px", borderRadius: RADIUS.md,
                   background: active ? COLORS.accentFaint : "rgba(255,255,255,0.04)",
                   border: `1px solid ${active ? COLORS.accentSoft : COLORS.borderMid}`,
                   color: active ? COLORS.accent : COLORS.textMuted,
@@ -409,7 +409,7 @@ export function IntelPanel({
               <button
                 onClick={() => setPickedGroups([])}
                 style={{
-                  padding: "3px 8px", borderRadius: 4,
+                  padding: "3px 8px", borderRadius: RADIUS.md,
                   background: "rgba(255,255,255,0.04)",
                   border: `1px solid ${COLORS.borderMid}`,
                   color: COLORS.textMuted, fontFamily: FONT_CJK, fontSize: 10.5,
@@ -431,7 +431,7 @@ export function IntelPanel({
         >
           <span
             style={{
-              fontFamily: FONT_DATA, fontSize: 9, letterSpacing: "1.5px",
+              fontFamily: FONT_DATA, fontSize: FONT_SIZE.xs, letterSpacing: "1.5px",
               color: COLORS.textFaint, marginRight: 4,
             }}
           >
@@ -444,7 +444,7 @@ export function IntelPanel({
                 key={r}
                 onClick={() => setTimeRange(r)}
                 style={{
-                  padding: "3px 10px", borderRadius: 4,
+                  padding: "3px 10px", borderRadius: RADIUS.md,
                   background: active ? COLORS.accentFaint : "rgba(255,255,255,0.04)",
                   border: `1px solid ${active ? COLORS.accentSoft : COLORS.borderMid}`,
                   color: active ? COLORS.accent : COLORS.textMuted,
@@ -478,7 +478,7 @@ export function IntelPanel({
               }}
             >
               <IntelIcon d={ICON.alert} size={28} color={COLORS.textGhost} />
-              <div style={{ fontFamily: FONT_CJK, fontSize: 12, color: COLORS.textMuted }}>
+              <div style={{ fontFamily: FONT_CJK, fontSize: FONT_SIZE.md, color: COLORS.textMuted }}>
                 目前無符合條件的警報
               </div>
             </div>
@@ -524,7 +524,7 @@ export function IntelPanel({
                   }}
                 >
                   <IntelIcon d={ICON.radio} size={28} color={COLORS.textGhost} />
-                  <div style={{ fontFamily: FONT_CJK, fontSize: 12, color: COLORS.textMuted }}>
+                  <div style={{ fontFamily: FONT_CJK, fontSize: FONT_SIZE.md, color: COLORS.textMuted }}>
                     目前無事件 / 警報
                   </div>
                 </div>
@@ -580,10 +580,10 @@ export function IntelPanel({
             }}
           >
             <IntelIcon d={ICON.radio} size={28} color={COLORS.textGhost} />
-            <div style={{ fontFamily: FONT_CJK, fontSize: 12, color: COLORS.textMuted }}>
+            <div style={{ fontFamily: FONT_CJK, fontSize: FONT_SIZE.md, color: COLORS.textMuted }}>
               目前無符合條件的事件
             </div>
-            <div style={{ fontFamily: FONT_CJK, fontSize: 10, color: COLORS.textFaint }}>
+            <div style={{ fontFamily: FONT_CJK, fontSize: FONT_SIZE.sm, color: COLORS.textFaint }}>
               調整分類 / 時間範圍 / 縣市，或回到即時
             </div>
           </div>

--- a/src/components/intel/IntelReplay.tsx
+++ b/src/components/intel/IntelReplay.tsx
@@ -1,5 +1,6 @@
 import { IntelIcon, ICON } from "./IntelIcon";
 import { COLORS, FONT_DATA, clockTime } from "./intelTokens";
+import { RADIUS, FONT_SIZE } from "../../styles/designTokens";
 
 interface Props {
   /** unix sec — 當前 scrub 位置 */
@@ -32,7 +33,7 @@ export function IntelReplay({
       }}
     >
       <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
-        <span style={{ fontFamily: FONT_DATA, fontSize: 9, letterSpacing: "1.5px", color: COLORS.textFaint }}>
+        <span style={{ fontFamily: FONT_DATA, fontSize: FONT_SIZE.xs, letterSpacing: "1.5px", color: COLORS.textFaint }}>
           回放 REPLAY
         </span>
         <span
@@ -52,7 +53,7 @@ export function IntelReplay({
           style={{
             width: 24,
             height: 24,
-            borderRadius: 4,
+            borderRadius: RADIUS.md,
             border: `1px solid ${COLORS.borderMid}`,
             background: "rgba(255,255,255,0.05)",
             color: COLORS.textDefault,
@@ -72,10 +73,10 @@ export function IntelReplay({
           onClick={onLive}
           style={{
             padding: "3px 9px",
-            borderRadius: 4,
+            borderRadius: RADIUS.md,
             cursor: "pointer",
             fontFamily: FONT_DATA,
-            fontSize: 10,
+            fontSize: FONT_SIZE.sm,
             background: isLive ? COLORS.statusLiveSoft : "rgba(255,255,255,0.05)",
             border: `1px solid ${isLive ? COLORS.statusLiveBorder : COLORS.borderMid}`,
             color: isLive ? COLORS.statusLive : COLORS.textMuted,
@@ -85,7 +86,7 @@ export function IntelReplay({
         </button>
       </div>
       <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
-        <span style={{ fontFamily: FONT_DATA, fontSize: 9, color: COLORS.textFaint }}>
+        <span style={{ fontFamily: FONT_DATA, fontSize: FONT_SIZE.xs, color: COLORS.textFaint }}>
           {clockTime(windowStartTs)}
         </span>
         <input
@@ -97,7 +98,7 @@ export function IntelReplay({
           onChange={(ev) => onScrub(Number(ev.target.value))}
           style={{ flex: 1, height: 3, accentColor: COLORS.accent, cursor: "pointer" }}
         />
-        <span style={{ fontFamily: FONT_DATA, fontSize: 9, color: COLORS.textFaint }}>
+        <span style={{ fontFamily: FONT_DATA, fontSize: FONT_SIZE.xs, color: COLORS.textFaint }}>
           {clockTime(nowTs)}
         </span>
       </div>

--- a/src/components/intel/IntelSituation.tsx
+++ b/src/components/intel/IntelSituation.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useState } from "react";
 import { IntelIcon, ICON } from "./IntelIcon";
 import { COLORS, FONT_CJK, FONT_DATA } from "./intelTokens";
+import { RADIUS, FONT_SIZE } from "../../styles/designTokens";
 import { NEWS_CATEGORIES, getNewsCategoryDef, type NewsCategory } from "../../data/newsEventTypes";
 import type { ClusterEvent } from "../../data/newsEventsLoader";
 import type { TrendingRow } from "../../data/intelLoaders";
@@ -178,7 +179,7 @@ export function IntelSituation({ events, countyByEventId, trending }: Props) {
                 <span
                   key={c.key}
                   title={c.label}
-                  style={{ width: 7, height: 7, borderRadius: 2, background: c.color, opacity: 0.85 }}
+                  style={{ width: 7, height: 7, borderRadius: RADIUS.sm, background: c.color, opacity: 0.85 }}
                 />
               ))}
             </div>
@@ -233,7 +234,7 @@ export function IntelSituation({ events, countyByEventId, trending }: Props) {
               justifyContent: "space-between",
               marginTop: 2,
               fontFamily: FONT_DATA,
-              fontSize: 8,
+              fontSize: FONT_SIZE.xs,
               color: COLORS.textGhost,
             }}
           >
@@ -258,7 +259,7 @@ export function IntelSituation({ events, countyByEventId, trending }: Props) {
             熱區 TOP 5 · HOTSPOTS
           </div>
           {hotspots.length === 0 ? (
-            <div style={{ fontFamily: FONT_CJK, fontSize: 10, color: COLORS.textFaint, padding: "2px 0" }}>
+            <div style={{ fontFamily: FONT_CJK, fontSize: FONT_SIZE.sm, color: COLORS.textFaint, padding: "2px 0" }}>
               ⚠ 尚無資料
             </div>
           ) : (
@@ -267,11 +268,11 @@ export function IntelSituation({ events, countyByEventId, trending }: Props) {
                 const cat = getNewsCategoryDef(r.topCat);
                 return (
                   <div key={r.county} style={{ display: "flex", alignItems: "center", gap: 7 }}>
-                    <span style={{ fontFamily: FONT_DATA, fontSize: 9, color: COLORS.textDim, width: 9 }}>
+                    <span style={{ fontFamily: FONT_DATA, fontSize: FONT_SIZE.xs, color: COLORS.textDim, width: 9 }}>
                       {i + 1}
                     </span>
                     <span
-                      style={{ width: 7, height: 7, borderRadius: "50%", background: cat.color, flexShrink: 0 }}
+                      style={{ width: 7, height: 7, borderRadius: RADIUS.full, background: cat.color, flexShrink: 0 }}
                     />
                     <span
                       style={{
@@ -287,7 +288,7 @@ export function IntelSituation({ events, countyByEventId, trending }: Props) {
                       style={{
                         flex: 1,
                         height: 4,
-                        borderRadius: 2,
+                        borderRadius: RADIUS.sm,
                         background: "rgba(255,255,255,0.05)",
                         overflow: "hidden",
                         minWidth: 14,
@@ -309,7 +310,7 @@ export function IntelSituation({ events, countyByEventId, trending }: Props) {
                     <span
                       style={{
                         fontFamily: FONT_DATA,
-                        fontSize: 11,
+                        fontSize: FONT_SIZE.base,
                         fontWeight: 700,
                         color: "#fff",
                         width: 16,

--- a/src/components/intel/alerts/AlertBoard.tsx
+++ b/src/components/intel/alerts/AlertBoard.tsx
@@ -10,6 +10,7 @@ import {
   type AlertTally,
   type ActiveAlert,
 } from "../../../data/alertsLoader";
+import { RADIUS, FONT_SIZE } from "../../../styles/designTokens";
 
 interface Props {
   tally: AlertTally;
@@ -42,7 +43,7 @@ function AlertTrend({
     <div
       style={{
         padding: "8px 10px",
-        borderRadius: 7,
+        borderRadius: RADIUS.lg,
         background: "rgba(255,255,255,0.025)",
         border: `1px solid ${COLORS.borderMid}`,
         marginBottom: 10,
@@ -55,7 +56,7 @@ function AlertTrend({
       >
         <span
           style={{
-            fontFamily: FONT_DATA, fontSize: 9, letterSpacing: "1.5px",
+            fontFamily: FONT_DATA, fontSize: FONT_SIZE.xs, letterSpacing: "1.5px",
             color: COLORS.textFaint,
           }}
         >
@@ -64,7 +65,7 @@ function AlertTrend({
         <span style={{ flex: 1 }} />
         <span
           style={{
-            fontFamily: FONT_DATA, fontSize: 10,
+            fontFamily: FONT_DATA, fontSize: FONT_SIZE.sm,
             color: COLORS.textMuted,
           }}
         >
@@ -143,7 +144,7 @@ function GroupCard({
       style={{
         textAlign: "left",
         padding: "9px 10px",
-        borderRadius: 7,
+        borderRadius: RADIUS.lg,
         background: dim
           ? "rgba(255,255,255,0.015)"
           : hot
@@ -160,7 +161,7 @@ function GroupCard({
         <IntelIcon d={MICON[def.iconKey]!} size={11} color={def.color} />
         <span
           style={{
-            fontFamily: FONT_CJK, fontSize: 11, fontWeight: 600,
+            fontFamily: FONT_CJK, fontSize: FONT_SIZE.base, fontWeight: 600,
             color: COLORS.textDefault,
           }}
         >
@@ -169,7 +170,7 @@ function GroupCard({
         <div style={{ flex: 1 }} />
         <span
           style={{
-            fontFamily: FONT_DATA, fontSize: 9, color: def.color,
+            fontFamily: FONT_DATA, fontSize: FONT_SIZE.xs, color: def.color,
             letterSpacing: "0.5px",
           }}
         >
@@ -179,7 +180,7 @@ function GroupCard({
       <div style={{ display: "flex", alignItems: "baseline", gap: 6 }}>
         <span
           style={{
-            fontFamily: FONT_DATA, fontSize: 22, fontWeight: 700,
+            fontFamily: FONT_DATA, fontSize: FONT_SIZE.xxl, fontWeight: 700,
             color: hot ? def.color : COLORS.textStrong,
             lineHeight: 1,
           }}
@@ -199,7 +200,7 @@ function GroupCard({
       </div>
       <span
         style={{
-          fontFamily: FONT_CJK, fontSize: 10, color: COLORS.textFaint,
+          fontFamily: FONT_CJK, fontSize: FONT_SIZE.sm, color: COLORS.textFaint,
           height: 12, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap",
         }}
       >
@@ -229,7 +230,7 @@ function AlertDrawer({
     return (
       <div
         style={{
-          padding: "10px 12px", fontFamily: FONT_CJK, fontSize: 11,
+          padding: "10px 12px", fontFamily: FONT_CJK, fontSize: FONT_SIZE.base,
           color: COLORS.textFaint,
         }}
       >
@@ -242,7 +243,7 @@ function AlertDrawer({
     return (
       <div
         style={{
-          padding: "10px 12px", fontFamily: FONT_CJK, fontSize: 11,
+          padding: "10px 12px", fontFamily: FONT_CJK, fontSize: FONT_SIZE.base,
           color: COLORS.textFaint,
         }}
       >
@@ -273,20 +274,20 @@ function AlertDrawer({
           >
             <span
               style={{
-                width: 6, height: 6, borderRadius: "50%",
+                width: 6, height: 6, borderRadius: RADIUS.full,
                 background: sev.color, flexShrink: 0,
                 boxShadow: r.severity >= 3 ? `0 0 5px ${sev.color}` : "none",
               }}
             />
             <span
               style={{
-                fontFamily: FONT_CJK, fontSize: 11,
+                fontFamily: FONT_CJK, fontSize: FONT_SIZE.base,
                 color: COLORS.textDefault, flex: 1,
                 overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap",
               }}
               title={r.headline}
             >
-              <span style={{ color: COLORS.textMuted, fontSize: 10 }}>{r.county} · </span>
+              <span style={{ color: COLORS.textMuted, fontSize: FONT_SIZE.sm }}>{r.county} · </span>
               {r.headline || r.term}
             </span>
             <span style={{ fontFamily: FONT_DATA, fontSize: 9.5, color: COLORS.textFaint }}>
@@ -309,7 +310,7 @@ export function AlertBoard({ tally, series, accent, nowTs }: Props) {
       <div
         style={{
           padding: "9px 12px",
-          borderRadius: 7,
+          borderRadius: RADIUS.lg,
           background: "rgba(34,197,94,0.06)",
           border: `1px solid ${COLORS.statusLiveBorder}`,
           display: "flex", alignItems: "center", gap: 7,
@@ -327,7 +328,7 @@ export function AlertBoard({ tally, series, accent, nowTs }: Props) {
         <div style={{ flex: 1 }} />
         <span
           style={{
-            fontFamily: FONT_DATA, fontSize: 9, letterSpacing: "1.5px",
+            fontFamily: FONT_DATA, fontSize: FONT_SIZE.xs, letterSpacing: "1.5px",
             color: COLORS.textFaint,
           }}
         >
@@ -349,7 +350,7 @@ export function AlertBoard({ tally, series, accent, nowTs }: Props) {
         <IntelIcon d={MICON.warn!} size={12} color="#ef4444" />
         <span
           style={{
-            fontFamily: FONT_CJK, fontSize: 11, fontWeight: 700,
+            fontFamily: FONT_CJK, fontSize: FONT_SIZE.base, fontWeight: 700,
             color: COLORS.textStrong, letterSpacing: "0.5px",
           }}
         >
@@ -357,23 +358,23 @@ export function AlertBoard({ tally, series, accent, nowTs }: Props) {
         </span>
         <span
           style={{
-            fontFamily: FONT_DATA, fontSize: 9, letterSpacing: "1.5px",
+            fontFamily: FONT_DATA, fontSize: FONT_SIZE.xs, letterSpacing: "1.5px",
             color: COLORS.textDim,
           }}
         >
           NCDR + CWA
         </span>
         <div style={{ flex: 1 }} />
-        <span style={{ fontFamily: FONT_DATA, fontSize: 10, color: COLORS.textMuted }}>
+        <span style={{ fontFamily: FONT_DATA, fontSize: FONT_SIZE.sm, color: COLORS.textMuted }}>
           {tally.total} 則
         </span>
         {tally.severe > 0 && (
           <span
             style={{
-              padding: "1px 6px", borderRadius: 4,
+              padding: "1px 6px", borderRadius: RADIUS.md,
               background: "rgba(239,68,68,0.18)",
               border: "1px solid rgba(239,68,68,0.45)",
-              fontFamily: FONT_DATA, fontSize: 9, fontWeight: 700,
+              fontFamily: FONT_DATA, fontSize: FONT_SIZE.xs, fontWeight: 700,
               color: "#ef4444",
               animation: "alertBreathe 2s ease-in-out infinite",
             }}
@@ -411,7 +412,7 @@ export function AlertBoard({ tally, series, accent, nowTs }: Props) {
         <div
           style={{
             marginTop: 8,
-            borderRadius: 7,
+            borderRadius: RADIUS.lg,
             background: "rgba(0,0,0,0.32)",
             border: `1px solid ${COLORS.borderMid}`,
           }}

--- a/src/components/intel/alerts/AlertCard.tsx
+++ b/src/components/intel/alerts/AlertCard.tsx
@@ -5,6 +5,7 @@ import {
   ALERT_GROUPS_DEF, alertSeverity, fmtExpiry, relTime, clockTime,
 } from "../intelTokens";
 import type { ActiveAlert } from "../../../data/alertsLoader";
+import { RADIUS, FONT_SIZE } from "../../../styles/designTokens";
 
 interface Props {
   a: ActiveAlert;
@@ -46,7 +47,7 @@ export function AlertCard({ a, selected, expanded, onSelect, onToggle, nowTs }: 
           position: "absolute",
           left: 7, top: 14,
           width: 11, height: 11,
-          borderRadius: "50%",
+          borderRadius: RADIUS.full,
           background: sev.color,
           border: "2px solid #0a0a14",
           zIndex: 1,
@@ -59,7 +60,7 @@ export function AlertCard({ a, selected, expanded, onSelect, onToggle, nowTs }: 
         style={{
           cursor: "pointer",
           padding: "10px 12px",
-          borderRadius: 7,
+          borderRadius: RADIUS.lg,
           background: selected ? "rgba(100,170,255,0.06)" : "rgba(255,255,255,0.025)",
           border: `1px solid ${selected ? COLORS.borderAccent : COLORS.borderMid}`,
           animation: a.severity >= 3 ? "alertEdge 2s ease-in-out infinite" : undefined,
@@ -70,7 +71,7 @@ export function AlertCard({ a, selected, expanded, onSelect, onToggle, nowTs }: 
           <span
             style={{
               display: "inline-flex", alignItems: "center", gap: 4,
-              padding: "1px 7px", borderRadius: 4,
+              padding: "1px 7px", borderRadius: RADIUS.md,
               background: `${def.color}22`,
               border: `1px solid ${def.color}55`,
               fontFamily: FONT_DATA, fontSize: 9.5, fontWeight: 700,
@@ -82,7 +83,7 @@ export function AlertCard({ a, selected, expanded, onSelect, onToggle, nowTs }: 
           </span>
           <span
             style={{
-              padding: "1px 7px", borderRadius: 4,
+              padding: "1px 7px", borderRadius: RADIUS.md,
               background: `${sev.color}22`,
               border: `1px solid ${sev.color}55`,
               fontFamily: FONT_DATA, fontSize: 9.5, fontWeight: 700,
@@ -114,7 +115,7 @@ export function AlertCard({ a, selected, expanded, onSelect, onToggle, nowTs }: 
         {/* headline */}
         <div
           style={{
-            fontFamily: FONT_CJK, fontSize: 13, fontWeight: 600,
+            fontFamily: FONT_CJK, fontSize: FONT_SIZE.lg, fontWeight: 600,
             color: COLORS.textStrong, lineHeight: 1.45, marginBottom: 4,
           }}
         >
@@ -125,7 +126,7 @@ export function AlertCard({ a, selected, expanded, onSelect, onToggle, nowTs }: 
         <div style={{ display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap" }}>
           <span style={{ display: "inline-flex", alignItems: "center", gap: 3 }}>
             <IntelIcon d={MICON.pin!} size={10} color={COLORS.textMuted} />
-            <span style={{ fontFamily: FONT_CJK, fontSize: 11, color: COLORS.textMuted }}>
+            <span style={{ fontFamily: FONT_CJK, fontSize: FONT_SIZE.base, color: COLORS.textMuted }}>
               {a.county}
               {a.area_count > 1 && (
                 <span style={{ color: COLORS.textFaint }}> · {a.area_count} 區</span>
@@ -165,7 +166,7 @@ export function AlertCard({ a, selected, expanded, onSelect, onToggle, nowTs }: 
               <div
                 style={{
                   padding: "7px 9px",
-                  borderRadius: 5,
+                  borderRadius: RADIUS.lg,
                   background: `${def.color}10`,
                   border: `1px solid ${def.color}33`,
                   marginBottom: 8,
@@ -173,7 +174,7 @@ export function AlertCard({ a, selected, expanded, onSelect, onToggle, nowTs }: 
               >
                 <div
                   style={{
-                    fontFamily: FONT_DATA, fontSize: 9, fontWeight: 700,
+                    fontFamily: FONT_DATA, fontSize: FONT_SIZE.xs, fontWeight: 700,
                     color: def.color, letterSpacing: "1px", marginBottom: 3,
                   }}
                 >
@@ -194,7 +195,7 @@ export function AlertCard({ a, selected, expanded, onSelect, onToggle, nowTs }: 
             <div
               style={{
                 display: "grid", gridTemplateColumns: "auto 1fr", gap: "4px 10px",
-                fontFamily: FONT_DATA, fontSize: 10,
+                fontFamily: FONT_DATA, fontSize: FONT_SIZE.sm,
               }}
             >
               <span style={{ color: COLORS.textFaint }}>發佈</span>

--- a/src/components/intel/alerts/AlertSummaryBar.tsx
+++ b/src/components/intel/alerts/AlertSummaryBar.tsx
@@ -5,6 +5,7 @@ import {
   type AlertGroupShort,
 } from "../intelTokens";
 import type { AlertTally } from "../../../data/alertsLoader";
+import { RADIUS, FONT_SIZE } from "../../../styles/designTokens";
 
 interface Props {
   tally: AlertTally;
@@ -27,7 +28,7 @@ export function AlertSummaryBar({
           flexShrink: 0,
           display: "flex", alignItems: "center", gap: 6,
           padding: "6px 14px",
-          fontFamily: FONT_CJK, fontSize: 11,
+          fontFamily: FONT_CJK, fontSize: FONT_SIZE.base,
           color: COLORS.textFaint,
           borderBottom: `1px solid ${COLORS.borderSoft}`,
         }}
@@ -71,7 +72,7 @@ export function AlertSummaryBar({
           <span
             style={{
               display: "inline-flex", alignItems: "center", gap: 4,
-              padding: "1px 7px", borderRadius: 4,
+              padding: "1px 7px", borderRadius: RADIUS.md,
               background: "rgba(239,68,68,0.18)",
               border: "1px solid rgba(239,68,68,0.45)",
               fontFamily: FONT_DATA, fontSize: 9.5, fontWeight: 700,
@@ -94,7 +95,7 @@ export function AlertSummaryBar({
                   key={g}
                   title={`${def.label} ${s.count}`}
                   style={{
-                    width: 7, height: 7, borderRadius: "50%",
+                    width: 7, height: 7, borderRadius: RADIUS.full,
                     background: def.color,
                     boxShadow: hot ? `0 0 6px ${def.color}` : "none",
                     opacity: hot ? 1 : 0.78,
@@ -136,7 +137,7 @@ export function AlertSummaryBar({
                 style={{
                   display: "flex", alignItems: "center", gap: 6,
                   padding: "6px 8px",
-                  borderRadius: 6,
+                  borderRadius: RADIUS.lg,
                   background: active
                     ? "rgba(100,170,255,0.14)"
                     : dim
@@ -151,7 +152,7 @@ export function AlertSummaryBar({
                 <IntelIcon d={MICON[def.iconKey]!} size={12} color={def.color} />
                 <span
                   style={{
-                    fontFamily: FONT_CJK, fontSize: 11, fontWeight: 600,
+                    fontFamily: FONT_CJK, fontSize: FONT_SIZE.base, fontWeight: 600,
                     color: COLORS.textDefault, whiteSpace: "nowrap",
                   }}
                 >
@@ -160,7 +161,7 @@ export function AlertSummaryBar({
                 <div style={{ flex: 1 }} />
                 <span
                   style={{
-                    fontFamily: FONT_DATA, fontSize: 11, fontWeight: 700,
+                    fontFamily: FONT_DATA, fontSize: FONT_SIZE.base, fontWeight: 700,
                     color: sev > 0 ? "#ef4444" : COLORS.textStrong,
                   }}
                 >

--- a/src/components/intel/alerts/FeedTabs.tsx
+++ b/src/components/intel/alerts/FeedTabs.tsx
@@ -1,4 +1,5 @@
 import { COLORS, FONT_CJK, FONT_DATA } from "../intelTokens";
+import { RADIUS, FONT_SIZE } from "../../../styles/designTokens";
 
 export type FeedTab = "all" | "news" | "alerts";
 
@@ -42,7 +43,7 @@ export function FeedTabs({ tab, onTab, newsCount, alertCount, alertSevere }: Pro
               flex: 1,
               display: "flex", alignItems: "center", justifyContent: "center", gap: 5,
               padding: "5px 8px",
-              borderRadius: 5,
+              borderRadius: RADIUS.lg,
               cursor: "pointer",
               background: active
                 ? (hot ? "rgba(239,68,68,0.16)" : COLORS.accentFaint)
@@ -59,7 +60,7 @@ export function FeedTabs({ tab, onTab, newsCount, alertCount, alertSevere }: Pro
             {t.label}
             <span
               style={{
-                fontFamily: FONT_DATA, fontSize: 10, fontWeight: 700,
+                fontFamily: FONT_DATA, fontSize: FONT_SIZE.sm, fontWeight: 700,
                 color: hot && active ? "#ef4444" : "inherit",
                 opacity: 0.9,
               }}

--- a/src/components/intel/intelTokens.ts
+++ b/src/components/intel/intelTokens.ts
@@ -162,10 +162,13 @@ export interface AlertGroupDef {
   iconKey: keyof typeof MICON;
 }
 
+// 警示語意色 — 以 LAYER_COLORS（地圖色）為基準對齊，讓地圖、warning bar、popup
+// 三處同色（design-system.md §3）。earthquake / flood 從原 magenta / teal 改為紅色。
+// weather / transit / lifeline / safety 在 LAYER_COLORS 無對應 layer，沿用原色保留視覺多樣性。
 export const ALERT_GROUPS_DEF: Record<AlertGroupShort, AlertGroupDef> = {
-  earthquake: { id: "earthquake", label: "地震", en: "EQ",       color: "#d946ef", iconKey: "quake" },
+  earthquake: { id: "earthquake", label: "地震", en: "EQ",       color: "#ff3b30", iconKey: "quake" },
   weather:    { id: "weather",    label: "氣象", en: "WEATHER",  color: "#38bdf8", iconKey: "cloud" },
-  flood:      { id: "flood",      label: "水文", en: "WATER",    color: "#2dd4bf", iconKey: "wave"  },
+  flood:      { id: "flood",      label: "水文", en: "WATER",    color: "#ef4444", iconKey: "wave"  },
   transit:    { id: "transit",    label: "交通", en: "TRANSIT",  color: "#fb923c", iconKey: "cone"  },
   lifeline:   { id: "lifeline",   label: "民生", en: "LIFELINE", color: "#a3e635", iconKey: "plug"  },
   safety:     { id: "safety",     label: "安全", en: "SAFETY",   color: "#fb7185", iconKey: "flame" },

--- a/src/components/intel/monitor/HazardWatchStrip.tsx
+++ b/src/components/intel/monitor/HazardWatchStrip.tsx
@@ -119,7 +119,7 @@ function HazardSlot({ ch }: { ch: HazardCh }) {
           </span>
           <span
             style={{
-              fontFamily: FONT_DATA, fontSize: 8.5, color: "rgba(255,255,255,0.7)",
+              fontFamily: FONT_DATA, fontSize: 8.5, color: COLORS.textDefault,
               letterSpacing: "0.5px",
               textShadow: "0 1px 3px rgba(0,0,0,0.9)",
             }}
@@ -152,7 +152,7 @@ function HazardSlot({ ch }: { ch: HazardCh }) {
         <span style={{ flex: 1 }} />
         <span
           style={{
-            fontFamily: FONT_DATA, fontSize: 8, color: "rgba(255,255,255,0.55)",
+            fontFamily: FONT_DATA, fontSize: 8, color: COLORS.textMuted,
             textShadow: "0 1px 3px rgba(0,0,0,0.9)",
           }}
         >

--- a/src/components/intel/monitor/HazardWatchStrip.tsx
+++ b/src/components/intel/monitor/HazardWatchStrip.tsx
@@ -11,6 +11,7 @@
 
 import { memo, useRef } from "react";
 import { COLORS, FONT_CJK, FONT_DATA } from "../intelTokens";
+import { RADIUS, FONT_SIZE } from "../../../styles/designTokens";
 import { useInView } from "../../../hooks/useInView";
 
 interface HazardCh {
@@ -47,12 +48,12 @@ function HazardSlot({ ch }: { ch: HazardCh }) {
     <div
       ref={slotRef}
       style={{
-        position: "relative", borderRadius: 8, overflow: "visible",
+        position: "relative", borderRadius: RADIUS.xl, overflow: "visible",
         aspectRatio: "16 / 9", background: "#000",
         border: "1px solid rgba(255,152,0,0.45)",
       }}
     >
-      <div style={{ position: "absolute", inset: 0, borderRadius: 8, overflow: "hidden" }}>
+      <div style={{ position: "absolute", inset: 0, borderRadius: RADIUS.xl, overflow: "hidden" }}>
         {visible ? (
         <iframe
           title={ch.name}
@@ -71,7 +72,7 @@ function HazardSlot({ ch }: { ch: HazardCh }) {
             style={{
               position: "absolute", inset: 0, display: "flex",
               alignItems: "center", justifyContent: "center",
-              fontFamily: FONT_DATA, fontSize: 9, letterSpacing: "1.5px",
+              fontFamily: FONT_DATA, fontSize: FONT_SIZE.xs, letterSpacing: "1.5px",
               color: COLORS.textFaint, background: "#000",
             }}
           >
@@ -90,13 +91,13 @@ function HazardSlot({ ch }: { ch: HazardCh }) {
           <span
             style={{
               display: "inline-flex", alignItems: "center", gap: 4,
-              padding: "1px 6px", borderRadius: 3,
+              padding: "1px 6px", borderRadius: RADIUS.md,
               background: "rgba(255,152,0,0.95)",
             }}
           >
             <span
               style={{
-                width: 5, height: 5, borderRadius: "50%", background: "#fff",
+                width: 5, height: 5, borderRadius: RADIUS.full, background: "#fff",
                 animation: "intelRing 1.6s ease-in-out infinite",
               }}
             />
@@ -111,7 +112,7 @@ function HazardSlot({ ch }: { ch: HazardCh }) {
           </span>
           <span
             style={{
-              fontFamily: FONT_CJK, fontSize: 11, fontWeight: 700, color: "#fff",
+              fontFamily: FONT_CJK, fontSize: FONT_SIZE.base, fontWeight: 700, color: "#fff",
               textShadow: "0 1px 4px rgba(0,0,0,0.8)",
             }}
           >
@@ -139,10 +140,10 @@ function HazardSlot({ ch }: { ch: HazardCh }) {
         <span
           style={{
             display: "inline-flex", alignItems: "center", gap: 5,
-            padding: "3px 9px", borderRadius: 5,
+            padding: "3px 9px", borderRadius: RADIUS.lg,
             background: "rgba(0,0,0,0.72)",
             border: `1px solid ${COLORS.borderMid}`,
-            fontFamily: FONT_CJK, fontSize: 10,
+            fontFamily: FONT_CJK, fontSize: FONT_SIZE.sm,
             color: COLORS.textDefault,
             backdropFilter: "blur(6px)", WebkitBackdropFilter: "blur(6px)",
           }}
@@ -152,7 +153,7 @@ function HazardSlot({ ch }: { ch: HazardCh }) {
         <span style={{ flex: 1 }} />
         <span
           style={{
-            fontFamily: FONT_DATA, fontSize: 8, color: COLORS.textMuted,
+            fontFamily: FONT_DATA, fontSize: FONT_SIZE.xs, color: COLORS.textMuted,
             textShadow: "0 1px 3px rgba(0,0,0,0.9)",
           }}
         >
@@ -167,24 +168,24 @@ export const HazardWatchStrip = memo(function HazardWatchStrip() {
   return (
     <div
       style={{
-        gridColumn: "1 / -1", borderRadius: 9,
+        gridColumn: "1 / -1", borderRadius: RADIUS.xl,
         border: `1px solid ${COLORS.panelBorder}`,
         background: "rgba(255,152,0,0.04)",
         padding: 13, display: "flex", flexDirection: "column",
       }}
     >
       <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 11 }}>
-        <span style={{ width: 3, height: 12, borderRadius: 2, background: COLORS.statusWarn }} />
+        <span style={{ width: 3, height: 12, borderRadius: RADIUS.sm, background: COLORS.statusWarn }} />
         <span
           style={{
-            fontFamily: FONT_DATA, fontSize: 10, letterSpacing: "1.5px",
+            fontFamily: FONT_DATA, fontSize: FONT_SIZE.sm, letterSpacing: "1.5px",
             color: COLORS.textDefault,
           }}
         >
           災防觀測 · HAZARD WATCH
         </span>
         <div style={{ flex: 1 }} />
-        <span style={{ fontFamily: FONT_CJK, fontSize: 9, color: COLORS.textFaint }}>
+        <span style={{ fontFamily: FONT_CJK, fontSize: FONT_SIZE.xs, color: COLORS.textFaint }}>
           地震 + 天氣 · 24h 監測
         </span>
       </div>

--- a/src/components/intel/monitor/IndicatorPanel.tsx
+++ b/src/components/intel/monitor/IndicatorPanel.tsx
@@ -14,6 +14,7 @@ import type {
   PressureIndexNow, MarketIndex, PlaActivity, PublicHealthWeek, SourceHealthSummary,
 } from "../../../data/intelLoaders";
 import { SectionLabel, Widget } from "./PressureRing";
+import { RADIUS, FONT_SIZE } from "../../../styles/designTokens";
 import { SituationOverview } from "./SituationOverview";
 import { SituationCards } from "./SituationCards";
 import { LiveWall } from "./LiveWall";
@@ -110,7 +111,7 @@ function DistBar({
     <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
       <span
         style={{
-          fontFamily: FONT_DATA, fontSize: 9, letterSpacing: "0.5px",
+          fontFamily: FONT_DATA, fontSize: FONT_SIZE.xs, letterSpacing: "0.5px",
           color: COLORS.textDim,
         }}
       >
@@ -118,7 +119,7 @@ function DistBar({
       </span>
       <div
         style={{
-          display: "flex", height: 9, borderRadius: 3, overflow: "hidden",
+          display: "flex", height: 9, borderRadius: RADIUS.md, overflow: "hidden",
           background: "rgba(255,255,255,0.04)",
         }}
       >
@@ -147,7 +148,7 @@ function DistBar({
           >
             <span
               style={{
-                width: 7, height: 7, borderRadius: 2, background: lv.color,
+                width: 7, height: 7, borderRadius: RADIUS.sm, background: lv.color,
                 opacity: counts[i] ? 1 : 0.4,
               }}
             />
@@ -245,7 +246,7 @@ export function IndicatorPanel({
                 onClick={() => onPickHotspot(r.county)}
                 style={{
                   display: "flex", alignItems: "center", gap: 9,
-                  padding: "6px 8px", borderRadius: 6, cursor: "pointer",
+                  padding: "6px 8px", borderRadius: RADIUS.lg, cursor: "pointer",
                   background: "rgba(255,255,255,0.02)",
                   border: `1px solid ${COLORS.borderSoft}`,
                   textAlign: "left", transition: "background .12s",
@@ -259,7 +260,7 @@ export function IndicatorPanel({
               >
                 <span
                   style={{
-                    fontFamily: FONT_DATA, fontSize: 11, fontWeight: 700,
+                    fontFamily: FONT_DATA, fontSize: FONT_SIZE.base, fontWeight: 700,
                     color: COLORS.textDim, width: 14,
                   }}
                 >
@@ -267,13 +268,13 @@ export function IndicatorPanel({
                 </span>
                 <span
                   style={{
-                    width: 8, height: 8, borderRadius: "50%",
+                    width: 8, height: 8, borderRadius: RADIUS.full,
                     background: cat.color, flexShrink: 0,
                   }}
                 />
                 <span
                   style={{
-                    fontFamily: FONT_CJK, fontSize: 12,
+                    fontFamily: FONT_CJK, fontSize: FONT_SIZE.md,
                     color: COLORS.textStrong, whiteSpace: "nowrap",
                   }}
                 >
@@ -282,7 +283,7 @@ export function IndicatorPanel({
                 <span
                   style={{
                     fontFamily: FONT_CJK, fontSize: 9.5, color: cat.color,
-                    padding: "1px 6px", borderRadius: 3,
+                    padding: "1px 6px", borderRadius: RADIUS.md,
                     background: `${cat.color}1f`, whiteSpace: "nowrap",
                   }}
                 >
@@ -290,7 +291,7 @@ export function IndicatorPanel({
                 </span>
                 <div
                   style={{
-                    flex: 1, height: 5, borderRadius: 3,
+                    flex: 1, height: 5, borderRadius: RADIUS.md,
                     background: "rgba(255,255,255,0.05)",
                     overflow: "hidden", minWidth: 20,
                   }}
@@ -305,7 +306,7 @@ export function IndicatorPanel({
                 </div>
                 <span
                   style={{
-                    fontFamily: FONT_DATA, fontSize: 13, fontWeight: 700,
+                    fontFamily: FONT_DATA, fontSize: FONT_SIZE.lg, fontWeight: 700,
                     color: "#fff", width: 18, textAlign: "right",
                   }}
                 >
@@ -330,7 +331,7 @@ export function IndicatorPanel({
           {stats.ranked.length === 0 && (
             <div
               style={{
-                fontFamily: FONT_CJK, fontSize: 11, color: COLORS.textFaint,
+                fontFamily: FONT_CJK, fontSize: FONT_SIZE.base, color: COLORS.textFaint,
                 padding: "10px 2px",
               }}
             >
@@ -359,13 +360,13 @@ export function IndicatorPanel({
                 key={c.key}
                 style={{
                   display: "inline-flex", alignItems: "center", gap: 3,
-                  fontFamily: FONT_CJK, fontSize: 9, color: COLORS.textDim,
+                  fontFamily: FONT_CJK, fontSize: FONT_SIZE.xs, color: COLORS.textDim,
                   whiteSpace: "nowrap",
                 }}
               >
                 <span
                   style={{
-                    width: 7, height: 7, borderRadius: 2, background: c.color,
+                    width: 7, height: 7, borderRadius: RADIUS.sm, background: c.color,
                   }}
                 />
                 {c.label}
@@ -398,7 +399,7 @@ export function IndicatorPanel({
                   flex: 1, display: "flex", flexDirection: "column-reverse",
                   height: `${(hd.total / peak) * 100}%`,
                   minHeight: hd.total ? 3 : 0,
-                  borderRadius: 2, overflow: "hidden",
+                  borderRadius: RADIUS.sm, overflow: "hidden",
                   opacity: isFuture ? 0.25 : 1,
                 }}
               >
@@ -420,7 +421,7 @@ export function IndicatorPanel({
         <div
           style={{
             display: "flex", justifyContent: "space-between", marginTop: 4,
-            fontFamily: FONT_DATA, fontSize: 9, color: COLORS.textFaint,
+            fontFamily: FONT_DATA, fontSize: FONT_SIZE.xs, color: COLORS.textFaint,
           }}
         >
           <span>00:00</span>
@@ -452,7 +453,7 @@ export function IndicatorPanel({
       <div
         style={{
           gridColumn: "1 / -1",
-          fontFamily: FONT_DATA, fontSize: 9, color: COLORS.textFaint,
+          fontFamily: FONT_DATA, fontSize: FONT_SIZE.xs, color: COLORS.textFaint,
           textAlign: "right",
         }}
       >

--- a/src/components/intel/monitor/IndicatorPanel.tsx
+++ b/src/components/intel/monitor/IndicatorPanel.tsx
@@ -441,7 +441,7 @@ export function IndicatorPanel({
             label="事件性質 IS_EVENT"
             levels={[
               { label: "事件", color: COLORS.accent },
-              { label: "聲明", color: "rgba(255,255,255,0.3)" },
+              { label: "聲明", color: COLORS.textDim },
             ]}
             counts={[tri.event, tri.statement]}
           />

--- a/src/components/intel/monitor/LiveWall.tsx
+++ b/src/components/intel/monitor/LiveWall.tsx
@@ -1,6 +1,6 @@
 import { memo, useEffect, useMemo, useRef, useState } from "react";
 import { COLORS, FONT_CJK, FONT_DATA } from "../intelTokens";
-import { SURFACE, ELEVATION } from "../../../styles/designTokens";
+import { SURFACE, ELEVATION, RADIUS, FONT_SIZE } from "../../../styles/designTokens";
 import { fetchLiveVideos, type YtLiveVideo } from "../../../data/intelLoaders";
 import { useInView } from "../../../hooks/useInView";
 
@@ -79,7 +79,7 @@ function ChannelMenu({ value, onPick, usedIds }: MenuProps) {
       <button
         onClick={() => setOpen((v) => !v)}
         style={{
-          display: "inline-flex", alignItems: "center", gap: 6, padding: "3px 9px", borderRadius: 5,
+          display: "inline-flex", alignItems: "center", gap: 6, padding: "3px 9px", borderRadius: RADIUS.lg,
           background: "rgba(0,0,0,0.72)", color: "#fff",
           border: `1px solid ${COLORS.borderMid}`, cursor: "pointer",
           backdropFilter: "blur(6px)", WebkitBackdropFilter: "blur(6px)",
@@ -89,7 +89,7 @@ function ChannelMenu({ value, onPick, usedIds }: MenuProps) {
         <span style={{ fontWeight: 700 }}>{cur.name}</span>
         <span
           style={{
-            fontFamily: FONT_DATA, fontSize: 8,
+            fontFamily: FONT_DATA, fontSize: FONT_SIZE.xs,
             color: COLORS.textMuted, letterSpacing: "0.5px",
           }}
         >
@@ -100,7 +100,7 @@ function ChannelMenu({ value, onPick, usedIds }: MenuProps) {
             display: "inline-block",
             transform: open ? "rotate(180deg)" : "none",
             transition: "transform .2s",
-            fontSize: 8, color: COLORS.textMuted,
+            fontSize: FONT_SIZE.xs, color: COLORS.textMuted,
           }}
         >
           ▾
@@ -111,7 +111,7 @@ function ChannelMenu({ value, onPick, usedIds }: MenuProps) {
         <div
           style={{
             position: "absolute", bottom: "calc(100% + 6px)", left: 0,
-            width: 232, zIndex: 30, borderRadius: 9, overflow: "hidden",
+            width: 232, zIndex: 30, borderRadius: RADIUS.xl, overflow: "hidden",
             border: `1px solid ${COLORS.borderMid}`,
             background: SURFACE.solid,
             backdropFilter: "blur(14px)", WebkitBackdropFilter: "blur(14px)",
@@ -186,7 +186,7 @@ function ChannelMenu({ value, onPick, usedIds }: MenuProps) {
                   >
                     <span
                       style={{
-                        width: 6, height: 6, borderRadius: "50%", flexShrink: 0,
+                        width: 6, height: 6, borderRadius: RADIUS.full, flexShrink: 0,
                         background: c.emergency ? COLORS.statusWarn : "#ff3b30",
                         boxShadow: `0 0 5px ${c.emergency ? COLORS.statusWarn : "#ff3b30"}`,
                         animation: "intelRing 1.6s ease-in-out infinite",
@@ -209,7 +209,7 @@ function ChannelMenu({ value, onPick, usedIds }: MenuProps) {
                         </span>
                         <span
                           style={{
-                            fontFamily: FONT_DATA, fontSize: 8,
+                            fontFamily: FONT_DATA, fontSize: FONT_SIZE.xs,
                             color: COLORS.textFaint, letterSpacing: "0.5px",
                           }}
                         >
@@ -218,8 +218,8 @@ function ChannelMenu({ value, onPick, usedIds }: MenuProps) {
                         {c.emergency && (
                           <span
                             style={{
-                              fontFamily: FONT_CJK, fontSize: 8, color: "#04121f", fontWeight: 700,
-                              padding: "0px 5px", borderRadius: 3,
+                              fontFamily: FONT_CJK, fontSize: FONT_SIZE.xs, color: "#04121f", fontWeight: 700,
+                              padding: "0px 5px", borderRadius: RADIUS.md,
                               background: COLORS.statusWarn,
                             }}
                           >
@@ -242,7 +242,7 @@ function ChannelMenu({ value, onPick, usedIds }: MenuProps) {
                     {active && (
                       <span
                         style={{
-                          fontFamily: FONT_DATA, fontSize: 11, color: COLORS.accent, flexShrink: 0,
+                          fontFamily: FONT_DATA, fontSize: FONT_SIZE.base, color: COLORS.accent, flexShrink: 0,
                         }}
                       >
                         ✓
@@ -286,12 +286,12 @@ function LiveSlot({
     <div
       ref={slotRef}
       style={{
-        position: "relative", borderRadius: 8, overflow: "visible",
+        position: "relative", borderRadius: RADIUS.xl, overflow: "visible",
         aspectRatio: "16 / 9", background: "#000",
         border: emergency ? "1px solid rgba(255,152,0,0.55)" : `1px solid ${COLORS.borderSoft}`,
       }}
     >
-      <div style={{ position: "absolute", inset: 0, borderRadius: 8, overflow: "hidden" }}>
+      <div style={{ position: "absolute", inset: 0, borderRadius: RADIUS.xl, overflow: "hidden" }}>
         {src && visible ? (
           <iframe
             title={ch.name}
@@ -311,10 +311,10 @@ function LiveSlot({
               position: "absolute", inset: 0, display: "flex",
               flexDirection: "column", alignItems: "center", justifyContent: "center",
               gap: 6, color: COLORS.textFaint,
-              fontFamily: FONT_CJK, fontSize: 11, textAlign: "center", padding: 16,
+              fontFamily: FONT_CJK, fontSize: FONT_SIZE.base, textAlign: "center", padding: 16,
             }}
           >
-            <span style={{ fontFamily: FONT_DATA, fontSize: 9, letterSpacing: "1.5px" }}>
+            <span style={{ fontFamily: FONT_DATA, fontSize: FONT_SIZE.xs, letterSpacing: "1.5px" }}>
               {resolved?.last_error ? "RESOLVER ERROR" : "RESOLVING…"}
             </span>
             <span>
@@ -336,13 +336,13 @@ function LiveSlot({
           <span
             style={{
               display: "inline-flex", alignItems: "center", gap: 4,
-              padding: "1px 6px", borderRadius: 3,
+              padding: "1px 6px", borderRadius: RADIUS.md,
               background: "rgba(239,68,68,0.9)",
             }}
           >
             <span
               style={{
-                width: 5, height: 5, borderRadius: "50%", background: "#fff",
+                width: 5, height: 5, borderRadius: RADIUS.full, background: "#fff",
                 animation: "intelRing 1.6s ease-in-out infinite",
               }}
             />
@@ -357,7 +357,7 @@ function LiveSlot({
           </span>
           <span
             style={{
-              fontFamily: FONT_CJK, fontSize: 11, fontWeight: 700, color: "#fff",
+              fontFamily: FONT_CJK, fontSize: FONT_SIZE.base, fontWeight: 700, color: "#fff",
               textShadow: "0 1px 4px rgba(0,0,0,0.8)",
             }}
           >
@@ -366,8 +366,8 @@ function LiveSlot({
           {emergency && (
             <span
               style={{
-                fontFamily: FONT_CJK, fontSize: 9, color: "#04121f", fontWeight: 700,
-                padding: "1px 6px", borderRadius: 3, background: COLORS.statusWarn,
+                fontFamily: FONT_CJK, fontSize: FONT_SIZE.xs, color: "#04121f", fontWeight: 700,
+                padding: "1px 6px", borderRadius: RADIUS.md, background: COLORS.statusWarn,
               }}
             >
               目前播放：{ch.emergencyLabel}
@@ -385,7 +385,7 @@ function LiveSlot({
         <ChannelMenu value={chId} onPick={onPick} usedIds={usedIds} />
         <span
           style={{
-            fontFamily: FONT_DATA, fontSize: 8, color: COLORS.textMuted,
+            fontFamily: FONT_DATA, fontSize: FONT_SIZE.xs, color: COLORS.textMuted,
             textShadow: "0 1px 3px rgba(0,0,0,0.9)", pointerEvents: "none",
           }}
         >
@@ -428,17 +428,17 @@ export const LiveWall = memo(function LiveWall() {
   return (
     <div
       style={{
-        gridColumn: "1 / -1", borderRadius: 9,
+        gridColumn: "1 / -1", borderRadius: RADIUS.xl,
         border: `1px solid ${COLORS.panelBorder}`,
         background: "rgba(255,255,255,0.022)",
         padding: 13, display: "flex", flexDirection: "column",
       }}
     >
       <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 11 }}>
-        <span style={{ width: 3, height: 12, borderRadius: 2, background: COLORS.accent }} />
+        <span style={{ width: 3, height: 12, borderRadius: RADIUS.sm, background: COLORS.accent }} />
         <span
           style={{
-            fontFamily: FONT_DATA, fontSize: 10, letterSpacing: "1.5px",
+            fontFamily: FONT_DATA, fontSize: FONT_SIZE.sm, letterSpacing: "1.5px",
             color: COLORS.textDefault,
           }}
         >
@@ -448,8 +448,8 @@ export const LiveWall = memo(function LiveWall() {
         {ctsLive ? (
           <span
             style={{
-              fontFamily: FONT_CJK, fontSize: 9, color: COLORS.statusWarn,
-              padding: "2px 8px", borderRadius: 3,
+              fontFamily: FONT_CJK, fontSize: FONT_SIZE.xs, color: COLORS.statusWarn,
+              padding: "2px 8px", borderRadius: RADIUS.md,
               background: COLORS.statusWarnSoft,
               border: "1px solid rgba(255,152,0,0.3)",
             }}
@@ -457,7 +457,7 @@ export const LiveWall = memo(function LiveWall() {
             ⚠ 華視已切換防災直播
           </span>
         ) : (
-          <span style={{ fontFamily: FONT_CJK, fontSize: 9, color: COLORS.textFaint }}>
+          <span style={{ fontFamily: FONT_CJK, fontSize: FONT_SIZE.xs, color: COLORS.textFaint }}>
             4 格同步 · 可切換 {LIVE_CHANNELS.length} 家
           </span>
         )}

--- a/src/components/intel/monitor/LiveWall.tsx
+++ b/src/components/intel/monitor/LiveWall.tsx
@@ -90,7 +90,7 @@ function ChannelMenu({ value, onPick, usedIds }: MenuProps) {
         <span
           style={{
             fontFamily: FONT_DATA, fontSize: 8,
-            color: "rgba(255,255,255,0.5)", letterSpacing: "0.5px",
+            color: COLORS.textMuted, letterSpacing: "0.5px",
           }}
         >
           {cur.en}
@@ -100,7 +100,7 @@ function ChannelMenu({ value, onPick, usedIds }: MenuProps) {
             display: "inline-block",
             transform: open ? "rotate(180deg)" : "none",
             transition: "transform .2s",
-            fontSize: 8, color: "rgba(255,255,255,0.6)",
+            fontSize: 8, color: COLORS.textMuted,
           }}
         >
           ▾
@@ -385,7 +385,7 @@ function LiveSlot({
         <ChannelMenu value={chId} onPick={onPick} usedIds={usedIds} />
         <span
           style={{
-            fontFamily: FONT_DATA, fontSize: 8, color: "rgba(255,255,255,0.55)",
+            fontFamily: FONT_DATA, fontSize: 8, color: COLORS.textMuted,
             textShadow: "0 1px 3px rgba(0,0,0,0.9)", pointerEvents: "none",
           }}
         >

--- a/src/components/intel/monitor/LiveWall.tsx
+++ b/src/components/intel/monitor/LiveWall.tsx
@@ -1,5 +1,6 @@
 import { memo, useEffect, useMemo, useRef, useState } from "react";
 import { COLORS, FONT_CJK, FONT_DATA } from "../intelTokens";
+import { SURFACE, ELEVATION } from "../../../styles/designTokens";
 import { fetchLiveVideos, type YtLiveVideo } from "../../../data/intelLoaders";
 import { useInView } from "../../../hooks/useInView";
 
@@ -112,9 +113,9 @@ function ChannelMenu({ value, onPick, usedIds }: MenuProps) {
             position: "absolute", bottom: "calc(100% + 6px)", left: 0,
             width: 232, zIndex: 30, borderRadius: 9, overflow: "hidden",
             border: `1px solid ${COLORS.borderMid}`,
-            background: "rgba(10,10,20,0.94)",
+            background: SURFACE.solid,
             backdropFilter: "blur(14px)", WebkitBackdropFilter: "blur(14px)",
-            boxShadow: "0 8px 32px rgba(0,0,0,0.55)",
+            boxShadow: ELEVATION.md,
             animation: "drawerOpen .18s cubic-bezier(.22,1,.36,1)",
           }}
         >

--- a/src/components/intel/monitor/MonitorPanel.tsx
+++ b/src/components/intel/monitor/MonitorPanel.tsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { useWallClock } from "../../../hooks/useWallClock";
 import { IntelIcon, ICON } from "../IntelIcon";
 import { COLORS, FONT_CJK, FONT_DATA, MICON, smoothPressure } from "../intelTokens";
-import { ELEVATION } from "../../../styles/designTokens";
+import { ELEVATION, RADIUS, FONT_SIZE } from "../../../styles/designTokens";
 import { IntelCard, type IntelCardEvent } from "../IntelCard";
 import { IntelFilters, type TimeRange } from "../IntelFilters";
 import {
@@ -376,7 +376,7 @@ export function MonitorPanel({
         WebkitBackdropFilter: "blur(18px)",
         borderTop: wall ? "none" : `1px solid ${COLORS.borderMid}`,
         border: wall ? "none" : `1px solid ${COLORS.panelBorder}`,
-        borderRadius: wall ? 0 : 10,
+        borderRadius: wall ? 0 : RADIUS.xl,
         zIndex: 40,
         display: "flex", flexDirection: "column",
         overflow: "hidden",
@@ -406,7 +406,7 @@ export function MonitorPanel({
             style={{
               position: "absolute", left: "50%", top: 5,
               transform: "translateX(-50%)",
-              width: 44, height: 4, borderRadius: 3,
+              width: 44, height: 4, borderRadius: RADIUS.md,
               background: COLORS.borderStrong,
             }}
           />
@@ -418,22 +418,22 @@ export function MonitorPanel({
           }}
         >
           <IntelIcon d={MICON.grid!} size={15} color={COLORS.accent} />
-          <span style={{ fontFamily: FONT_CJK, fontSize: 13, fontWeight: 700, color: "#fff" }}>
+          <span style={{ fontFamily: FONT_CJK, fontSize: FONT_SIZE.lg, fontWeight: 700, color: "#fff" }}>
             監看模式
           </span>
           <span
             style={{
-              fontFamily: FONT_DATA, fontSize: 9, letterSpacing: "2.5px", color: COLORS.textDim,
+              fontFamily: FONT_DATA, fontSize: FONT_SIZE.xs, letterSpacing: "2.5px", color: COLORS.textDim,
             }}
           >
             MONITOR
           </span>
           <span
             style={{
-              padding: "1px 7px", borderRadius: 4,
+              padding: "1px 7px", borderRadius: RADIUS.md,
               background: "rgba(255,152,0,0.16)",
               border: "1px solid rgba(255,152,0,0.45)",
-              fontFamily: FONT_DATA, fontSize: 9, fontWeight: 700, letterSpacing: "1px",
+              fontFamily: FONT_DATA, fontSize: FONT_SIZE.xs, fontWeight: 700, letterSpacing: "1px",
               color: COLORS.statusWarn,
               animation: "presBreathe 3s ease-in-out infinite",
             }}
@@ -444,7 +444,7 @@ export function MonitorPanel({
         </div>
         <span
           style={{
-            fontFamily: FONT_DATA, fontSize: 10, color: COLORS.textFaint,
+            fontFamily: FONT_DATA, fontSize: FONT_SIZE.sm, color: COLORS.textFaint,
             marginTop: wall ? 0 : 4, whiteSpace: "nowrap",
           }}
         >
@@ -459,8 +459,8 @@ export function MonitorPanel({
           onMouseDown={(e) => e.stopPropagation()}
           style={{
             display: "inline-flex", alignItems: "center", gap: 6,
-            padding: "5px 11px", borderRadius: 6, cursor: "pointer",
-            marginTop: wall ? 0 : 4, fontFamily: FONT_CJK, fontSize: 11,
+            padding: "5px 11px", borderRadius: RADIUS.lg, cursor: "pointer",
+            marginTop: wall ? 0 : 4, fontFamily: FONT_CJK, fontSize: FONT_SIZE.base,
             whiteSpace: "nowrap",
             background: wall ? COLORS.accentFaint : "rgba(255,255,255,0.05)",
             border: wall ? `1px solid ${COLORS.accentSoft}` : `1px solid ${COLORS.borderMid}`,
@@ -482,9 +482,9 @@ export function MonitorPanel({
           onMouseDown={(e) => e.stopPropagation()}
           style={{
             display: "inline-flex", alignItems: "center", gap: 6,
-            padding: "5px 11px", borderRadius: 6, cursor: "pointer",
+            padding: "5px 11px", borderRadius: RADIUS.lg, cursor: "pointer",
             marginTop: wall ? 0 : 4,
-            fontFamily: FONT_CJK, fontSize: 11, whiteSpace: "nowrap",
+            fontFamily: FONT_CJK, fontSize: FONT_SIZE.base, whiteSpace: "nowrap",
             background: "rgba(255,255,255,0.05)",
             border: `1px solid ${COLORS.borderMid}`,
             color: COLORS.textDefault,
@@ -536,14 +536,14 @@ export function MonitorPanel({
             <span
               style={{
                 display: "inline-flex", alignItems: "center", gap: 4,
-                padding: "1px 7px", borderRadius: 4,
+                padding: "1px 7px", borderRadius: RADIUS.md,
                 background: COLORS.statusLiveSoft,
                 border: `1px solid ${COLORS.statusLiveBorder}`,
               }}
             >
               <span
                 style={{
-                  width: 5, height: 5, borderRadius: "50%",
+                  width: 5, height: 5, borderRadius: RADIUS.full,
                   background: COLORS.statusLive,
                   boxShadow: `0 0 5px ${COLORS.statusLive}`,
                   animation: "intelRing 1.6s ease-in-out infinite",
@@ -551,7 +551,7 @@ export function MonitorPanel({
               />
               <span
                 style={{
-                  fontFamily: FONT_DATA, fontSize: 9, fontWeight: 700,
+                  fontFamily: FONT_DATA, fontSize: FONT_SIZE.xs, fontWeight: 700,
                   color: COLORS.statusLive,
                 }}
               >
@@ -596,10 +596,10 @@ export function MonitorPanel({
                 }}
               >
                 <IntelIcon d={ICON.radio} size={26} color={COLORS.textGhost} />
-                <div style={{ fontFamily: FONT_CJK, fontSize: 12, color: COLORS.textMuted }}>
+                <div style={{ fontFamily: FONT_CJK, fontSize: FONT_SIZE.md, color: COLORS.textMuted }}>
                   目前無符合條件的事件
                 </div>
-                <div style={{ fontFamily: FONT_CJK, fontSize: 10, color: COLORS.textFaint }}>
+                <div style={{ fontFamily: FONT_CJK, fontSize: FONT_SIZE.sm, color: COLORS.textFaint }}>
                   調整分類 / 縣市，或回到即時
                 </div>
               </div>

--- a/src/components/intel/monitor/MonitorPanel.tsx
+++ b/src/components/intel/monitor/MonitorPanel.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { useWallClock } from "../../../hooks/useWallClock";
 import { IntelIcon, ICON } from "../IntelIcon";
 import { COLORS, FONT_CJK, FONT_DATA, MICON, smoothPressure } from "../intelTokens";
+import { ELEVATION } from "../../../styles/designTokens";
 import { IntelCard, type IntelCardEvent } from "../IntelCard";
 import { IntelFilters, type TimeRange } from "../IntelFilters";
 import {
@@ -379,7 +380,7 @@ export function MonitorPanel({
         zIndex: 40,
         display: "flex", flexDirection: "column",
         overflow: "hidden",
-        boxShadow: wall ? "none" : "0 -16px 50px rgba(0,0,0,0.5)",
+        boxShadow: wall ? "none" : ELEVATION.dock,
         animation: "monitorRise .32s cubic-bezier(0.22,1,0.36,1)",
       }}
     >

--- a/src/components/intel/monitor/PressureRing.tsx
+++ b/src/components/intel/monitor/PressureRing.tsx
@@ -1,4 +1,5 @@
 import { COLORS, FONT_CJK, FONT_DATA, type PressureLevelDef } from "../intelTokens";
+import { RADIUS, FONT_SIZE } from "../../../styles/designTokens";
 import type { MarketIndex } from "../../../data/intelLoaders";
 
 /** 270° SVG gauge — 主環 + 動畫，中央留洞給數字（caller 負責疊上 score 文字） */
@@ -55,7 +56,7 @@ export function PressureRing({
         >
           {Math.round(score)}
         </span>
-        <span style={{ fontFamily: FONT_CJK, fontSize: 13, fontWeight: 700, color: level.color }}>
+        <span style={{ fontFamily: FONT_CJK, fontSize: FONT_SIZE.lg, fontWeight: 700, color: level.color }}>
           {level.label}
         </span>
         <span
@@ -74,7 +75,7 @@ export function CompareLine({ delta, label }: { delta: number; label: string }) 
     <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
       <span
         style={{
-          fontFamily: FONT_DATA, fontSize: 12, fontWeight: 700, width: 40,
+          fontFamily: FONT_DATA, fontSize: FONT_SIZE.md, fontWeight: 700, width: 40,
           color: up ? COLORS.statusWarn : COLORS.statusLive,
         }}
       >
@@ -96,7 +97,7 @@ export function TwseTicker({ data }: { data: MarketIndex }) {
   return (
     <div
       style={{
-        borderRadius: 8,
+        borderRadius: RADIUS.xl,
         border: `1px solid ${COLORS.panelBorder}`,
         background: "linear-gradient(160deg, rgba(255,255,255,0.04), rgba(255,255,255,0.01))",
         padding: "10px 14px",
@@ -106,7 +107,7 @@ export function TwseTicker({ data }: { data: MarketIndex }) {
       <div style={{ display: "flex", alignItems: "center", gap: 7 }}>
         <span
           style={{
-            fontFamily: FONT_DATA, fontSize: 9, letterSpacing: "1.2px",
+            fontFamily: FONT_DATA, fontSize: FONT_SIZE.xs, letterSpacing: "1.2px",
             color: COLORS.textDim, whiteSpace: "nowrap",
           }}
         >
@@ -116,7 +117,7 @@ export function TwseTicker({ data }: { data: MarketIndex }) {
         <span
           style={{
             fontFamily: FONT_CJK, fontSize: 8.5, color: COLORS.textFaint,
-            padding: "1px 6px", borderRadius: 3, background: "rgba(255,255,255,0.05)", whiteSpace: "nowrap",
+            padding: "1px 6px", borderRadius: RADIUS.md, background: "rgba(255,255,255,0.05)", whiteSpace: "nowrap",
           }}
         >
           {data.status ?? "—"} {data.time ?? ""}
@@ -133,10 +134,10 @@ export function TwseTicker({ data }: { data: MarketIndex }) {
         </span>
         {has && (
           <>
-            <span style={{ fontFamily: FONT_DATA, fontSize: 13, fontWeight: 700, color: mk }}>
+            <span style={{ fontFamily: FONT_DATA, fontSize: FONT_SIZE.lg, fontWeight: 700, color: mk }}>
               {up ? "▲" : "▼"} {up ? "+" : ""}{data.change.toLocaleString()}
             </span>
-            <span style={{ fontFamily: FONT_DATA, fontSize: 12, fontWeight: 700, color: mk }}>
+            <span style={{ fontFamily: FONT_DATA, fontSize: FONT_SIZE.md, fontWeight: 700, color: mk }}>
               {up ? "+" : ""}{data.change_pct}%
             </span>
           </>
@@ -144,7 +145,7 @@ export function TwseTicker({ data }: { data: MarketIndex }) {
       </div>
       <div
         style={{
-          display: "flex", gap: 12, fontFamily: FONT_DATA, fontSize: 9,
+          display: "flex", gap: 12, fontFamily: FONT_DATA, fontSize: FONT_SIZE.xs,
           color: COLORS.textDim, whiteSpace: "nowrap",
         }}
       >
@@ -181,12 +182,12 @@ export function SectionLabel({ children, color }: { children: React.ReactNode; c
     <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 9 }}>
       <span
         style={{
-          width: 3, height: 12, borderRadius: 2, background: color ?? COLORS.accent,
+          width: 3, height: 12, borderRadius: RADIUS.sm, background: color ?? COLORS.accent,
         }}
       />
       <span
         style={{
-          fontFamily: FONT_DATA, fontSize: 10, letterSpacing: "1.5px",
+          fontFamily: FONT_DATA, fontSize: FONT_SIZE.sm, letterSpacing: "1.5px",
           color: COLORS.textDefault, textTransform: "uppercase",
         }}
       >
@@ -202,7 +203,7 @@ export function Widget({
   return (
     <div
       style={{
-        borderRadius: 9, border: `1px solid ${COLORS.panelBorder}`,
+        borderRadius: RADIUS.xl, border: `1px solid ${COLORS.panelBorder}`,
         background: "rgba(255,255,255,0.022)", padding: 13,
         display: "flex", flexDirection: "column", ...style,
       }}

--- a/src/components/intel/monitor/SituationCards.tsx
+++ b/src/components/intel/monitor/SituationCards.tsx
@@ -1,5 +1,6 @@
 import { IntelIcon } from "../IntelIcon";
 import { COLORS, FONT_CJK, FONT_DATA, MICON } from "../intelTokens";
+import { RADIUS, FONT_SIZE } from "../../../styles/designTokens";
 import { Sparkline } from "./PressureRing";
 import type { PlaActivity, PublicHealthWeek, CdcDisease } from "../../../data/intelLoaders";
 
@@ -8,7 +9,7 @@ function PlaCard({ data }: { data: PlaActivity }) {
   return (
     <div
       style={{
-        borderRadius: 9,
+        borderRadius: RADIUS.xl,
         border: `1px solid ${COLORS.panelBorder}`,
         background: "linear-gradient(160deg, rgba(239,68,68,0.06), rgba(255,255,255,0.012))",
         padding: "12px 13px",
@@ -19,7 +20,7 @@ function PlaCard({ data }: { data: PlaActivity }) {
         <IntelIcon d={MICON.plane!} size={13} color="#ff6b6b" />
         <span
           style={{
-            fontFamily: FONT_DATA, fontSize: 9, letterSpacing: "1.2px", color: COLORS.textDim,
+            fontFamily: FONT_DATA, fontSize: FONT_SIZE.xs, letterSpacing: "1.2px", color: COLORS.textDim,
           }}
         >
           PLA ACTIVITY
@@ -28,7 +29,7 @@ function PlaCard({ data }: { data: PlaActivity }) {
         <span
           style={{
             fontFamily: FONT_CJK, fontSize: 8.5, color: COLORS.textFaint,
-            padding: "1px 6px", borderRadius: 3, background: "rgba(255,255,255,0.05)",
+            padding: "1px 6px", borderRadius: RADIUS.md, background: "rgba(255,255,255,0.05)",
             whiteSpace: "nowrap",
           }}
         >
@@ -42,20 +43,20 @@ function PlaCard({ data }: { data: PlaActivity }) {
         >
           {data.sorties}
         </span>
-        <span style={{ fontFamily: FONT_CJK, fontSize: 11, color: COLORS.textMuted }}>架次</span>
+        <span style={{ fontFamily: FONT_CJK, fontSize: FONT_SIZE.base, color: COLORS.textMuted }}>架次</span>
         <div style={{ flex: 1 }} />
         {data.crossed_median > 0 && (
           <span
             style={{
               display: "inline-flex", alignItems: "center", gap: 4, padding: "3px 8px",
-              borderRadius: 5,
+              borderRadius: RADIUS.lg,
               background: "rgba(239,68,68,0.16)",
               border: "1px solid rgba(239,68,68,0.5)",
             }}
           >
             <span
               style={{
-                fontFamily: FONT_DATA, fontSize: 14, fontWeight: 700, color: "#ff5a5a", lineHeight: 1,
+                fontFamily: FONT_DATA, fontSize: FONT_SIZE.lg, fontWeight: 700, color: "#ff5a5a", lineHeight: 1,
               }}
             >
               {data.crossed_median}
@@ -71,14 +72,14 @@ function PlaCard({ data }: { data: PlaActivity }) {
             key={z.key}
             style={{
               flex: 1, display: "flex", alignItems: "center", justifyContent: "center", gap: 4,
-              padding: "3px 0", borderRadius: 4,
+              padding: "3px 0", borderRadius: RADIUS.md,
               background: z.active ? "rgba(255,152,0,0.12)" : "rgba(255,255,255,0.03)",
               border: z.active ? "1px solid rgba(255,152,0,0.4)" : `1px solid ${COLORS.borderSoft}`,
             }}
           >
             <span
               style={{
-                width: 5, height: 5, borderRadius: "50%",
+                width: 5, height: 5, borderRadius: RADIUS.full,
                 background: z.active ? COLORS.statusWarn : COLORS.textGhost,
                 boxShadow: z.active ? `0 0 5px ${COLORS.statusWarn}` : "none",
               }}
@@ -95,7 +96,7 @@ function PlaCard({ data }: { data: PlaActivity }) {
         ))}
       </div>
 
-      <div style={{ display: "flex", gap: 14, fontFamily: FONT_DATA, fontSize: 10, color: COLORS.textDim }}>
+      <div style={{ display: "flex", gap: 14, fontFamily: FONT_DATA, fontSize: FONT_SIZE.sm, color: COLORS.textDim }}>
         <span>
           海軍 <b style={{ color: COLORS.textDefault }}>{data.plan_vessels}</b> 艦
         </span>
@@ -126,7 +127,7 @@ function DiseaseCard({ d, week }: { d: CdcDisease; week: number }) {
   return (
     <div
       style={{
-        borderRadius: 9, border: `1px solid ${COLORS.panelBorder}`,
+        borderRadius: RADIUS.xl, border: `1px solid ${COLORS.panelBorder}`,
         background: "linear-gradient(160deg, rgba(255,255,255,0.04), rgba(255,255,255,0.012))",
         padding: "12px 13px", display: "flex", flexDirection: "column", gap: 9,
       }}
@@ -134,11 +135,11 @@ function DiseaseCard({ d, week }: { d: CdcDisease; week: number }) {
       <div style={{ display: "flex", alignItems: "center", gap: 7 }}>
         <span
           style={{
-            width: 8, height: 8, borderRadius: "50%", background: d.color, flexShrink: 0,
+            width: 8, height: 8, borderRadius: RADIUS.full, background: d.color, flexShrink: 0,
           }}
         />
         <span
-          style={{ fontFamily: FONT_CJK, fontSize: 12, fontWeight: 700, color: COLORS.textStrong }}
+          style={{ fontFamily: FONT_CJK, fontSize: FONT_SIZE.md, fontWeight: 700, color: COLORS.textStrong }}
         >
           {d.label}
         </span>
@@ -146,7 +147,7 @@ function DiseaseCard({ d, week }: { d: CdcDisease; week: number }) {
         <span
           style={{
             fontFamily: FONT_DATA, fontSize: 8.5, color: COLORS.textFaint,
-            padding: "1px 6px", borderRadius: 3, background: "rgba(255,255,255,0.05)",
+            padding: "1px 6px", borderRadius: RADIUS.md, background: "rgba(255,255,255,0.05)",
           }}
         >
           W{week}
@@ -170,12 +171,12 @@ function DiseaseCard({ d, week }: { d: CdcDisease; week: number }) {
         }}
       >
         <span style={{ display: "inline-flex", alignItems: "center", gap: 3 }}>
-          <span style={{ fontFamily: FONT_DATA, fontSize: 11, fontWeight: 700, color: yc }}>
+          <span style={{ fontFamily: FONT_DATA, fontSize: FONT_SIZE.base, fontWeight: 700, color: yc }}>
             {worse ? "↑" : "↓"}
             {worse ? "+" : ""}
             {d.yoy}%
           </span>
-          <span style={{ fontFamily: FONT_CJK, fontSize: 9, color: COLORS.textFaint }}>
+          <span style={{ fontFamily: FONT_CJK, fontSize: FONT_SIZE.xs, color: COLORS.textFaint }}>
             vs 去年同期
           </span>
         </span>
@@ -204,16 +205,16 @@ export function SituationCards({ pla, health }: Props) {
   return (
     <div style={{ gridColumn: "1 / -1", display: "flex", flexDirection: "column", gap: 10 }}>
       <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
-        <span style={{ width: 3, height: 12, borderRadius: 2, background: COLORS.accent }} />
+        <span style={{ width: 3, height: 12, borderRadius: RADIUS.sm, background: COLORS.accent }} />
         <span
           style={{
-            fontFamily: FONT_DATA, fontSize: 10, letterSpacing: "1.5px", color: COLORS.textDefault,
+            fontFamily: FONT_DATA, fontSize: FONT_SIZE.sm, letterSpacing: "1.5px", color: COLORS.textDefault,
           }}
         >
           情勢 · SITUATION BOARD
         </span>
         <div style={{ flex: 1 }} />
-        <span style={{ fontFamily: FONT_CJK, fontSize: 9, color: COLORS.textFaint }}>
+        <span style={{ fontFamily: FONT_CJK, fontSize: FONT_SIZE.xs, color: COLORS.textFaint }}>
           共機每日 06:00 · CDC 截至 ISO 第 W{health.week} 週
         </span>
       </div>
@@ -235,8 +236,8 @@ export function SituationCards({ pla, health }: Props) {
 }
 
 const emptyCardStyle: React.CSSProperties = {
-  borderRadius: 9, border: `1px dashed ${COLORS.borderSoft}`,
+  borderRadius: RADIUS.xl, border: `1px dashed ${COLORS.borderSoft}`,
   background: "rgba(255,255,255,0.01)", padding: "12px 13px",
-  fontFamily: FONT_CJK, fontSize: 10, color: COLORS.textFaint,
+  fontFamily: FONT_CJK, fontSize: FONT_SIZE.sm, color: COLORS.textFaint,
   display: "flex", alignItems: "center", justifyContent: "center",
 };

--- a/src/components/intel/monitor/SituationOverview.tsx
+++ b/src/components/intel/monitor/SituationOverview.tsx
@@ -4,6 +4,7 @@ import {
   COLORS, FONT_CJK, FONT_DATA, PRESSURE_LEVELS, pressureLevel,
 } from "../intelTokens";
 import { PressureRing, CompareLine, TwseTicker, Widget } from "./PressureRing";
+import { RADIUS, FONT_SIZE } from "../../../styles/designTokens";
 import type {
   PressureIndexNow, PressureSignal, MarketIndex, SourceHealthSummary,
 } from "../../../data/intelLoaders";
@@ -23,14 +24,14 @@ function MiniStat({
       <div style={{ display: "flex", alignItems: "baseline", gap: 4 }}>
         <span
           style={{
-            fontFamily: FONT_DATA, fontSize: 20, fontWeight: 700, lineHeight: 1,
+            fontFamily: FONT_DATA, fontSize: FONT_SIZE.xxl, fontWeight: 700, lineHeight: 1,
             color: color ?? "#fff",
           }}
         >
           {value}
         </span>
         <span
-          style={{ fontFamily: FONT_CJK, fontSize: 10, color: COLORS.textMuted, whiteSpace: "nowrap" }}
+          style={{ fontFamily: FONT_CJK, fontSize: FONT_SIZE.sm, color: COLORS.textMuted, whiteSpace: "nowrap" }}
         >
           {label}
         </span>
@@ -46,7 +47,7 @@ function PressureDrawer({ signals }: { signals: PressureSignal[] }) {
       <div
         style={{
           marginTop: 12, paddingTop: 12, borderTop: `1px dashed ${COLORS.borderMid}`,
-          fontFamily: FONT_CJK, fontSize: 11, color: COLORS.textFaint,
+          fontFamily: FONT_CJK, fontSize: FONT_SIZE.base, color: COLORS.textFaint,
           animation: "drawerOpen .32s cubic-bezier(.22,1,.36,1)",
         }}
       >
@@ -66,12 +67,12 @@ function PressureDrawer({ signals }: { signals: PressureSignal[] }) {
       <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 10 }}>
         <span
           style={{
-            fontFamily: FONT_DATA, fontSize: 9, letterSpacing: "1.5px", color: COLORS.textDefault,
+            fontFamily: FONT_DATA, fontSize: FONT_SIZE.xs, letterSpacing: "1.5px", color: COLORS.textDefault,
           }}
         >
           指數組成 · SIGNAL BREAKDOWN
         </span>
-        <span style={{ fontFamily: FONT_CJK, fontSize: 9, color: COLORS.textFaint }}>
+        <span style={{ fontFamily: FONT_CJK, fontSize: FONT_SIZE.xs, color: COLORS.textFaint }}>
           權重「災害重」· 5min EMA
         </span>
       </div>
@@ -83,7 +84,7 @@ function PressureDrawer({ signals }: { signals: PressureSignal[] }) {
               <span style={{ width: 56, flexShrink: 0, display: "flex", alignItems: "baseline", gap: 4 }}>
                 <span
                   style={{
-                    fontFamily: FONT_CJK, fontSize: 11, color: COLORS.textDefault, whiteSpace: "nowrap",
+                    fontFamily: FONT_CJK, fontSize: FONT_SIZE.base, color: COLORS.textDefault, whiteSpace: "nowrap",
                   }}
                 >
                   {s.label}
@@ -91,7 +92,7 @@ function PressureDrawer({ signals }: { signals: PressureSignal[] }) {
               </span>
               <span
                 style={{
-                  fontFamily: FONT_DATA, fontSize: 8, color: COLORS.textFaint,
+                  fontFamily: FONT_DATA, fontSize: FONT_SIZE.xs, color: COLORS.textFaint,
                   width: 30, flexShrink: 0,
                 }}
               >
@@ -99,7 +100,7 @@ function PressureDrawer({ signals }: { signals: PressureSignal[] }) {
               </span>
               <div
                 style={{
-                  flex: 1, height: 7, borderRadius: 4, background: "rgba(255,255,255,0.05)",
+                  flex: 1, height: 7, borderRadius: RADIUS.md, background: "rgba(255,255,255,0.05)",
                   overflow: "hidden", minWidth: 26,
                 }}
               >
@@ -107,7 +108,7 @@ function PressureDrawer({ signals }: { signals: PressureSignal[] }) {
                   style={{
                     display: "block", height: "100%",
                     width: `${(s.contribution / maxC) * 100}%`,
-                    background: lvl.color, borderRadius: 4, opacity: 0.9,
+                    background: lvl.color, borderRadius: RADIUS.md, opacity: 0.9,
                     transition: "width .5s cubic-bezier(.22,1,.36,1)",
                   }}
                 />
@@ -115,7 +116,7 @@ function PressureDrawer({ signals }: { signals: PressureSignal[] }) {
               <span
                 title={s.note ?? undefined}
                 style={{
-                  fontFamily: FONT_DATA, fontSize: 11, fontWeight: 700,
+                  fontFamily: FONT_DATA, fontSize: FONT_SIZE.base, fontWeight: 700,
                   color: lvl.color, width: 30, textAlign: "right", flexShrink: 0,
                 }}
               >
@@ -140,7 +141,7 @@ function PressureDrawer({ signals }: { signals: PressureSignal[] }) {
               fontFamily: FONT_CJK, fontSize: 9.5, color: COLORS.textMuted,
             }}
           >
-            <span style={{ width: 8, height: 8, borderRadius: "50%", background: l.color }} />
+            <span style={{ width: 8, height: 8, borderRadius: RADIUS.full, background: l.color }} />
             {l.label}{" "}
             <span style={{ fontFamily: FONT_DATA, color: COLORS.textFaint }}>
               {l.min}–{l.max}
@@ -179,24 +180,24 @@ export function SituationOverview({
       {level.key === "emergency" && (
         <span
           style={{
-            position: "absolute", inset: 0, borderRadius: 9, pointerEvents: "none",
+            position: "absolute", inset: 0, borderRadius: RADIUS.xl, pointerEvents: "none",
             boxShadow: `inset 0 0 30px ${level.glow}`,
             animation: "presPulse 1s ease-in-out infinite",
           }}
         />
       )}
       <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 13 }}>
-        <span style={{ width: 3, height: 12, borderRadius: 2, background: level.color }} />
+        <span style={{ width: 3, height: 12, borderRadius: RADIUS.sm, background: level.color }} />
         <span
           style={{
-            fontFamily: FONT_DATA, fontSize: 10, letterSpacing: "1.5px", color: COLORS.textDefault,
+            fontFamily: FONT_DATA, fontSize: FONT_SIZE.sm, letterSpacing: "1.5px", color: COLORS.textDefault,
           }}
         >
           戰情概覽 · PRESSURE INDEX
         </span>
         <span
           style={{
-            fontFamily: FONT_CJK, fontSize: 9, color: COLORS.textFaint, whiteSpace: "nowrap",
+            fontFamily: FONT_CJK, fontSize: FONT_SIZE.xs, color: COLORS.textFaint, whiteSpace: "nowrap",
           }}
         >
           10 訊號加權 0–100
@@ -217,7 +218,7 @@ export function SituationOverview({
             style={{
               position: "absolute", bottom: 6, left: "50%", transform: "translateX(-50%)",
               display: "inline-flex", alignItems: "center", gap: 3, padding: "2px 7px",
-              borderRadius: 10, background: "rgba(0,0,0,0.45)",
+              borderRadius: RADIUS.xl, background: "rgba(0,0,0,0.45)",
               border: `1px solid ${COLORS.borderSoft}`,
               fontFamily: FONT_CJK, fontSize: 8.5, color: COLORS.textMuted, whiteSpace: "nowrap",
             }}

--- a/src/components/intel/monitor/TimelineDock.tsx
+++ b/src/components/intel/monitor/TimelineDock.tsx
@@ -4,6 +4,7 @@ import {
   COLORS, FONT_CJK, FONT_DATA, clockTime,
   type AlertGroupShort,
 } from "../intelTokens";
+import { ELEVATION } from "../../../styles/designTokens";
 import { NEWS_CATEGORIES, type NewsCategory } from "../../../data/newsEventTypes";
 import type { ClusterEvent } from "../../../data/newsEventsLoader";
 import { AlertsTrack } from "../alerts/AlertsTrack";
@@ -287,7 +288,7 @@ export function TimelineDock({
               border: `1px solid ${COLORS.borderMid}`, borderRadius: 7,
               padding: "7px 9px", whiteSpace: "nowrap", pointerEvents: "none",
               backdropFilter: "blur(8px)", WebkitBackdropFilter: "blur(8px)",
-              boxShadow: "0 6px 20px rgba(0,0,0,0.5)",
+              boxShadow: ELEVATION.sm,
             }}
           >
             <div

--- a/src/components/intel/monitor/TimelineDock.tsx
+++ b/src/components/intel/monitor/TimelineDock.tsx
@@ -4,7 +4,7 @@ import {
   COLORS, FONT_CJK, FONT_DATA, clockTime,
   type AlertGroupShort,
 } from "../intelTokens";
-import { ELEVATION } from "../../../styles/designTokens";
+import { ELEVATION, RADIUS, FONT_SIZE } from "../../../styles/designTokens";
 import { NEWS_CATEGORIES, type NewsCategory } from "../../../data/newsEventTypes";
 import type { ClusterEvent } from "../../../data/newsEventsLoader";
 import { AlertsTrack } from "../alerts/AlertsTrack";
@@ -122,7 +122,7 @@ export function TimelineDock({
       <div style={{ display: "flex", alignItems: "center", gap: 10, marginBottom: 8 }}>
         <span
           style={{
-            fontFamily: FONT_DATA, fontSize: 9, letterSpacing: "2px",
+            fontFamily: FONT_DATA, fontSize: FONT_SIZE.xs, letterSpacing: "2px",
             color: COLORS.textMuted, whiteSpace: "nowrap",
           }}
         >
@@ -138,7 +138,7 @@ export function TimelineDock({
               key={c.key}
               title={c.label}
               style={{
-                width: 8, height: 8, borderRadius: 2, background: c.color, opacity: 0.85,
+                width: 8, height: 8, borderRadius: RADIUS.sm, background: c.color, opacity: 0.85,
               }}
             />
           ))}
@@ -148,7 +148,7 @@ export function TimelineDock({
           onClick={onTogglePlay}
           title="play/pause"
           style={{
-            width: 26, height: 26, borderRadius: 5,
+            width: 26, height: 26, borderRadius: RADIUS.lg,
             border: `1px solid ${COLORS.borderMid}`,
             background: "rgba(255,255,255,0.05)",
             color: COLORS.textDefault, cursor: "pointer",
@@ -163,7 +163,7 @@ export function TimelineDock({
         </button>
         <span
           style={{
-            fontFamily: FONT_DATA, fontSize: 12, fontWeight: 700,
+            fontFamily: FONT_DATA, fontSize: FONT_SIZE.md, fontWeight: 700,
             minWidth: 58, textAlign: "center",
             color: isLive ? COLORS.statusLive : COLORS.statusWarn,
           }}
@@ -174,8 +174,8 @@ export function TimelineDock({
           onClick={onLive}
           style={{
             display: "inline-flex", alignItems: "center", gap: 5,
-            padding: "4px 10px", borderRadius: 5, cursor: "pointer",
-            fontFamily: FONT_DATA, fontSize: 10, fontWeight: 700, letterSpacing: "0.5px",
+            padding: "4px 10px", borderRadius: RADIUS.lg, cursor: "pointer",
+            fontFamily: FONT_DATA, fontSize: FONT_SIZE.sm, fontWeight: 700, letterSpacing: "0.5px",
             background: isLive ? COLORS.statusLiveSoft : "rgba(255,255,255,0.05)",
             border: isLive ? `1px solid ${COLORS.statusLiveBorder}` : `1px solid ${COLORS.borderMid}`,
             color: isLive ? COLORS.statusLive : COLORS.textMuted,
@@ -183,7 +183,7 @@ export function TimelineDock({
         >
           <span
             style={{
-              width: 6, height: 6, borderRadius: "50%",
+              width: 6, height: 6, borderRadius: RADIUS.full,
               background: isLive ? COLORS.statusLive : COLORS.textDim,
               boxShadow: isLive ? `0 0 6px ${COLORS.statusLive}` : "none",
             }}
@@ -239,7 +239,7 @@ export function TimelineDock({
                   style={{
                     display: "flex", flexDirection: "column-reverse",
                     height: `${hPct}%`, minHeight: hd.total ? 3 : 0,
-                    borderRadius: 2, overflow: "hidden",
+                    borderRadius: RADIUS.sm, overflow: "hidden",
                     outline: isHover ? "1px solid rgba(255,255,255,0.35)" : "none",
                   }}
                 >
@@ -272,7 +272,7 @@ export function TimelineDock({
           <span
             style={{
               position: "absolute", top: -4, left: -3,
-              width: 8, height: 8, borderRadius: "50%",
+              width: 8, height: 8, borderRadius: RADIUS.full,
               background: isLive ? COLORS.statusLive : COLORS.accent,
             }}
           />
@@ -285,7 +285,7 @@ export function TimelineDock({
               left: `${((hovered.h + 0.5) / 24) * 100}%`,
               transform: "translateX(-50%)", zIndex: 5,
               background: "rgba(0,0,0,0.88)",
-              border: `1px solid ${COLORS.borderMid}`, borderRadius: 7,
+              border: `1px solid ${COLORS.borderMid}`, borderRadius: RADIUS.lg,
               padding: "7px 9px", whiteSpace: "nowrap", pointerEvents: "none",
               backdropFilter: "blur(8px)", WebkitBackdropFilter: "blur(8px)",
               boxShadow: ELEVATION.sm,
@@ -310,7 +310,7 @@ export function TimelineDock({
                 >
                   <span
                     style={{
-                      width: 6, height: 6, borderRadius: "50%", background: c.color,
+                      width: 6, height: 6, borderRadius: RADIUS.full, background: c.color,
                     }}
                   />
                   {c.label} {hovered.c[c.key]}
@@ -334,7 +334,7 @@ export function TimelineDock({
               position: "absolute", left: `${(t / 24) * 100}%`,
               transform:
                 t === 0 ? "none" : t === 24 ? "translateX(-100%)" : "translateX(-50%)",
-              fontFamily: FONT_DATA, fontSize: 9, color: COLORS.textFaint,
+              fontFamily: FONT_DATA, fontSize: FONT_SIZE.xs, color: COLORS.textFaint,
             }}
           >
             {t === 24 ? "23:59" : `${String(t).padStart(2, "0")}:00`}

--- a/src/components/satelliteConsole/CNGroupSection.tsx
+++ b/src/components/satelliteConsole/CNGroupSection.tsx
@@ -10,6 +10,7 @@
  */
 import { useEffect, useMemo, useState } from "react";
 import { COLORS, FONT_CJK, FONT_DATA, CN_GROUPS_META, INTL_GROUPS_META } from "./satelliteConsoleTokens";
+import { RADIUS, FONT_SIZE } from "../../styles/designTokens";
 import { loadSatellites } from "../../data/satelliteLoader";
 import type { SatelliteRecord, SatelliteCategory } from "../../data/satelliteTypes";
 import type { ManeuverRow } from "../../data/satelliteManeuversLoader";
@@ -105,23 +106,23 @@ export function CNGroupSection({ maneuvers, layerVisibility, setLayerVisibility,
             padding: "8px 14px", cursor: "pointer", userSelect: "none",
           }}
         >
-          <span style={{ width: 8, height: 8, borderRadius: "50%", background: g.color, flexShrink: 0 }} />
-          <span style={{ fontFamily: FONT_CJK, fontSize: 12, fontWeight: 600, color: COLORS.textStrong }}>
+          <span style={{ width: 8, height: 8, borderRadius: RADIUS.full, background: g.color, flexShrink: 0 }} />
+          <span style={{ fontFamily: FONT_CJK, fontSize: FONT_SIZE.md, fontWeight: 600, color: COLORS.textStrong }}>
             {g.label}
           </span>
           <span style={{
-            padding: "0 5px", borderRadius: 3,
+            padding: "0 5px", borderRadius: RADIUS.md,
             border: `1px solid ${COLORS.borderMid}`,
-            fontFamily: FONT_DATA, fontSize: 9, color: COLORS.textMuted, lineHeight: "14px",
+            fontFamily: FONT_DATA, fontSize: FONT_SIZE.xs, color: COLORS.textMuted, lineHeight: "14px",
           }}>{g.tier}</span>
-          <span style={{ marginLeft: 4, fontFamily: FONT_DATA, fontSize: 10, color: COLORS.textMuted }}>
+          <span style={{ marginLeft: 4, fontFamily: FONT_DATA, fontSize: FONT_SIZE.sm, color: COLORS.textMuted }}>
             {list.length} 顆
           </span>
           {manCount > 0 && (
             <span style={{
-              marginLeft: 4, padding: "1px 6px", borderRadius: 3,
+              marginLeft: 4, padding: "1px 6px", borderRadius: RADIUS.md,
               background: "rgba(239,68,68,0.16)", border: "1px solid rgba(239,68,68,0.45)",
-              fontFamily: FONT_DATA, fontSize: 9, fontWeight: 700, color: COLORS.statusErr,
+              fontFamily: FONT_DATA, fontSize: FONT_SIZE.xs, fontWeight: 700, color: COLORS.statusErr,
               animation: "satManeuverPulse 1.1s ease-in-out infinite",
             }}>⚡{manCount}</span>
           )}
@@ -133,7 +134,7 @@ export function CNGroupSection({ maneuvers, layerVisibility, setLayerVisibility,
             }}
             aria-label="toggle layer"
             style={{
-              width: 28, height: 16, borderRadius: 8,
+              width: 28, height: 16, borderRadius: RADIUS.xl,
               border: `1px solid ${layerOn ? COLORS.borderAccent : COLORS.borderMid}`,
               background: layerOn ? COLORS.accentFaint : "transparent",
               cursor: "pointer", position: "relative", padding: 0,
@@ -141,19 +142,19 @@ export function CNGroupSection({ maneuvers, layerVisibility, setLayerVisibility,
           >
             <span style={{
               position: "absolute", top: 1, left: layerOn ? 13 : 1,
-              width: 12, height: 12, borderRadius: "50%",
+              width: 12, height: 12, borderRadius: RADIUS.full,
               background: layerOn ? COLORS.accent : COLORS.textDim,
               transition: "left 0.15s ease",
             }} />
           </button>
-          <span style={{ color: COLORS.textDim, fontSize: 10, marginLeft: 4 }}>
+          <span style={{ color: COLORS.textDim, fontSize: FONT_SIZE.sm, marginLeft: 4 }}>
             {isOpen ? "▾" : "▸"}
           </span>
         </div>
         {isOpen && (
           <div style={{ padding: "0 14px 8px" }}>
             {list.length === 0 ? (
-              <div style={{ fontFamily: FONT_CJK, fontSize: 10, color: COLORS.textFaint, padding: "4px 0" }}>
+              <div style={{ fontFamily: FONT_CJK, fontSize: FONT_SIZE.sm, color: COLORS.textFaint, padding: "4px 0" }}>
                 {layerOn ? "無資料（loader 仍在抓 TLE）" : "尚未開啟此圖層"}
               </div>
             ) : (
@@ -166,7 +167,7 @@ export function CNGroupSection({ maneuvers, layerVisibility, setLayerVisibility,
                       style={{
                         display: "flex", alignItems: "center", gap: 6,
                         padding: "3px 0", cursor: "pointer",
-                        fontFamily: FONT_CJK, fontSize: 11, color: COLORS.textDefault,
+                        fontFamily: FONT_CJK, fontSize: FONT_SIZE.base, color: COLORS.textDefault,
                       }}
                       onMouseEnter={(e) => (e.currentTarget.style.background = "rgba(255,255,255,0.03)")}
                       onMouseLeave={(e) => (e.currentTarget.style.background = "transparent")}
@@ -180,13 +181,13 @@ export function CNGroupSection({ maneuvers, layerVisibility, setLayerVisibility,
                         </span>
                       )}
                       {isManeuver && (
-                        <span style={{ color: COLORS.statusErr, fontSize: 11 }} title="近 24h 變軌">⚡</span>
+                        <span style={{ color: COLORS.statusErr, fontSize: FONT_SIZE.base }} title="近 24h 變軌">⚡</span>
                       )}
                     </div>
                   );
                 })}
                 {list.length > 80 && (
-                  <div style={{ padding: "4px 0", fontFamily: FONT_DATA, fontSize: 9, color: COLORS.textFaint, textAlign: "center" }}>
+                  <div style={{ padding: "4px 0", fontFamily: FONT_DATA, fontSize: FONT_SIZE.xs, color: COLORS.textFaint, textAlign: "center" }}>
                     … 共 {list.length}，顯示前 80
                   </div>
                 )}
@@ -203,7 +204,7 @@ export function CNGroupSection({ maneuvers, layerVisibility, setLayerVisibility,
       <div style={{
         padding: "9px 14px 6px",
         fontFamily: FONT_DATA,
-        fontSize: 9,
+        fontSize: FONT_SIZE.xs,
         letterSpacing: "2px",
         color: COLORS.textFaint,
       }}>
@@ -216,7 +217,7 @@ export function CNGroupSection({ maneuvers, layerVisibility, setLayerVisibility,
         padding: "9px 14px 6px",
         marginTop: 4,
         borderTop: `1px solid ${COLORS.borderSoft}`,
-        fontFamily: FONT_DATA, fontSize: 9, letterSpacing: "2px", color: COLORS.textFaint,
+        fontFamily: FONT_DATA, fontSize: FONT_SIZE.xs, letterSpacing: "2px", color: COLORS.textFaint,
       }}>
         INTL RECON · 9 COUNTRIES
       </div>

--- a/src/components/satelliteConsole/CoverageStatsSection.tsx
+++ b/src/components/satelliteConsole/CoverageStatsSection.tsx
@@ -11,6 +11,7 @@
 import { useEffect, useMemo, useState } from "react";
 import * as satellite from "satellite.js";
 import { COLORS, FONT_CJK, FONT_DATA } from "./satelliteConsoleTokens";
+import { RADIUS, FONT_SIZE } from "../../styles/designTokens";
 import { loadSatellites } from "../../data/satelliteLoader";
 import type { SatelliteRecord } from "../../data/satelliteTypes";
 import { SATELLITE_COLORS } from "../../data/satelliteTypes";
@@ -220,10 +221,10 @@ export function CoverageStatsSection({ maneuvers }: Props) {
   return (
     <div style={{ padding: "10px 14px 8px", borderBottom: `1px solid ${COLORS.borderSoft}`, fontFamily: FONT_CJK }}>
       {/* 主數字列 — 覆蓋中 + 6h 通過 + breakdown */}
-      <div style={{ display: "flex", alignItems: "center", gap: 12, fontSize: 11 }}>
+      <div style={{ display: "flex", alignItems: "center", gap: 12, fontSize: FONT_SIZE.base }}>
         <div>
           <span style={{ color: COLORS.textDim }}>覆蓋台灣中</span>
-          <span style={{ marginLeft: 6, fontFamily: FONT_DATA, fontSize: 16, fontWeight: 700, color: coveringNow.length > 0 ? "#4fc3f7" : COLORS.textDefault }}>
+          <span style={{ marginLeft: 6, fontFamily: FONT_DATA, fontSize: FONT_SIZE.xl, fontWeight: 700, color: coveringNow.length > 0 ? "#4fc3f7" : COLORS.textDefault }}>
             {coveringNow.length}
           </span>
           <span style={{ color: COLORS.textDim, marginLeft: 2 }}>顆</span>
@@ -231,7 +232,7 @@ export function CoverageStatsSection({ maneuvers }: Props) {
         <div style={{ width: 1, height: 18, background: COLORS.borderSoft }} />
         <div>
           <span style={{ color: COLORS.textDim }}>未來 6h 通過</span>
-          <span style={{ marginLeft: 6, fontFamily: FONT_DATA, fontSize: 16, fontWeight: 700, color: COLORS.textDefault }}>
+          <span style={{ marginLeft: 6, fontFamily: FONT_DATA, fontSize: FONT_SIZE.xl, fontWeight: 700, color: COLORS.textDefault }}>
             {computingScan ? "…" : passes.length}
           </span>
           <span style={{ color: COLORS.textDim, marginLeft: 2 }}>次</span>
@@ -241,12 +242,12 @@ export function CoverageStatsSection({ maneuvers }: Props) {
           style={{
             marginLeft: "auto",
             padding: "3px 8px",
-            borderRadius: 4,
+            borderRadius: RADIUS.md,
             background: "transparent",
             border: `1px solid ${COLORS.borderMid}`,
             color: COLORS.textMuted,
             fontFamily: FONT_CJK,
-            fontSize: 10,
+            fontSize: FONT_SIZE.sm,
             cursor: "pointer",
           }}
         >
@@ -259,7 +260,7 @@ export function CoverageStatsSection({ maneuvers }: Props) {
         <div style={{
           marginTop: 5,
           display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap",
-          fontFamily: FONT_DATA, fontSize: 10, color: COLORS.textMuted,
+          fontFamily: FONT_DATA, fontSize: FONT_SIZE.sm, color: COLORS.textMuted,
         }}>
           <span>CN <span style={{ color: COLORS.textDefault, fontWeight: 600 }}>{coverageBreakdown.cn}</span></span>
           <span>/ TW <span style={{ color: "#4fc3f7", fontWeight: 600 }}>{coverageBreakdown.tw}</span></span>
@@ -283,7 +284,7 @@ export function CoverageStatsSection({ maneuvers }: Props) {
         <div style={{
           marginTop: 4,
           fontFamily: FONT_DATA,
-          fontSize: 10,
+          fontSize: FONT_SIZE.sm,
           color: COLORS.textMuted,
           whiteSpace: "nowrap",
           overflow: "hidden",
@@ -296,7 +297,7 @@ export function CoverageStatsSection({ maneuvers }: Props) {
 
       {/* 6h timeline 展開 */}
       {expanded && (
-        <div style={{ marginTop: 10, padding: 10, borderRadius: 6, background: "rgba(0,0,0,0.25)" }}>
+        <div style={{ marginTop: 10, padding: 10, borderRadius: RADIUS.lg, background: "rgba(0,0,0,0.25)" }}>
           {/* 過濾 toggle */}
           <div style={{
             display: "flex", alignItems: "center", gap: 8, marginBottom: 8,
@@ -307,7 +308,7 @@ export function CoverageStatsSection({ maneuvers }: Props) {
               onClick={() => setReconOnly(true)}
               style={{
                 padding: "3px 8px",
-                borderRadius: 4,
+                borderRadius: RADIUS.md,
                 background: reconOnly ? "rgba(34,197,94,0.16)" : "transparent",
                 border: `1px solid ${reconOnly ? "rgba(34,197,94,0.55)" : COLORS.borderMid}`,
                 color: reconOnly ? "#22c55e" : COLORS.textMuted,
@@ -320,7 +321,7 @@ export function CoverageStatsSection({ maneuvers }: Props) {
               onClick={() => setReconOnly(false)}
               style={{
                 padding: "3px 8px",
-                borderRadius: 4,
+                borderRadius: RADIUS.md,
                 background: !reconOnly ? COLORS.accentFaint : "transparent",
                 border: `1px solid ${!reconOnly ? COLORS.borderAccent : COLORS.borderMid}`,
                 color: !reconOnly ? "#cfe4ff" : COLORS.textMuted,
@@ -343,7 +344,7 @@ export function CoverageStatsSection({ maneuvers }: Props) {
                 top: 0,
                 transform: "translateX(-50%)",
                 fontFamily: FONT_DATA,
-                fontSize: 9,
+                fontSize: FONT_SIZE.xs,
                 color: COLORS.textFaint,
               }}>
                 +{h}h
@@ -353,7 +354,7 @@ export function CoverageStatsSection({ maneuvers }: Props) {
           {/* tick rows */}
           <div style={{ position: "relative", maxHeight: 220, overflowY: "auto" }} className="mtp-scroll">
             {filteredPasses.length === 0 ? (
-              <div style={{ fontFamily: FONT_CJK, fontSize: 10, color: COLORS.textFaint, padding: "8px 0", textAlign: "center" }}>
+              <div style={{ fontFamily: FONT_CJK, fontSize: FONT_SIZE.sm, color: COLORS.textFaint, padding: "8px 0", textAlign: "center" }}>
                 {computingScan ? "計算中…" : reconOnly ? "未來 6h 無遙測偵察類通過" : "未來 6h 無預計通過"}
               </div>
             ) : (
@@ -369,7 +370,7 @@ export function CoverageStatsSection({ maneuvers }: Props) {
                       top: 5,
                       width: 8,
                       height: 8,
-                      borderRadius: "50%",
+                      borderRadius: RADIUS.full,
                       background: color,
                       transform: "translateX(-50%)",
                       boxShadow: isManeuver ? `0 0 5px ${COLORS.statusErr}` : "none",
@@ -393,7 +394,7 @@ export function CoverageStatsSection({ maneuvers }: Props) {
               })
             )}
             {filteredPasses.length > 80 && (
-              <div style={{ padding: "4px 0", fontFamily: FONT_DATA, fontSize: 9, color: COLORS.textFaint, textAlign: "center" }}>
+              <div style={{ padding: "4px 0", fontFamily: FONT_DATA, fontSize: FONT_SIZE.xs, color: COLORS.textFaint, textAlign: "center" }}>
                 共 {filteredPasses.length} 次 · 顯示前 80
               </div>
             )}

--- a/src/components/satelliteConsole/ManeuverAlertSection.tsx
+++ b/src/components/satelliteConsole/ManeuverAlertSection.tsx
@@ -8,6 +8,7 @@
  */
 import { useMemo, useState } from "react";
 import { COLORS, FONT_CJK, FONT_DATA, MANEUVER_TOKEN, CN_GROUP_TO_CATEGORY, GROUP_FLAG } from "./satelliteConsoleTokens";
+import { RADIUS, FONT_SIZE } from "../../styles/designTokens";
 import { SATELLITE_COLORS } from "../../data/satelliteTypes";
 import type { ManeuverRow } from "../../data/satelliteManeuversLoader";
 import {
@@ -69,7 +70,7 @@ export function ManeuverAlertSection({ maneuvers, onSelectNorad, onOpenCompare }
       <div style={{ padding: "12px 14px", borderBottom: `1px solid ${COLORS.borderSoft}` }}>
         <div style={{
           padding: "8px 10px",
-          borderRadius: 6,
+          borderRadius: RADIUS.lg,
           background: COLORS.statusLiveSoft,
           border: `1px solid ${COLORS.statusLiveBorder}`,
           fontFamily: FONT_CJK,
@@ -79,7 +80,7 @@ export function ManeuverAlertSection({ maneuvers, onSelectNorad, onOpenCompare }
           alignItems: "center",
           gap: 8,
         }}>
-          <span style={{ width: 7, height: 7, borderRadius: "50%", background: COLORS.statusLive }} />
+          <span style={{ width: 7, height: 7, borderRadius: RADIUS.full, background: COLORS.statusLive }} />
           近 24h 無變軌偵測 · 監測中
         </div>
       </div>
@@ -99,7 +100,7 @@ export function ManeuverAlertSection({ maneuvers, onSelectNorad, onOpenCompare }
         gap: 8,
         padding: "8px 10px",
         marginBottom: 9,
-        borderRadius: 6,
+        borderRadius: RADIUS.lg,
         background: hasFeatured ? "rgba(239,68,68,0.12)" : "rgba(156,163,175,0.10)",
         border: hasFeatured ? "1px solid rgba(239,68,68,0.45)" : `1px solid ${COLORS.borderMid}`,
         fontFamily: FONT_CJK,
@@ -107,7 +108,7 @@ export function ManeuverAlertSection({ maneuvers, onSelectNorad, onOpenCompare }
         color: COLORS.textStrong,
       }}>
         <span style={{
-          width: 7, height: 7, borderRadius: "50%",
+          width: 7, height: 7, borderRadius: RADIUS.full,
           background: hasFeatured ? COLORS.statusErr : COLORS.textDim,
           boxShadow: hasFeatured ? `0 0 6px ${COLORS.statusErr}` : "none",
           animation: hasFeatured ? "satManeuverPulse 1.1s ease-in-out infinite" : "none",
@@ -126,7 +127,7 @@ export function ManeuverAlertSection({ maneuvers, onSelectNorad, onOpenCompare }
       {(sortedRed.length > 0 || sortedOrange.length > 0) && (
         <div style={{
           marginBottom: 8,
-          fontFamily: FONT_DATA, fontSize: 9, color: COLORS.textFaint,
+          fontFamily: FONT_DATA, fontSize: FONT_SIZE.xs, color: COLORS.textFaint,
           display: "flex", alignItems: "center", gap: 8,
         }}>
           <SevDot s="red" /> 重大 {sortedRed.length}
@@ -159,12 +160,12 @@ export function ManeuverAlertSection({ maneuvers, onSelectNorad, onOpenCompare }
             style={{
               width: "100%",
               padding: "6px 10px",
-              borderRadius: 5,
+              borderRadius: RADIUS.lg,
               background: "rgba(255,255,255,0.025)",
               border: `1px dashed ${COLORS.borderMid}`,
               color: COLORS.textMuted,
               fontFamily: FONT_CJK,
-              fontSize: 11,
+              fontSize: FONT_SIZE.base,
               cursor: "pointer",
               display: "flex",
               alignItems: "center",
@@ -199,7 +200,7 @@ export function ManeuverAlertSection({ maneuvers, onSelectNorad, onOpenCompare }
 function SevDot({ s }: { s: ManeuverSeverity }) {
   return (
     <span style={{
-      width: 6, height: 6, borderRadius: "50%",
+      width: 6, height: 6, borderRadius: RADIUS.full,
       background: SEV_TOKEN[s].color,
       animation: SEV_TOKEN[s].pulse ? "satManeuverPulse 1.1s ease-in-out infinite" : "none",
     }} />
@@ -225,7 +226,7 @@ function ManeuverCard({ row, severity, impact, onSelectNorad, onOpenCompare, com
   return (
     <div style={{
       padding: compact ? "5px 9px" : "9px 11px",
-      borderRadius: 7,
+      borderRadius: RADIUS.lg,
       background: sev.soft,
       border: `1px solid ${sev.border}`,
       display: "flex",
@@ -235,15 +236,15 @@ function ManeuverCard({ row, severity, impact, onSelectNorad, onOpenCompare, com
     }}>
       {/* 上行 */}
       <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
-        <span style={{ width: 7, height: 7, borderRadius: "50%", background: groupColor, flexShrink: 0 }} />
-        <span style={{ fontSize: 13, flexShrink: 0 }} title={row.country_operator || row.cn_group}>
+        <span style={{ width: 7, height: 7, borderRadius: RADIUS.full, background: groupColor, flexShrink: 0 }} />
+        <span style={{ fontSize: FONT_SIZE.lg, flexShrink: 0 }} title={row.country_operator || row.cn_group}>
           {GROUP_FLAG[row.cn_group] ?? "🌐"}
         </span>
         <span
           onClick={() => onSelectNorad(row.norad_id)}
           style={{
             fontFamily: FONT_CJK,
-            fontSize: compact ? 11 : 12,
+            fontSize: compact ? FONT_SIZE.base : FONT_SIZE.md,
             fontWeight: 600,
             color: COLORS.textStrong,
             whiteSpace: "nowrap",
@@ -258,11 +259,11 @@ function ManeuverCard({ row, severity, impact, onSelectNorad, onOpenCompare, com
         {/* 嚴重度 chip */}
         <span style={{
           padding: "1px 6px",
-          borderRadius: 3,
+          borderRadius: RADIUS.md,
           background: `${sev.color}22`,
           border: `1px solid ${sev.color}55`,
           fontFamily: FONT_DATA,
-          fontSize: 9,
+          fontSize: FONT_SIZE.xs,
           fontWeight: 700,
           color: sev.color,
           flexShrink: 0,
@@ -272,11 +273,11 @@ function ManeuverCard({ row, severity, impact, onSelectNorad, onOpenCompare, com
         {/* 類型 chip */}
         <span style={{
           padding: "1px 6px",
-          borderRadius: 3,
+          borderRadius: RADIUS.md,
           background: `${typeToken.color}22`,
           border: `1px solid ${typeToken.color}55`,
           fontFamily: FONT_DATA,
-          fontSize: 9,
+          fontSize: FONT_SIZE.xs,
           fontWeight: 700,
           color: typeToken.color,
           flexShrink: 0,
@@ -292,7 +293,7 @@ function ManeuverCard({ row, severity, impact, onSelectNorad, onOpenCompare, com
       {/* 中行：detail + relTime */}
       <div style={{
         display: "flex", alignItems: "center", gap: 8,
-        fontFamily: FONT_DATA, fontSize: 10, color: COLORS.textMuted,
+        fontFamily: FONT_DATA, fontSize: FONT_SIZE.sm, color: COLORS.textMuted,
       }}>
         <span>{formatManeuverDetail(row)}</span>
         <span style={{ marginLeft: "auto", color: COLORS.textDim }}>{formatRelTime(row.curr_fetched_at)}</span>
@@ -320,7 +321,7 @@ function ManeuverCard({ row, severity, impact, onSelectNorad, onOpenCompare, com
           <ImpactChip impact={impact} small />
           <button
             onClick={() => onOpenCompare(row)}
-            style={{ ...btnStyle("rgba(100,170,255,0.35)", "#cfe4ff", "transparent"), fontSize: 10, padding: "3px 8px" }}
+            style={{ ...btnStyle("rgba(100,170,255,0.35)", "#cfe4ff", "transparent"), fontSize: FONT_SIZE.sm, padding: "3px 8px" }}
           >
             對比
           </button>
@@ -336,10 +337,10 @@ function ImpactChip({ impact, small }: { impact: ReturnType<ReturnType<typeof us
     return (
       <span style={{
         padding: small ? "1px 6px" : "2px 7px",
-        borderRadius: 3,
+        borderRadius: RADIUS.md,
         background: "rgba(255,255,255,0.04)",
         border: `1px solid ${COLORS.borderMid}`,
-        fontFamily: FONT_DATA, fontSize: 9, color: COLORS.textDim,
+        fontFamily: FONT_DATA, fontSize: FONT_SIZE.xs, color: COLORS.textDim,
       }}>
         計算 TW 影響中…
       </span>
@@ -350,14 +351,14 @@ function ImpactChip({ impact, small }: { impact: ReturnType<ReturnType<typeof us
     return (
       <span style={{
         padding: small ? "1px 6px" : "2px 7px",
-        borderRadius: 3,
+        borderRadius: RADIUS.md,
         background: "rgba(34,197,94,0.16)",
         border: "1px solid rgba(34,197,94,0.55)",
-        fontFamily: FONT_CJK, fontSize: 10, color: "#22c55e", fontWeight: 600,
+        fontFamily: FONT_CJK, fontSize: FONT_SIZE.sm, color: "#22c55e", fontWeight: 600,
         display: "inline-flex", alignItems: "center", gap: 3,
       }}>
         ✓ 影響 TW
-        <span style={{ fontFamily: FONT_DATA, fontSize: 9, opacity: 0.8 }}>
+        <span style={{ fontFamily: FONT_DATA, fontSize: FONT_SIZE.xs, opacity: 0.8 }}>
           ({impact.passBefore}→{impact.passAfter})
         </span>
       </span>
@@ -367,10 +368,10 @@ function ImpactChip({ impact, small }: { impact: ReturnType<ReturnType<typeof us
   return (
     <span style={{
       padding: small ? "1px 6px" : "2px 7px",
-      borderRadius: 3,
+      borderRadius: RADIUS.md,
       background: "rgba(255,255,255,0.03)",
       border: `1px solid ${COLORS.borderSoft}`,
-      fontFamily: FONT_CJK, fontSize: 10, color: COLORS.textFaint,
+      fontFamily: FONT_CJK, fontSize: FONT_SIZE.sm, color: COLORS.textFaint,
     }}>
       過台不變 ({impact.passBefore}=)
     </span>
@@ -380,12 +381,12 @@ function ImpactChip({ impact, small }: { impact: ReturnType<ReturnType<typeof us
 function btnStyle(border: string, color: string, bg: string) {
   return {
     padding: "5px 10px",
-    borderRadius: 4,
+    borderRadius: RADIUS.md,
     background: bg,
     border: `1px solid ${border}`,
     color,
     fontFamily: FONT_CJK,
-    fontSize: 11,
+    fontSize: FONT_SIZE.base,
     cursor: "pointer",
     transition: "all 0.15s ease",
     flexShrink: 0,

--- a/src/components/satelliteConsole/ManeuverCompareModal.tsx
+++ b/src/components/satelliteConsole/ManeuverCompareModal.tsx
@@ -12,6 +12,7 @@
  * 起點 = 變軌事件本身（curr_fetched_at），不跟現實 now 不跟時間軸
  */
 import { useEffect, useMemo, useState } from "react";
+import { X } from "lucide-react";
 import * as satellite from "satellite.js";
 import { COLORS, FONT_CJK, FONT_DATA, MANEUVER_TOKEN } from "./satelliteConsoleTokens";
 import { RADIUS, FONT_SIZE } from "../../styles/designTokens";
@@ -355,9 +356,9 @@ export function ManeuverCompareModal({ maneuver, onClose }: Props) {
               marginLeft: "auto",
               width: 28, height: 28, borderRadius: RADIUS.md, border: "none",
               background: "transparent", color: COLORS.textDim, cursor: "pointer",
-              fontSize: FONT_SIZE.xxl, lineHeight: 1,
+              display: "flex", alignItems: "center", justifyContent: "center",
             }}
-          >×</button>
+          ><X size={14} /></button>
         </div>
 
         <div className="mtp-scroll" style={{ flex: 1, overflowY: "auto", padding: "14px 16px 16px" }}>

--- a/src/components/satelliteConsole/ManeuverCompareModal.tsx
+++ b/src/components/satelliteConsole/ManeuverCompareModal.tsx
@@ -14,6 +14,7 @@
 import { useEffect, useMemo, useState } from "react";
 import * as satellite from "satellite.js";
 import { COLORS, FONT_CJK, FONT_DATA, MANEUVER_TOKEN } from "./satelliteConsoleTokens";
+import { RADIUS, FONT_SIZE } from "../../styles/designTokens";
 import { fetchTlePair, type TleHistoryRow } from "../../data/satelliteHistoryLoader";
 import { formatManeuverDetail, type ManeuverRow } from "../../data/satelliteManeuversLoader";
 
@@ -197,18 +198,18 @@ function MiniMap({
   return (
     <div style={{ flex: 1 }}>
       <div style={{ display: "flex", alignItems: "center", gap: 6, marginBottom: 4 }}>
-        <span style={{ width: 8, height: 8, borderRadius: "50%", background: color }} />
+        <span style={{ width: 8, height: 8, borderRadius: RADIUS.full, background: color }} />
         <span style={{ fontFamily: FONT_DATA, fontSize: 9.5, letterSpacing: "1.5px", color: COLORS.textMuted }}>
           {label}
         </span>
         {track && (
-          <span style={{ marginLeft: "auto", fontFamily: FONT_DATA, fontSize: 10, color: COLORS.textDefault, fontWeight: 600 }}>
+          <span style={{ marginLeft: "auto", fontFamily: FONT_DATA, fontSize: FONT_SIZE.sm, color: COLORS.textDefault, fontWeight: 600 }}>
             過台 {track.twPasses} 次 / 7d
           </span>
         )}
       </div>
       <svg width={width} height={height} viewBox={`0 0 ${width} ${height}`}
-           style={{ background: "#0b0f14", border: `1px solid ${COLORS.borderSoft}`, borderRadius: 6, display: "block" }}>
+           style={{ background: "#0b0f14", border: `1px solid ${COLORS.borderSoft}`, borderRadius: RADIUS.lg, display: "block" }}>
         {/* 經緯線（每 5°） */}
         {Array.from({ length: 8 }).map((_, i) => {
           const lng = TW_FRAME.lngMin + i * 5;
@@ -319,7 +320,7 @@ export function ManeuverCompareModal({ maneuver, onClose }: Props) {
         style={{
           width: 760, maxWidth: "100%", maxHeight: "92vh",
           background: COLORS.panelBg, border: `1px solid ${COLORS.panelBorder}`,
-          borderRadius: 10, fontFamily: FONT_CJK, color: COLORS.textDefault,
+          borderRadius: RADIUS.xl, fontFamily: FONT_CJK, color: COLORS.textDefault,
           display: "flex", flexDirection: "column", overflow: "hidden",
           animation: "satConsoleFadeIn .25s ease-out",
         }}
@@ -332,40 +333,40 @@ export function ManeuverCompareModal({ maneuver, onClose }: Props) {
         }}>
           <span style={{
             display: "inline-flex", alignItems: "center", gap: 4,
-            padding: "2px 8px", borderRadius: 4,
+            padding: "2px 8px", borderRadius: RADIUS.md,
             background: token.soft, border: `1px solid ${token.color}66`,
-            fontFamily: FONT_DATA, fontSize: 10, fontWeight: 700, color: token.color,
+            fontFamily: FONT_DATA, fontSize: FONT_SIZE.sm, fontWeight: 700, color: token.color,
             animation: token.pulse ? "satManeuverPulse 1.1s ease-in-out infinite" : "none",
           }}>
             {token.icon} {token.zh}
           </span>
-          <span style={{ fontSize: 14, fontWeight: 700, color: COLORS.textStrong }}>
+          <span style={{ fontSize: FONT_SIZE.lg, fontWeight: 700, color: COLORS.textStrong }}>
             {maneuver.name}
           </span>
-          <span style={{ fontFamily: FONT_DATA, fontSize: 10, color: COLORS.textDim }}>
+          <span style={{ fontFamily: FONT_DATA, fontSize: FONT_SIZE.sm, color: COLORS.textDim }}>
             NORAD {maneuver.norad_id}
           </span>
-          <span style={{ fontFamily: FONT_DATA, fontSize: 11, color: COLORS.textDefault, marginLeft: 6 }}>
+          <span style={{ fontFamily: FONT_DATA, fontSize: FONT_SIZE.base, color: COLORS.textDefault, marginLeft: 6 }}>
             {formatManeuverDetail(maneuver)}
           </span>
           <button
             onClick={onClose}
             style={{
               marginLeft: "auto",
-              width: 28, height: 28, borderRadius: 4, border: "none",
+              width: 28, height: 28, borderRadius: RADIUS.md, border: "none",
               background: "transparent", color: COLORS.textDim, cursor: "pointer",
-              fontSize: 20, lineHeight: 1,
+              fontSize: FONT_SIZE.xxl, lineHeight: 1,
             }}
           >×</button>
         </div>
 
         <div className="mtp-scroll" style={{ flex: 1, overflowY: "auto", padding: "14px 16px 16px" }}>
           {loading ? (
-            <div style={{ padding: "40px 0", textAlign: "center", color: COLORS.textFaint, fontSize: 11 }}>
+            <div style={{ padding: "40px 0", textAlign: "center", color: COLORS.textFaint, fontSize: FONT_SIZE.base }}>
               載入 TLE pair + 計算 7 天 ground track…
             </div>
           ) : !pair.prev || !pair.curr ? (
-            <div style={{ padding: "20px 0", textAlign: "center", color: COLORS.statusWarn, fontSize: 11 }}>
+            <div style={{ padding: "20px 0", textAlign: "center", color: COLORS.statusWarn, fontSize: FONT_SIZE.base }}>
               tle_history 找不到對應的 prev/curr TLE（epoch 可能尚未歸檔）
             </div>
           ) : (
@@ -386,7 +387,7 @@ export function ManeuverCompareModal({ maneuver, onClose }: Props) {
                 </div>
               )}
 
-              <div style={{ marginTop: 10, fontFamily: FONT_DATA, fontSize: 9, color: COLORS.textFaint }}>
+              <div style={{ marginTop: 10, fontFamily: FONT_DATA, fontSize: FONT_SIZE.xs, color: COLORS.textFaint }}>
                 顯示框：經度 {TW_FRAME.lngMin}–{TW_FRAME.lngMax}°E · 緯度 {TW_FRAME.latMin}–{TW_FRAME.latMax}°N
                 ｜ 比對方法：前後兩條 TLE 跑 SGP4 7 天（10 min 步進），elevation&gt;10° 入境邊緣 = 1 次過台
               </div>
@@ -409,12 +410,12 @@ function PassDiffHeadline({ diff }: { diff: { twBefore: number; twAfter: number;
   return (
     <div style={{
       padding: "12px 14px",
-      borderRadius: 8,
+      borderRadius: RADIUS.xl,
       background: "rgba(255,255,255,0.025)",
       border: `1px solid ${COLORS.borderSoft}`,
     }}>
       <div style={{
-        fontFamily: FONT_DATA, fontSize: 9, letterSpacing: "2px",
+        fontFamily: FONT_DATA, fontSize: FONT_SIZE.xs, letterSpacing: "2px",
         color: COLORS.textFaint, marginBottom: 8,
       }}>
         OVERHEAD PASSES · 過台頻次 7 天
@@ -426,11 +427,11 @@ function PassDiffHeadline({ diff }: { diff: { twBefore: number; twAfter: number;
           minWidth: 80, gap: 2,
         }}>
           <span style={{
-            fontFamily: FONT_DATA, fontSize: 22, fontWeight: 800, color: pctColor, lineHeight: 1,
+            fontFamily: FONT_DATA, fontSize: FONT_SIZE.xxl, fontWeight: 800, color: pctColor, lineHeight: 1,
           }}>
             {isUp ? "+" : ""}{diff.pct}%
           </span>
-          <span style={{ fontFamily: FONT_DATA, fontSize: 10, color: COLORS.textMuted }}>
+          <span style={{ fontFamily: FONT_DATA, fontSize: FONT_SIZE.sm, color: COLORS.textMuted }}>
             {isUp ? "↑ 增加" : isDown ? "↓ 減少" : "持平"}
             {" "}
             {isUp || isDown ? `${Math.abs(diff.twDiff)} 次` : ""}
@@ -447,18 +448,18 @@ function PassBar({ label, value, max, color }: { label: string; value: number; m
   return (
     <div style={{ flex: 1, display: "flex", flexDirection: "column", justifyContent: "center", gap: 4 }}>
       <div style={{ display: "flex", alignItems: "baseline", gap: 6 }}>
-        <span style={{ fontFamily: FONT_DATA, fontSize: 9, letterSpacing: "1.5px", color: COLORS.textFaint }}>
+        <span style={{ fontFamily: FONT_DATA, fontSize: FONT_SIZE.xs, letterSpacing: "1.5px", color: COLORS.textFaint }}>
           {label}
         </span>
-        <span style={{ marginLeft: "auto", fontFamily: FONT_DATA, fontSize: 18, fontWeight: 700, color: COLORS.textStrong, lineHeight: 1 }}>
+        <span style={{ marginLeft: "auto", fontFamily: FONT_DATA, fontSize: FONT_SIZE.xl, fontWeight: 700, color: COLORS.textStrong, lineHeight: 1 }}>
           {value}
         </span>
-        <span style={{ fontFamily: FONT_DATA, fontSize: 10, color: COLORS.textDim }}>次</span>
+        <span style={{ fontFamily: FONT_DATA, fontSize: FONT_SIZE.sm, color: COLORS.textDim }}>次</span>
       </div>
-      <div style={{ position: "relative", height: 8, borderRadius: 4, background: "rgba(255,255,255,0.05)" }}>
+      <div style={{ position: "relative", height: 8, borderRadius: RADIUS.md, background: "rgba(255,255,255,0.05)" }}>
         <div style={{
           position: "absolute", left: 0, top: 0, bottom: 0, width: `${pct}%`,
-          background: color, borderRadius: 4, transition: "width 0.3s ease",
+          background: color, borderRadius: RADIUS.md, transition: "width 0.3s ease",
         }} />
       </div>
     </div>
@@ -474,7 +475,7 @@ function RegionDiffChips({ gained, lost }: { gained: Region[]; lost: Region[] })
 
   if (gained.length === 0 && lost.length === 0) {
     return (
-      <div style={{ fontFamily: FONT_CJK, fontSize: 11, color: COLORS.textFaint, padding: "4px 0" }}>
+      <div style={{ fontFamily: FONT_CJK, fontSize: FONT_SIZE.base, color: COLORS.textFaint, padding: "4px 0" }}>
         7 天內覆蓋區域無實質差異（軌道平面微移，bbox 命中不變）
       </div>
     );
@@ -484,7 +485,7 @@ function RegionDiffChips({ gained, lost }: { gained: Region[]; lost: Region[] })
     <div style={{ display: "flex", flexWrap: "wrap", alignItems: "center", gap: 6 }}>
       {gained.length > 0 && (
         <>
-          <span style={{ fontFamily: FONT_DATA, fontSize: 9, color: COLORS.textFaint, letterSpacing: "1.5px" }}>
+          <span style={{ fontFamily: FONT_DATA, fontSize: FONT_SIZE.xs, color: COLORS.textFaint, letterSpacing: "1.5px" }}>
             新增覆蓋
           </span>
           {gainedInFrame.map((r) => (
@@ -498,7 +499,7 @@ function RegionDiffChips({ gained, lost }: { gained: Region[]; lost: Region[] })
       {lost.length > 0 && (
         <>
           {gained.length > 0 && <span style={{ color: COLORS.borderMid }}>·</span>}
-          <span style={{ fontFamily: FONT_DATA, fontSize: 9, color: COLORS.textFaint, letterSpacing: "1.5px" }}>
+          <span style={{ fontFamily: FONT_DATA, fontSize: FONT_SIZE.xs, color: COLORS.textFaint, letterSpacing: "1.5px" }}>
             失去覆蓋
           </span>
           {lostInFrame.map((r) => (
@@ -520,18 +521,18 @@ function Chip({ color, zh, prefix, offFrame }: { color: string; zh: string; pref
       style={{
         display: "inline-flex", alignItems: "center", gap: 3,
         padding: "2px 7px",
-        borderRadius: 4,
+        borderRadius: RADIUS.md,
         background: `${color}22`,
         border: `1px solid ${color}66`,
         fontFamily: FONT_CJK,
-        fontSize: 11,
+        fontSize: FONT_SIZE.base,
         color,
         opacity: offFrame ? 0.75 : 1,
       }}
     >
       <span style={{ fontWeight: 700 }}>{prefix}</span>
       {zh}
-      {offFrame && <span style={{ fontSize: 9, opacity: 0.8 }}>(框外)</span>}
+      {offFrame && <span style={{ fontSize: FONT_SIZE.xs, opacity: 0.8 }}>(框外)</span>}
     </span>
   );
 }

--- a/src/components/satelliteConsole/SatelliteConsole.tsx
+++ b/src/components/satelliteConsole/SatelliteConsole.tsx
@@ -6,6 +6,7 @@
  */
 import { useEffect, useState } from "react";
 import { COLORS, FONT_CJK, FONT_DATA, PANEL_WIDTH } from "./satelliteConsoleTokens";
+import { RADIUS, FONT_SIZE } from "../../styles/designTokens";
 import { SatelliteConsoleHeader } from "./SatelliteConsoleHeader";
 import { ManeuverAlertSection } from "./ManeuverAlertSection";
 import { CNGroupSection } from "./CNGroupSection";
@@ -72,7 +73,7 @@ export function SatelliteConsole({ open, onClose, layerVisibility, setLayerVisib
           boxShadow: isHistory
             ? "0 0 0 1px rgba(255,152,0,0.18), 0 12px 40px rgba(0,0,0,0.45)"
             : "0 12px 40px rgba(0,0,0,0.45)",
-          borderRadius: 10,
+          borderRadius: RADIUS.xl,
           zIndex: 30,
           display: "flex",
           flexDirection: "column",
@@ -120,7 +121,7 @@ export function SatelliteConsole({ open, onClose, layerVisibility, setLayerVisib
           padding: "8px 14px",
           borderTop: `1px solid ${COLORS.borderSoft}`,
           fontFamily: FONT_DATA,
-          fontSize: 9,
+          fontSize: FONT_SIZE.xs,
           color: COLORS.textFaint,
           display: "flex",
           alignItems: "center",

--- a/src/components/satelliteConsole/SatelliteConsoleHeader.tsx
+++ b/src/components/satelliteConsole/SatelliteConsoleHeader.tsx
@@ -1,5 +1,6 @@
 import { IntelIcon, ICON } from "../intel/IntelIcon";
 import { COLORS, FONT_CJK, FONT_DATA, clockTime } from "./satelliteConsoleTokens";
+import { RADIUS, FONT_SIZE } from "../../styles/designTokens";
 import { isHistoryMode, formatTimelineOffset } from "../../hooks/useTimeStoreTime";
 
 interface Props {
@@ -43,7 +44,7 @@ export function SatelliteConsoleHeader({ totalManeuvers, timelineSec, onClose }:
           <span style={{ fontFamily: FONT_CJK, fontSize: 13.5, fontWeight: 700, color: COLORS.textStrong }}>
             衛星情報
           </span>
-          <span style={{ fontFamily: FONT_DATA, fontSize: 9, letterSpacing: "2.5px", color: COLORS.textDim }}>
+          <span style={{ fontFamily: FONT_DATA, fontSize: FONT_SIZE.xs, letterSpacing: "2.5px", color: COLORS.textDim }}>
             SATELLITE
           </span>
         </div>
@@ -56,7 +57,7 @@ export function SatelliteConsoleHeader({ totalManeuvers, timelineSec, onClose }:
               gap: 5,
               marginLeft: 6,
               padding: "2px 8px",
-              borderRadius: 4,
+              borderRadius: RADIUS.md,
               background: "rgba(239,68,68,0.16)",
               border: "1px solid rgba(239,68,68,0.45)",
             }}
@@ -65,13 +66,13 @@ export function SatelliteConsoleHeader({ totalManeuvers, timelineSec, onClose }:
               style={{
                 width: 6,
                 height: 6,
-                borderRadius: "50%",
+                borderRadius: RADIUS.full,
                 background: COLORS.statusErr,
                 boxShadow: `0 0 6px ${COLORS.statusErr}`,
                 animation: "intelRing 1.6s ease-in-out infinite",
               }}
             />
-            <span style={{ fontFamily: FONT_DATA, fontSize: 10, fontWeight: 700, color: COLORS.statusErr }}>
+            <span style={{ fontFamily: FONT_DATA, fontSize: FONT_SIZE.sm, fontWeight: 700, color: COLORS.statusErr }}>
               ALERT
             </span>
           </span>
@@ -83,7 +84,7 @@ export function SatelliteConsoleHeader({ totalManeuvers, timelineSec, onClose }:
           style={{
             width: 24,
             height: 24,
-            borderRadius: 4,
+            borderRadius: RADIUS.md,
             border: "none",
             background: "transparent",
             color: COLORS.textDim,
@@ -107,7 +108,7 @@ export function SatelliteConsoleHeader({ totalManeuvers, timelineSec, onClose }:
           alignItems: "center",
           gap: 8,
           fontFamily: FONT_DATA,
-          fontSize: 10,
+          fontSize: FONT_SIZE.sm,
           background: isHistory ? "rgba(255,152,0,0.06)" : "transparent",
         }}
       >
@@ -117,7 +118,7 @@ export function SatelliteConsoleHeader({ totalManeuvers, timelineSec, onClose }:
             alignItems: "center",
             gap: 5,
             padding: "2px 8px",
-            borderRadius: 4,
+            borderRadius: RADIUS.md,
             background: badgeSoft,
             border: `1px solid ${badgeBorder}`,
             fontFamily: FONT_DATA,
@@ -125,7 +126,7 @@ export function SatelliteConsoleHeader({ totalManeuvers, timelineSec, onClose }:
             color: badgeColor,
           }}
         >
-          <span style={{ width: 6, height: 6, borderRadius: "50%", background: badgeColor }} />
+          <span style={{ width: 6, height: 6, borderRadius: RADIUS.full, background: badgeColor }} />
           {isHistory ? "HISTORY" : "LIVE"}
         </span>
         <span style={{ color: COLORS.textDim }}>顯示時間</span>

--- a/src/components/satelliteConsole/SatelliteDetailCard.tsx
+++ b/src/components/satelliteConsole/SatelliteDetailCard.tsx
@@ -11,6 +11,7 @@
  * - 預測 ← computePrediction(events)
  */
 import { useEffect, useMemo, useState } from "react";
+import { X } from "lucide-react";
 import { COLORS, FONT_CJK, FONT_DATA, MANEUVER_TOKEN } from "./satelliteConsoleTokens";
 import { ELEVATION, RADIUS, FONT_SIZE } from "../../styles/designTokens";
 import { fetchCatalog, formatOperatingSince, type CatalogRow } from "../../data/satelliteCatalogLoader";
@@ -119,9 +120,9 @@ export function SatelliteDetailCard({ norad, onClose }: Props) {
           style={{
             width: 24, height: 24, borderRadius: RADIUS.md, border: "none",
             background: "transparent", color: COLORS.textDim, cursor: "pointer",
-            fontSize: FONT_SIZE.xl, lineHeight: 1,
+            display: "flex", alignItems: "center", justifyContent: "center",
           }}
-        >×</button>
+        ><X size={14} /></button>
       </div>
 
       <div className="mtp-scroll" style={{ flex: 1, overflowY: "auto", padding: "11px 14px 14px" }}>

--- a/src/components/satelliteConsole/SatelliteDetailCard.tsx
+++ b/src/components/satelliteConsole/SatelliteDetailCard.tsx
@@ -12,6 +12,7 @@
  */
 import { useEffect, useMemo, useState } from "react";
 import { COLORS, FONT_CJK, FONT_DATA, MANEUVER_TOKEN } from "./satelliteConsoleTokens";
+import { ELEVATION } from "../../styles/designTokens";
 import { fetchCatalog, formatOperatingSince, type CatalogRow } from "../../data/satelliteCatalogLoader";
 import {
   fetchTleHistory,
@@ -92,7 +93,7 @@ export function SatelliteDetailCard({ norad, onClose }: Props) {
         overflow: "hidden",
         fontFamily: FONT_CJK,
         color: COLORS.textDefault,
-        boxShadow: "0 12px 40px rgba(0,0,0,0.45)",
+        boxShadow: ELEVATION.lg,
         animation: "satConsoleFadeIn .25s ease-out",
       }}
     >

--- a/src/components/satelliteConsole/SatelliteDetailCard.tsx
+++ b/src/components/satelliteConsole/SatelliteDetailCard.tsx
@@ -12,7 +12,7 @@
  */
 import { useEffect, useMemo, useState } from "react";
 import { COLORS, FONT_CJK, FONT_DATA, MANEUVER_TOKEN } from "./satelliteConsoleTokens";
-import { ELEVATION } from "../../styles/designTokens";
+import { ELEVATION, RADIUS, FONT_SIZE } from "../../styles/designTokens";
 import { fetchCatalog, formatOperatingSince, type CatalogRow } from "../../data/satelliteCatalogLoader";
 import {
   fetchTleHistory,
@@ -86,7 +86,7 @@ export function SatelliteDetailCard({ norad, onClose }: Props) {
         backdropFilter: "blur(16px)",
         WebkitBackdropFilter: "blur(16px)",
         border: `1px solid ${COLORS.panelBorder}`,
-        borderRadius: 10,
+        borderRadius: RADIUS.xl,
         zIndex: 35,
         display: "flex",
         flexDirection: "column",
@@ -106,10 +106,10 @@ export function SatelliteDetailCard({ norad, onClose }: Props) {
         gap: 8,
       }}>
         <div style={{ flex: 1, minWidth: 0 }}>
-          <div style={{ fontSize: 13, fontWeight: 700, color: COLORS.textStrong, whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>
+          <div style={{ fontSize: FONT_SIZE.lg, fontWeight: 700, color: COLORS.textStrong, whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>
             {twLocale ? twLocale.zh : (catalog?.name || `NORAD ${norad}`)}
           </div>
-          <div style={{ fontFamily: FONT_DATA, fontSize: 10, color: COLORS.textDim, marginTop: 2 }}>
+          <div style={{ fontFamily: FONT_DATA, fontSize: FONT_SIZE.sm, color: COLORS.textDim, marginTop: 2 }}>
             NORAD {norad}{catalog?.cospar_number ? ` · COSPAR ${catalog.cospar_number}` : ""}
           </div>
         </div>
@@ -117,16 +117,16 @@ export function SatelliteDetailCard({ norad, onClose }: Props) {
           onClick={onClose}
           aria-label="close"
           style={{
-            width: 24, height: 24, borderRadius: 4, border: "none",
+            width: 24, height: 24, borderRadius: RADIUS.md, border: "none",
             background: "transparent", color: COLORS.textDim, cursor: "pointer",
-            fontSize: 18, lineHeight: 1,
+            fontSize: FONT_SIZE.xl, lineHeight: 1,
           }}
         >×</button>
       </div>
 
       <div className="mtp-scroll" style={{ flex: 1, overflowY: "auto", padding: "11px 14px 14px" }}>
         {loading ? (
-          <div style={{ fontSize: 11, color: COLORS.textFaint, padding: "20px 0", textAlign: "center" }}>
+          <div style={{ fontSize: FONT_SIZE.base, color: COLORS.textFaint, padding: "20px 0", textAlign: "center" }}>
             載入中…
           </div>
         ) : (
@@ -176,7 +176,7 @@ export function SatelliteDetailCard({ norad, onClose }: Props) {
                   {events.slice(0, 8).map((e, i) => {
                     const token = MANEUVER_TOKEN[e.type];
                     return (
-                      <div key={i} style={{ display: "flex", alignItems: "center", gap: 8, fontSize: 11 }}>
+                      <div key={i} style={{ display: "flex", alignItems: "center", gap: 8, fontSize: FONT_SIZE.base }}>
                         <span style={{ color: token.color, fontFamily: FONT_DATA, width: 16 }}>{token.icon}</span>
                         <span style={{ fontFamily: FONT_DATA, fontSize: 10.5, color: COLORS.textMuted, width: 78 }}>
                           {e.date}
@@ -184,7 +184,7 @@ export function SatelliteDetailCard({ norad, onClose }: Props) {
                         <span style={{ fontFamily: FONT_DATA, fontSize: 9.5, color: token.color, width: 50 }}>
                           {e.type === "PLANE_CHANGE" ? "PLANE" : e.type === "ALTITUDE_CHANGE" ? "ALT" : "SHAPE"}
                         </span>
-                        <span style={{ color: COLORS.textDefault, fontFamily: FONT_DATA, fontSize: 10 }}>{e.detail}</span>
+                        <span style={{ color: COLORS.textDefault, fontFamily: FONT_DATA, fontSize: FONT_SIZE.sm }}>{e.detail}</span>
                       </div>
                     );
                   })}
@@ -195,14 +195,14 @@ export function SatelliteDetailCard({ norad, onClose }: Props) {
             {/* 啟發式預測 */}
             {prediction.muDays != null && prediction.muDays > 0 && (
               <Section title="啟發式預測">
-                <div style={{ padding: "8px 10px", borderRadius: 6, background: "rgba(100,170,255,0.08)", border: "1px solid rgba(100,170,255,0.25)" }}>
+                <div style={{ padding: "8px 10px", borderRadius: RADIUS.lg, background: "rgba(100,170,255,0.08)", border: "1px solid rgba(100,170,255,0.25)" }}>
                   <div style={{ display: "flex", alignItems: "baseline", gap: 8 }}>
-                    <span style={{ fontSize: 10, color: COLORS.textMuted }}>下次變軌約</span>
-                    <span style={{ fontFamily: FONT_DATA, fontSize: 16, fontWeight: 700, color: "#cfe4ff" }}>
+                    <span style={{ fontSize: FONT_SIZE.sm, color: COLORS.textMuted }}>下次變軌約</span>
+                    <span style={{ fontFamily: FONT_DATA, fontSize: FONT_SIZE.xl, fontWeight: 700, color: "#cfe4ff" }}>
                       {prediction.nextLowDays}–{prediction.nextHighDays}
                     </span>
-                    <span style={{ fontSize: 10, color: COLORS.textMuted }}>天內</span>
-                    <span style={{ marginLeft: "auto", fontFamily: FONT_DATA, fontSize: 10, color: COLORS.textMuted }}>
+                    <span style={{ fontSize: FONT_SIZE.sm, color: COLORS.textMuted }}>天內</span>
+                    <span style={{ marginLeft: "auto", fontFamily: FONT_DATA, fontSize: FONT_SIZE.sm, color: COLORS.textMuted }}>
                       信心 {prediction.confidencePercent}%
                     </span>
                   </div>
@@ -210,13 +210,13 @@ export function SatelliteDetailCard({ norad, onClose }: Props) {
                     μ = {prediction.muDays.toFixed(1)}d · σ = {prediction.sigmaDays?.toFixed(1)}d · n = {prediction.sampleSize}
                   </div>
                   {/* mini bar visualization */}
-                  <div style={{ marginTop: 6, position: "relative", height: 6, borderRadius: 3, background: "rgba(255,255,255,0.08)" }}>
+                  <div style={{ marginTop: 6, position: "relative", height: 6, borderRadius: RADIUS.md, background: "rgba(255,255,255,0.08)" }}>
                     <div style={{
                       position: "absolute",
                       left: `${Math.min(100, (prediction.nextLowDays! / 30) * 100)}%`,
                       width: `${Math.min(100, ((prediction.nextHighDays! - prediction.nextLowDays!) / 30) * 100)}%`,
                       height: "100%",
-                      borderRadius: 3,
+                      borderRadius: RADIUS.md,
                       background: "rgba(100,170,255,0.5)",
                     }} />
                   </div>
@@ -228,7 +228,7 @@ export function SatelliteDetailCard({ norad, onClose }: Props) {
             )}
 
             {/* footnote */}
-            <div style={{ marginTop: 10, fontFamily: FONT_DATA, fontSize: 9, color: COLORS.textFaint, lineHeight: 1.5 }}>
+            <div style={{ marginTop: 10, fontFamily: FONT_DATA, fontSize: FONT_SIZE.xs, color: COLORS.textFaint, lineHeight: 1.5 }}>
               來源：UCS Satellite Database (reference.satellite_catalog) · TLE history (realtime.satellite_tle_history)
             </div>
           </>
@@ -243,7 +243,7 @@ function Section({ title, children }: { title: string; children: React.ReactNode
     <div style={{ marginBottom: 10 }}>
       <div style={{
         fontFamily: FONT_DATA,
-        fontSize: 9,
+        fontSize: FONT_SIZE.xs,
         letterSpacing: "1.5px",
         color: COLORS.textFaint,
         marginBottom: 4,
@@ -259,7 +259,7 @@ function Section({ title, children }: { title: string; children: React.ReactNode
 
 function Row({ label, value }: { label: string; value: string }) {
   return (
-    <div style={{ display: "flex", gap: 8, fontSize: 11, padding: "2px 0" }}>
+    <div style={{ display: "flex", gap: 8, fontSize: FONT_SIZE.base, padding: "2px 0" }}>
       <span style={{ width: 70, color: COLORS.textDim, flexShrink: 0 }}>{label}</span>
       <span style={{ color: COLORS.textDefault, flex: 1, wordBreak: "break-word" }}>{value}</span>
     </div>

--- a/src/components/satelliteConsole/TWFleetSection.tsx
+++ b/src/components/satelliteConsole/TWFleetSection.tsx
@@ -14,6 +14,7 @@
 import { useEffect, useMemo, useState } from "react";
 import * as satellite from "satellite.js";
 import { COLORS, FONT_CJK, FONT_DATA } from "./satelliteConsoleTokens";
+import { RADIUS, FONT_SIZE } from "../../styles/designTokens";
 import { loadSatellites } from "../../data/satelliteLoader";
 import type { SatelliteRecord } from "../../data/satelliteTypes";
 import { localeForTaiwanSat } from "../../data/satelliteTaiwanLocale";
@@ -172,7 +173,7 @@ export function TWFleetSection({ maneuvers, onSelectNorad, onFlyTo }: Props) {
 
   if (rows.length === 0) {
     return (
-      <div style={{ padding: "12px 14px", borderBottom: `1px solid ${COLORS.borderSoft}`, fontFamily: FONT_CJK, fontSize: 11, color: COLORS.textFaint }}>
+      <div style={{ padding: "12px 14px", borderBottom: `1px solid ${COLORS.borderSoft}`, fontFamily: FONT_CJK, fontSize: FONT_SIZE.base, color: COLORS.textFaint }}>
         台灣衛星 — 載入中…
       </div>
     );
@@ -183,7 +184,7 @@ export function TWFleetSection({ maneuvers, onSelectNorad, onFlyTo }: Props) {
       <div style={{
         padding: "9px 14px 6px",
         fontFamily: FONT_DATA,
-        fontSize: 9,
+        fontSize: FONT_SIZE.xs,
         letterSpacing: "2px",
         color: COLORS.textFaint,
         display: "flex",
@@ -204,7 +205,7 @@ export function TWFleetSection({ maneuvers, onSelectNorad, onFlyTo }: Props) {
               key={r.norad}
               style={{
                 padding: "8px 11px",
-                borderRadius: 8,
+                borderRadius: RADIUS.xl,
                 background: isCovering ? "rgba(79,195,247,0.10)" : "rgba(255,255,255,0.025)",
                 border: `1px solid ${isCovering ? "rgba(79,195,247,0.45)" : COLORS.borderSoft}`,
                 fontFamily: FONT_CJK,
@@ -223,7 +224,7 @@ export function TWFleetSection({ maneuvers, onSelectNorad, onFlyTo }: Props) {
                 {isLegacy && (
                   <span style={{
                     padding: "0 5px",
-                    borderRadius: 3,
+                    borderRadius: RADIUS.md,
                     background: "rgba(255,152,0,0.16)",
                     border: "1px solid rgba(255,152,0,0.45)",
                     fontSize: 9.5,
@@ -235,7 +236,7 @@ export function TWFleetSection({ maneuvers, onSelectNorad, onFlyTo }: Props) {
                 {r.tier === "research" && (
                   <span style={{
                     padding: "0 5px",
-                    borderRadius: 3,
+                    borderRadius: RADIUS.md,
                     background: "rgba(255,255,255,0.06)",
                     border: `1px solid ${COLORS.borderMid}`,
                     fontSize: 9.5,
@@ -261,7 +262,7 @@ export function TWFleetSection({ maneuvers, onSelectNorad, onFlyTo }: Props) {
                 alignItems: "center",
                 gap: 10,
                 fontFamily: FONT_DATA,
-                fontSize: 10,
+                fontSize: FONT_SIZE.sm,
                 color: COLORS.textMuted,
               }}>
                 <span>{r.lat.toFixed(1)}°{r.lat >= 0 ? "N" : "S"} {Math.abs(r.lon).toFixed(1)}°{r.lon >= 0 ? "E" : "W"}</span>
@@ -287,7 +288,7 @@ export function TWFleetSection({ maneuvers, onSelectNorad, onFlyTo }: Props) {
                   style={{
                     flex: 1,
                     padding: "4px 0",
-                    borderRadius: 4,
+                    borderRadius: RADIUS.md,
                     border: `1px solid ${COLORS.borderMid}`,
                     background: "transparent",
                     color: COLORS.textDefault,
@@ -303,7 +304,7 @@ export function TWFleetSection({ maneuvers, onSelectNorad, onFlyTo }: Props) {
                   style={{
                     flex: 1,
                     padding: "4px 0",
-                    borderRadius: 4,
+                    borderRadius: RADIUS.md,
                     border: "1px solid rgba(100,170,255,0.55)",
                     background: "rgba(100,170,255,0.16)",
                     color: "#cfe4ff",

--- a/src/styles/designTokens.ts
+++ b/src/styles/designTokens.ts
@@ -1,0 +1,167 @@
+/**
+ * Mini Taiwan Pulse — Design Tokens（全專案 SSOT）
+ *
+ * 規範與遷移狀態見 docs/design-system.md
+ *
+ * 結構：
+ * - 沿用 intel/intelTokens.ts 的既有 token（re-export，不重複定義）
+ * - 在此擴張 SURFACE / WHITE_ALPHA / BORDER / RADIUS / FONT_SIZE / ELEVATION / SPACING
+ * - 新元件統一從本檔 import；intel/satellite 既有元件不強制改
+ */
+
+import {
+  COLORS as INTEL_COLORS,
+} from "../components/intel/intelTokens";
+
+// ─── Re-export 既有 token（沿用無痛）────────────────────────────
+export {
+  FONT_CJK,
+  FONT_DATA,
+  GIS_LEVELS,
+  SEV_LEVELS,
+  COUNTY_OPTIONS,
+  PRESSURE_LEVELS,
+  pressureLevel,
+  MICON,
+  ALERT_GROUPS_DEF,
+  ALERT_GROUP_ORDER,
+  ALERT_SEVERITY,
+  alertSeverity,
+  relTime,
+  clockTime,
+  fmtCountdown,
+  fmtExpiry,
+  smoothPressure,
+} from "../components/intel/intelTokens";
+export type {
+  PressureLevelKey,
+  PressureLevelDef,
+  AlertGroupShort,
+  AlertGroupDef,
+  AlertSeverityDef,
+} from "../components/intel/intelTokens";
+
+// ─── SURFACE — 面板背景五階 ────────────────────────────────────
+/**
+ * 新元件**唯一 canonical** 面板背景出口；`COLORS.panelBg*` 是 legacy alias，僅為相容保留。
+ *
+ * 規則：
+ * - app    → 全域底（地圖底 / LoadingScreen）
+ * - subtle → narrow sidebar / floating overlay（最透）
+ * - panel  → 主面板預設（intel / satellite / legend 已使用）
+ * - strong → 需要更高可讀性（feature info / data calendar）
+ * - solid  → 全屏 / 模態 / LiveWall
+ */
+export const SURFACE = {
+  app: "#0a0a14",
+  subtle: "rgba(0,0,0,0.40)",
+  panel: "rgba(0,0,0,0.52)",
+  strong: "rgba(10,10,20,0.88)",
+  solid: "rgba(10,10,20,0.94)",
+} as const;
+
+// ─── COLORS — 文字 / 強調 / 狀態（沿用 intelTokens）
+/**
+ * 文字、強調、狀態色沿用 intelTokens 原始定義。
+ *
+ * ⚠️ **不再新增 panelBg / border 相關 key**：新元件請改用 `SURFACE.*` / `BORDER.*`。
+ * `INTEL_COLORS.panelBg` / `panelBorder` / `border*` 為相容保留，遷移完成後將被移除。
+ */
+export const COLORS = {
+  ...INTEL_COLORS,
+} as const;
+
+// ─── WHITE_ALPHA — 白色半透階梯（裝飾線 / 軟分隔）─────────────
+/**
+ * 取代散落的 rgba(255,255,255,0.04~0.60)。
+ * 文字色請用 COLORS.textStrong / textDefault / textMuted / textDim / textFaint / textGhost。
+ */
+export const WHITE_ALPHA = {
+  4: "rgba(255,255,255,0.04)",
+  8: "rgba(255,255,255,0.08)",
+  12: "rgba(255,255,255,0.12)",
+  20: "rgba(255,255,255,0.20)",
+  40: "rgba(255,255,255,0.40)",
+  60: "rgba(255,255,255,0.60)",
+} as const;
+
+// ─── BORDER — 分隔線 / 邊框 ────────────────────────────────────
+export const BORDER = {
+  soft: "rgba(255,255,255,0.06)",
+  panel: "rgba(255,255,255,0.10)",
+  mid: "rgba(255,255,255,0.14)",
+  strong: "rgba(255,255,255,0.22)",
+  accent: "rgba(100,170,255,0.55)",
+} as const;
+
+// ─── RADIUS — 圓角階梯 ────────────────────────────────────────
+/**
+ * 收斂 12 種散值 → 4 階尺寸（sm/md/lg/xl）+ 2 種 shape token（pill / full）。
+ * 既有 `borderRadius: 3 / 5 / 7 / 10` 全部改用最接近的一階；
+ * 罕用 12 / 16 / 24px（共 3 處）保留 inline 一次性數值，不進 scale。
+ *
+ * 註：`full` 為字串 `"50%"`（圓形百分比語意），與其他 number token 共用時
+ * `borderRadius` prop 接受 number | string，無實務型別問題。
+ */
+export const RADIUS = {
+  sm: 2,
+  md: 4,
+  lg: 6,
+  xl: 8,
+  pill: 9999,
+  full: "50%",
+} as const;
+
+// ─── FONT_SIZE — 字級階梯 ─────────────────────────────────────
+/**
+ * 收斂 16 種散值 → 7 階。audit 顯示 9–13px 佔 80%（9:174 / 10:157 / 11:106 / 12:66 / 13:82）。
+ * 14px (13 use) → md(12) 或 lg(13)；16px (5 use) → xl(18) — 視場景 round 就近。
+ * 32px / 40px 各 1 use → 保留 inline 一次性數值，不進 scale。
+ */
+export const FONT_SIZE = {
+  xs: 9,
+  sm: 10,
+  base: 11,
+  md: 12,
+  lg: 13,
+  xl: 18,
+  xxl: 22,
+} as const;
+
+// ─── FONT_WEIGHT — 字重 ───────────────────────────────────────
+/** 本專案實務上只用 600 / 700。regular 留給未來。 */
+export const FONT_WEIGHT = {
+  regular: 400,
+  semibold: 600,
+  bold: 700,
+} as const;
+
+// ─── ELEVATION — 主面板陰影 ───────────────────────────────────
+/**
+ * 4 種 panel shadow 散值 → 3 階 + 1 反向。
+ * - sm  → TimelineDock 等貼地控件
+ * - md  → LiveWall / overlay
+ * - lg  → IntelPanel / SatelliteDetailCard / ManeuverCompareModal
+ * - dock → MonitorPanel 從上緣往上散
+ */
+export const ELEVATION = {
+  sm: "0 6px 20px rgba(0,0,0,0.50)",
+  md: "0 8px 32px rgba(0,0,0,0.55)",
+  lg: "0 12px 40px rgba(0,0,0,0.45)",
+  dock: "0 -16px 50px rgba(0,0,0,0.50)",
+} as const;
+
+// ─── SPACING — 間距階梯 ──────────────────────────────────────
+/**
+ * gap / padding 大宗為 4 / 6 / 8 / 12，對齊到此階梯。
+ * 不收斂全部 padding 寫法（pill-style "1px 6px" 等 inline 直寫保留）。
+ */
+export const SPACING = {
+  xxs: 2,
+  xs: 4,
+  sm: 6,
+  md: 8,
+  lg: 12,
+  xl: 16,
+  xxl: 24,
+} as const;


### PR DESCRIPTION
## Summary

建立全專案 design tokens SSOT (`src/styles/designTokens.ts`) + 規範文件 (`docs/design-system.md`)，把散落在 60+ 元件的 inline style 收斂到 token scale。**不引入 CSS 框架、不抽通用元件庫**，維持 inline `style={{}}` + token import 模式。

## 動機

過往元件 `style={{}}` 散落大量硬寫值（panel bg 4 種、borderRadius 12 種、fontSize 16 種、白色 alpha 20 階…），新增 layer / panel 時容易漂移，視覺一致性靠記憶力維護。本 PR 建立 token scale + 規範文件 + 新元件 checklist 解決此問題。

## 6 Phases 一覽

| Phase | Commit | 影響 |
|---|---|---|
| 0 | \`d9aaf28\` | 新增 \`designTokens.ts\` + \`docs/design-system.md\`（純新增） |
| 1 | \`1cb6f9b\` | 8 檔 panel bg + shadow → SURFACE / ELEVATION |
| 2 | \`86391f4\` | 16 檔 / 83 處 \`monospace\` → \`FONT_DATA\` |
| 3 | \`cc744e1\` | 22 檔 / 165 處 text color → \`COLORS.text*\` |
| 4 | \`7ee817b\` | 57 檔 / ~935 處 borderRadius + fontSize → scale |
| 5 | \`c6a4e7e\` | 警示語意色對齊地圖色（earthquake / flood） |
| 6 | \`22c8d64\` | CloseButton 統一 + LoadingScreen 套 SURFACE |
| docs | \`9c810b2\` | 加新元件 checklist + 標註 phase commit hash |

**總計**：~60 元件改動、1200+ inline 值收斂、0 tsc error、每 phase 獨立 commit 可單獨 revert。

## 新增 token scale

- **SURFACE** 面板背景 5 階（app / subtle / panel / strong / solid）
- **COLORS.text\*** 文字 6 階（strong / default / muted / dim / faint / ghost）
- **BORDER** 邊框 5 階（soft / panel / mid / strong / accent）
- **RADIUS** 圓角 4 階尺寸 + 2 shape（sm:2 / md:4 / lg:6 / xl:8 / pill / full）
- **FONT_SIZE** 字級 7 階（xs:9 / sm:10 / base:11 / md:12 / lg:13 / xl:18 / xxl:22）
- **ELEVATION** 陰影 4 階（sm / md / lg / dock）
- **SPACING** / **WHITE_ALPHA** / **FONT_FAMILY** 等

詳見 \`docs/design-system.md\` §2 token 全表。

## 設計原則（design-system.md §0）

- **不引入 CSS 框架** — Mapbox / Three.js / 動態 opacity 多，框架反成負擔
- **token 為唯一 SSOT** — 禁止 inline 寫 hex / rgba
- **\`LAYER_COLORS\` 不動** — 已有 \`layerConsistency\` 測試保護
- **業務元件不抽通用庫** — 避免 over-abstract
- **每階段獨立 PR** — 可獨立 review / revert

## Codex 交叉檢驗

每 phase 完成跑 codex code review：
- Phase 0：抓到 SURFACE 註解 outdated、雙軌命名風險、circular dep 警告、fontSize 12px 缺位 → 全數修正
- Phase 1：抓到 10 處 over-replacement（button/select 互動態誤收進 SURFACE）→ 全數還原
- Phase 2：clean
- Phase 3：Codex 卡 23 分鐘改手動 spot check
- Phase 4–6：手動 grep + tsc 驗證

## ⚠️ 視覺影響重點（需 reviewer 注意）

| Phase | 風險 | 影響範圍 |
|---|---|---|
| 5 | **AlertBoard 警示色變化**：地震卡從紫粉變紅、水文卡從青綠變紅。flood (#ef4444) 與 safety (#fb7185) 較難分辨 | 中 |
| 3 | 文字色從半透明白變純灰 hex（極微差） | 已驗收體感無差 |
| 4 | 字級 / 圓角極微調整（多數同值 round，少數 round up 1px） | 低 |
| 1 / 2 / 6 | 預期零視覺差 | 極低 |

## 後續題目（未抽 token 範圍 — design-system.md §8）

刻意延後、待真實痛點出現再開：
- **Z_INDEX scale** — 堆疊衝突 bug 出現時
- **transition / duration / easing** — 一致性訴求出現時
- **互動狀態色** — button family / form UI 浮現時
- **Breakpoint tokens** — 出現第 3 種 viewport 時
- **Control sizing scale** — 不一致抱怨出現時

## Test plan

- [x] \`npx tsc -b\` 過（每 phase 後驗證）
- [x] User browser 驗收 Phase 0-3（體感無差）
- [ ] User browser 驗收 Phase 5 警示色變化（地震 / 水文 / safety 三色辨識度）
- [ ] User browser 驗收 Phase 6 close button × → X 互動

## 文件

- \`docs/design-system.md\` — 完整規範（§9 新元件 checklist 可直接抄用）
- \`src/styles/designTokens.ts\` — token SSOT
- CLAUDE.md §5/§5a 既有 UX 鐵則仍適用

## 萬一不滿意

每 phase 獨立 commit 可單獨 revert：
- \`git revert c6a4e7e\` — 還原警示色
- \`git revert cc744e1\` — 還原文字色
- ...

🤖 Generated with [Claude Code](https://claude.com/claude-code)