### PR TITLE
perf(real-estate): 點圖層改 WebGL CustomLayer + GPU fade

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,7 @@ public/fire/*.pmtiles
 # 房地產 PMTiles（grid 26MB + point 43MB，走 S3 deploy-assets/coverage/，勿入 git；
 # gas coverage 小檔 taiwan_*_nearest.pmtiles 仍進 git/dist）
 public/coverage/real_estate_*.pmtiles
+public/coverage/real_estate_points_buffer.bin
 # 醫療 GeoJSON（走 S3 deploy-assets，5 檔合計 ~65MB）
 public/geo/medical_*.geojson
 # 醫療 PMTiles（走 S3 deploy-assets/medical/）

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -98,6 +98,7 @@ import { useSatelliteManeuvers } from "./hooks/useSatelliteManeuvers";
 import { TimelineControls } from "./components/TimelineControls";
 import { HistoricalTimeline, type HistoricalGranularity } from "./components/HistoricalTimeline";
 import { useRealEstateTimeline } from "./hooks/useRealEstateTimeline";
+import { useRealEstatePointsLayer } from "./hooks/useRealEstatePointsLayer";
 import { RANGE_START, RANGE_END, DAY, reLabel, snapQuarterStart, tsToDate, type ReGran } from "./lib/realEstateTime";
 import { ModeToggle } from "./components/ModeToggle";
 import { StyleSelector, getStyleUrl } from "./components/StyleSelector";
@@ -576,6 +577,14 @@ export default function App() {
     speed: historicalSpeed,
     onCursorChange: setReCursorTs,
     onStop: stopHistorical,
+  });
+  // 房地產「點」WebGL CustomLayer（GPU fade，取代 3 個 PMTiles circle）
+  useRealEstatePointsLayer(mapRef, {
+    showRental: layerVisibility.realEstateRentalPoint,
+    showSale: layerVisibility.realEstateSalePoint,
+    showPresale: layerVisibility.realEstatePresalePoint,
+    excludeTaipei: !!transportParams.overlayParams.realEstateExcludeTaipei,
+    baseOpacity: transportParams.overlayParams.realEstateOpacity ?? 0.85,
   });
 
   const { socioDataMap, loadSocioResolution } = useH3Socioeconomic();

--- a/src/hooks/useMapInteraction.ts
+++ b/src/hooks/useMapInteraction.ts
@@ -360,10 +360,7 @@ export function useMapInteraction(
       map.on("mousemove", id, reMove("grid"));
       map.on("mouseleave", id, reLeave);
     }
-    for (const id of ["re-points-rental-circle", "re-points-sale-circle", "re-points-presale-circle"]) {
-      map.on("mousemove", id, reMove("point"));
-      map.on("mouseleave", id, reLeave);
-    }
+    // 點 hover 暫時移除：point 已改 WebGL CustomLayer，不支援 queryRenderedFeatures（待補 GPU/空間索引 picking）
   };
 
   // ESC 鍵取消跟隨

--- a/src/hooks/useRealEstatePointsLayer.ts
+++ b/src/hooks/useRealEstatePointsLayer.ts
@@ -1,0 +1,54 @@
+import { useEffect } from "react";
+import type { Map as MapboxMap } from "mapbox-gl";
+import { createRealEstatePointsLayer, RE_POINTS_LAYER_ID } from "../map/realEstatePointsCustomLayer";
+import { rePointsStore } from "../state/realEstatePointsStore";
+
+/**
+ * 掛載房地產「點」CustomLayer，並把控制欄位（show / excludeTaipei / baseOpacity）寫進 rePointsStore。
+ * 時間欄位（cursorTs / mode / 季窗 / fade 窗）由 useRealEstateTimeline 寫。
+ *
+ * ⚠️ 不要用 isStyleLoaded() 守 mount（style.load 可能已 fire 過）— 沿用 useOsmPowerLinesGlowLayer 的 idle 重試。
+ */
+export function useRealEstatePointsLayer(
+  mapRef: React.RefObject<MapboxMap | null>,
+  opts: {
+    showRental: boolean;
+    showSale: boolean;
+    showPresale: boolean;
+    excludeTaipei: boolean;
+    baseOpacity: number;
+  },
+) {
+  const { showRental, showSale, showPresale, excludeTaipei, baseOpacity } = opts;
+  const anyShown = showRental || showSale || showPresale;
+
+  // Lazy mount：第一次有任一點層開啟才掛（此時 map 必已 ready）。
+  // ⚠️ deps 必含 anyShown — 否則首 render map 還是 null 時 return 後永不重試（ref identity 不變）。
+  // 不要用 isStyleLoaded() 守（style.load 可能已 fire 過）— 沿用 idle 重試。
+  useEffect(() => {
+    const map = mapRef.current;
+    if (!map || !anyShown) return;
+    const tryMount = () => {
+      if (map.getLayer(RE_POINTS_LAYER_ID)) return;
+      try {
+        map.addLayer(createRealEstatePointsLayer());
+      } catch {
+        map.once("idle", tryMount);
+      }
+    };
+    tryMount();
+    map.on("style.load", tryMount); // 切 basemap → style.load 後重掛
+    return () => {
+      map.off("style.load", tryMount);
+      if (map.getLayer(RE_POINTS_LAYER_ID)) map.removeLayer(RE_POINTS_LAYER_ID);
+    };
+  }, [mapRef, anyShown]);
+
+  // 控制欄位 → store + 重繪（暫停/切換時的唯一重繪觸發；播放中由 timeline RAF 帶動）
+  useEffect(() => {
+    rePointsStore.show = [showRental, showSale, showPresale];
+    rePointsStore.excludeTaipei = excludeTaipei;
+    rePointsStore.baseOpacity = baseOpacity;
+    mapRef.current?.triggerRepaint();
+  }, [mapRef, showRental, showSale, showPresale, excludeTaipei, baseOpacity]);
+}

--- a/src/hooks/useRealEstateTimeline.ts
+++ b/src/hooks/useRealEstateTimeline.ts
@@ -3,32 +3,31 @@ import type { Map as MapboxMap } from "mapbox-gl";
 import type { AppMode } from "../types";
 import {
   quarterOfTs, reWindow, rePlaySeconds, snapQuarterStart, nextQuarterStart,
-  RANGE_START, RANGE_END, type ReGran,
+  RANGE_START, RANGE_END, DAY, type ReGran,
 } from "../lib/realEstateTime";
+import { rePointsStore } from "../state/realEstatePointsStore";
 
 /**
- * 房地產時間軸 + 播放引擎（純 setFilter / setPaintProperty，零 RPC、零 React 逐格 re-render）
+ * 房地產時間軸 + 播放引擎（grid 走 PMTiles setFilter；point 走 WebGL CustomLayer）。
  *
- * - realtime：grid=period"ALL"、point 全部、全不透明。
- * - historical：grid 永遠按游標所在「季」snapshot；point：
- *   - 季：filter 當季 + 全不透明（snap）。
- *   - 月/週：依 trade_ts 與游標距離做梯形窗 circle-opacity → 漸入漸出。
- * - 播放：月/週 用 requestAnimationFrame **連續**推進游標（cursorRef，不進 React），
- *   每 ~40ms 更新一次 paint → 平滑演變；季用 interval 逐季 snap。
- * - 暫停/拖曳：依 React cursorTs 套用。
+ * 本 hook 負責：
+ *   - grid（PMTiles fill/line）的 period filter：realtime → "ALL"、historical → 當季 snapshot。
+ *   - 寫 rePointsStore 的「時間欄位」（mode / cursorTs / 季窗 / fade 窗）給 CustomLayer 讀。
+ *   - 播放：月/週用 requestAnimationFrame 連續推進游標（只更新 store.cursorTs + triggerRepaint，
+ *     fade 在 GPU 算 → 每幀零逐 feature 成本）；季用 interval 逐季 snap。
+ *
+ * point 的 opacity/fade 不再由這裡 setPaintProperty —— 改由 RealEstatePointsScene 的 uCursorTs uniform。
+ * 控制欄位（show / excludeTaipei / baseOpacity）由 useRealEstatePointsLayer 寫入 store。
  */
 
-type Kind = "grid" | "point";
-const RE_LAYERS: { id: string; type: string; kind: Kind }[] = [
-  { id: "re-grid-rental-fill", type: "rental", kind: "grid" },
-  { id: "re-grid-rental-line", type: "rental", kind: "grid" },
-  { id: "re-grid-sale-fill", type: "sale", kind: "grid" },
-  { id: "re-grid-sale-line", type: "sale", kind: "grid" },
-  { id: "re-grid-presale-fill", type: "presale", kind: "grid" },
-  { id: "re-grid-presale-line", type: "presale", kind: "grid" },
-  { id: "re-points-rental-circle", type: "rental", kind: "point" },
-  { id: "re-points-sale-circle", type: "sale", kind: "point" },
-  { id: "re-points-presale-circle", type: "presale", kind: "point" },
+// grid PMTiles 圖層（fill + line × 3 類）；point 已移除
+const RE_GRID_LAYERS: { id: string; type: string }[] = [
+  { id: "re-grid-rental-fill", type: "rental" },
+  { id: "re-grid-rental-line", type: "rental" },
+  { id: "re-grid-sale-fill", type: "sale" },
+  { id: "re-grid-sale-line", type: "sale" },
+  { id: "re-grid-presale-fill", type: "presale" },
+  { id: "re-grid-presale-line", type: "presale" },
 ];
 
 const TAIPEI_CITIES = ["taipei", "newtaipei"];
@@ -40,11 +39,11 @@ function withClauses(base: unknown[], excludeTaipei: boolean): unknown[] {
   return ["all", ...c];
 }
 
-function fadeFactor(cursorTs: number, full: number, fade: number): unknown[] {
-  return [
-    "interpolate", ["linear"], ["-", cursorTs, ["coalesce", ["get", "trade_ts"], 0]],
-    -1, 0, 0, 1, full, 1, full + fade, 0,
-  ];
+/** 當季 [start, end)（絕對 unix 秒）；最後一季 end 用 RANGE_END+1天 */
+function quarterBounds(ts: number): { start: number; end: number } {
+  const start = snapQuarterStart(ts);
+  const next = nextQuarterStart(start);
+  return { start, end: next > start ? next : RANGE_END + DAY };
 }
 
 export interface ReTimelineOpts {
@@ -65,53 +64,40 @@ export function useRealEstateTimeline(
 ) {
   const { appMode, gran, cursorTs, excludeTaipei, baseOpacity, playing, speed, onCursorChange, onStop } = opts;
   const cursorRef = useRef(cursorTs);
-  // 非播放時：React 游標 → ref（拖曳/初始）
   if (!playing) cursorRef.current = cursorTs;
 
-  // 全套用：grid+point 的 filter + 初始 opacity（scrub / 播放起點 / 換季時呼叫）
+  // grid filter 套用 + 寫 store 時間欄位（scrub / 播放起點 / 換季時呼叫）
   const applyRef = useRef<(ts: number) => void>(() => {});
-  // 僅更新點 opacity（RAF 每幀呼叫，避免每幀重設 grid filter）
-  const paintPointsRef = useRef<(ts: number) => void>(() => {});
-
   applyRef.current = (ts: number) => {
     const map = mapRef.current;
     if (!map) return;
     const historical = appMode === "historical";
     const quarter = historical ? quarterOfTs(ts) : "ALL";
-    const fadeMode = historical && gran !== "quarter";
-    const win = reWindow(gran);
-    for (const l of RE_LAYERS) {
+
+    // grid PMTiles filter
+    for (const l of RE_GRID_LAYERS) {
       if (!map.getLayer(l.id)) continue;
       const typeF = ["==", ["get", "type"], l.type];
-      if (l.kind === "grid") {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        map.setFilter(l.id, withClauses([typeF, ["==", ["get", "period"], quarter]], excludeTaipei) as any);
-      } else if (fadeMode) {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        map.setFilter(l.id, withClauses([typeF], excludeTaipei) as any);
-        // 短 transition：讓 ~20fps 的 opacity 更新平滑銜接（不用預設 300ms，否則會 chase 變鈍）
-        map.setPaintProperty(l.id, "circle-opacity-transition", { duration: 150, delay: 0 });
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        map.setPaintProperty(l.id, "circle-opacity", ["*", baseOpacity, fadeFactor(ts, win.full, win.fade)] as any);
-      } else {
-        const base: unknown[] = historical ? [typeF, ["==", ["get", "period"], quarter]] : [typeF];
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        map.setFilter(l.id, withClauses(base, excludeTaipei) as any);
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        map.setPaintProperty(l.id, "circle-opacity", baseOpacity as any);
-      }
-    }
-  };
-
-  paintPointsRef.current = (ts: number) => {
-    const map = mapRef.current;
-    if (!map) return;
-    const win = reWindow(gran);
-    for (const l of RE_LAYERS) {
-      if (l.kind !== "point" || !map.getLayer(l.id)) continue;
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      map.setPaintProperty(l.id, "circle-opacity", ["*", baseOpacity, fadeFactor(ts, win.full, win.fade)] as any);
+      map.setFilter(l.id, withClauses([typeF, ["==", ["get", "period"], quarter]], excludeTaipei) as any);
     }
+
+    // store 時間欄位 → CustomLayer
+    if (!historical) {
+      rePointsStore.mode = "realtime";
+    } else if (gran === "quarter") {
+      rePointsStore.mode = "quarter";
+      const b = quarterBounds(ts);
+      rePointsStore.qStart = b.start;
+      rePointsStore.qEnd = b.end;
+    } else {
+      rePointsStore.mode = "fadewindow";
+      const win = reWindow(gran);
+      rePointsStore.full = win.full;
+      rePointsStore.fade = win.fade;
+    }
+    rePointsStore.cursorTs = ts;
+    map.triggerRepaint();
   };
 
   // 暫停 / realtime / 拖曳：靜態套用 + style.load 重套
@@ -147,16 +133,16 @@ export function useRealEstateTimeline(
       return () => window.clearInterval(id);
     }
 
-    // 月/週：RAF 連續推進
+    // 月/週：RAF 連續推進（只更新 store.cursorTs + triggerRepaint，fade 在 GPU）
     const span = RANGE_END - RANGE_START;
     const ratePerMs = span / ((rePlaySeconds(gran) * 1000) / speed); // 資料秒 / 真實毫秒
     let cur = cursorRef.current;
-    if (cur >= RANGE_END) cur = RANGE_START; // 已到底 → 從頭播
+    if (cur >= RANGE_END) cur = RANGE_START;
     let raf = 0;
     let last = performance.now();
-    let lastPaint = 0;
     let lastSync = 0;
     let lastQuarter = quarterOfTs(cur);
+    applyRef.current(cur); // 起點：grid + store 全套用
     const tick = (now: number) => {
       cur += ratePerMs * (now - last);
       last = now;
@@ -170,12 +156,16 @@ export function useRealEstateTimeline(
       }
       cursorRef.current = cur;
       const q = quarterOfTs(cur);
-      if (q !== lastQuarter) { applyRef.current(cur); lastQuarter = q; lastPaint = now; } // 換季 → 連 grid 一起刷
-      else if (now - lastPaint > 50) { paintPointsRef.current(cur); lastPaint = now; } // 平常只更新點 opacity
+      if (q !== lastQuarter) {
+        applyRef.current(cur); // 換季 → 連 grid filter 一起刷（內含 triggerRepaint）
+        lastQuarter = q;
+      } else {
+        rePointsStore.cursorTs = cur; // 平常只推游標
+        map.triggerRepaint();
+      }
       if (now - lastSync > 200) { onCursorChange(cur); lastSync = now; }
       raf = requestAnimationFrame(tick);
     };
-    applyRef.current(cur); // 起點全套用一次
     raf = requestAnimationFrame(tick);
     return () => cancelAnimationFrame(raf);
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/lib/realEstateTime.ts
+++ b/src/lib/realEstateTime.ts
@@ -54,8 +54,9 @@ export function reLabel(gran: ReGran, ts: number): string {
 
 /** point 梯形時間窗（秒）：full = 全亮、fade = 之後淡出尾段 */
 export function reWindow(gran: ReGran): { full: number; fade: number } {
-  if (gran === "week") return { full: 5 * DAY, fade: 10 * DAY };
-  if (gran === "month") return { full: 20 * DAY, fade: 30 * DAY };
+  // 俐落版：縮短淡出尾，減少「延續」感（畫面較稀疏為取捨）
+  if (gran === "week") return { full: 2 * DAY, fade: 3 * DAY };
+  if (gran === "month") return { full: 6 * DAY, fade: 10 * DAY };
   return { full: 0, fade: 0 }; // quarter 用 period filter
 }
 

--- a/src/map/overlayRegistry.ts
+++ b/src/map/overlayRegistry.ts
@@ -122,30 +122,6 @@ function realEstateGridOverlay(id: OverlayConfig["id"], palette: RePalette, type
     ],
   };
 }
-function realEstatePointOverlay(id: OverlayConfig["id"], palette: RePalette, type: string): OverlayConfig {
-  return {
-    id,
-    sourceUrl: "./coverage/real_estate_points.pmtiles",
-    sourceId: "re-points",
-    pmtiles: { sourceLayer: "real_estate_points", minzoom: 6, maxzoom: 14 },
-    // 點無 period=ALL：realtime 顯示全部交易（僅 type filter）；historical 由 hook 加當季
-    filter: ["==", ["get", "type"], type],
-    layers: [
-      {
-        suffix: `${type}-circle`,
-        type: "circle",
-        paint: (_isDark, params) => ({
-          "circle-radius": ["interpolate", ["linear"], ["zoom"], 6, 1.5, 9, 2.5, 14, 5],
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          "circle-color": reColorExpr(palette, "price_per_sqm", !!(params?.realEstateExcludeTaipei)) as any,
-          "circle-opacity": params?.realEstateOpacity ?? 0.85,
-          "circle-stroke-width": 0.3,
-          "circle-stroke-color": "rgba(0,0,0,0.25)",
-        }),
-      },
-    ],
-  };
-}
 
 export const OVERLAY_REGISTRY: OverlayConfig[] = [
   // ── THSR Station Polygon (高鐵站) ──
@@ -4726,12 +4702,9 @@ export const OVERLAY_REGISTRY: OverlayConfig[] = [
     palette: "gas",
   }),
 
-  // ── 房地產 REAL ESTATE（6 layer：3 類 × {grid, point}） ──
+  // ── 房地產 REAL ESTATE（grid 走 PMTiles；point 改走 WebGL CustomLayer，見 useRealEstatePointsLayer） ──
   realEstateGridOverlay("realEstateRentalGrid", "rental", "rental"),
-  realEstatePointOverlay("realEstateRentalPoint", "rental", "rental"),
   realEstateGridOverlay("realEstateSaleGrid", "sale", "sale"),
-  realEstatePointOverlay("realEstateSalePoint", "sale", "sale"),
   realEstateGridOverlay("realEstatePresaleGrid", "presale", "presale"),
-  realEstatePointOverlay("realEstatePresalePoint", "presale", "presale"),
 
 ];

--- a/src/map/realEstatePointsCustomLayer.ts
+++ b/src/map/realEstatePointsCustomLayer.ts
@@ -1,0 +1,79 @@
+import type { CustomLayerInterface, Map as MapboxMap } from "mapbox-gl";
+import { RealEstatePointsScene } from "../three/RealEstatePointsScene";
+import { rePointsStore } from "../state/realEstatePointsStore";
+
+/**
+ * 房地產交易「點」CustomLayer — 取代 3 個 PMTiles circle 圖層。
+ * fade 全在 GPU 算（見 RealEstatePointsScene），每幀只更新 uniforms。
+ *
+ * 狀態走 module-level rePointsStore（時間欄位由 useRealEstateTimeline 寫、控制欄位由 App 寫）。
+ * 重繪節奏由 useRealEstateTimeline 的 RAF（播放中）或 useRealEstatePointsLayer 的 effect（暫停/切換）triggerRepaint 帶動，
+ * 本 layer 不自轉 RAF（避免雙重 render loop）。
+ */
+
+export const RE_POINTS_LAYER_ID = "re-points-three";
+const BUFFER_URL = "./coverage/real_estate_points_buffer.bin";
+
+// module 級快取：lazy mount / 切 basemap 重掛時免重抓 7MB
+let cachedBuffer: Float32Array | null = null;
+let bufferPromise: Promise<Float32Array> | null = null;
+function loadBuffer(): Promise<Float32Array> {
+  if (cachedBuffer) return Promise.resolve(cachedBuffer);
+  if (!bufferPromise) {
+    bufferPromise = fetch(BUFFER_URL)
+      .then((r) => r.arrayBuffer())
+      .then((b) => (cachedBuffer = new Float32Array(b)));
+  }
+  return bufferPromise;
+}
+
+/** 對齊原 circle-radius interpolate（zoom 6→1.5 / 9→2.5 / 14→5），回傳 CSS 半徑 px */
+function radiusForZoom(z: number): number {
+  if (z <= 6) return 1.5;
+  if (z < 9) return 1.5 + (2.5 - 1.5) * ((z - 6) / 3);
+  if (z < 14) return 2.5 + (5 - 2.5) * ((z - 9) / 5);
+  return 5;
+}
+
+export function createRealEstatePointsLayer(): CustomLayerInterface {
+  const scene = new RealEstatePointsScene();
+  let map: MapboxMap | null = null;
+  let loaded = false;
+
+  const loadData = async () => {
+    try {
+      const buf = await loadBuffer();
+      scene.setBuffer(buf);
+      loaded = true;
+      console.log("[realEstatePoints] buffer 載入 ✓", buf.length / 5, "點");
+      map?.triggerRepaint();
+    } catch (e) {
+      console.warn("[realEstatePoints] buffer 載入失敗：", e);
+    }
+  };
+
+  return {
+    id: RE_POINTS_LAYER_ID,
+    type: "custom" as const,
+    renderingMode: "2d" as const,
+
+    onAdd(mapInstance, gl) {
+      map = mapInstance;
+      scene.init(gl);
+      loadData();
+    },
+
+    render(_gl, matrix) {
+      const anyShown = rePointsStore.show[0] || rePointsStore.show[1] || rePointsStore.show[2];
+      if (!loaded || !anyShown) return;
+      const dpr = window.devicePixelRatio || 1;
+      const pointSize = 2 * radiusForZoom(map?.getZoom() ?? 7) * dpr;
+      scene.applyState(rePointsStore, pointSize);
+      scene.render(matrix);
+    },
+
+    onRemove() {
+      scene.dispose();
+    },
+  };
+}

--- a/src/state/realEstatePointsStore.ts
+++ b/src/state/realEstatePointsStore.ts
@@ -1,0 +1,34 @@
+// 房地產「點」WebGL CustomLayer 的共用狀態（module-level singleton）。
+//
+// 寫入者分兩路（避免 React re-render 進每幀路徑）：
+//   - 時間欄位（cursorTs / mode / 季窗 / fade 窗）：useRealEstateTimeline 的 RAF / 靜態 apply 寫入
+//   - 控制欄位（show / excludeTaipei / baseOpacity）：App 依 layerVisibility + params 寫入
+// 讀取者：realEstatePointsCustomLayer 每幀 render 時讀，餵進 Scene uniforms。
+//
+// cursorTs / qStart / qEnd 為「絕對 unix 秒」；Scene 內會減去 RANGE_START 對齊 buffer 的相對 trade_ts。
+
+export type RePointsMode = "realtime" | "quarter" | "fadewindow";
+
+export interface RePointsState {
+  cursorTs: number;                    // 絕對 unix 秒（fadewindow 用）
+  mode: RePointsMode;
+  full: number;                        // fadewindow 全亮窗（秒）
+  fade: number;                        // fadewindow 淡出尾段（秒）
+  qStart: number;                      // 當季起（絕對 unix 秒，quarter 用）
+  qEnd: number;                        // 當季迄（絕對 unix 秒，quarter 用）
+  show: [boolean, boolean, boolean];   // rental, sale, presale
+  excludeTaipei: boolean;
+  baseOpacity: number;
+}
+
+export const rePointsStore: RePointsState = {
+  cursorTs: 0,
+  mode: "realtime",
+  full: 0,
+  fade: 0,
+  qStart: 0,
+  qEnd: 0,
+  show: [false, false, false],
+  excludeTaipei: false,
+  baseOpacity: 0.85,
+};

--- a/src/three/RealEstatePointsScene.ts
+++ b/src/three/RealEstatePointsScene.ts
@@ -1,0 +1,293 @@
+/**
+ * RealEstatePointsScene — 房地產交易「點」的 WebGL 渲染（取代 3 個 PMTiles circle 圖層）。
+ *
+ * 為何存在：原本播放歷史（月/週）時，每幀對 365k 點重設資料驅動 circle-opacity 運算式，
+ * Mapbox 必須逐 feature 重算 + 重灌 GPU buffer（O(feature) / 幀）→ 卡頓。
+ * 改用一次性 GPU buffer + 一個 uCursorTs uniform，fade 全在 shader 算，每幀成本固定。
+ *
+ * 對標：WasteMusicNoteScene（uTime uniform GPU fade）+ OsmPowerLinesGlowScene（GL state 存還 / 關 frustum cull）。
+ *
+ * ⚠️ float32 精度：trade_ts ~1.7e9 超出 float32 尾數，buffer 內存「相對 RANGE_START 的差值」；
+ *    uCursorTs / 季窗也同樣相對化。
+ */
+import * as THREE from "three";
+import mapboxgl from "mapbox-gl";
+import { RANGE_START } from "../lib/realEstateTime";
+import { RE_PALETTES } from "../map/overlayRegistry";
+import type { RePointsState } from "../state/realEstatePointsStore";
+
+const PALETTE_KEYS = ["rental", "sale", "presale"] as const;
+const MODE_CODE: Record<RePointsState["mode"], number> = { realtime: 0, quarter: 1, fadewindow: 2 };
+
+const VERTEX_SHADER = /* glsl */ `
+precision highp float;
+
+attribute float aTradeTs;   // 相對 RANGE_START 的交易秒
+attribute float aType;      // 0 rental / 1 sale / 2 presale
+attribute float aIsTaipei;  // 0 / 1
+attribute vec3  aColor;     // 已在 JS 端依 domain 算好
+
+uniform float uCursorTs;    // 相對 RANGE_START
+uniform float uMode;        // 0 realtime / 1 quarter / 2 fadewindow
+uniform float uFull;
+uniform float uFade;
+uniform float uQStart;
+uniform float uQEnd;
+uniform float uShowRental;
+uniform float uShowSale;
+uniform float uShowPresale;
+uniform float uExcludeTaipei;
+uniform float uBaseOpacity;
+uniform float uPointSize;
+
+varying float vOpacity;
+varying vec3  vColor;
+
+void main() {
+  // type 顯示開關
+  float shown = aType < 0.5 ? uShowRental : (aType < 1.5 ? uShowSale : uShowPresale);
+
+  // 模式 opacity
+  float op = 0.0;
+  if (uMode < 0.5) {
+    op = 1.0;                                   // realtime：全顯示
+  } else if (uMode < 1.5) {
+    op = (aTradeTs >= uQStart && aTradeTs < uQEnd) ? 1.0 : 0.0;  // quarter snapshot
+  } else {
+    float diff = uCursorTs - aTradeTs;          // fadewindow：單側拖尾梯形
+    if (diff < 0.0) op = 0.0;
+    else if (diff < uFull) op = 1.0;
+    else if (diff < uFull + uFade) op = 1.0 - (diff - uFull) / uFade;
+    else op = 0.0;
+  }
+
+  op *= shown;
+  if (uExcludeTaipei > 0.5 && aIsTaipei > 0.5) op = 0.0;
+  op *= uBaseOpacity;
+
+  vOpacity = op;
+  vColor = aColor;
+
+  if (op <= 0.001) {
+    // 不顯示 → 推到 clip 外避免 fragment 工作
+    gl_Position = vec4(2.0, 2.0, 2.0, 1.0);
+    gl_PointSize = 0.0;
+    return;
+  }
+
+  gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+  gl_PointSize = uPointSize;
+}
+`;
+
+const FRAGMENT_SHADER = /* glsl */ `
+precision mediump float;
+
+varying float vOpacity;
+varying vec3  vColor;
+
+void main() {
+  // 圓點：裁掉方形角落
+  vec2 c = gl_PointCoord - vec2(0.5);
+  float d2 = dot(c, c);
+  if (d2 > 0.25) discard;
+  // 邊緣柔化 1px 感
+  float edge = smoothstep(0.25, 0.18, d2);
+  float a = vOpacity * edge;
+  if (a < 0.01) discard;
+  gl_FragColor = vec4(vColor, a);
+}
+`;
+
+function hexToRgb(hex: string): [number, number, number] {
+  const h = hex.replace("#", "");
+  return [
+    parseInt(h.slice(0, 2), 16) / 255,
+    parseInt(h.slice(2, 4), 16) / 255,
+    parseInt(h.slice(4, 6), 16) / 255,
+  ];
+}
+
+/** 對齊 overlayRegistry reColorExpr：在 domain 上均分色票、線性插值（excludeTaipei 換 domainExcl） */
+function colorForValue(typeIdx: number, value: number, excludeTaipei: boolean): [number, number, number] {
+  const p = RE_PALETTES[PALETTE_KEYS[typeIdx]!];
+  const rgbs = p.colors.map(hexToRgb);
+  const [lo, hi] = excludeTaipei ? p.domainExcl : p.domain;
+  const n = rgbs.length;
+  if (value <= lo || hi <= lo) return rgbs[0]!;
+  if (value >= hi) return rgbs[n - 1]!;
+  const t = ((value - lo) / (hi - lo)) * (n - 1);
+  const i = Math.min(n - 2, Math.floor(t));
+  const f = t - i;
+  const a = rgbs[i]!;
+  const b = rgbs[i + 1]!;
+  return [a[0] + (b[0] - a[0]) * f, a[1] + (b[1] - a[1]) * f, a[2] + (b[2] - a[2]) * f];
+}
+
+export class RealEstatePointsScene {
+  scene = new THREE.Scene();
+  camera = new THREE.Camera();
+  renderer!: THREE.WebGLRenderer;
+
+  private points: THREE.Points | null = null;
+  private material: THREE.ShaderMaterial | null = null;
+  private geometry: THREE.BufferGeometry | null = null;
+  private colorAttr: THREE.BufferAttribute | null = null;
+
+  // 供 excludeTaipei 切換時重算顏色
+  private typeArr: Float32Array | null = null;
+  private priceArr: Float32Array | null = null;
+  private count = 0;
+  private lastExcludeTaipei: boolean | null = null;
+  private lastMatrix = new THREE.Matrix4();
+
+  init(gl: WebGLRenderingContext) {
+    this.renderer = new THREE.WebGLRenderer({
+      canvas: gl.canvas as HTMLCanvasElement,
+      context: gl as unknown as WebGL2RenderingContext,
+      antialias: true,
+    });
+    this.renderer.autoClear = false;
+
+    this.material = new THREE.ShaderMaterial({
+      vertexShader: VERTEX_SHADER,
+      fragmentShader: FRAGMENT_SHADER,
+      transparent: true,
+      depthTest: false,
+      depthWrite: false,
+      blending: THREE.NormalBlending,
+      uniforms: {
+        uCursorTs: { value: 0 },
+        uMode: { value: 0 },
+        uFull: { value: 0 },
+        uFade: { value: 0 },
+        uQStart: { value: 0 },
+        uQEnd: { value: 0 },
+        uShowRental: { value: 0 },
+        uShowSale: { value: 0 },
+        uShowPresale: { value: 0 },
+        uExcludeTaipei: { value: 0 },
+        uBaseOpacity: { value: 0.85 },
+        uPointSize: { value: 4 },
+      },
+    });
+  }
+
+  /** 一次性灌入全部點（interleaved Float32：[lng, lat, tradeTsRel, price, packed] × N） */
+  setBuffer(data: Float32Array) {
+    const n = Math.floor(data.length / 5);
+    this.count = n;
+    const positions = new Float32Array(n * 3);
+    const tradeTs = new Float32Array(n);
+    const type = new Float32Array(n);
+    const isTaipei = new Float32Array(n);
+    const price = new Float32Array(n);
+
+    for (let i = 0; i < n; i++) {
+      const o = i * 5;
+      const lng = data[o]!;
+      const lat = data[o + 1]!;
+      const mc = mapboxgl.MercatorCoordinate.fromLngLat([lng, lat], 0);
+      positions[i * 3] = mc.x;
+      positions[i * 3 + 1] = mc.y;
+      positions[i * 3 + 2] = 0;
+      tradeTs[i] = data[o + 2]!;
+      price[i] = data[o + 3]!;
+      const packed = data[o + 4]!;
+      const isTp = packed >= 4 ? 1 : 0;
+      type[i] = packed - isTp * 4;
+      isTaipei[i] = isTp;
+    }
+
+    this.typeArr = type;
+    this.priceArr = price;
+
+    const geo = new THREE.BufferGeometry();
+    geo.setAttribute("position", new THREE.BufferAttribute(positions, 3));
+    geo.setAttribute("aTradeTs", new THREE.BufferAttribute(tradeTs, 1));
+    geo.setAttribute("aType", new THREE.BufferAttribute(type, 1));
+    geo.setAttribute("aIsTaipei", new THREE.BufferAttribute(isTaipei, 1));
+    this.colorAttr = new THREE.BufferAttribute(new Float32Array(n * 3), 3);
+    geo.setAttribute("aColor", this.colorAttr);
+    geo.boundingSphere = new THREE.Sphere(new THREE.Vector3(0.5, 0.5, 0), 2);
+
+    this.geometry?.dispose();
+    this.geometry = geo;
+    if (this.points) this.scene.remove(this.points);
+    this.points = new THREE.Points(geo, this.material!);
+    this.points.frustumCulled = false;
+    this.scene.add(this.points);
+
+    // 首次上色（lastExcludeTaipei null → 強制算）
+    this.recomputeColors(false);
+  }
+
+  /** excludeTaipei 切換時重算 aColor（不進每幀路徑） */
+  recomputeColors(excludeTaipei: boolean) {
+    if (!this.colorAttr || !this.typeArr || !this.priceArr) return;
+    if (this.lastExcludeTaipei === excludeTaipei) return;
+    const col = this.colorAttr.array as Float32Array;
+    for (let i = 0; i < this.count; i++) {
+      const [r, g, b] = colorForValue(this.typeArr[i]!, this.priceArr[i]!, excludeTaipei);
+      col[i * 3] = r;
+      col[i * 3 + 1] = g;
+      col[i * 3 + 2] = b;
+    }
+    this.colorAttr.needsUpdate = true;
+    this.lastExcludeTaipei = excludeTaipei;
+  }
+
+  /** 每幀套用 store 狀態到 uniforms */
+  applyState(s: RePointsState, pointSizePx: number) {
+    if (!this.material) return;
+    const u = this.material.uniforms;
+    u.uCursorTs!.value = s.cursorTs - RANGE_START;
+    u.uMode!.value = MODE_CODE[s.mode];
+    u.uFull!.value = s.full;
+    u.uFade!.value = s.fade;
+    u.uQStart!.value = s.qStart - RANGE_START;
+    u.uQEnd!.value = s.qEnd - RANGE_START;
+    u.uShowRental!.value = s.show[0] ? 1 : 0;
+    u.uShowSale!.value = s.show[1] ? 1 : 0;
+    u.uShowPresale!.value = s.show[2] ? 1 : 0;
+    u.uExcludeTaipei!.value = s.excludeTaipei ? 1 : 0;
+    u.uBaseOpacity!.value = s.baseOpacity;
+    u.uPointSize!.value = pointSizePx;
+    this.recomputeColors(s.excludeTaipei);
+  }
+
+  hasData(): boolean {
+    return this.count > 0;
+  }
+
+  render(matrix: number[]) {
+    if (!this.material || !this.points) return;
+
+    const gl = this.renderer.getContext();
+    const blendEnabled = gl.isEnabled(gl.BLEND);
+    const blendSrc = gl.getParameter(gl.BLEND_SRC_RGB);
+    const blendDst = gl.getParameter(gl.BLEND_DST_RGB);
+    const blendSrcA = gl.getParameter(gl.BLEND_SRC_ALPHA);
+    const blendDstA = gl.getParameter(gl.BLEND_DST_ALPHA);
+
+    this.lastMatrix.fromArray(matrix);
+    this.camera.projectionMatrix.copy(this.lastMatrix);
+    this.renderer.resetState();
+    this.renderer.render(this.scene, this.camera);
+    this.renderer.resetState();
+
+    if (blendEnabled) gl.enable(gl.BLEND);
+    else gl.disable(gl.BLEND);
+    gl.blendFuncSeparate(blendSrc, blendDst, blendSrcA, blendDstA);
+  }
+
+  dispose() {
+    if (this.points) {
+      this.scene.remove(this.points);
+      this.points = null;
+    }
+    this.geometry?.dispose();
+    this.material?.dispose();
+    this.renderer?.dispose();
+  }
+}


### PR DESCRIPTION
## 動機
不動產「點」圖層在歷史月/週播放時卡頓。根因：每幀對 365k 點重設資料驅動 circle-opacity（O(feature)/幀）。

## 做法
3 個 PMTiles circle 點圖層 → 一個 Three.js × Mapbox **CustomLayer**，所有點一次上 GPU buffer，fade 由 shader 用 `uCursorTs` uniform 在 GPU 算（梯形窗）。每幀成本固定、與點數無關 → 消除卡頓。grid（格子）維持 PMTiles 不動。

## 變更
- 新增 `RealEstatePointsScene.ts`（GPU fade shader）/ `realEstatePointsCustomLayer.ts`（module 級 buffer 快取）/ `useRealEstatePointsLayer.ts`（lazy mount）/ `realEstatePointsStore.ts`
- `useRealEstateTimeline.ts` 刪點 paint 改寫 store；`overlayRegistry.ts` 移除 3 point overlay；`App.tsx` 接線；`useMapInteraction.ts` 停用點 hover
- 配色 JS 端用 `RE_PALETTES` 算 aColor，只在 excludeTaipei 切換重算
- fade 窗調俐落（週 5+10→2+3 天、月 20+30→6+10 天）
- 新資料檔 `real_estate_points_buffer.bin`（Float32×5/點，走 S3，epoch=RANGE_START）

## 取捨
- 點 hover/click 暫時放棄（custom layer 無 queryRenderedFeatures，待補 picking）

## 驗證
- `npx tsc -b` 0 error、`pnpm test` 155 pass（含 layerConsistency）
- browser 確認 realtime / 季 / 週播放 / excludeTaipei 皆正常、週播放流暢無卡頓

## 相關資料更新（已上 S3 deploy-assets）
- 補抓租賃 2025-09/10 + 預售 2025-09/10 缺口
- 修正 city="?" 8.8%→0.02%（影響排除雙北準度）

🤖 Generated with [Claude Code](https://claude.com/claude-code)