### PR TITLE
fix(energy): EHV 變電所 halo zoom 表達式合法化（修 console error）

### DIFF
--- a/docs/scaling-resilience-runbook.md
+++ b/docs/scaling-resilience-runbook.md
@@ -174,11 +174,10 @@ DB hang / 網路黑洞時寫入無限阻塞 → 因為全 collector 共用同一
 4. ✅ 通過 = watchdog 全鏈成立；測完**移除 `WATCHDOG_SELFTEST` env**。
 5. ❌ 沒重啟 = Zeabur 不重啟崩潰進程 → 改用外部 cron ping + API 重啟。
 
-### 第 4 項 — Cloudflare 邊緣快取（網站解 suspend 後）
-1. Cloudflare Cache Rules 應只剩**一條** `cache-static-assets`（Active）。
-2. 無痕開站 → DevTools → Network → 點任一 `.pmtiles` / `.geojson`。
-3. 看 Response Header `cf-cache-status`：第一次 `MISS`，**重整後 `HIT`** = 成功。
-4. 一直 `DYNAMIC` = 規則沒對到（檢查 expression 路徑前綴）。
+### 第 4 項 — Cloudflare 邊緣快取 ✅ 已驗證（2026-06-25）
+- `ftw_fields_2025.pmtiles` 回 `Cf-Cache-Status: HIT` + `Server: cloudflare` + `Cache-Control: public, max-age=86400`，Age 55800。
+- 確認：站走 itsmigu.com 經 Cloudflare，`.pmtiles` 已由邊緣供應、不回 origin。
+- ⏳ 剩：刪掉那條無效的「Cache GIS static assets」規則（保留 `cache-static-assets`）。
 
 ## 進度追蹤
 

--- a/src/map/overlayRegistry.ts
+++ b/src/map/overlayRegistry.ts
@@ -3068,11 +3068,12 @@ export const OVERLAY_REGISTRY: OverlayConfig[] = [
         paint: (_isDark, params) => {
           const o = params?.osmSubstationsEhvOpacity ?? 0.85;
           return {
+            // zoom 必須在 interpolate 最上層；per-class 倍率放進每個 stop 的 match 輸出
             "circle-radius": [
-              "match", ["get", "class"],
-              "EHV_SWITCH", ["interpolate", ["linear"], ["zoom"], 6, 8, 11, 14, 14, 20],
-              "EHV",        ["interpolate", ["linear"], ["zoom"], 6, 6, 11, 11, 14, 16],
-              0,
+              "interpolate", ["linear"], ["zoom"],
+              6,  ["match", ["get", "class"], "EHV_SWITCH", 8,  "EHV", 6,  0],
+              11, ["match", ["get", "class"], "EHV_SWITCH", 14, "EHV", 11, 0],
+              14, ["match", ["get", "class"], "EHV_SWITCH", 20, "EHV", 16, 0],
             ],
             "circle-blur": 0.9,
             "circle-color": [


### PR DESCRIPTION
既有 bug（非今晚 relaunch 造成）：`energy-substations-ehv-halo` 的 `circle-radius` 把 `["zoom"]` 包在 `match` 分支裡，違反 Mapbox「zoom 須在 interpolate/step 最外層」→ `addLayer` 失敗，該 halo 層加不進去、噴 console error。

## 修法
zoom 提到 `interpolate` 最外層，per-class 倍率放進每個 zoom stop 的 `match` 輸出。**視覺值完全不變**（EHV_SWITCH 6→8/11→14/14→20、EHV 6→6/11→11/14→16）。掃過全檔確認此反模式只有這一處。

`npx tsc -b` 0 error。

順帶：runbook 標記 item 4（Cloudflare 邊緣快取）已驗證 `Cf-Cache-Status: HIT`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)