### PR TITLE
perf(startup): defer mount-time fetches + lazy hydrate overlays

### DIFF
--- a/.claude/memory/BACKLOG.md
+++ b/.claude/memory/BACKLOG.md
@@ -54,6 +54,7 @@
 | G001 | P2 | 刪 `useTransportParams` 裡的 `reservoirBubbleOpacity/Glow/Size` 殘留 slider | done | 2026-04-22 已拆 |
 | G002 | P3 | `[ReservoirLayer] render #N` 改 `DEBUG_RESERVOIR` env flag 控制 | done | 2026-04-23 render loop 修掉時順手移除 |
 | G003 | P3 | `public/three-showcase.html` / `public/showcase/` 去留 | open | 2026-05-25 review 確認：獨立 Three.js demo，`src/` 未引用，從 unpkg 載 three@0.160（app 用 0.172）。用戶決定**暫留原地**（已 tracked）。未來可移 `examples/three-showcase/`（連同 `docs/three-showcase-library.md`）排除 build |
+| CS-1 | P3 | Code Splitting / Dynamic Import 重型依賴 | open | 對象：`mapbox-gl` / `three` / `pmtiles` / `@deck.gl/*` / `satellite.js` / `h3-js` 全部 eager import。效益：首屏 JS bundle 變小、TTI 加快（次要瓶頸，主要瓶頸已由 perf ①+② 解決）。風險：Vite chunk 邊界 / Mapbox worker 註冊時機 / PMTiles protocol 註冊順序常踩坑，需完整回歸。工時：1-2 天。觸發時機：等到出現「首頁 JS bundle 過大」用戶抱怨，或 ①+② 完成後仍想再壓首屏。**規劃源**：`/Users/migu/.claude/plans/1-2-modular-rossum.md` |
 
 ### 結構 / 部署 Review（2026-05-25 全專案結構審查 — G004~G010）
 

--- a/.claude/memory/BACKLOG.md
+++ b/.claude/memory/BACKLOG.md
@@ -55,6 +55,7 @@
 | G002 | P3 | `[ReservoirLayer] render #N` 改 `DEBUG_RESERVOIR` env flag 控制 | done | 2026-04-23 render loop 修掉時順手移除 |
 | G003 | P3 | `public/three-showcase.html` / `public/showcase/` 去留 | open | 2026-05-25 review 確認：獨立 Three.js demo，`src/` 未引用，從 unpkg 載 three@0.160（app 用 0.172）。用戶決定**暫留原地**（已 tracked）。未來可移 `examples/three-showcase/`（連同 `docs/three-showcase-library.md`）排除 build |
 | CS-1 | P3 | Code Splitting / Dynamic Import 重型依賴 | open | 對象：`mapbox-gl` / `three` / `pmtiles` / `@deck.gl/*` / `satellite.js` / `h3-js` 全部 eager import。效益：首屏 JS bundle 變小、TTI 加快（次要瓶頸，主要瓶頸已由 perf ①+② 解決）。風險：Vite chunk 邊界 / Mapbox worker 註冊時機 / PMTiles protocol 註冊順序常踩坑，需完整回歸。工時：1-2 天。觸發時機：等到出現「首頁 JS bundle 過大」用戶抱怨，或 ①+② 完成後仍想再壓首屏。**規劃源**：`/Users/migu/.claude/plans/1-2-modular-rossum.md` |
+| PT-1 | P2 | 大型 GeoJSON → PMTiles 轉換 | open | perf ② 把靜態 GeoJSON 改成 toggle 才抓，但「toggle 後 fetch 整檔」對大檔仍重。改 PMTiles + HTTP Range Request 後實際下載量可壓到 1/20~1/50。候選（按 size 排）：`provincial_road` 44MB / `medical_clinic` 26MB / `medical_ltc` 17MB / `forest_trail_signs` 17MB / `fire_hydrants` 13MB / `medical_aed` 9.4MB / `medical_pharmacy` 8.4MB / `national_highway` 7.9MB（共 ~142MB）。流程：collector 端跑 tippecanoe 切 tiles + 包 .pmtiles，前端 overlayRegistry 該 entry 加 `pmtiles: { sourceLayer, minzoom, maxzoom }`，hydrate 路徑自動 no-op（Mapbox 自動 tile-on-demand）。先試 `provincial_road` 一條，驗證流程後再批次。工時：先做 1 個 ~半天（含 tippecanoe 參數調），後續每個 ~1h |
 
 ### 結構 / 部署 Review（2026-05-25 全專案結構審查 — G004~G010）
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -140,17 +140,23 @@ export default function App() {
 
   // ── Data Source Registry ──
   const dataRegistry = useDataRegistry();
-  // 燈塔座標
+  // 燈塔座標（lazy：toggle 開啟才抓）
   const [lighthousePositions, setLighthousePositions] = useState<[number, number][]>([]);
+  const lighthouseFetchedRef = useRef(false);
   useEffect(() => {
+    if (!layerVisibility.lighthouses || lighthouseFetchedRef.current) return;
+    lighthouseFetchedRef.current = true;
     fetch("./geo/lighthouse.geojson")
       .then((r) => r.json())
       .then((geojson: GeoJSON.FeatureCollection<GeoJSON.Point>) => {
         const positions = geojson.features.map((f) => f.geometry.coordinates.slice(0, 2) as [number, number]);
         setLighthousePositions(positions);
       })
-      .catch((err) => console.warn("Lighthouse data not available:", err));
-  }, []);
+      .catch((err) => {
+        lighthouseFetchedRef.current = false;
+        console.warn("Lighthouse data not available:", err);
+      });
+  }, [layerVisibility.lighthouses]);
 
   // 車站光柱資料 — 三體系各自獨立
   const [thsrPillarData, setThsrPillarData] = useState<StationPillarData[]>([]);
@@ -212,8 +218,12 @@ export default function App() {
     }
   }, [temperatureTimeRange, dataRegistry.register]);
 
-  // 預計算光柱資料（靜態 JSON，不依賴 railData）
+  // 預計算光柱資料（靜態 JSON，不依賴 railData；lazy：任一車站 toggle 開才抓）
+  const stationPillarFetchedRef = useRef(false);
+  const needStationPillars = layerVisibility.stationsTHSR || layerVisibility.stationsTRA || layerVisibility.stationsMetro;
   useEffect(() => {
+    if (!needStationPillars || stationPillarFetchedRef.current) return;
+    stationPillarFetchedRef.current = true;
     fetch("./station_pillars.json")
       .then((r) => r.json())
       .then((data: Record<string, { lng: number; lat: number; height: number }[]>) => {
@@ -223,11 +233,17 @@ export default function App() {
         setTraPillarData(toArr(data.tra ?? []));
         setMetroPillarData(toArr(data.metro ?? []));
       })
-      .catch((err) => console.warn("Station pillar data:", err));
-  }, []);
+      .catch((err) => {
+        stationPillarFetchedRef.current = false;
+        console.warn("Station pillar data:", err);
+      });
+  }, [needStationPillars]);
 
-  // 機場光柱 — 從 airports.geojson 算質心，高度依起降量排序
+  // 機場光柱 — 從 airports.geojson 算質心，高度依起降量排序（lazy：airports toggle 開才抓）
+  const airportPillarFetchedRef = useRef(false);
   useEffect(() => {
+    if (!layerVisibility.airports || airportPillarFetchedRef.current) return;
+    airportPillarFetchedRef.current = true;
     const AIRPORT_HEIGHTS: Record<string, number> = {
       RCTP: 1.0, RCSS: 0.85, RCKH: 0.7, RCMQ: 0.55,
       RCBS: 0.45, RCNN: 0.35, RCFN: 0.3, RCKU: 0.25,
@@ -248,11 +264,17 @@ export default function App() {
         });
         setAirportPillarData(data);
       })
-      .catch((err) => console.warn("Airport pillar data:", err));
-  }, []);
+      .catch((err) => {
+        airportPillarFetchedRef.current = false;
+        console.warn("Airport pillar data:", err);
+      });
+  }, [layerVisibility.airports]);
 
-  // 碼頭光柱 — 從 port_polygons.geojson 算質心
+  // 碼頭光柱 — 從 port_polygons.geojson 算質心（lazy：ports toggle 開才抓）
+  const portPillarFetchedRef = useRef(false);
   useEffect(() => {
+    if (!layerVisibility.ports || portPillarFetchedRef.current) return;
+    portPillarFetchedRef.current = true;
     fetch("./geo/port_polygons.geojson")
       .then((r) => r.json())
       .then((geojson: GeoJSON.FeatureCollection) => {
@@ -267,8 +289,11 @@ export default function App() {
         });
         setPortPillarData(data);
       })
-      .catch((err) => console.warn("Port pillar data:", err));
-  }, []);
+      .catch((err) => {
+        portPillarFetchedRef.current = false;
+        console.warn("Port pillar data:", err);
+      });
+  }, [layerVisibility.ports]);
 
   const { isMobile, isLandscape } = useIsMobile();
 
@@ -307,6 +332,9 @@ export default function App() {
   });
 
   // ── 活躍日追蹤：訂閱 timeStore 日期粒度（不走 React re-render） ──
+  // 注意：handler 內 loadShipDay / loadFlightDay 看似 mount 就 fire，
+  // 但下游 useShipData / useAirspaceData 用 apiAvailable.current 守門，
+  // layer 關著時 silent no-op；保留訂閱是為了切日時已開啟的 layer 能立即跟上。
   useEffect(() => {
     const handler = (dayStr: string) => {
       if (!dayStr) return;
@@ -932,9 +960,29 @@ export default function App() {
     isDarkTheme,
   );
 
+  // 地圖首次渲染完成（idle 或 4s 保底）— 需在下方 waste lazy setup effect 之前宣告
+  const [mapPrepared, setMapPrepared] = useState(false);
+
   // ── 垃圾設施 / 投放點 Mapbox circle（8 個量級大子類型） ──
-  // setup 在 handleMapReady 直接呼叫（避開 useEffect mount 時 mapRef 仍 null 的 race）
+  // Lazy setup：任一 wf* toggle 開 + map 已 ready 才建 8 sources + 16 layers
   const wasteMapboxSetupRef = useRef(false);
+  const anyWasteFacilityOn = layerVisibility.wfIncinerator || layerVisibility.wfLandfill
+    || layerVisibility.wfLandfillCoastal || layerVisibility.wfTransfer
+    || layerVisibility.wfMedical || layerVisibility.wfMonitoring;
+  useEffect(() => {
+    if (!anyWasteFacilityOn || wasteMapboxSetupRef.current) return;
+    const map = mapRef.current;
+    if (!styleReady(map)) return;
+    setupWasteMapboxLayers(map, {
+      isDark: isDarkTheme,
+      onFeatureClick: setFeatureInfo,
+    });
+    wasteMapboxSetupRef.current = true;
+    // setup 完立刻把目前 byType / visibility / params 同步進去
+    syncWasteMapboxData(map, wasteFacilityByTypeRef.current ?? new Map(), wasteDisposalByType);
+    syncWasteMapboxVisibility(map, layerVisibilityRef.current);
+    syncWasteMapboxParams(map, transportParams.wasteSubParams);
+  }, [anyWasteFacilityOn, mapPrepared, isDarkTheme, wasteDisposalByType, transportParams.wasteSubParams]);
   useEffect(() => {
     const map = mapRef.current;
     if (!styleReady(map) || !wasteMapboxSetupRef.current) return;
@@ -968,8 +1016,7 @@ export default function App() {
   // ── Map ready handler ──
 
   // 地圖首次渲染完成（idle 或 4s 保底）才允許 LoadingScreen 收掉，
-  // 避免「資料 RPC 完成但場景還沒畫出來」的空窗
-  const [mapPrepared, setMapPrepared] = useState(false);
+  // 避免「資料 RPC 完成但場景還沒畫出來」的空窗 — state 宣告已上移至 waste lazy setup 前
 
   const handleMapReady = (map: MapboxMap) => {
     mapRef.current = map;
@@ -999,25 +1046,11 @@ export default function App() {
     };
     map.on("zoomend", onZoomH3);
     onZoomH3(); // initial
-    loadResolution(7); // preload default resolution
-    loadDemographicsResolution(7); // preload demographics
-    loadSocioResolution(7); // preload socioeconomic
-    loadSpatialResolution(7); // preload spatial economy
+    // H3 res 預載已移除 — 各 h3* subscriber（L1086 / L1105 / L1119 / L1126）會在 visibility 開啟時自行 loadResolution
 
     bindEvents(map);
 
-    // 垃圾設施 / 投放點 Mapbox circle setup — map ready 後立刻建 8 個 source + 16 個 layer
-    if (!wasteMapboxSetupRef.current) {
-      setupWasteMapboxLayers(map, {
-        isDark: isDarkTheme,
-        onFeatureClick: setFeatureInfo,
-      });
-      wasteMapboxSetupRef.current = true;
-      // map 還沒拿到目前的 byType / visibility / params → 立刻同步一次
-      syncWasteMapboxData(map, wasteFacilityByTypeRef.current ?? new Map(), wasteDisposalByType);
-      syncWasteMapboxVisibility(map, layerVisibilityRef.current);
-      syncWasteMapboxParams(map, transportParams.wasteSubParams);
-    }
+    // 垃圾設施 / 投放點 Mapbox circle setup 已移至獨立 effect（lazy：任一 wf* toggle 開才 setup）
 
     // 3D 垃圾處理設施 click pick（5 sub-scene 任一命中 → popup）
     map.on("click", (e) => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1351,7 +1351,11 @@ export default function App() {
   // LoadingScreen 改為 overlay（fixed, zIndex 9999）蓋在主 UI 上，
   // 讓 Mapbox + Three.js 場景在 loading 期間於底下平行初始化；
   // 舊版 early return 會讓地圖等 loading 收掉才開始載，造成進場後動態點空窗。
-  const showLoadingScreen = !loadingTimedOut && (!allReady || !dismissedLoading);
+  //
+  // 一次性：只在初次 mount 顯示，dismissedLoading=true 後絕不重開。
+  // 之後使用者 toggle 動態圖層的 loading 由 loadingRegistry 的小型 indicator 處理，
+  // 不再用 full-screen splash 蓋整個畫面（會打斷已經在用地圖的使用者）。
+  const showLoadingScreen = !loadingTimedOut && !dismissedLoading;
 
   return (
     <div style={{ position: "relative", width: "100vw", height: "100vh" }}>

--- a/src/components/sidebar/layerCatalog.ts
+++ b/src/components/sidebar/layerCatalog.ts
@@ -588,3 +588,12 @@ export const SECTIONS: SectionDef[] = [
     ],
   },
 ];
+
+// SECTIONS 派生 → 給 overlayManager hydrate 等需要 user-facing label 的場景查表
+export const LAYER_LABELS: Partial<Record<keyof LayerVisibility, string>> = (() => {
+  const out: Partial<Record<keyof LayerVisibility, string>> = {};
+  for (const section of SECTIONS) {
+    for (const def of section.layers) out[def.key] = def.label;
+  }
+  return out;
+})();

--- a/src/hooks/useEarthquakeLayer.ts
+++ b/src/hooks/useEarthquakeLayer.ts
@@ -126,22 +126,22 @@ export function useEarthquakeLayer(
   const rafRef = useRef(0);
   const lastFrameRef = useRef(0);
 
-  // 載入一次
+  // 載入一次（lazy：visible 為 true 才抓，之後不重抓）
   useEffect(() => {
+    if (!visible || dataReadyRef.current) return;
     let cancelled = false;
     fetchEarthquakes()
       .then((evs) => {
         if (cancelled) return;
         eventsRef.current = evs;
         dataReadyRef.current = true;
-        // 嘗試立即注入
         const map = mapRef.current;
         if (map && map.isStyleLoaded()) ensureSource(map);
       })
       .catch((err) => console.warn("[Earthquake] load failed:", err));
     return () => { cancelled = true; };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [visible]);
 
   const ensureSource = useCallback((map: MapboxMap) => {
     if (!dataReadyRef.current) return false;

--- a/src/hooks/useSatellitesLayer.ts
+++ b/src/hooks/useSatellitesLayer.ts
@@ -147,8 +147,9 @@ export function useSatellitesLayer(
   const trackMinutesRef = useRef(trackMinutes);
   trackMinutesRef.current = trackMinutes;
 
-  // ── 載入 TLE（一次性，6h cache） ──
+  // ── 載入 TLE（一次性，6h cache；lazy：anyVisible 為 true 才抓） ──
   useEffect(() => {
+    if (!anyVisible || recordsRef.current.length > 0) return;
     let cancelled = false;
     loadSatellites().then((records) => {
       if (cancelled) return;
@@ -164,7 +165,7 @@ export function useSatellitesLayer(
       setDataReady(true);
     });
     return () => { cancelled = true; };
-  }, []);
+  }, [anyVisible]);
 
   // ── 建立 sources + layers ──
   const ensureLayers = useCallback((map: MapboxMap): boolean => {

--- a/src/map/MapView.tsx
+++ b/src/map/MapView.tsx
@@ -4,7 +4,7 @@ import "mapbox-gl/dist/mapbox-gl.css";
 import type { CameraPreset, Flight, RenderMode, LayerVisibility } from "../types";
 import { updateStaticTrails, setStaticTrailsOpacity, setStaticTrailsVisible } from "./staticTrails";
 import { OVERLAY_REGISTRY } from "./overlayRegistry";
-import { addAllOverlays, updateAllOverlayThemes, setOverlayVisible } from "./overlayManager";
+import { addAllOverlays, updateAllOverlayThemes, setOverlayVisible, hydrateOverlayIfNeeded } from "./overlayManager";
 import { registerPmtilesSourceTypeOnce } from "./pmtilesSourceType";
 import { ensureFireIsochroneLayer, updateFireIsochroneLayer } from "./fireIsochroneLayerFactory";
 import { ensureMedicalIsochroneLayers, updateMedicalIsochroneLayers } from "./medicalIsochroneLayerFactory";
@@ -277,7 +277,9 @@ export function MapView({ preset, styleUrl, pureBlack = false, flights, renderMo
       // 期間 visibility / params effect 全部 no-op（mapRef null）。
       // 這裡用 ref 的最新值重放一次，避免「toggle 開了但圖層沒出現」。
       for (const config of OVERLAY_REGISTRY) {
-        setOverlayVisible(map, config, layerVisibilityRef.current[config.id]);
+        const vis = layerVisibilityRef.current[config.id];
+        if (vis) void hydrateOverlayIfNeeded(map, config);
+        setOverlayVisible(map, config, vis);
       }
       updateAllOverlayThemes(map, OVERLAY_REGISTRY, isDarkThemeRef.current, overlayParamsRef.current);
       onMapReadyRef.current?.(map);
@@ -394,7 +396,9 @@ export function MapView({ preset, styleUrl, pureBlack = false, flights, renderMo
     const map = mapRef.current;
     if (!map || !readyRef.current) return;
     for (const config of OVERLAY_REGISTRY) {
-      setOverlayVisible(map, config, layerVisibility[config.id]);
+      const vis = layerVisibility[config.id];
+      if (vis) void hydrateOverlayIfNeeded(map, config);
+      setOverlayVisible(map, config, vis);
     }
     // OVERLAY_REGISTRY 之外的專屬圖層
     updateAllAgricultureLayers(map, layerVisibility, overlayParamsRef.current);

--- a/src/map/agricultureLayerFactory.ts
+++ b/src/map/agricultureLayerFactory.ts
@@ -14,6 +14,7 @@ import {
 // PMTiles SourceType 註冊統一走 pmtilesSourceType.ts（所有 PMTiles 圖層共用）
 import { registerPmtilesSourceTypeOnce } from "./pmtilesSourceType";
 import { PMTILES_SOURCE_TYPE } from "./pmtilesConstants";
+import { loadingRegistry } from "../lib/loadingRegistry";
 
 const BASE = `${import.meta.env.BASE_URL ?? "/"}agriculture`;
 
@@ -431,9 +432,11 @@ export const AGRI_POI_PARAMS_DEFAULT: AgriPOIParams = { opacity: 1, scale: 1 };
 
 export function ensureAgriPOILayers(map: MapboxMap): void {
   if (!map.getSource(POI_SOURCE_ID)) {
+    // 空 FC 起手，避免 mount 時 Mapbox 自動 fetch。
+    // 真正 fetch 由 updateAgriPOILayer 在 visible=true 時 lazy 觸發。
     map.addSource(POI_SOURCE_ID, {
       type: "geojson",
-      data: `${BASE}/agriculture_pois.geojson`,
+      data: { type: "FeatureCollection", features: [] } as GeoJSON.FeatureCollection,
     });
   }
   if (!map.getLayer(POI_CIRCLE_ID)) {
@@ -458,12 +461,32 @@ export function ensureAgriPOILayers(map: MapboxMap): void {
   }
 }
 
+let agriPOIHydrated = false;
 export function updateAgriPOILayer(
   map: MapboxMap,
   visible: boolean,
   params: AgriPOIParams = AGRI_POI_PARAMS_DEFAULT,
 ): void {
   if (!map.getLayer(POI_CIRCLE_ID)) return;
+  if (visible && !agriPOIHydrated) {
+    agriPOIHydrated = true;
+    const taskId = "overlay-hydrate:agri-pois";
+    loadingRegistry.start(taskId, "農業 POI");
+    fetch(`${BASE}/agriculture_pois.geojson`)
+      .then((r) => r.json() as Promise<GeoJSON.FeatureCollection>)
+      .then((json) => {
+        const src = map.getSource(POI_SOURCE_ID);
+        if (src && "setData" in src) {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          (src as any).setData(json);
+        }
+      })
+      .catch((e) => {
+        agriPOIHydrated = false;
+        console.warn("[agri-pois] hydrate failed:", e);
+      })
+      .finally(() => loadingRegistry.end(taskId));
+  }
   map.setLayoutProperty(POI_CIRCLE_ID, "visibility", visible ? "visible" : "none");
   map.setPaintProperty(POI_CIRCLE_ID, "circle-opacity", 0.9 * params.opacity);
   map.setPaintProperty(POI_CIRCLE_ID, "circle-radius", [

--- a/src/map/overlayManager.ts
+++ b/src/map/overlayManager.ts
@@ -7,6 +7,8 @@ import {
   type SerializedPaint,
 } from "./overlayPaintDiff";
 import { PMTILES_SOURCE_TYPE } from "./pmtilesConstants";
+import { loadingRegistry } from "../lib/loadingRegistry";
+import { LAYER_LABELS } from "../components/sidebar/layerCatalog";
 
 function layerId(config: OverlayConfig, suffix: string) {
   return `${config.sourceId}-${suffix}`;
@@ -62,12 +64,12 @@ export function addOverlay(
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
       } as any);
     } else {
+      // 全部用空 FC 起手，避免 mount 時 Mapbox 自動 fetch sourceUrl。
+      // 靜態 GeoJSON 改由 hydrateOverlayIfNeeded（toggle on 觸發）setData。
+      // dynamicData：由對應 loader/hook 按日 setData 餵入。
       map.addSource(config.sourceId, {
         type: "geojson",
-        // dynamicData：空 FC 起手，由對應 loader/hook 按日 setData 餵入
-        data: config.dynamicData
-          ? ({ type: "FeatureCollection", features: [] } as GeoJSON.FeatureCollection)
-          : config.sourceUrl,
+        data: { type: "FeatureCollection", features: [] } as GeoJSON.FeatureCollection,
         ...geojsonSourceOptions(config),
       });
     }
@@ -229,6 +231,47 @@ function applyPaintDiff(
     map.setPaintProperty(id, key as any, value);
   }
   cache.set(id, serialized);
+}
+
+// ── Static GeoJSON lazy hydration ──
+// 全域單例：紀錄哪些 sourceId 已經 hydrate（fetch + setData）過，避免重抓。
+// key 用 sourceId（不是 config.id），自然處理「多個 overlay 共用同一 sourceUrl」。
+const hydratedSources = new Set<string>();
+
+/**
+ * 若 config 是靜態 GeoJSON 且尚未 hydrate → fetch sourceUrl + setData。
+ * dynamicData / pmtiles 配置直接 no-op（pmtiles 由 Mapbox 自動 lazy load tile，
+ * dynamicData 由各自 loader 負責）。
+ *
+ * 設計：
+ * - 失敗時清掉 set 讓下次 toggle 可重試
+ * - 先標記 hydrated 防同一 toggle 內重複觸發 race
+ */
+export async function hydrateOverlayIfNeeded(
+  map: MapboxMap,
+  config: OverlayConfig,
+): Promise<void> {
+  if (config.pmtiles || config.dynamicData) return;
+  if (hydratedSources.has(config.sourceId)) return;
+  hydratedSources.add(config.sourceId);
+  const taskId = `overlay-hydrate:${config.sourceId}`;
+  const label = LAYER_LABELS[config.id] ?? config.sourceId;
+  loadingRegistry.start(taskId, label);
+  try {
+    const res = await fetch(config.sourceUrl);
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    const json = (await res.json()) as GeoJSON.FeatureCollection;
+    const src = map.getSource(config.sourceId);
+    if (src && "setData" in src) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (src as any).setData(json);
+    }
+  } catch (e) {
+    hydratedSources.delete(config.sourceId);
+    console.warn(`[overlay] hydrate ${config.sourceId} failed:`, e);
+  } finally {
+    loadingRegistry.end(taskId);
+  }
 }
 
 /** 設定單一 overlay 可見性 */


### PR DESCRIPTION
## Summary

為「對外開放、多人使用」做的啟動效能改造。訪客一進站從 ~10 RPC + 25+ geojson + ~150MB 下載 → **0 RPC + 0 geojson + 0 額外靜態下載**，所有資料改為 toggle 開啟才 lazy 載入。

兩階段：

**階段 ① (commit `9e680f9`) — App.tsx mount fetch 拔除 + hook gate 補齊**
- 4 個 Three.js pillar fetch（lighthouse / station_pillars / airports / port_polygons）改 visibility-gated
- 刪除 4 個 H3 `loadResolution(7)` preload（subscriber 已自 gate）
- Waste Mapbox setup 改 lazy effect，任一 wf* toggle 開才建 8 sources + 16 layers
- `useEarthquakeLayer` / `useSatellitesLayer` 補 visible gate

**階段 ② (commit `f76b2b4`) — overlayRegistry lazy hydrate**
- `overlayManager.addOverlay` 統一空 FC 起手
- 新增 `hydrateOverlayIfNeeded(map, config)`：toggle 開才 fetch + setData，含 `loadingRegistry` 進度回報
- `MapView` 兩個 toggle 入口（replay + visibility effect）接 hydrate
- `agricultureLayerFactory.ensureAgriPOILayers` 同樣套 lazy 模式
- `LoadingScreen` 改為一次性 splash，避免 toggle 動態圖層時被 splash 蓋畫面
- BACKLOG 新增 CS-1（code splitting）+ PT-1（大 GeoJSON → PMTiles）

## 驗證

| | Before | After |
|---|---|---|
| Mount Supabase RPC | ~10 | **0** |
| Mount geojson 請求 | 25+ | **0** |
| Mount 靜態下載 | ~150 MB | **0** |

截圖驗證：All Off + reload 後 Network panel 完全乾淨；toggle 河川 / 國道 / 省道 / 農業 POI 等正常 lazy 載入並顯示。

## Test plan

- [x] `npx tsc -b` 0 error
- [x] 本機 dev server 跑過：All Off + reload → 0 我們的 mount 請求
- [x] toggle 河川 / 國道 / 省道 / 農業 POI / 機場 / 港口 / 燈塔 → 對應檔正確 lazy 載入
- [x] toggle 航班 / 船舶 / 鐵道 → splash 不再重現
- [ ] 上 staging 後再對重型 layer（醫療 62MB / 林業 / 消防栓 13MB）做一次完整驗證

🤖 Generated with [Claude Code](https://claude.com/claude-code)