### PR TITLE
docs(ops): 韌性 session 完整留存 + BACKLOG

### DIFF
--- a/.claude/memory/BACKLOG.md
+++ b/.claude/memory/BACKLOG.md
@@ -278,3 +278,23 @@
 - ❌ 缺 residential（市區巷弄）
 - ❌ 缺 service / track（產業道路、林道、登山口前山徑）
 - 實務影響：加油站本身就分布在主要道路上，「最近加油站」分析誤差小；但「視覺覆蓋密度」會比 fire/medical isochrone（路網全染）稀疏
+
+### 房地產 REAL ESTATE（RE 系列，2026-06-25 加 — 點圖層 CustomLayer + 資料補抓 + city 修正）
+
+> 點圖層改 WebGL CustomLayer + GPU fade（PR #32 已 merge master）；同步補抓缺口資料 + 修 city 分類。
+> 前端時間軸 = **交易/訂約日期**（trade_ts），範圍寫死 RANGE_START 2024-07-01 ~ RANGE_END 2026-03-31（2024Q3~2026Q1）。
+> 資料管線 runbook：`taipei-gis-analytics/docs/systems/real_estate_sync_runbook.md`；打包 buffer：`scripts/pack_real_estate_points_buffer.py`。
+
+| ID | 優先級 | 項目 | 狀態 | Blocker / 備註 |
+|---|---|---|---|---|
+| RE-1 | — | 點圖層改 WebGL CustomLayer + GPU fade | **done** | 2026-06-24 PR #32（master `b4bb90c`）。每幀對 365k 點重設 circle-opacity → GPU uCursorTs uniform。fade 窗調俐落（週 2+3 / 月 6+10 天）。點 hover/click 暫放棄 → RE-3 |
+| RE-2 | — | 補抓租賃+預售 2025-09/10 缺口 | **done** | 2026-06-25。下載官方 114S3/S4 季 zip（`DownloadSeason?season=114S3`）→ convert mirror → 離線 geocode（L1 cache 97%）→ 02b → 06 → build → S3。租賃 0→13,290/12,431、預售 0→2,164/2,993。ALL_points 365k→423,404 |
+| RE-3 | P2 | 點 hover/click picking 待補 | open | CustomLayer 無 `queryRenderedFeatures`。需自建 GPU/空間索引 picking（或保留隱形 PMTiles 點層供 query）。grid hover 不受影響仍正常 |
+| RE-4 | P2 | TGOS 934 筆批次離線補座標 | open | 離線 geocode 解不到的 1.6%（262 地號 + 672 地址）。批次檔已備 `taipei-gis-analytics/data/intermediate/tgos/real_estate/tgos_batch_rental_gap_2025Q3Q4.csv`（cp950, 5 欄）。用戶離線跑 TGOS → 拿 `Address_Finish*.csv` 放 `results/` → `_build_geocode_cache.py` → 重跑 02b/06/07/09/build。262 地號 TGOS 地址定位可能解不到，走 NLSC 地段地號 |
+| RE-5 | P2 | 補 115S1 季回填 2026 年初 + 收登記延遲尾巴 | open | 2026-02（458）/2026-03（5）幾乎空 = 近月登記延遲，下載 115S1 季可回填。⚠️ 若要顯示 2026Q2 以後，需同步延伸前端 `realEstateTime.ts` 的 `RANGE_END`/`RE_PERIODS`/`Q_START_TS` 三處（buffer epoch 仍是 RANGE_START 不動） |
+| RE-6 | P3 | 2024 上半邊界偏少補齊 | open | 2024-07~10 偏少是**資料邊界**（缺 113 年更早季檔，那些交易早就登記在我們沒下載的季）。非市況。需更早季檔才補得齊，ROI 低 |
+
+**資料品質結論（2026-06-25 盤查，已查證）**：
+- ✅ 2025-04~09 **買賣**量縮（2025-06 谷底 2,296）是**真實市況**：央行 2024-09 第七波信用管制，2025 全年買賣移轉年減 23~25%、創 1991 來最大跌幅（六都八年新低）。只買賣崩、租賃高檔 = 打房貸特徵。**非資料問題，不需處理**。
+- ⚠️ city="?" 36,354(8.8%)→77(0.02%)：根因地號地址無縣市前綴，06_merge 只解地址 → 改**優先用 MOI 來源權威 `city` 欄位**（避 district 名稱歧義如信義/東/中正區）。96% 來自單一檔 sale_moi_B5_B6_extended。analytics commit `a5f98c7`（本地 master 未 push，依慣例）。
+- ⚠️ "?" 點有少量段-中心疊點（地號無門牌 geocode 落地段中心，最多 196 點疊一處，但 83% 唯一座標），屬地號精度正常現象。

--- a/docs/scaling-resilience-runbook.md
+++ b/docs/scaling-resilience-runbook.md
@@ -194,3 +194,48 @@ DB hang / 網路黑洞時寫入無限阻塞 → 因為全 collector 共用同一
 - [ ] 5B/5C（**延後，看數據再決定**）：B = targeted 反代無參快照走 Cloudflare 邊緣（cross-user 減量）；C = read replica（讀寫隔離治本，要花錢）。兩者互補，等網站重開觀察連線池再選。
 - [ ] 6. Read Replica（評估）
 - [ ] staging 環境建置
+
+---
+
+## 本 session 額外處理（原 6 項以外，2026-06-24~25）
+
+| 項目 | 內容 | 產出 / commit |
+|---|---|---|
+| **資料停寫死人開關** | Supabase pg_cron 每 15 分檢查 `metadata.collector_status` 的 `MAX(last_success_at)`，停寫 > 30 分用 pg_net 發 Telegram、恢復再發一封。**完全外部於 collector**，連 collector/Zeabur 整個死也會通知（補 14h 靜默缺口）。憑證存 Supabase Vault；`metadata.alert_state` 防洗版。已套線上 + 驗證 pg_net 回 200。 | gis-platform `migrations/255_collector_freshness_alert.sql`（PR #18） |
+| **EHV halo bug** | `energy-substations-ehv-halo` 的 `circle-radius` 把 `["zoom"]` 包在 `match` 裡（違反 Mapbox 規則）→ addLayer 失敗噴 console error。zoom 提到 interpolate 最外層、倍率放進每 stop。視覺不變。 | mini-taiwan-pulse `overlayRegistry.ts`（PR #34） |
+| **precipitation_raster 空列** | collector 刻意存 `image_bytes=NULL` 空 raster 佔位列（搭配 `is_empty` 欄），但表有 NOT NULL → 反覆寫入失敗。`ALTER COLUMN image_bytes DROP NOT NULL` 讓表配合程式原意。 | gis-platform `migrations/256_precipitation_raster_nullable_image.sql`（PR #19） |
+| **S3 durability 查證** | 確認 Supabase 掛了，S3 仍有：①即時 collector 原始 JSON（每日 03:00 tar.gz，獨立於 Supabase）②靜態/衍生表快照（prod `BACKUP_ENABLED=true`，Robot A 03:30）。唯一缺口=「今天未歸檔」窗口最多 1 天只在本地 volume+Supabase。 | （無 code，結論記此） |
+| **config drift 釐清** | 本地 `.env` 無 `BACKUP_ENABLED`（dev），但 prod gomn service 早已 `=true`。無害漂移。 | （查證） |
+
+## 最終健康快照（2026-06-25 14:35 台北）
+
+- **整體管線健康**：47 個 enabled collectors，死人開關指標 `MAX(last_success_at)=0 分`。
+- **10 個 stale-by-success（>30min）幾乎全是低頻/事件型**（驗證死人開關用 MAX 而非逐一 collector 的設計正確）：
+  - 正常低頻：`wra_drought_alert`(乾旱事件)、`rail_timetable`/`water_reservoir_daily_ops`(每日)、`road_event_planned`(低頻)、`earthquake`(地震事件型)、`cdc_public_health_weekly`(週級, 外部 VM)。
+  - **待留意**：`precipitation_raster`(剛修 NOT NULL，待下次 run 恢復；source 自 06-24 05:37 停供)、`lightning_events`(dedup 撞鍵, 既有小毛病)、`ship_ais`/`waste_positions`(外部 VM, 停 ~19 天)。
+
+---
+
+## BACKLOG — 還可以做的（未來，非緊急）
+
+### 讀取側減量 / 隔離（看數據再決定）
+- **5B targeted 反代**：把 ~8 個無參全域快照 RPC（`get_source_health`/`get_pressure_index_now`/`get_market_index_now`/`get_pla_activity_latest`/`get_power_dashboard`/`get_alert_summary`…）改走 itsmigu.com 反代 + Cloudflare 邊緣快取（cross-user 減量）。需 nginx `/sb/` proxy + 前端 helper + Cache Rule。`VITE_SUPABASE_URL` 單點改即整 app 跟著走。
+- **5C / 6 Read Replica**：Supabase Pro 加唯讀副本，public 讀 → replica、collector 寫 → primary，讀寫物理隔離治本。要花錢（+1 台同規格 compute）。與 5B 互補（一個減量、一個隔離）。
+
+### 韌性 / 監控收尾
+- **第 3 項 staging 驗收**：`WATCHDOG_SELFTEST=true` 確認 Zeabur 會重啟崩潰進程（見上方待驗收清單）。若 Zeabur 不重啟 → 改外部 cron ping `/health` + API 重啟。
+- **staging 環境建置**：master(prod) + staging 兩分支 + Zeabur 兩 deploy；DB 用 Supabase Branching 或免費 Micro 當 staging DB。
+- **死人開關門檻調校**：目前 30 分；觀察實際後可調。也可加「單一高頻 canary collector 停寫」的更細告警（目前只看 MAX）。
+
+### 既有小毛病（pre-existing，獨立修）
+- **`lightning_events` dedup**：寫入應用 `ON CONFLICT (dedup_hash) DO NOTHING`，而非當失敗 buffer 重試（省 buffer churn + 告警噪音）。
+- **`precipitation_raster` 後續**：確認下次 run 真的恢復（存 `is_empty=true` 空列）；若 source 長期停供需查 CWA 來源。
+- **外部 VM collectors**：`ship_ais` / `waste_positions` 停 ~19 天 → 查 VM 是否該重啟或已棄用。
+- **`cdc_public_health_weekly`**：~9 天 overdue（週級，外部 VM）→ 查 VM 排程。
+
+### 資料保命強化（可選）
+- **縮短當日未歸檔窗口**：archive 每日 03:00 才跑且跳過今天 → 當日資料只在本地 volume+Supabase。可改更頻繁歸檔或加第二副本，降低「Supabase+volume 同時掛」的 ≤1 天遺失風險。
+
+### 效能 / 體驗（低優先）
+- **靜態資產 content hash**：目前靠 1d TTL + 部署後 purge；長遠可加 hash 走 `immutable` 1y（需動扁平檔名契約 + 部署腳本）。
+- **per-user GET 讀取快取**：對無參快照 RPC 加 `{ get: true }` + Cache-Control 讓瀏覽器快取（per-user 補強，非 cross-user）。


### PR DESCRIPTION
留存 2026-06-24~25 整輪韌性/快取處理的完整記錄 + 最終健康快照 + 未來 BACKLOG。純文件。

🤖 Generated with [Claude Code](https://claude.com/claude-code)