### PR TITLE
feat(cwa-imagery): per-day LRU cache + 1~7d 可調預載

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -939,7 +939,6 @@ export default function App() {
     radarVisible: layerVisibility.cwaRadarImagery,
     cloudOpacity: transportParams.cwaCloudOpacity,
     radarOpacity: transportParams.cwaRadarOpacity,
-    preloadDays: transportParams.imageryPreloadDays,
   });
 
   // ── 空氣品質：色階 raster + 77 站 + LASS 微型感測 ──

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -939,6 +939,7 @@ export default function App() {
     radarVisible: layerVisibility.cwaRadarImagery,
     cloudOpacity: transportParams.cwaCloudOpacity,
     radarOpacity: transportParams.cwaRadarOpacity,
+    preloadDays: transportParams.imageryPreloadDays,
   });
 
   // ── 空氣品質：色階 raster + 77 站 + LASS 微型感測 ──

--- a/src/components/TimelineControls.tsx
+++ b/src/components/TimelineControls.tsx
@@ -191,7 +191,11 @@ export function TimelineControls({
           title="顯示天數"
         >
           <option value={1}>1d</option>
+          <option value={2}>2d</option>
           <option value={3}>3d</option>
+          <option value={4}>4d</option>
+          <option value={5}>5d</option>
+          <option value={6}>6d</option>
           <option value={7}>7d</option>
         </select>
       </div>

--- a/src/data/cwaImageryLoader.ts
+++ b/src/data/cwaImageryLoader.ts
@@ -55,20 +55,23 @@ export interface CwaImageryWindow {
 export async function loadCwaImageryBatch(
   datasetIds: string[],
   window: CwaImageryWindow,
+  opts: { silent?: boolean } = {},
 ): Promise<Map<string, { bundle: CwaImageryBundle; urls: Map<string, string> }>> {
-  const key = `cwa-imagery-batch:${datasetIds.join(",")}`;
-  const label = `CWA 影像批次載入 ${datasetIds.join("/")}`;
+  const rpcPromise = supabase.rpc("get_cwa_imagery_frames_batch", {
+    p_dataset_ids: datasetIds,
+    p_since: window.sinceIso,
+    p_until: window.untilIso,
+    p_step_minutes: window.stepMinutes,
+  });
 
-  const { data, error } = await withLoading(
-    key,
-    label,
-    supabase.rpc("get_cwa_imagery_frames_batch", {
-      p_dataset_ids: datasetIds,
-      p_since: window.sinceIso,
-      p_until: window.untilIso,
-      p_step_minutes: window.stepMinutes,
-    }),
-  );
+  // silent=true 走背景 prefetch 路徑，不灌 LOADING panel
+  const { data, error } = await (opts.silent
+    ? rpcPromise
+    : withLoading(
+        `cwa-imagery-batch:${datasetIds.join(",")}`,
+        `CWA 影像批次載入 ${datasetIds.join("/")}`,
+        rpcPromise,
+      ));
 
   if (error) throw new Error(`get_cwa_imagery_frames_batch: ${error.message}`);
 

--- a/src/data/lightningLoader.ts
+++ b/src/data/lightningLoader.ts
@@ -78,22 +78,23 @@ export const fetchLightningWindow = (centerTs: number, halfMin: number): Promise
 export const invalidateLightningWindow = (): void => fetchLightningWindowCached.invalidate();
 
 // ── day preload（v2 Phase B++，RPC 226）─────────────────────
-// 整天落雷一次抓，前端 client-side filter + fade，scrub 不再打 server
-async function fetchLightningDayUncached(dateKey: string): Promise<LightningStrike[]> {
-  const { data, error } = await withLoading(
-    `lightning:day:${dateKey}`,
-    `落雷 ${dateKey} 整日`,
-    supabase.rpc("get_lightning_day", { date_key: dateKey }),
-  );
+// 整天落雷一次抓，前端 client-side filter + fade，scrub 不再打 server。
+// 2026-06-26：分 raw + wrapped — prefetch 走 raw（背景靜默不灌 LOADING panel）。
+async function fetchLightningDayRaw(dateKey: string): Promise<LightningStrike[]> {
+  const { data, error } = await supabase.rpc("get_lightning_day", { date_key: dateKey });
   if (error) throw new Error(`get_lightning_day: ${error.message}`);
   return (data ?? []) as LightningStrike[];
 }
 const fetchLightningDayCached = cachedByKey<LightningStrike[]>(
-  (key) => fetchLightningDayUncached(key),
+  fetchLightningDayRaw,
   10 * 60_000,
-  3, // 通常只用今日 / 昨日 / 前日
+  8, // 配合 timeline rangeDays 最高 7 + 1 spare
 );
+/** Foreground — 顯示 LOADING tracker。Hook 應該用這個載當前日。 */
 export const fetchLightningDay = (dateKey: string): Promise<LightningStrike[]> =>
+  withLoading(`lightning:day:${dateKey}`, `落雷 ${dateKey} 整日`, fetchLightningDayCached(dateKey));
+/** Prefetch — 靜默，不灌 LOADING panel。與 fetchLightningDay 共用 cache。 */
+export const prefetchLightningDay = (dateKey: string): Promise<LightningStrike[]> =>
   fetchLightningDayCached(dateKey);
 export const invalidateLightningDay = (dateKey?: string): void =>
   fetchLightningDayCached.invalidate(dateKey);

--- a/src/data/nuclearLoader.ts
+++ b/src/data/nuclearLoader.ts
@@ -80,12 +80,9 @@ export interface NuclearDay {
   stations: NuclearStationSeries[];
 }
 
-async function fetchNuclearDayUncached(dateKey: string): Promise<NuclearDay> {
-  const { data, error } = await withLoading(
-    `nuclear:day:${dateKey}`,
-    `核安 ${dateKey} 整日`,
-    supabase.rpc("get_nuclear_radiation_day", { date_key: dateKey }),
-  );
+// 2026-06-26：分 raw + wrapped — prefetch 走 raw（背景靜默不灌 LOADING panel）。
+async function fetchNuclearDayRaw(dateKey: string): Promise<NuclearDay> {
+  const { data, error } = await supabase.rpc("get_nuclear_radiation_day", { date_key: dateKey });
   if (error) throw new Error(`get_nuclear_radiation_day: ${error.message}`);
   const obj = (data ?? {}) as Partial<NuclearDay>;
   return {
@@ -94,11 +91,15 @@ async function fetchNuclearDayUncached(dateKey: string): Promise<NuclearDay> {
   };
 }
 const fetchNuclearDayCached = cachedByKey<NuclearDay>(
-  (key) => fetchNuclearDayUncached(key),
+  fetchNuclearDayRaw,
   10 * 60_000,
-  3,
+  8, // 配合 timeline rangeDays 最高 7 + 1 spare
 );
+/** Foreground — 顯示 LOADING tracker。Hook 應該用這個載當前日。 */
 export const fetchNuclearDay = (dateKey: string): Promise<NuclearDay> =>
+  withLoading(`nuclear:day:${dateKey}`, `核安 ${dateKey} 整日`, fetchNuclearDayCached(dateKey));
+/** Prefetch — 靜默，不灌 LOADING panel。與 fetchNuclearDay 共用 cache。 */
+export const prefetchNuclearDay = (dateKey: string): Promise<NuclearDay> =>
   fetchNuclearDayCached(dateKey);
 
 /**

--- a/src/hooks/useCwaImageryLayer.ts
+++ b/src/hooks/useCwaImageryLayer.ts
@@ -22,7 +22,7 @@
  *  - 用戶調小 preloadDays → 立刻 evict 多出的最舊日
  */
 
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useSyncExternalStore } from "react";
 import type { Map as MapboxMap } from "mapbox-gl";
 import {
   loadCwaImageryBatch,
@@ -148,8 +148,14 @@ interface UseCwaImageryLayerOptions {
   radarVisible: boolean;
   cloudOpacity: number;
   radarOpacity: number;
-  /** Cache + 預載天數（1~7）；以當前日為中心 ±days，cache 上限 = 此值 */
-  preloadDays: number;
+}
+
+// Cache + prefetch 視窗從 timeStore.getRangeDays() 讀取（與 TimelineControls 共用 SSOT）
+function subscribeRange(cb: () => void) {
+  return timeStore.subscribeRangeDays(cb);
+}
+function getRangeSnapshot() {
+  return timeStore.getRangeDays();
 }
 
 export function useCwaImageryLayer({
@@ -158,8 +164,9 @@ export function useCwaImageryLayer({
   radarVisible,
   cloudOpacity,
   radarOpacity,
-  preloadDays,
 }: UseCwaImageryLayerOptions) {
+  // 與全域共用：用戶切 TimelineControls 上的 1~7d，整批 time-aware layer 一起改
+  const preloadDays = useSyncExternalStore(subscribeRange, getRangeSnapshot);
   const cloudRef = useRef<LayerState>(createEmptyState());
   const radarRef = useRef<LayerState>(createEmptyState());
   // 最新可見性 / preloadDays（給 subscribeDate / 背景預載 callback 避免閉包過期）

--- a/src/hooks/useCwaImageryLayer.ts
+++ b/src/hooks/useCwaImageryLayer.ts
@@ -290,23 +290,23 @@ export function useCwaImageryLayer({
       currentTimeSec: number,
     ) => {
       if (!visible) {
-        // 關閉：移除 handle 但**保留 cache**（再開啟可秒切回原日資料）
-        if (state.handle) {
-          state.handle.remove();
-          state.handle = null;
-        }
-        state.currentIso = null;
-        state.activeDateKey = null;
+        // 軟隱藏：保留 handle + cache + activeDateKey，再開啟只要 setVisible(true)
+        // (map.removeLayer/removeSource 在 in-flight 期間有時不生效，setVisible 較穩)
+        state.handle?.setVisible(false);
         return;
       }
       const dsCache = cacheRef.current.get(dsId);
       const slot = state.activeDateKey ? dsCache?.get(state.activeDateKey) : undefined;
-      if (!slot || slot.bundle.frames.length === 0) return;
+      if (!slot || slot.bundle.frames.length === 0) {
+        // 沒資料：handle 仍存在但隱藏（避免顯示空白）
+        state.handle?.setVisible(false);
+        return;
+      }
 
       const frame = pickFrameForTime(slot.bundle.frames, currentTimeSec * 1000);
-      if (!frame) return;
+      if (!frame) { state.handle?.setVisible(false); return; }
       const url = slot.urls.get(frame.observedAtIso);
-      if (!url) return;
+      if (!url) { state.handle?.setVisible(false); return; }
 
       if (!state.handle) {
         state.handle = createCwaImageryLayer(map, {
@@ -324,6 +324,7 @@ export function useCwaImageryLayer({
         state.currentIso = frame.observedAtIso;
         keepLoadingUntilMapIdle(map, `cwa-render:${sourceId}`, `CWA 影像 渲染中`, null);
       } else {
+        state.handle.setVisible(true); // 從軟隱藏恢復
         if (state.currentIso !== frame.observedAtIso) {
           state.handle.setUrl(url);
           state.currentIso = frame.observedAtIso;

--- a/src/hooks/useCwaImageryLayer.ts
+++ b/src/hooks/useCwaImageryLayer.ts
@@ -4,7 +4,7 @@
  * 職責：
  *  - 依 timeline 日期載入該日 frames（base64 → object URL）；切日（subscribeDate）重載
  *  - 根據 timeline.currentTime 找「時間不晚於 currentTime 的最近一張」並切換 image source
- *  - 關閉時 remove layer/source + revoke object URLs
+ *  - 關閉時 remove handle（但保留 cache，再開啟立即可用）
  *
  * 時間窗策略（migration 160）：
  *  - 今天（即時模式）：滾動 now-24h、全解析度（10min cadence），行為與舊版相同
@@ -14,6 +14,12 @@
  * 兩個 dataset：
  *   - O-C0042-004  衛星雲圖 (底層, 不透明預設 1.0)
  *   - O-A0058-005  雷達回波 (上層, 透明 0.85)
+ *
+ * Per-day LRU cache（2026-06-26）：
+ *  - cacheRef: dsId → dateKey → { bundle, urls }，access order 維護 LRU
+ *  - preloadDays (1~7) 控制 cache 上限 + 在當前日附近背景預載 ±days
+ *  - 切日命中 cache 就立即套用（不發 RPC、不 revoke）；layer 關閉只 remove handle，cache 留著
+ *  - 用戶調小 preloadDays → 立刻 evict 多出的最舊日
  */
 
 import { useEffect, useRef } from "react";
@@ -57,27 +63,71 @@ function windowForDate(dateKey: string): CwaImageryWindow {
   };
 }
 
-interface LayerState {
-  bundle: CwaImageryBundle | null;
+/** Cache slot：單 dataset × 單日 的 frames + object URLs */
+interface CacheSlot {
+  bundle: CwaImageryBundle;
   urls: Map<string, string>; // observedAtIso → object URL
+}
+
+/** LayerState：只追蹤目前 active handle / 渲染中 frame，資料一律從 cache 拿 */
+interface LayerState {
   handle: CwaImageryLayerHandle | null;
-  loading: boolean;
-  loaded: boolean;
   currentIso: string | null;
-  /** 已載入 frames 所屬的 timeline 日期 key（YYYY-MM-DD） */
-  dateKey: string | null;
+  /** 目前 handle 對應的 cache slot 日期（YYYY-MM-DD） */
+  activeDateKey: string | null;
 }
 
 function createEmptyState(): LayerState {
-  return {
-    bundle: null,
-    urls: new Map(),
-    handle: null,
-    loading: false,
-    loaded: false,
-    currentIso: null,
-    dateKey: null,
-  };
+  return { handle: null, currentIso: null, activeDateKey: null };
+}
+
+/** Cache 管理：LRU 容量 = preloadDays */
+function getOrCreate<K, V>(m: Map<K, V>, k: K, factory: () => V): V {
+  let v = m.get(k);
+  if (v === undefined) { v = factory(); m.set(k, v); }
+  return v;
+}
+
+function touchLRU(arr: string[], dateKey: string) {
+  const idx = arr.indexOf(dateKey);
+  if (idx >= 0) arr.splice(idx, 1);
+  arr.push(dateKey);
+}
+
+function evictExcess(
+  cache: Map<string, CacheSlot>,
+  order: string[],
+  maxSize: number,
+  protectKeys: ReadonlySet<string>,
+) {
+  // 從最舊開始 evict，但不動 protectKeys（當前 active + 鄰近待預載日）
+  let i = 0;
+  while (cache.size > maxSize && i < order.length) {
+    const k = order[i]!;
+    if (protectKeys.has(k)) { i++; continue; }
+    const slot = cache.get(k);
+    if (slot) for (const u of slot.urls.values()) URL.revokeObjectURL(u);
+    cache.delete(k);
+    order.splice(i, 1);
+  }
+}
+
+/** 以當前日為中心，回傳要預載的 ±days dateKey 陣列（含當日） */
+function prefetchDateKeys(center: string, totalDays: number): string[] {
+  const out: string[] = [center];
+  if (totalDays <= 1) return out;
+  const back = Math.floor((totalDays - 1) / 2);
+  const fwd = Math.ceil((totalDays - 1) / 2);
+  const centerMs = new Date(`${center}T00:00:00+08:00`).getTime();
+  for (let d = 1; d <= back; d++) {
+    const ms = centerMs - d * 86400_000;
+    out.push(new Date(ms).toLocaleDateString("sv-SE", { timeZone: "Asia/Taipei" }));
+  }
+  for (let d = 1; d <= fwd; d++) {
+    const ms = centerMs + d * 86400_000;
+    out.push(new Date(ms).toLocaleDateString("sv-SE", { timeZone: "Asia/Taipei" }));
+  }
+  return out;
 }
 
 /** 找出時間 <= currentMs 的最近一張 frame（若全部晚於 currentMs 則回傳第一張） */
@@ -98,6 +148,8 @@ interface UseCwaImageryLayerOptions {
   radarVisible: boolean;
   cloudOpacity: number;
   radarOpacity: number;
+  /** Cache + 預載天數（1~7）；以當前日為中心 ±days，cache 上限 = 此值 */
+  preloadDays: number;
 }
 
 export function useCwaImageryLayer({
@@ -106,80 +158,123 @@ export function useCwaImageryLayer({
   radarVisible,
   cloudOpacity,
   radarOpacity,
+  preloadDays,
 }: UseCwaImageryLayerOptions) {
   const cloudRef = useRef<LayerState>(createEmptyState());
   const radarRef = useRef<LayerState>(createEmptyState());
-  // 最新可見性（給 subscribeDate callback 用，避免閉包過期）
+  // 最新可見性 / preloadDays（給 subscribeDate / 背景預載 callback 避免閉包過期）
   const visRef = useRef({ cloud: cloudVisible, radar: radarVisible });
   visRef.current = { cloud: cloudVisible, radar: radarVisible };
+  const preloadDaysRef = useRef(preloadDays);
+  preloadDaysRef.current = preloadDays;
+  // per-dataset cache：dsId → dateKey → CacheSlot；access order 維護 LRU（last = 最近用過）
+  const cacheRef = useRef<Map<string, Map<string, CacheSlot>>>(new Map());
+  const orderRef = useRef<Map<string, string[]>>(new Map());
+  // in-flight 防併發：dsId → set of dateKey 載入中
+  const inflightRef = useRef<Map<string, Set<string>>>(new Map());
   // reconcile 觸發器：載入完成後立即重算 frame，不等下一個 time tick
   const runRef = useRef<((t: number) => void) | null>(null);
   const disposedRef = useRef(false);
 
-  // ── Loader：可見性變化或 timeline 切日 → 載入該日 frames ──
+  // ── Loader / cache 管理 ──
   useEffect(() => {
-    // StrictMode 會 mount→unmount→remount：unmount 清理設了 disposed，
-    // remount 時必須重置，否則所有載入被永久擋掉
     disposedRef.current = false;
 
     const stateOf = (dsId: string) =>
       dsId === CLOUD_DATASET ? cloudRef.current : radarRef.current;
 
-    const loadDatasets = async (dateKey: string, datasets: string[]) => {
-      try {
-        const batch = await loadCwaImageryBatch(datasets, windowForDate(dateKey));
-        for (const dsId of datasets) {
-          const state = stateOf(dsId);
-          const slot = batch.get(dsId);
-          if (disposedRef.current) {
-            if (slot) for (const u of slot.urls.values()) URL.revokeObjectURL(u);
-            continue;
-          }
-          // 換日：釋放舊日 object URLs 再接上新資料
-          for (const u of state.urls.values()) URL.revokeObjectURL(u);
-          state.urls = slot?.urls ?? new Map();
-          state.bundle = slot?.bundle ?? { datasetId: dsId, frames: [] };
-          state.dateKey = dateKey;
-          state.loaded = true;
-          state.loading = false;
-          state.currentIso = null;
-          if (state.bundle.frames.length === 0) {
-            console.warn(`[CWA Imagery] no frames for ${dsId} @ ${dateKey}`);
-            state.handle?.setVisible(false);
-          } else {
-            state.handle?.setVisible(true);
-            console.log(`[CWA Imagery] ${dsId} loaded ${state.bundle.frames.length} frames @ ${dateKey}`);
-          }
-        }
-      } catch (err) {
-        console.warn("[CWA Imagery] load failed", err);
-        for (const dsId of datasets) stateOf(dsId).loading = false;
+    const getCache = (dsId: string) => getOrCreate(cacheRef.current, dsId, () => new Map<string, CacheSlot>());
+    const getOrder = (dsId: string) => getOrCreate(orderRef.current, dsId, () => [] as string[]);
+    const getInflight = (dsId: string) => getOrCreate(inflightRef.current, dsId, () => new Set<string>());
+
+    /** 套用 cache slot 到 active state（已在 cache 內），通知 reconcile 重算 */
+    const applyActive = (state: LayerState, dsId: string, dateKey: string) => {
+      if (state.activeDateKey === dateKey) return;
+      state.activeDateKey = dateKey;
+      state.currentIso = null; // 強制 reconcile 重選 frame + setUrl
+      touchLRU(getOrder(dsId), dateKey);
+    };
+
+    /** 載入單一 (dsId, dateKey) 進 cache；foreground=true 走 withLoading 顯示 spinner */
+    const loadOne = async (dsId: string, dateKey: string, foreground: boolean) => {
+      const cache = getCache(dsId);
+      if (cache.has(dateKey)) {
+        touchLRU(getOrder(dsId), dateKey);
         return;
       }
-      runRef.current?.(timeStore.getTime());
-      // 載入期間日期又變了 → 立刻補載正確日期
-      if (timeStore.getDateKey() !== dateKey) ensureFresh();
+      const inflight = getInflight(dsId);
+      if (inflight.has(dateKey)) return;
+      inflight.add(dateKey);
+      try {
+        const batch = await loadCwaImageryBatch([dsId], windowForDate(dateKey));
+        const slot = batch.get(dsId);
+        if (disposedRef.current) {
+          if (slot) for (const u of slot.urls.values()) URL.revokeObjectURL(u);
+          return;
+        }
+        if (!slot) return;
+        cache.set(dateKey, slot);
+        touchLRU(getOrder(dsId), dateKey);
+        if (slot.bundle.frames.length === 0) {
+          console.warn(`[CWA Imagery] no frames for ${dsId} @ ${dateKey}`);
+        } else {
+          console.log(`[CWA Imagery] ${dsId} ${foreground ? "loaded" : "prefetched"} ${slot.bundle.frames.length} frames @ ${dateKey}`);
+        }
+      } catch (err) {
+        console.warn(`[CWA Imagery] load failed ${dsId}@${dateKey}`, err);
+      } finally {
+        inflight.delete(dateKey);
+      }
     };
 
-    const ensureFresh = () => {
+    /** 對 visible datasets，foreground 載入當天 + background 預載鄰近日 + LRU 清舊 */
+    const ensureFresh = async () => {
       if (disposedRef.current) return;
       const dk = timeStore.getDateKey();
-      const need: string[] = [];
-      const check = (visible: boolean, state: LayerState, dsId: string) => {
-        if (visible && !state.loading && (!state.loaded || state.dateKey !== dk)) {
-          state.loading = true;
-          need.push(dsId);
+      const datasets: string[] = [];
+      if (visRef.current.cloud) datasets.push(CLOUD_DATASET);
+      if (visRef.current.radar) datasets.push(RADAR_DATASET);
+      if (datasets.length === 0) return;
+
+      const N = Math.max(1, Math.min(7, preloadDaysRef.current));
+      const allKeys = prefetchDateKeys(dk, N);
+
+      // 1) 當天前景載入（若 cache 已有 = no-op）
+      const fg = datasets.map(async (dsId) => {
+        await loadOne(dsId, dk, true);
+        if (disposedRef.current) return;
+        // 載完立刻 apply 並通知 reconcile，避免 race
+        applyActive(stateOf(dsId), dsId, dk);
+        runRef.current?.(timeStore.getTime());
+      });
+      await Promise.all(fg);
+      if (disposedRef.current) return;
+
+      // 載入期間日期又變了 → 重新跑（避免渲染舊日）
+      if (timeStore.getDateKey() !== dk) {
+        void ensureFresh();
+        return;
+      }
+
+      // 2) 背景預載鄰近日（不 await，不擋 UI）
+      for (const dsId of datasets) {
+        for (const k of allKeys) {
+          if (k === dk) continue; // 當天已 foreground 載過
+          void loadOne(dsId, k, false);
         }
-      };
-      check(visRef.current.cloud, cloudRef.current, CLOUD_DATASET);
-      check(visRef.current.radar, radarRef.current, RADAR_DATASET);
-      if (need.length > 0) void loadDatasets(dk, need);
+      }
+
+      // 3) LRU 清舊（保護當前 active + 即將預載的鄰近日）
+      const protect = new Set(allKeys);
+      for (const dsId of datasets) {
+        evictExcess(getCache(dsId), getOrder(dsId), N, protect);
+      }
     };
 
-    ensureFresh();
-    const unsubDate = timeStore.subscribeDate(() => ensureFresh());
+    void ensureFresh();
+    const unsubDate = timeStore.subscribeDate(() => { void ensureFresh(); });
     return () => unsubDate();
-  }, [cloudVisible, radarVisible]);
+  }, [cloudVisible, radarVisible, preloadDays]);
 
   // ── Layer 生命週期 + frame 切換 ──
   // visibility / opacity 變動 → reconcile；時間變動由 timeStore 訂閱觸發 reconcile
@@ -189,6 +284,7 @@ export function useCwaImageryLayer({
 
     const reconcile = (
       state: LayerState,
+      dsId: string,
       visible: boolean,
       opacity: number,
       sourceId: string,
@@ -196,25 +292,22 @@ export function useCwaImageryLayer({
       currentTimeSec: number,
     ) => {
       if (!visible) {
-        // 關閉：移除 layer + source，釋放 object URLs
+        // 關閉：移除 handle 但**保留 cache**（再開啟可秒切回原日資料）
         if (state.handle) {
           state.handle.remove();
           state.handle = null;
         }
-        for (const url of state.urls.values()) URL.revokeObjectURL(url);
-        state.urls = new Map();
-        state.bundle = null;
-        state.loaded = false;
-        state.loading = false;
         state.currentIso = null;
-        state.dateKey = null;
+        state.activeDateKey = null;
         return;
       }
-      if (!state.bundle || !state.loaded || state.urls.size === 0) return;
+      const dsCache = cacheRef.current.get(dsId);
+      const slot = state.activeDateKey ? dsCache?.get(state.activeDateKey) : undefined;
+      if (!slot || slot.bundle.frames.length === 0) return;
 
-      const frame = pickFrameForTime(state.bundle.frames, currentTimeSec * 1000);
+      const frame = pickFrameForTime(slot.bundle.frames, currentTimeSec * 1000);
       if (!frame) return;
-      const url = state.urls.get(frame.observedAtIso);
+      const url = slot.urls.get(frame.observedAtIso);
       if (!url) return;
 
       if (!state.handle) {
@@ -243,8 +336,8 @@ export function useCwaImageryLayer({
     };
 
     const run = (currentTimeSec: number) => {
-      reconcile(cloudRef.current, cloudVisible, cloudOpacity, "cwa-cloud-src", "cwa-cloud-layer", currentTimeSec);
-      reconcile(radarRef.current, radarVisible, radarOpacity, "cwa-radar-src", "cwa-radar-layer", currentTimeSec);
+      reconcile(cloudRef.current, CLOUD_DATASET, cloudVisible, cloudOpacity, "cwa-cloud-src", "cwa-cloud-layer", currentTimeSec);
+      reconcile(radarRef.current, RADAR_DATASET, radarVisible, radarOpacity, "cwa-radar-src", "cwa-radar-layer", currentTimeSec);
     };
     runRef.current = run;
 
@@ -272,6 +365,18 @@ export function useCwaImageryLayer({
     };
   }, [mapRef, cloudVisible, radarVisible, cloudOpacity, radarOpacity]);
 
+  // ── 調整 preloadDays 時：以當前日為中心 evict 多出的最舊日 ──
+  useEffect(() => {
+    const N = Math.max(1, Math.min(7, preloadDays));
+    const dk = timeStore.getDateKey();
+    const protect = new Set(prefetchDateKeys(dk, N));
+    for (const [dsId, cache] of cacheRef.current) {
+      const order = orderRef.current.get(dsId);
+      if (!order) continue;
+      evictExcess(cache, order, N, protect);
+    }
+  }, [preloadDays]);
+
   // ── Unmount 清理 ──
   useEffect(() => {
     disposedRef.current = false; // StrictMode remount 重置
@@ -279,16 +384,19 @@ export function useCwaImageryLayer({
       disposedRef.current = true;
       for (const state of [cloudRef.current, radarRef.current]) {
         if (state.handle) {
-          try {
-            state.handle.remove();
-          } catch {
-            /* map 可能已銷毀 */
-          }
+          try { state.handle.remove(); } catch { /* map 可能已銷毀 */ }
           state.handle = null;
         }
-        for (const url of state.urls.values()) URL.revokeObjectURL(url);
-        state.urls = new Map();
       }
+      // 全清 cache 內的 object URLs（避免洩漏）
+      for (const cache of cacheRef.current.values()) {
+        for (const slot of cache.values()) {
+          for (const u of slot.urls.values()) URL.revokeObjectURL(u);
+        }
+      }
+      cacheRef.current.clear();
+      orderRef.current.clear();
+      inflightRef.current.clear();
     };
   }, []);
 }

--- a/src/hooks/useCwaImageryLayer.ts
+++ b/src/hooks/useCwaImageryLayer.ts
@@ -204,8 +204,11 @@ export function useCwaImageryLayer({
       }
     };
 
-    /** 對 visible datasets，foreground 載入當天 + background 預載視窗其他日 + LRU 清舊 */
-    const ensureFresh = async () => {
+    /**
+     * Foreground 載入當天（馬上要顯示）— 不 debounce、不排隊
+     * 注意：CWA 一個 day = ~30MB base64，foreground 已經夠重，不能再外推
+     */
+    const ensureForeground = async () => {
       if (disposedRef.current) return;
       const dk = timeStore.getDateKey();
       const datasets: string[] = [];
@@ -213,48 +216,62 @@ export function useCwaImageryLayer({
       if (visRef.current.radar) datasets.push(RADAR_DATASET);
       if (datasets.length === 0) return;
 
-      // 嚴格用 timeline 視窗的日期清單，不外推 ±N（視窗外不打 RPC）
-      const allKeys = timeStore.getWindowDateKeys();
-      if (!allKeys.includes(dk)) allKeys.push(dk); // 當前日不在視窗也要載
-      const N = Math.max(allKeys.length, 1);
-
-      // 1) 當天前景載入（若 cache 已有 = no-op）
       const fg = datasets.map(async (dsId) => {
         await loadOne(dsId, dk, true);
         if (disposedRef.current) return;
-        // 載完立刻 apply 並通知 reconcile，避免 race
         applyActive(stateOf(dsId), dsId, dk);
         runRef.current?.(timeStore.getTime());
       });
       await Promise.all(fg);
       if (disposedRef.current) return;
-
-      // 載入期間日期又變了 → 重新跑（避免渲染舊日）
-      if (timeStore.getDateKey() !== dk) {
-        void ensureFresh();
-        return;
-      }
-
-      // 2) 背景預載鄰近日（不 await，不擋 UI）
-      for (const dsId of datasets) {
-        for (const k of allKeys) {
-          if (k === dk) continue; // 當天已 foreground 載過
-          void loadOne(dsId, k, false);
-        }
-      }
-
-      // 3) LRU 清舊（保護當前 active + 即將預載的鄰近日）
-      const protect = new Set(allKeys);
-      for (const dsId of datasets) {
-        evictExcess(getCache(dsId), getOrder(dsId), N, protect);
-      }
+      if (timeStore.getDateKey() !== dk) void ensureForeground();
     };
 
-    void ensureFresh();
-    const unsubDate = timeStore.subscribeDate(() => { void ensureFresh(); });
-    // 視窗變動 → 重跑預載 + LRU evict
-    const unsubWindow = timeStore.subscribeWindowDateKeys(() => { void ensureFresh(); });
-    return () => { unsubDate(); unsubWindow(); };
+    /**
+     * Background prefetch 視窗其他日 + LRU 清舊
+     * 串行（每次只一個 RPC）+ debounce，避免 rangeDays=7 × 2 dataset 同時打 14 個 RPC 把 Supabase 撐死
+     */
+    let prefetchTimer: number | null = null;
+    let prefetchSeq = 0;
+    const PREFETCH_DEBOUNCE_MS = 600;
+    const schedulePrefetch = () => {
+      if (prefetchTimer !== null) window.clearTimeout(prefetchTimer);
+      prefetchTimer = window.setTimeout(async () => {
+        prefetchTimer = null;
+        if (disposedRef.current) return;
+        const mySeq = ++prefetchSeq;
+        const dk = timeStore.getDateKey();
+        const datasets: string[] = [];
+        if (visRef.current.cloud) datasets.push(CLOUD_DATASET);
+        if (visRef.current.radar) datasets.push(RADAR_DATASET);
+        if (datasets.length === 0) return;
+        const allKeys = timeStore.getWindowDateKeys();
+        if (!allKeys.includes(dk)) allKeys.push(dk);
+        // LRU evict 先做（保護視窗 + 當前日）
+        const protect = new Set(allKeys);
+        for (const dsId of datasets) {
+          evictExcess(getCache(dsId), getOrder(dsId), Math.max(allKeys.length, 1), protect);
+        }
+        // 串行 prefetch — 一次一個 RPC（CWA payload 重，並發會撐死 pooler）
+        for (const k of allKeys) {
+          if (k === dk) continue; // 當前日由 foreground 處理
+          for (const dsId of datasets) {
+            if (disposedRef.current || mySeq !== prefetchSeq) return;
+            await loadOne(dsId, k, false);
+          }
+        }
+      }, PREFETCH_DEBOUNCE_MS);
+    };
+
+    void ensureForeground();
+    schedulePrefetch();
+    const unsubDate = timeStore.subscribeDate(() => { void ensureForeground(); schedulePrefetch(); });
+    const unsubWindow = timeStore.subscribeWindowDateKeys(() => schedulePrefetch());
+    return () => {
+      if (prefetchTimer !== null) window.clearTimeout(prefetchTimer);
+      unsubDate();
+      unsubWindow();
+    };
   }, [cloudVisible, radarVisible]);
 
   // ── Layer 生命週期 + frame 切換 ──

--- a/src/hooks/useCwaImageryLayer.ts
+++ b/src/hooks/useCwaImageryLayer.ts
@@ -22,7 +22,7 @@
  *  - 用戶調小 preloadDays → 立刻 evict 多出的最舊日
  */
 
-import { useEffect, useRef, useSyncExternalStore } from "react";
+import { useEffect, useRef } from "react";
 import type { Map as MapboxMap } from "mapbox-gl";
 import {
   loadCwaImageryBatch,
@@ -112,24 +112,6 @@ function evictExcess(
   }
 }
 
-/** 以當前日為中心，回傳要預載的 ±days dateKey 陣列（含當日） */
-function prefetchDateKeys(center: string, totalDays: number): string[] {
-  const out: string[] = [center];
-  if (totalDays <= 1) return out;
-  const back = Math.floor((totalDays - 1) / 2);
-  const fwd = Math.ceil((totalDays - 1) / 2);
-  const centerMs = new Date(`${center}T00:00:00+08:00`).getTime();
-  for (let d = 1; d <= back; d++) {
-    const ms = centerMs - d * 86400_000;
-    out.push(new Date(ms).toLocaleDateString("sv-SE", { timeZone: "Asia/Taipei" }));
-  }
-  for (let d = 1; d <= fwd; d++) {
-    const ms = centerMs + d * 86400_000;
-    out.push(new Date(ms).toLocaleDateString("sv-SE", { timeZone: "Asia/Taipei" }));
-  }
-  return out;
-}
-
 /** 找出時間 <= currentMs 的最近一張 frame（若全部晚於 currentMs 則回傳第一張） */
 function pickFrameForTime(frames: CwaImageryFrame[], currentMs: number): CwaImageryFrame | null {
   if (frames.length === 0) return null;
@@ -150,14 +132,6 @@ interface UseCwaImageryLayerOptions {
   radarOpacity: number;
 }
 
-// Cache + prefetch 視窗從 timeStore.getRangeDays() 讀取（與 TimelineControls 共用 SSOT）
-function subscribeRange(cb: () => void) {
-  return timeStore.subscribeRangeDays(cb);
-}
-function getRangeSnapshot() {
-  return timeStore.getRangeDays();
-}
-
 export function useCwaImageryLayer({
   mapRef,
   cloudVisible,
@@ -165,15 +139,11 @@ export function useCwaImageryLayer({
   cloudOpacity,
   radarOpacity,
 }: UseCwaImageryLayerOptions) {
-  // 與全域共用：用戶切 TimelineControls 上的 1~7d，整批 time-aware layer 一起改
-  const preloadDays = useSyncExternalStore(subscribeRange, getRangeSnapshot);
   const cloudRef = useRef<LayerState>(createEmptyState());
   const radarRef = useRef<LayerState>(createEmptyState());
-  // 最新可見性 / preloadDays（給 subscribeDate / 背景預載 callback 避免閉包過期）
+  // 最新可見性（給 subscribeDate / 背景預載 callback 避免閉包過期）
   const visRef = useRef({ cloud: cloudVisible, radar: radarVisible });
   visRef.current = { cloud: cloudVisible, radar: radarVisible };
-  const preloadDaysRef = useRef(preloadDays);
-  preloadDaysRef.current = preloadDays;
   // per-dataset cache：dsId → dateKey → CacheSlot；access order 維護 LRU（last = 最近用過）
   const cacheRef = useRef<Map<string, Map<string, CacheSlot>>>(new Map());
   const orderRef = useRef<Map<string, string[]>>(new Map());
@@ -202,7 +172,7 @@ export function useCwaImageryLayer({
       touchLRU(getOrder(dsId), dateKey);
     };
 
-    /** 載入單一 (dsId, dateKey) 進 cache；foreground=true 走 withLoading 顯示 spinner */
+    /** 載入單一 (dsId, dateKey) 進 cache；foreground=true 才灌 LOADING panel */
     const loadOne = async (dsId: string, dateKey: string, foreground: boolean) => {
       const cache = getCache(dsId);
       if (cache.has(dateKey)) {
@@ -213,7 +183,7 @@ export function useCwaImageryLayer({
       if (inflight.has(dateKey)) return;
       inflight.add(dateKey);
       try {
-        const batch = await loadCwaImageryBatch([dsId], windowForDate(dateKey));
+        const batch = await loadCwaImageryBatch([dsId], windowForDate(dateKey), { silent: !foreground });
         const slot = batch.get(dsId);
         if (disposedRef.current) {
           if (slot) for (const u of slot.urls.values()) URL.revokeObjectURL(u);
@@ -234,7 +204,7 @@ export function useCwaImageryLayer({
       }
     };
 
-    /** 對 visible datasets，foreground 載入當天 + background 預載鄰近日 + LRU 清舊 */
+    /** 對 visible datasets，foreground 載入當天 + background 預載視窗其他日 + LRU 清舊 */
     const ensureFresh = async () => {
       if (disposedRef.current) return;
       const dk = timeStore.getDateKey();
@@ -243,8 +213,10 @@ export function useCwaImageryLayer({
       if (visRef.current.radar) datasets.push(RADAR_DATASET);
       if (datasets.length === 0) return;
 
-      const N = Math.max(1, Math.min(7, preloadDaysRef.current));
-      const allKeys = prefetchDateKeys(dk, N);
+      // 嚴格用 timeline 視窗的日期清單，不外推 ±N（視窗外不打 RPC）
+      const allKeys = timeStore.getWindowDateKeys();
+      if (!allKeys.includes(dk)) allKeys.push(dk); // 當前日不在視窗也要載
+      const N = Math.max(allKeys.length, 1);
 
       // 1) 當天前景載入（若 cache 已有 = no-op）
       const fg = datasets.map(async (dsId) => {
@@ -280,8 +252,10 @@ export function useCwaImageryLayer({
 
     void ensureFresh();
     const unsubDate = timeStore.subscribeDate(() => { void ensureFresh(); });
-    return () => unsubDate();
-  }, [cloudVisible, radarVisible, preloadDays]);
+    // 視窗變動 → 重跑預載 + LRU evict
+    const unsubWindow = timeStore.subscribeWindowDateKeys(() => { void ensureFresh(); });
+    return () => { unsubDate(); unsubWindow(); };
+  }, [cloudVisible, radarVisible]);
 
   // ── Layer 生命週期 + frame 切換 ──
   // visibility / opacity 變動 → reconcile；時間變動由 timeStore 訂閱觸發 reconcile
@@ -372,17 +346,8 @@ export function useCwaImageryLayer({
     };
   }, [mapRef, cloudVisible, radarVisible, cloudOpacity, radarOpacity]);
 
-  // ── 調整 preloadDays 時：以當前日為中心 evict 多出的最舊日 ──
-  useEffect(() => {
-    const N = Math.max(1, Math.min(7, preloadDays));
-    const dk = timeStore.getDateKey();
-    const protect = new Set(prefetchDateKeys(dk, N));
-    for (const [dsId, cache] of cacheRef.current) {
-      const order = orderRef.current.get(dsId);
-      if (!order) continue;
-      evictExcess(cache, order, N, protect);
-    }
-  }, [preloadDays]);
+  // 注：原本獨立的 preloadDays effect 已不需要 — window 變動會由 subscribeWindowDateKeys
+  // 觸發 ensureFresh，evict 邏輯在那裡執行（保護視窗內所有日）。
 
   // ── Unmount 清理 ──
   useEffect(() => {

--- a/src/hooks/useHazardLayer.ts
+++ b/src/hooks/useHazardLayer.ts
@@ -1,17 +1,17 @@
 import { useEffect, useRef, useCallback } from "react";
 import type { Map as MapboxMap, GeoJSONSource } from "mapbox-gl";
 import {
-  fetchLightningDay, invalidateLightningDay,
+  fetchLightningDay, prefetchLightningDay, invalidateLightningDay,
   toLightningFCAt,
   type LightningStrike,
 } from "../data/lightningLoader";
 import {
-  fetchNuclearDay,
+  fetchNuclearDay, prefetchNuclearDay,
   buildNuclearFCAt,
   type NuclearDay,
 } from "../data/nuclearLoader";
 import { timeStore } from "../state/timeStore";
-import { prefetchAroundDate } from "../lib/dayPrefetch";
+import { subscribePrefetchWindow } from "../lib/dayPrefetch";
 
 /**
  * HAZARD（v2 Phase B++）— 落雷 + 核安，**day preload + scrub fade**
@@ -111,16 +111,11 @@ export function useLightningLayer(
         .catch((err) => console.warn("[HAZARD/lightning] day load failed:", err));
     };
 
-    const prefetchNeighbors = (dateKey: string) => {
-      // 預載 ±days 進 fetchLightningDay 的 cache（cachedByKey 10min TTL 自動去重）
-      prefetchAroundDate(dateKey, timeStore.getRangeDays(), fetchLightningDay, "[HAZARD/lightning]");
-    };
-
     loadDay(timeStore.getDateKey());
-    prefetchNeighbors(timeStore.getDateKey());
+    // 視窗內其他日 → silent prefetch（共用 cachedByKey，不灌 LOADING panel）
+    const unsubPrefetch = subscribePrefetchWindow(prefetchLightningDay, "[HAZARD/lightning]");
 
-    const unsubDate = timeStore.subscribeDate((key) => { loadDay(key); prefetchNeighbors(key); });
-    const unsubRange = timeStore.subscribeRangeDays(() => prefetchNeighbors(timeStore.getDateKey()));
+    const unsubDate = timeStore.subscribeDate((key) => loadDay(key));
     const unsubTime = timeStore.subscribeThrottled(SCRUB_THROTTLE_LIGHTNING, recompute);
 
     const id = window.setInterval(() => {
@@ -131,7 +126,7 @@ export function useLightningLayer(
     return () => {
       cancelled = true;
       unsubDate();
-      unsubRange();
+      unsubPrefetch();
       unsubTime();
       window.clearInterval(id);
     };
@@ -173,15 +168,10 @@ export function useNuclearLayer(
         .catch((err) => console.warn("[HAZARD/nuclear] day load failed:", err));
     };
 
-    const prefetchNeighbors = (dateKey: string) => {
-      prefetchAroundDate(dateKey, timeStore.getRangeDays(), fetchNuclearDay, "[HAZARD/nuclear]");
-    };
-
     loadDay(timeStore.getDateKey());
-    prefetchNeighbors(timeStore.getDateKey());
+    const unsubPrefetch = subscribePrefetchWindow(prefetchNuclearDay, "[HAZARD/nuclear]");
 
-    const unsubDate = timeStore.subscribeDate((key) => { loadDay(key); prefetchNeighbors(key); });
-    const unsubRange = timeStore.subscribeRangeDays(() => prefetchNeighbors(timeStore.getDateKey()));
+    const unsubDate = timeStore.subscribeDate((key) => loadDay(key));
     const unsubTime = timeStore.subscribeThrottled(SCRUB_THROTTLE_NUCLEAR, recompute);
 
     const id = window.setInterval(() => {
@@ -191,7 +181,7 @@ export function useNuclearLayer(
     return () => {
       cancelled = true;
       unsubDate();
-      unsubRange();
+      unsubPrefetch();
       unsubTime();
       window.clearInterval(id);
     };

--- a/src/hooks/useHazardLayer.ts
+++ b/src/hooks/useHazardLayer.ts
@@ -11,6 +11,7 @@ import {
   type NuclearDay,
 } from "../data/nuclearLoader";
 import { timeStore } from "../state/timeStore";
+import { prefetchAroundDate } from "../lib/dayPrefetch";
 
 /**
  * HAZARD（v2 Phase B++）— 落雷 + 核安，**day preload + scrub fade**
@@ -110,9 +111,16 @@ export function useLightningLayer(
         .catch((err) => console.warn("[HAZARD/lightning] day load failed:", err));
     };
 
-    loadDay(timeStore.getDateKey());
+    const prefetchNeighbors = (dateKey: string) => {
+      // 預載 ±days 進 fetchLightningDay 的 cache（cachedByKey 10min TTL 自動去重）
+      prefetchAroundDate(dateKey, timeStore.getRangeDays(), fetchLightningDay, "[HAZARD/lightning]");
+    };
 
-    const unsubDate = timeStore.subscribeDate((key) => loadDay(key));
+    loadDay(timeStore.getDateKey());
+    prefetchNeighbors(timeStore.getDateKey());
+
+    const unsubDate = timeStore.subscribeDate((key) => { loadDay(key); prefetchNeighbors(key); });
+    const unsubRange = timeStore.subscribeRangeDays(() => prefetchNeighbors(timeStore.getDateKey()));
     const unsubTime = timeStore.subscribeThrottled(SCRUB_THROTTLE_LIGHTNING, recompute);
 
     const id = window.setInterval(() => {
@@ -123,6 +131,7 @@ export function useLightningLayer(
     return () => {
       cancelled = true;
       unsubDate();
+      unsubRange();
       unsubTime();
       window.clearInterval(id);
     };
@@ -164,9 +173,15 @@ export function useNuclearLayer(
         .catch((err) => console.warn("[HAZARD/nuclear] day load failed:", err));
     };
 
-    loadDay(timeStore.getDateKey());
+    const prefetchNeighbors = (dateKey: string) => {
+      prefetchAroundDate(dateKey, timeStore.getRangeDays(), fetchNuclearDay, "[HAZARD/nuclear]");
+    };
 
-    const unsubDate = timeStore.subscribeDate((key) => loadDay(key));
+    loadDay(timeStore.getDateKey());
+    prefetchNeighbors(timeStore.getDateKey());
+
+    const unsubDate = timeStore.subscribeDate((key) => { loadDay(key); prefetchNeighbors(key); });
+    const unsubRange = timeStore.subscribeRangeDays(() => prefetchNeighbors(timeStore.getDateKey()));
     const unsubTime = timeStore.subscribeThrottled(SCRUB_THROTTLE_NUCLEAR, recompute);
 
     const id = window.setInterval(() => {
@@ -176,6 +191,7 @@ export function useNuclearLayer(
     return () => {
       cancelled = true;
       unsubDate();
+      unsubRange();
       unsubTime();
       window.clearInterval(id);
     };

--- a/src/hooks/useTimeline.ts
+++ b/src/hooks/useTimeline.ts
@@ -82,13 +82,11 @@ export function useTimeline({
     const todayStr = new Date().toLocaleDateString("sv-SE", { timeZone: "Asia/Taipei" });
     return new Date(todayStr + "T00:00:00+08:00");
   });
-  // rangeDays SSOT 在 timeStore（共用給 time-aware loader 的 prefetch 視窗）。
-  // 本地 mirror 一份給 React render，setRangeDays 雙寫保證 listener 收到。
-  const [rangeDays, setRangeDaysState] = useState<number>(() => timeStore.getRangeDays());
-  const setRangeDays = useCallback((n: number) => {
-    timeStore.setRangeDays(n);
-    setRangeDaysState(timeStore.getRangeDays());
-  }, []);
+  const [rangeDays, setRangeDays] = useState<number>(1);
+  // rangeDays 同步進 timeStore — 給 time-aware loader 訂閱 prefetch 視窗
+  useEffect(() => {
+    timeStore.setRangeDays(rangeDays);
+  }, [rangeDays]);
 
   // 視窗起止
   const windowStart = dayStartUnix(selectedDate);

--- a/src/hooks/useTimeline.ts
+++ b/src/hooks/useTimeline.ts
@@ -94,6 +94,16 @@ export function useTimeline({
   const windowStart = dayStartUnix(selectedDate);
   const windowEnd = dayEndUnix(addDays(selectedDate, rangeDays - 1));
 
+  // 視窗內每一天的 dateKey（YYYY-MM-DD, Asia/Taipei）→ 寫入 timeStore SSOT，
+  // time-aware loader 訂閱 subscribeWindowDateKeys 後嚴格只預載這份；視窗外不打 RPC。
+  useEffect(() => {
+    const keys: string[] = [];
+    for (let i = 0; i < rangeDays; i++) {
+      keys.push(addDays(selectedDate, i).toLocaleDateString("sv-SE", { timeZone: "Asia/Taipei" }));
+    }
+    timeStore.setWindowDateKeys(keys);
+  }, [selectedDate, rangeDays]);
+
   // 首次渲染寫入 timeStore 初始值（從「現在 - 1 小時」開始；過去日期從午夜開始）
   const initRef = useRef(false);
   if (!initRef.current) {

--- a/src/hooks/useTimeline.ts
+++ b/src/hooks/useTimeline.ts
@@ -82,7 +82,13 @@ export function useTimeline({
     const todayStr = new Date().toLocaleDateString("sv-SE", { timeZone: "Asia/Taipei" });
     return new Date(todayStr + "T00:00:00+08:00");
   });
-  const [rangeDays, setRangeDays] = useState(1);
+  // rangeDays SSOT 在 timeStore（共用給 time-aware loader 的 prefetch 視窗）。
+  // 本地 mirror 一份給 React render，setRangeDays 雙寫保證 listener 收到。
+  const [rangeDays, setRangeDaysState] = useState<number>(() => timeStore.getRangeDays());
+  const setRangeDays = useCallback((n: number) => {
+    timeStore.setRangeDays(n);
+    setRangeDaysState(timeStore.getRangeDays());
+  }, []);
 
   // 視窗起止
   const windowStart = dayStartUnix(selectedDate);

--- a/src/hooks/useTransportParams.ts
+++ b/src/hooks/useTransportParams.ts
@@ -261,6 +261,8 @@ export function useTransportParams() {
   // CWA Imagery (衛星雲圖 / 雷達)
   const [cwaCloudOpacity, setCwaCloudOpacity] = useState(1.0);
   const [cwaRadarOpacity, setCwaRadarOpacity] = useState(0.85);
+  // CWA 影像 LRU + 預載天數（雲圖 / 雷達共用）：當前日 ± floor((N-1)/2) ~ ceil((N-1)/2)
+  const [imageryPreloadDays, setImageryPreloadDays] = useState(3);
   // Earthquake
   const [eqOpacity, setEqOpacity] = useState(1.0);
   const [eqShowHistory, setEqShowHistory] = useState(false);
@@ -1180,9 +1182,11 @@ export function useTransportParams() {
       ];
       case "cwaCloudImagery": return [
         { label: `Opacity ${cwaCloudOpacity.toFixed(2)}`, value: cwaCloudOpacity, min: 0, max: 1, step: 0.05, onChange: setCwaCloudOpacity },
+        { label: `預載 ${imageryPreloadDays}d (cache)`, value: imageryPreloadDays, min: 1, max: 7, step: 1, onChange: setImageryPreloadDays },
       ];
       case "cwaRadarImagery": return [
         { label: `Opacity ${cwaRadarOpacity.toFixed(2)}`, value: cwaRadarOpacity, min: 0, max: 1, step: 0.05, onChange: setCwaRadarOpacity },
+        { label: `預載 ${imageryPreloadDays}d (cache)`, value: imageryPreloadDays, min: 1, max: 7, step: 1, onChange: setImageryPreloadDays },
       ];
       case "youbikeFullness": return [
         { type: "select" as const, label: "Grid", value: String(ybResolution), options: [{ label: "大", value: "7" }, { label: "中", value: "8" }, { label: "小", value: "9" }], onChange: (v: string) => setYbResolution(Number(v)) },
@@ -1765,6 +1769,7 @@ export function useTransportParams() {
     youbikeParams: useMemo(() => ({ opacity: ybOpacity, contrast: ybContrast, extruded: ybExtruded, elevationScale: ybElevationScale, heightMode: ybHeightMode }), [ybOpacity, ybContrast, ybExtruded, ybElevationScale, ybHeightMode]),
     cwaCloudOpacity,
     cwaRadarOpacity,
+    imageryPreloadDays,
     eqOpacity,
     eqShowHistory,
     daOpacity,

--- a/src/hooks/useTransportParams.ts
+++ b/src/hooks/useTransportParams.ts
@@ -261,8 +261,6 @@ export function useTransportParams() {
   // CWA Imagery (衛星雲圖 / 雷達)
   const [cwaCloudOpacity, setCwaCloudOpacity] = useState(1.0);
   const [cwaRadarOpacity, setCwaRadarOpacity] = useState(0.85);
-  // CWA 影像 LRU + 預載天數（雲圖 / 雷達共用）：當前日 ± floor((N-1)/2) ~ ceil((N-1)/2)
-  const [imageryPreloadDays, setImageryPreloadDays] = useState(3);
   // Earthquake
   const [eqOpacity, setEqOpacity] = useState(1.0);
   const [eqShowHistory, setEqShowHistory] = useState(false);
@@ -1180,13 +1178,12 @@ export function useTransportParams() {
       case "satellitesIsrael": return [
         { label: `Opacity ${satOpacity.toFixed(2)}`, value: satOpacity, min: 0, max: 1, step: 0.05, onChange: setSatOpacity },
       ];
+      // 預載 1~7d 共用 timeline rangeDays（TimelineControls 下拉），這裡不重覆出 slider
       case "cwaCloudImagery": return [
         { label: `Opacity ${cwaCloudOpacity.toFixed(2)}`, value: cwaCloudOpacity, min: 0, max: 1, step: 0.05, onChange: setCwaCloudOpacity },
-        { label: `預載 ${imageryPreloadDays}d (cache)`, value: imageryPreloadDays, min: 1, max: 7, step: 1, onChange: setImageryPreloadDays },
       ];
       case "cwaRadarImagery": return [
         { label: `Opacity ${cwaRadarOpacity.toFixed(2)}`, value: cwaRadarOpacity, min: 0, max: 1, step: 0.05, onChange: setCwaRadarOpacity },
-        { label: `預載 ${imageryPreloadDays}d (cache)`, value: imageryPreloadDays, min: 1, max: 7, step: 1, onChange: setImageryPreloadDays },
       ];
       case "youbikeFullness": return [
         { type: "select" as const, label: "Grid", value: String(ybResolution), options: [{ label: "大", value: "7" }, { label: "中", value: "8" }, { label: "小", value: "9" }], onChange: (v: string) => setYbResolution(Number(v)) },
@@ -1769,7 +1766,6 @@ export function useTransportParams() {
     youbikeParams: useMemo(() => ({ opacity: ybOpacity, contrast: ybContrast, extruded: ybExtruded, elevationScale: ybElevationScale, heightMode: ybHeightMode }), [ybOpacity, ybContrast, ybExtruded, ybElevationScale, ybHeightMode]),
     cwaCloudOpacity,
     cwaRadarOpacity,
-    imageryPreloadDays,
     eqOpacity,
     eqShowHistory,
     daOpacity,

--- a/src/lib/dayPrefetch.ts
+++ b/src/lib/dayPrefetch.ts
@@ -1,51 +1,53 @@
 /**
- * dayPrefetch — 以「當前日為中心、共用 prefetch 視窗」預熱 loader 的工具。
+ * dayPrefetch — 對 loader 預載 timeline 視窗內的日期清單。
  *
- * 背景：time-aware loader（lightning / nuclear / precipRaster / cwa-imagery / ...）
- * 多半已用 cachedByKey/cachedOnce 做 LRU+TTL 快取；缺的是「主動把鄰近日
- * fetch 進 cache」，否則切到鄰近日仍要等 RPC。
+ * 設計原則（2026-06-26 修正）：
+ *  - **嚴格只動視窗內**：清單由 timeStore.getWindowDateKeys() 給定，不外推 ±N，
+ *    避免畫面看不到的日期也打 RPC 把 LOADING panel 灌爆。
+ *  - **背景靜默**：fetcher 必須是「不走 withLoading」的 prefetch 版本
+ *    （如 prefetchLightningDay，與正常 fetchLightningDay 共用 cachedByKey 但跳過 loading panel）。
+ *  - **錯誤吞掉**：prefetch 失敗只警告，不影響主流程。
  *
- * 用法：在 subscribeDate 的 handler 內呼叫 prefetchAroundDate(...)
- *   prefetchAroundDate(dk, timeStore.getRangeDays(), fetchLightningDay);
- *
- * 規則：
- *  - days <= 1 一律 no-op
- *  - 不 await（背景進行），失敗只警告
- *  - 由 fetcher 自己的 cache 處理 dedup / 重複呼叫（這裡只負責喊一聲）
+ * 用法：
+ *   const unsub = subscribePrefetchWindow(prefetchLightningDay, "[HAZARD/lightning]");
+ *   // 初次 + 視窗變動時都會自動 fire
+ *   return () => unsub();
  */
 
-/** 以 centerKey 為中心算出 ±floor((N-1)/2) ~ ±ceil((N-1)/2) 的日期 keys（含中心） */
-export function neighborDateKeys(centerKey: string, totalDays: number): string[] {
-  const out = [centerKey];
-  if (totalDays <= 1) return out;
-  const back = Math.floor((totalDays - 1) / 2);
-  const fwd = Math.ceil((totalDays - 1) / 2);
-  const centerMs = new Date(`${centerKey}T00:00:00+08:00`).getTime();
-  for (let d = 1; d <= back; d++) {
-    out.push(new Date(centerMs - d * 86_400_000).toLocaleDateString("sv-SE", { timeZone: "Asia/Taipei" }));
-  }
-  for (let d = 1; d <= fwd; d++) {
-    out.push(new Date(centerMs + d * 86_400_000).toLocaleDateString("sv-SE", { timeZone: "Asia/Taipei" }));
-  }
-  return out;
-}
+import { timeStore } from "../state/timeStore";
 
 /**
- * 對 fetcher 預載 ±days 的鄰近日（含中心；中心由呼叫端自行 await 才能立刻渲染）。
- * 回傳 unsubscribe-style 取消器 — 但因為背景 promise 已 in-flight，取消只能拒收結果，
- * 實際 fetch 仍會完成並進 fetcher 的 cache（這在多數場景是想要的副作用）。
+ * 對視窗內的 dateKeys 全部呼叫 fetcher（背景、不 await）。
+ * 中心日由呼叫端自己 foreground 載入；prefetch 只負責「其他日塞 cache」。
  */
-export function prefetchAroundDate(
-  centerKey: string,
-  rangeDays: number,
+export function prefetchWindow(
   fetcher: (key: string) => Promise<unknown>,
   consoleTag = "",
+  skipKey?: string,
 ): void {
-  const keys = neighborDateKeys(centerKey, rangeDays);
+  const keys = timeStore.getWindowDateKeys();
   for (const k of keys) {
-    if (k === centerKey) continue; // 中心日由呼叫端 foreground 載入
+    if (k === skipKey) continue;
     fetcher(k).catch((err) => {
       console.warn(`${consoleTag}[prefetch] ${k} failed:`, err);
     });
   }
+}
+
+/**
+ * 訂閱視窗變動：subscribeDate / subscribeWindowDateKeys 任一觸發都會 fire 一次。
+ * 用 setTimeout(0) 把呼叫延後到 microtask 之後，避免和 center 日的 foreground load
+ * 同時打 RPC 卡頻寬。回傳 unsubscribe。
+ */
+export function subscribePrefetchWindow(
+  fetcher: (key: string) => Promise<unknown>,
+  consoleTag = "",
+): () => void {
+  const fire = () => {
+    setTimeout(() => prefetchWindow(fetcher, consoleTag, timeStore.getDateKey()), 0);
+  };
+  fire(); // 初始一次
+  const unsubWindow = timeStore.subscribeWindowDateKeys(fire);
+  const unsubDate = timeStore.subscribeDate(fire);
+  return () => { unsubWindow(); unsubDate(); };
 }

--- a/src/lib/dayPrefetch.ts
+++ b/src/lib/dayPrefetch.ts
@@ -17,7 +17,28 @@
 import { timeStore } from "../state/timeStore";
 
 /**
- * 對視窗內的 dateKeys 全部呼叫 fetcher（背景、不 await）。
+ * 全域 prefetch 序列：所有 layer 的 prefetch 共用此 queue，
+ * 上限 MAX_CONCURRENT 個同時打 Supabase（避免 pooler 連線爆掉）。
+ *
+ * 經驗值：rangeDays=7 + cwa cloud/radar + lightning + nuclear 同時開
+ * = 7×2 + 7 + 7 = 28 個 RPC，未限速時直接打掛 Supabase。
+ */
+const MAX_CONCURRENT_PREFETCH = 2;
+const PREFETCH_DEBOUNCE_MS = 500;
+
+let inflight = 0;
+const queue: Array<() => Promise<unknown>> = [];
+
+function pump() {
+  while (inflight < MAX_CONCURRENT_PREFETCH && queue.length > 0) {
+    const task = queue.shift()!;
+    inflight++;
+    task().finally(() => { inflight--; pump(); });
+  }
+}
+
+/**
+ * 對視窗內的 dateKeys 全部排入 prefetch queue（共用 concurrency cap）。
  * 中心日由呼叫端自己 foreground 載入；prefetch 只負責「其他日塞 cache」。
  */
 export function prefetchWindow(
@@ -28,26 +49,36 @@ export function prefetchWindow(
   const keys = timeStore.getWindowDateKeys();
   for (const k of keys) {
     if (k === skipKey) continue;
-    fetcher(k).catch((err) => {
+    queue.push(() => fetcher(k).catch((err) => {
       console.warn(`${consoleTag}[prefetch] ${k} failed:`, err);
-    });
+    }));
   }
+  pump();
 }
 
 /**
- * 訂閱視窗變動：subscribeDate / subscribeWindowDateKeys 任一觸發都會 fire 一次。
- * 用 setTimeout(0) 把呼叫延後到 microtask 之後，避免和 center 日的 foreground load
- * 同時打 RPC 卡頻寬。回傳 unsubscribe。
+ * 訂閱視窗變動：subscribeDate / subscribeWindowDateKeys 任一觸發都 debounce 後 fire。
+ * Debounce 防止快速 scrub 一秒內排入幾十個 RPC；最終以「停下來那個視窗」為準。
  */
 export function subscribePrefetchWindow(
   fetcher: (key: string) => Promise<unknown>,
   consoleTag = "",
 ): () => void {
+  let timer: number | null = null;
   const fire = () => {
-    setTimeout(() => prefetchWindow(fetcher, consoleTag, timeStore.getDateKey()), 0);
+    if (timer !== null) window.clearTimeout(timer);
+    timer = window.setTimeout(() => {
+      timer = null;
+      // 排隊前先把舊的同 tag 任務丟掉？簡化做法：仰賴 fetcher 自身的 cache + inflight 去重
+      prefetchWindow(fetcher, consoleTag, timeStore.getDateKey());
+    }, PREFETCH_DEBOUNCE_MS);
   };
-  fire(); // 初始一次
+  fire(); // 初始 debounce 後 fire
   const unsubWindow = timeStore.subscribeWindowDateKeys(fire);
   const unsubDate = timeStore.subscribeDate(fire);
-  return () => { unsubWindow(); unsubDate(); };
+  return () => {
+    if (timer !== null) window.clearTimeout(timer);
+    unsubWindow();
+    unsubDate();
+  };
 }

--- a/src/lib/dayPrefetch.ts
+++ b/src/lib/dayPrefetch.ts
@@ -1,0 +1,51 @@
+/**
+ * dayPrefetch — 以「當前日為中心、共用 prefetch 視窗」預熱 loader 的工具。
+ *
+ * 背景：time-aware loader（lightning / nuclear / precipRaster / cwa-imagery / ...）
+ * 多半已用 cachedByKey/cachedOnce 做 LRU+TTL 快取；缺的是「主動把鄰近日
+ * fetch 進 cache」，否則切到鄰近日仍要等 RPC。
+ *
+ * 用法：在 subscribeDate 的 handler 內呼叫 prefetchAroundDate(...)
+ *   prefetchAroundDate(dk, timeStore.getRangeDays(), fetchLightningDay);
+ *
+ * 規則：
+ *  - days <= 1 一律 no-op
+ *  - 不 await（背景進行），失敗只警告
+ *  - 由 fetcher 自己的 cache 處理 dedup / 重複呼叫（這裡只負責喊一聲）
+ */
+
+/** 以 centerKey 為中心算出 ±floor((N-1)/2) ~ ±ceil((N-1)/2) 的日期 keys（含中心） */
+export function neighborDateKeys(centerKey: string, totalDays: number): string[] {
+  const out = [centerKey];
+  if (totalDays <= 1) return out;
+  const back = Math.floor((totalDays - 1) / 2);
+  const fwd = Math.ceil((totalDays - 1) / 2);
+  const centerMs = new Date(`${centerKey}T00:00:00+08:00`).getTime();
+  for (let d = 1; d <= back; d++) {
+    out.push(new Date(centerMs - d * 86_400_000).toLocaleDateString("sv-SE", { timeZone: "Asia/Taipei" }));
+  }
+  for (let d = 1; d <= fwd; d++) {
+    out.push(new Date(centerMs + d * 86_400_000).toLocaleDateString("sv-SE", { timeZone: "Asia/Taipei" }));
+  }
+  return out;
+}
+
+/**
+ * 對 fetcher 預載 ±days 的鄰近日（含中心；中心由呼叫端自行 await 才能立刻渲染）。
+ * 回傳 unsubscribe-style 取消器 — 但因為背景 promise 已 in-flight，取消只能拒收結果，
+ * 實際 fetch 仍會完成並進 fetcher 的 cache（這在多數場景是想要的副作用）。
+ */
+export function prefetchAroundDate(
+  centerKey: string,
+  rangeDays: number,
+  fetcher: (key: string) => Promise<unknown>,
+  consoleTag = "",
+): void {
+  const keys = neighborDateKeys(centerKey, rangeDays);
+  for (const k of keys) {
+    if (k === centerKey) continue; // 中心日由呼叫端 foreground 載入
+    fetcher(k).catch((err) => {
+      console.warn(`${consoleTag}[prefetch] ${k} failed:`, err);
+    });
+  }
+}

--- a/src/state/timeStore.ts
+++ b/src/state/timeStore.ts
@@ -25,12 +25,15 @@ function toDateKey(unixSec: number): string {
 
 let currentTime = Date.now() / 1000;
 let currentDateKey = toDateKey(currentTime);
-// timeline 範圍天數（1~7）；time-aware loader 用它決定要 prefetch ±幾天
+// timeline 範圍天數（1~7）；time-aware loader 用它決定要 prefetch 幾天
 let currentRangeDays = 1;
+// timeline 視窗內的完整日期 keys（含 selectedDate 起 N 天）；prefetch 嚴格只認這份
+let currentWindowDateKeys: string[] = [currentDateKey];
 
 const rawListeners = new Set<Listener<number>>();
 const dateListeners = new Set<Listener<string>>();
 const rangeDaysListeners = new Set<Listener<number>>();
+const windowListeners = new Set<Listener<string[]>>();
 
 // 節流訂閱需要各自追蹤 last fire 時間，所以包成獨立 entry。
 interface ThrottledEntry {
@@ -155,6 +158,25 @@ export const timeStore = {
   subscribeRangeDays(cb: Listener<number>): () => void {
     rangeDaysListeners.add(cb);
     return () => rangeDaysListeners.delete(cb);
+  },
+
+  // ── Timeline 視窗內的日期 keys ──
+  // SSOT 由 useTimeline 寫入：selectedDate ~ selectedDate+rangeDays-1。
+  // time-aware loader 預載這份清單而**不**外推；視窗外完全不打 RPC。
+  getWindowDateKeys(): string[] {
+    return currentWindowDateKeys;
+  },
+  setWindowDateKeys(keys: string[]): void {
+    if (
+      keys.length === currentWindowDateKeys.length &&
+      keys.every((k, i) => k === currentWindowDateKeys[i])
+    ) return;
+    currentWindowDateKeys = keys.slice();
+    for (const cb of windowListeners) cb(currentWindowDateKeys);
+  },
+  subscribeWindowDateKeys(cb: Listener<string[]>): () => void {
+    windowListeners.add(cb);
+    return () => windowListeners.delete(cb);
   },
 };
 

--- a/src/state/timeStore.ts
+++ b/src/state/timeStore.ts
@@ -25,9 +25,12 @@ function toDateKey(unixSec: number): string {
 
 let currentTime = Date.now() / 1000;
 let currentDateKey = toDateKey(currentTime);
+// timeline 範圍天數（1~7）；time-aware loader 用它決定要 prefetch ±幾天
+let currentRangeDays = 1;
 
 const rawListeners = new Set<Listener<number>>();
 const dateListeners = new Set<Listener<string>>();
+const rangeDaysListeners = new Set<Listener<number>>();
 
 // 節流訂閱需要各自追蹤 last fire 時間，所以包成獨立 entry。
 interface ThrottledEntry {
@@ -135,6 +138,23 @@ export const timeStore = {
   subscribeDate(cb: Listener<string>): () => void {
     dateListeners.add(cb);
     return () => dateListeners.delete(cb);
+  },
+
+  // ── Timeline 範圍天數（共用 prefetch window）──
+  // SSOT 由 useTimeline 寫入；time-aware loader（cwa-imagery / lightning /
+  // precip / ...）讀此值決定要 prefetch ±幾天。1~7 由 TimelineControls 下拉。
+  getRangeDays(): number {
+    return currentRangeDays;
+  },
+  setRangeDays(n: number): void {
+    const clamped = Math.max(1, Math.min(7, Math.floor(n)));
+    if (clamped === currentRangeDays) return;
+    currentRangeDays = clamped;
+    for (const cb of rangeDaysListeners) cb(currentRangeDays);
+  },
+  subscribeRangeDays(cb: Listener<number>): () => void {
+    rangeDaysListeners.add(cb);
+    return () => rangeDaysListeners.delete(cb);
   },
 };
 

--- a/src/state/timeStore.ts
+++ b/src/state/timeStore.ts
@@ -164,7 +164,8 @@ export const timeStore = {
   // SSOT 由 useTimeline 寫入：selectedDate ~ selectedDate+rangeDays-1。
   // time-aware loader 預載這份清單而**不**外推；視窗外完全不打 RPC。
   getWindowDateKeys(): string[] {
-    return currentWindowDateKeys;
+    // 回傳 copy — 防止 caller 不小心 mutate 影響到下一次 equality 判斷
+    return currentWindowDateKeys.slice();
   },
   setWindowDateKeys(keys: string[]): void {
     if (


### PR DESCRIPTION
## Summary

修兩個 pain point：
1. 雷達 / 雲圖切日後跳回原日仍會重打 RPC（沒 cache，object URLs 被 revoke 掉）
2. timeline 的 3d/7d 範圍鍵只影響 UI 跳格，loader 端永遠只載當天

## Changes

- `useCwaImageryLayer` 重構：LayerState 只追 active handle + activeDateKey，資料一律從 cacheRef 拿
- Per-day LRU cache：`dsId → dateKey → CacheSlot`，access order 維護 LRU 順序
- 新增 `preloadDays` prop (1~7)：cache 上限 + 以當前日為中心 ±days 背景預載
- 切日命中 cache 立即套用（不發 RPC、不 revoke）；layer 關閉只 remove handle，cache 保留
- Inflight set 防同 dsId × dateKey 併發；disposed 時 fetched-but-late 的 urls 立刻 revoke
- `preloadDays` 變動 → 立即 evict 多出的最舊日（保護當前 active + 鄰近預載集）
- UI：cwaCloudImagery / cwaRadarImagery 各加一個 `預載 Nd (cache)` slider，共用同一 state

## Test plan

- [x] `npx tsc -b` 0 error
- [x] `pnpm test` 155/155
- [ ] Browser：開雷達 → 切日 → 再切回應秒切（不發 RPC）
- [ ] Browser：把 slider 從 3 拉到 7 → 看 console 有沒有 prefetched 訊息
- [ ] Browser：把 slider 從 7 拉到 1 → 看 evict log

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UC3pckJoH5sRZSsUFtpSEg