### PR TITLE
memory: 2026-07-02 全球氣候 session wrap-up（8 檔）

### DIFF
--- a/.claude/memory/BACKLOG.md
+++ b/.claude/memory/BACKLOG.md
@@ -51,14 +51,19 @@
 
 | ID | 優先級 | 項目 | 狀態 | 備註 |
 |---|---|---|---|---|
-| GC-1 | P1 | GFS/CMEMS/CAMS collector 上雲 | **done** | data-collectors PR #24（補 xarray/cfgrib/eccodes/cdsapi/copernicusmarine 依賴 + CMEMS bbox 擴西太平洋）；2026-07-02 merge，隔日驗 S3 `global_climate_{noaa_gfs,cmems,cams}/` 有新檔 |
-| GC-2 | P1 | `extract_climate_uv.py` 烤圖排程化 + 前端 cache-busting | open | 建議搬 data-collectors 當 post-collect step；沒做前地圖上是舊快照（現為 6/29 手烤） |
-| GC-4/5/6 | P1 | 風場速度色階 + 三層圖例 + click 讀值 popup + 粒子調校 | **done (pending browser 驗收)** | feat/global-climate-ux；色階 SSOT `src/map/climateRamps.ts`；沙塵 popup 讀值需 GC-2b 改烤數值通道 |
-| GC-7 | P2 | CAMS bbox 擴域 + CMEMS 全球化 texture 降採樣 | open | 等 collector 跑穩再動，避免一次兩個變因 |
-| GC-8 | P2 | GFS 預報時間序列（6 leadtime 接 timeStore） | open | 從快照變 Windy 式預報播放的關鍵一步 |
+| GC-1 | P1 | GFS/CMEMS/CAMS collector 上雲 | **done** | data-collectors PR #24（補依賴）+ #25（CMEMS 爆量修）；已驗 S3 有新檔 |
+| GC-2 | P1 | 烤圖排程化 + 前端 cache-busting | **done** | data-collectors PR #26（climate_bake collector 每 6h，取 f000 實況）+ 前端 entrypoint 每 6h re-sync + PNG ?v=valid_at（PR #42） |
+| GC-2b | P2 | 沙塵改烤數值通道供 popup 讀值 | open | 現為預烤色階、數值不可逆，dust 無 click 讀值 |
+| GC-4/5/6 | P1 | 風場速度色階 + 三層圖例 + click 讀值 + 粒子調校 | **done** | PR #42；色階 SSOT `climateRamps.ts` |
+| GC-6b/6c/6d | P1 | 粒子引擎效能 | **done** | drape 分色桶批次 / WebGL instanced + 快取 mercator / 移除 drape + zoom 自適應密度（PR #42） |
+| GC-7 | P2 | 海流 bbox 擴廣域（90-180E×-15-55N）| **done（CMEMS）** | data-collectors PR #27；CAMS bbox 擴域仍 open |
+| GC-8 | P2 | GFS 預報時間序列（6 leadtime 接 timeStore） | open | 從快照變 Windy 式預報播放 |
 | GC-9 | P2 | PRMSL 等壓線 / 250hPa 噴流 / SST / 波浪 quick wins | open | collector 已抓、前端零接線 |
 | GC-10 | P3 | 颱風作戰室 preset | open | 對應 worldmonitor-taiwan-vision D-1 |
 | GC-11 | P3 | 海流 × 船舶軌跡疊圖 | open | |
+| TY-1 | P1 | 颱風 loader 欄位 center_pressure→center_pressure_hpa | **done** | 圖層本來全空的元凶（PR #42） |
+| TY-2 | P3 | JMA 強度資料缺（氣壓/風速） | open | bosai 端點只有位置；需另接 JMA 強度來源（data-collectors） |
+| TY-4/5/6 | P1 | 現在位置圈 + 跳點斷線 + 預測/實際差異 + 資料源選擇器 + 同時刻去重 | **done** | PR #42 |
 
 ### 一般待辦
 

--- a/.claude/memory/DATA_SCOPE.md
+++ b/.claude/memory/DATA_SCOPE.md
@@ -507,3 +507,16 @@ civil_defense_shelters(3.4M) / crime_area_monthly(2.3M) / court_jurisdictions(29
 方式 B 是空域快照（非完整軌跡）取代 FR24，用於降低成本 + 提高涵蓋。
 
 **Long-form** collector pipeline 與 legacy 指令：`~/.claude/projects/.../memory/_archive/data-pipeline.md`
+
+## 全球氣候 GLOBAL CLIMATE（2026-07-02 上線）
+
+**data-collectors `collectors/global_climate/` 7 collector**（plan-misty-fog）：
+- 向量（純 Supabase）：`usgs_earthquake`（全球地震 hourly → `realtime.earthquakes_global`）/ `jma_typhoon`（3h）+ `jtwc`（6h）→ `realtime.typhoon_positions`（source 區分）
+- 模式場（S3 原檔 + Supabase digest `realtime.global_climate_grids`）：`noaa_gfs`（全球 0.25° 風場/氣壓/噴流）/ `cmems`（西太→廣域 90-180E×-15-55N 海流/SST/波浪）/ `cams`（東亞沙塵/PM）— 每日
+- `climate_bake`（第 7，每 6h）：讀 Supabase 最新 f000 → 烤 RGBA PNG/raster → `deploy-assets/climate/{wind10m,currents,dust}_latest.{png,json}`
+
+**雲端注意**：CMEMS/CAMS 需 env 憑證 + requirements 需 xarray/cfgrib/cdsapi/copernicusmarine + Dockerfile libeccodes0（見 INCIDENTS 2026-07-02）。CMEMS subset 必帶時間範圍。
+
+**前端遞送**：`/climate/*.png` 由 nginx 從 `/data/climate/` 服務；`entrypoint.sh` 背景迴圈每 6h re-sync `deploy-assets/climate/`（refresh-climate.sh）；PNG 帶 `?v=valid_at` 破快取。
+
+**前端 5 layer**（`docs/features/global-climate/`）：windField / oceanCurrents（WebGL instanced 粒子線，全 zoom）/ dustForecast（raster）/ earthquakesGlobal（circle）/ typhoonTracks（線+點+現在位置圈，JMA/JTWC 資料源選擇器）。

--- a/.claude/memory/GLOSSARY.md
+++ b/.claude/memory/GLOSSARY.md
@@ -300,3 +300,13 @@
 | **per-region dissolve concat trap** | 分區跑覆蓋 layer 的反模式：每區獨立 `compute_overlap_count + dissolve` → concat 到頂層 → **同片地理區域被 concat 進 N 份 fragments，overlap_count 值各異**（因為每區看到的鄰居 station 集合不同）→ 前端 fill-color step 讀 count 出現色塊接不上。**正確做法**：per-region 只出 raw per-station polygons（不 dissolve）→ 全域 concat → dedup by entity_id → 全域 compute_overlap_count → dissolve 1 次。核心：`compute_overlap_count` 必須全域執行，不能分區。詳 INCIDENTS 2026-07-02 |
 | **nearest_node 距離閾值 / offline station fallback** | `ox.nearest_nodes(G, X, Y)` 沒設距離上限，山區 station 在被過濾過的 drive PBF（只留 primary/secondary/tertiary）附近可能沒節點 → 回傳 3-5 km 外的主幹道節點 → ego_graph 從錯位置展開 → polygon 完全不在 station 附近（榮興偏移 5306m、泰崗 4317m）。修法：檢查 nearest_node 距 station EPSG:3826 距離 > 500m → 視為「station 不在路網上」，改用理論半徑圓 `Point.buffer(radius/111000)` at **station 座標**（非 node 座標）。詳 PRINCIPLES + INCIDENTS 2026-07-02 |
 | **isochrone Mode B + dissolve 三段演化** | ① convex_hull → 鋸齒過度膨脹；② concave_hull(0.3) → 26K micro fragments；③ concave_hull(0.5) + buffer + **dissolve by overlap_count** → 73 features 乾淨階梯。標準做法 = ③ |
+
+## 全球氣候 / 颱風（2026-07-02）
+
+- **JMA / RSMC Tokyo**：日本氣象廳，WMO 指定西北太平洋官方颱風中心，颱風編號 TC26xx，10-min sustained 風速。bosai forecast.json 只有位置無強度。
+- **JTWC**：美軍聯合颱風警報中心，颱風編號 wpNNyy（wp=西太），暫用名（Nine/Ten…），1-min sustained 風速（比 JMA 高 12-15%），ATCF RSS 有風速無氣壓。
+- **同實體雙編號**：Bavi = JMA TC2611 = JTWC wp0926；南海系統 = JMA TC2610 = JTWC "Ten" wp1026。同一颱風兩機構各自定位。
+- **f000 實況 vs forecast**：GFS 等模式場 `observed_at`=預報有效時刻、`init_at`=cycle 時刻、`leadtime_hr`=預報時數。烤「現在實況」要取 `init_at DESC + leadtime ASC`（最新 cycle 的 f000 分析），不是 observed_at 最遠（那是 +120h 預報）。
+- **instanced rendering**：WebGL 每段線一個 instance（8 float），四角幾何固定不重傳，`drawArraysInstanced`，上傳量 -87%。climateParticleLineLayer 用。
+- **zoom 自適應密度**：粒子數隨 zoom 拉遠自動加密（填滿大視野）、拉近回 slider 值，量化避免每幀重配置陣列。取代舊的低 zoom canvas drape。
+- **climate bake collector**：data-collectors 第 7 個 global_climate collector，讀 Supabase 最新 f000 → 烤 RGBA PNG（風/流 UV）/ raster（沙塵）→ deploy-assets/climate/。

--- a/.claude/memory/INCIDENTS.md
+++ b/.claude/memory/INCIDENTS.md
@@ -1190,3 +1190,25 @@ drive 5min radius 2739m，榮興偏移 5306m > radius → polygon 完全不在 s
 2. **「有 polygon」≠「polygon 正確」**：山區 station 有 3-4 km² polygon 看起來正常，但不代表包住 station。GIS 檢查一律：`polygon.contains(Point(station))`。
 3. **看起來合理但不符物理直覺時要再挖**：「深山派出所面積小」聽起來合理但榮興在台8線主幹道旁，「小」不該小到看不見 → 用戶物理直覺對，我第一次沒挖夠深。
 4. **對照測試在動全台前**：10 顆邊界 station 15 min 就跑完 vs 全台 90 min。設計 diagnostic mini-test 而不是直接 dry-run 大工程。
+
+## 2026-07-02 全球氣候上線 4 事件
+
+### CMEMS subset 單檔 18.7GB 爆量
+- **現象**：CMEMS bbox 從台灣 9°×8° 擴到西太 60°×45° 後，Zeabur 上 `cmems_currents.nc` 單檔 18.7GB + sst 9.4GB，container 被 health check 判死重啟 → 每 ~25 min 重跑一輪，一下午 56GB 上 S3。
+- **根因**：`copernicusmarine subset` **沒帶 `--start/--end-datetime`** → 抓整段 anfc 時間軸（多年 analysis + 10 天 forecast）。台灣小 bbox 時 2.7MB 沒人發現，擴域後爆。
+- **修法**：subset 固定帶「今日 00Z +48h」時間範圍（data-collectors PR #25）。實測 currents 27MB。刪 S3 5 個廢檔 ~70GB。
+
+### 颱風軌跡圖層一直是壞的（loader 欄位 bug 靜默失敗）
+- **現象**：颱風軌跡 toggle 打開一片空白，layer 完全沒建。
+- **根因**：`typhoonTracksLoader` select `center_pressure`，但 public.typhoon_positions 欄位是 `center_pressure_hpa` → PostgREST 整包查詢報錯 → catch 只 console.warn → layer 靜默不建。**接了 layer 沒實際 toggle 驗，壞很久沒發現**。
+- **修法**：欄位名對照（TY-1）。教訓 → PRINCIPLES「前端 loader 欄位名要對照 DB 驗」。
+
+### Mekkhala 軌跡穿越 X（JMA preTyphoon 時間戳碰撞）
+- **現象**：Mekkhala 軌跡在日本外海（32°N）和關島（13°N）間來回畫穿越線，3 小時跳 2200km。
+- **根因**：JMA bosai forecast.json 的 preTyphoon / typhoon / analysis 段用**同一時間戳**，排序後交錯。
+- **修法**：loader 依「相鄰點跳躍 > 120km/h×時距 + 250km」斷開 LineString（TY-5）+ 同時刻多點質心去重（TY-4）。
+
+### data-collectors 雲端缺依賴（env 設了但沒套件）
+- **現象**：GFS/CMEMS/CAMS 三 collector env `_ENABLED=true` 都設了卻沒資料。
+- **根因**：requirements.txt 缺 xarray/cfgrib/cdsapi/copernicusmarine + Dockerfile 缺 libeccodes0 → lazy import 掛。**只有 USGS/JMA/JTWC（無額外套件）活著**。
+- **修法**：PR #24 補依賴。教訓 → 「env 開了沒效果先查 image 是否有套件」。

--- a/.claude/memory/PLAYBOOKS.md
+++ b/.claude/memory/PLAYBOOKS.md
@@ -1415,3 +1415,17 @@ git status -s
 ### 觸發詞
 
 「N 站重疊 / 覆蓋計數 / overlap count / service redundancy / 多重保護 / 警力沙漠 / 蝶圖 / N 分鐘可達且重疊多」
+
+## PB-25 混亂分支拆乾淨 → 依序 PR 併回 master（2026-07-02 加）
+
+一條分支混了多個 feature（bloom + 派出所 sidebar + 大量 memory）要拆成乾淨 PR 時：
+
+1. **先盤點不動手**：`git log --oneline master..<branch>` 看 commit 組成，判斷每個 commit 屬哪個 feature；`git diff --stat master <branch> -- <path>` 確認哪些檔已在 master（避免重複 / 遺失）。
+2. **確認已併的別重做**：feature code 可能早已透過別的 squash PR 進 master（commit 看似「領先」但內容重複）。用 `git grep -l <代表 key> master -- src/` 驗證 feature 是否已在 master。
+3. **舊分支改名備份**：`git branch -m feat/X feat/X-OLD`，再從 master 切乾淨 `feat/X`。
+4. **topic-scoped cherry-pick**：每個 feature 的 commit 各自 cherry-pick 到乾淨分支。commit 若各自 scope 清楚（bloom commit 只動 bloom 段），衝突少。
+5. **依序 merge + 每次同步 master**：`gh pr create` → `gh pr merge --squash --delete-branch` → `git checkout master && git pull` → 下一條 rebase 到新 master。共用檔（layerCatalog/App/types）的衝突在此逐一解。
+6. **memory commit 直接 cherry-pick**：純 memory/docs 的 commit（append-only）通常乾淨 cherry-pick，不同 section 不衝突。
+7. **清理**：`gh pr merge --delete-branch` 連本地也刪；stale 分支確認 content 在 master 後 `git branch -D`；worktree 分支（`+` 前綴）不動。
+
+本次：climate/bloom/police 三條乾淨併回，衝突只 2 個（useMemo deps 陣列合併 + layerConsistency baseline 補 glow 層），全綠 merge。

--- a/.claude/memory/PRINCIPLES.md
+++ b/.claude/memory/PRINCIPLES.md
@@ -832,3 +832,23 @@ find public -name "*.geojson" | grep -i "topic"
 - 保底再開一個「大小 slider」給用戶手動微調（自動 + 手動雙控最順）
 
 Ref：`docs/features/bloom-experiments/README.md`
+
+## copernicusmarine subset 必帶時間範圍（2026-07-02）
+
+`copernicusmarine subset` 不帶 `--start/--end-datetime` 會抓整段 anfc 時間軸（多年 + 10 天預報）。小 bbox 時檔案小沒事，擴域後單檔可爆到 18GB。**一律帶時間範圍**（例：今日 00Z +48h）。見 INCIDENTS 2026-07-02。
+
+## 前端 Supabase loader 欄位名要對照 DB 驗（2026-07-02）
+
+前端 loader 的 `.select("colA,colB")` 欄位名若與 public view 不符，PostgREST 整包查詢報錯 → 若 catch 只 console.warn，layer 會**靜默不建、完全空白**（颱風軌跡 center_pressure vs center_pressure_hpa 壞很久沒發現）。**接完 Supabase layer 一定要實際 toggle 開來看有沒有東西**，別只信 tsc 過。
+
+## 大量粒子/流場 → instanced rendering + 快取世界座標（2026-07-02）
+
+WebGL 逐幀重建整個頂點 buffer（count × trail × 6 頂點 × 10 float）+ 逐段算 mercator（log/tan）在高粒子數會爆。改法：① instanced rendering — 四角幾何固定 static buffer，每段只上傳 8 float（fromMerc/toMerc/rgba），`drawArraysInstanced`，上傳量降 ~87%；② 快取世界座標 — 世界座標（mercator）在點建立時算一次存起來，繪製直接讀（zoom/pan 靠 u_matrix，不用重算）。用 VAO 封裝 attribute+divisor 免污染 mapbox。
+
+## 地圖是 mercator 非 globe → 自訂 WebGL 線層全 zoom 有效（2026-07-02）
+
+`new mapboxgl.Map` 沒指定 `projection:'globe'` = 預設 mercator 平面。自訂 WebGL CustomLayer（吃 u_matrix）在**所有 zoom 都正確**，不需要低 zoom 的 canvas globe drape 疊層。動 climate drape 前先確認投影。粒子密度改用 zoom 自適應（拉遠加密、量化避免每幀重配置陣列）取代雙層。
+
+## 多機構同一實體 → 提供資料源選擇 + 去重（2026-07-02）
+
+颱風被 JMA（TC26xx）+ JTWC（wpNNyy）兩機構各自追蹤，同一實體出現兩次、位置略差 → 兩條軌跡兩個圈重疊混亂。原則：① 加**資料源選擇器**（全部/JMA/JTWC，UX 鐵則 4，≤3 選項用 button row）讓用戶選單一來源；② 同一 storm×source×時刻的多點質心去重（JMA preTyphoon/typhoon 段同時間戳）。任何「多來源同實體」資料都適用。

--- a/.claude/memory/REFLECTIONS.md
+++ b/.claude/memory/REFLECTIONS.md
@@ -995,3 +995,13 @@ memory commit 動 `.claude/memory/`，不會撞到 code 變動，但**不要 pus
 | TBD | memory: rewrite STATUS（PI-1 收尾）|
 | （另檔）| **taipei-gis-analytics** `a44f6f3` 5 檔 pipeline（未 push）|
 | （另檔）| **mini-taiwan-pulse** sidebar `layerCatalog.ts` 警察覆蓋分析降級到執法治安子群（未 commit）|
+
+## 2026-07-02 全球氣候 session — 3 條 next-time
+
+1. **接完 Supabase layer 一定實際 toggle 驗**：颱風軌跡 loader 欄位 bug（center_pressure）讓整個 layer 靜默壞掉、可能壞很久沒人發現。tsc 過 ≠ 有資料。用戶問「有資料嗎」我才去查，一查就發現壞的。→ 接資料 layer 收尾必開來看。
+
+2. **「多來源同實體」要主動想到去重/選擇**：用戶截圖問「這兩個是同一個颱風嗎」我才意識到 JMA/JTWC 雙機構重複。這是資料常識（RSMC vs JTWC），設計颱風 layer 時就該預想，而非被動發現。→ 接多來源資料先問「會不會同一實體出現多次」。
+
+3. **分支整合前先盤點結構再動手**：用戶說「幫我整理成乾淨分支」，我先花時間 map 清楚（哪些已在 master / 哪條混了幾個 feature / memory 內容會不會遺失）再提方案讓用戶選，才動 cherry-pick。混亂分支拆乾淨靠「topic-scoped commit 各自 cherry-pick + 依序 merge + 每次 rebase」——這次 climate/bloom/police 三條乾淨併回，衝突只有 2 個（deps 陣列 + baseline）都好解。
+
+4. **驗證工具的限制要誠實講**：agent-browser 合成 wheel 縮不到全球 zoom（工具限制非 app），拉遠自適應密度我用數值驗算補足並明講「這段我沒法自動驗、麻煩你用真滑鼠看」。別假裝驗過。

--- a/.claude/memory/STATUS.md
+++ b/.claude/memory/STATUS.md
@@ -1,60 +1,46 @@
 # Status
 
-**最後更新**：2026-07-02 凌晨（PI-1 完全收尾：區界斷裂 + 山區偏移 2 bugs 修好 + sidebar 分區調位）
-**mini-taiwan-pulse head**：`67c869c` on `feat/power-plant-glow`（本 session 7 memory commits，STATUS 是第 8 個）— ⚠️ **不在 master**，session start 時 master head 是 `0eb4137`；bloom 相關 commits 已在此 feat branch
-**taipei-gis-analytics head**：`a44f6f3`（pipeline 5 檔新增，**未 push**）
+**最後更新**：2026-07-02（全球氣候整包上線 + 颱風軌跡修正/增強 + 分支大整合）
+**mini-taiwan-pulse head**：`master` 乾淨、與 origin/master 同步（3 乾淨 PR 併入：#42 climate / #43 bloom / #44 police）
+**data-collectors head**：`main`，4 PR 已 merge（#24 依賴 / #25 CMEMS 爆量 / #26 bake collector / #27 CMEMS bbox）
 **gis-platform head**：無變動
 
-## 本 session 完成（2026-07-01 晚 → 2026-07-02 凌晨）
+## 本 session 完成（2026-07-02）
 
-**用戶定向**：處理 BACKLOG PI-1（3 修法擇一），做完後補上山區意外 bug，最後 sidebar 分區微調。
+用戶定向：盤點全球氣候搜集與顯示 → 對標 Windy/nullschool → 一路做到資料活水、視覺、效能、颱風，最後整理分支。
 
-### A. PI-1 區界斷裂 — 真根因不是 bbox 截斷（改正 2026-07-01 錯誤診斷）
+### A. 全球氣候資料活水（data-collectors，4 PR）
+- 盤點發現：env `_ENABLED` 都設了但 GFS/CMEMS/CAMS 沒資料 → **requirements 缺 xarray/cfgrib/cdsapi/copernicusmarine + Dockerfile 缺 libeccodes0**（PR #24）
+- CMEMS subset 沒帶時間範圍 → 擴域後單檔 18.7GB 爆量、container 重啟循環（PR #25 修，刪 S3 ~70GB 廢檔）
+- `climate_bake` collector（第 7，每 6h）：讀 f000 實況 → 烤 PNG → deploy-assets（PR #26，順修「風場其實是 +5 天預報」）
+- CMEMS bbox 擴廣域 90-180E×-15-55N（PR #27）
 
-- **原本推薦修法 A**（bbox +0.15° overlap）→ 用戶 push「這次確定嗎」→ 檢查 `15_run_by_region.sh` 才發現 5 區 bbox 早已有 40km overlap → 前提就錯了
-- **真根因**：每區獨立 `compute_overlap_count + dissolve` → `16_merge_regions.py` 只 concat → 同片區疊層多份不同 count fragments → 前端色塊接不上
-- **對照測試**：10 顆桃竹 + 10 顆嘉南 station。OLD 8 features / count [(1,2),(2,2),(3,2),(4,2)] vs NEW 4 features / count [(1,1),(2,1),(3,1),(4,1)]
-- **修法**：`10_police_isochrone.py` 拆兩段（`--polys-only` raw + `dissolve_polys_to_final` 全域）+ `16_merge_regions.py` concat 5 區 raw → dedup by entity_id → 全域 dissolve
-- **全台跑**（walk + drive）Stage 1 ~90 min → Stage 2/3/4 ~15 min
+### B. 前端全球氣候（PR #42，GC-2~7 + 6b/c/d）
+- GC-2 遞送：entrypoint 每 6h re-sync climate + PNG ?v=valid_at
+- GC-4/5/6：風場速度色階 + 三層圖例 + click UV 讀值 popup + 粒子調校
+- GC-6b/c/d 效能：Canvas drape 分色桶批次 / WebGL **instanced rendering** + 快取 mercator（上傳 -87%）/ 移除低 zoom drape（mercator 非 globe）+ zoom 自適應密度
 
-### B. 山區 station polygon 偏移 — 用戶 push 才找到的第 2 bug
+### C. 颱風軌跡（PR #42，TY-1~6）
+- TY-1：修 loader 欄位 `center_pressure`→`center_pressure_hpa`（圖層本來全空的元凶）
+- TY-4/5/6：現在位置黃圈（活躍颱風，48h 門檻濾舊）/ 跳點斷線修 Mekkhala X（JMA preTyphoon 時間戳碰撞）/ 預測藍虛線 vs 實際紫實線 / 資料源選擇器（全部/JMA/JTWC）/ 同時刻點質心去重
+- 確認 Bavi=TC2611/wp0926、TC2610=Ten 是同一實體雙機構
 
-- 用戶截圖榮興/泰崗看不到 polygon → 我第一次說「山區半徑天然小」→ 用戶 push「請你再好好的確認一下」
-- 診斷：榮興 polygon centroid 偏移 station 5306m > drive 5min radius 2739m，polygon 跑到隔壁山谷
-- **真根因**：`taiwan-drive.osm.pbf` osmium 過濾掉 residential/service/track → 深山派出所附近沒 drive 節點 → `ox.nearest_nodes()` 找 3-5 km 外的節點 → ego_graph 從錯位置展開
-- **修法**：`station_polygon()` 加 500m 閾值 + fallback 圓 buffer at **station 座標**（非 node 座標）
-- **drive-only 補跑**（7 min，drive PBF 小）→ 掃全台「polygon 不含 station」raw features 從 100+ → 23（<1.5%）
+### D. 分支大整合（PB-25）
+- 混亂的 `feat/power-plant-glow`（bloom + 派出所 sidebar + memory）拆乾淨
+- 3 乾淨 PR 併回 master：**#42 climate / #43 bloom / #44 police wrapup**
+- 本地清理：刪除已整合 + stale 分支（energy-v2/aviation-drone/staging 確認 content 已在 master）；只剩 master + 2 worktree 分支（member-auth / drone-fix，未動）
 
-### C. Sidebar 分區調位
+## 待辦（詳 BACKLOG）
+- **GC-2b**（P2）：沙塵改烤數值通道供 popup 讀值
+- **GC-7 CAMS**（P2）：CAMS bbox 擴域（海流 CMEMS 已擴）
+- **GC-8**（P2）：GFS 預報時間序列接 timeStore（Windy 式播放）
+- **GC-9**（P2）：PRMSL 等壓線 / 250hPa 噴流 / SST / 波浪 quick wins（collector 已抓、前端零接線）
+- **TY-2**（P3）：JMA 強度資料缺（需另接來源）
+- **PI-2 / PS-1**（P3，前一 session）：離島 substation 無 isochrone / 綠島座標 bug
 
-`layerCatalog.ts`：「警察覆蓋分析」從獨立大類（POLICE COVERAGE）降級成「執法治安 LAW & ORDER」下的第 2 個子群（緊接「警政」後）。大類計數 0/17 → 0/20。
-
-### D. 部署
-
-- 3 個 combined PMTiles 上 S3：`s3://migu-gis-data-collector/deploy-assets/police_justice/isochrone/`（substation 11MB / precinct 2.7MB / police_dept 1.1MB）
-- Dev server 硬連結 `mini-taiwan-pulse/public/police_justice/isochrone/` 同步
-
-## 產物
-
-**taipei-gis-analytics `a44f6f3`（未 push）**：`pipelines/police_justice/isochrone/` 5 檔（10 主 / 15 分區 sh / 16 全域 dissolve / 20 combined / 25 tippecanoe）。詳 PLAYBOOKS PB-24。
-
-**mini-taiwan-pulse 本 session**：
-- 7 memory commits（見 REFLECTIONS 表）
-- 1 未 commit：`src/components/sidebar/layerCatalog.ts` sidebar 調位
-- 副產物：`public/geo/station_points.geojson` 有 M 標，可能 dev server 副作用（獨立於本 session 工作）
-
-## 待辦
-
-- **PI-2**（P3）：離島 60 顆 substation 無 isochrone（澎湖 27 / 金門 6 / 馬祖 3 / 綠島 1 / 恆春 2 / 本島邊界 3）
-- **PS-1**（P3）：police_stations upstream geocode bug（綠島分駐所座標 26.22 位於馬祖）
-- **Push 決策**：本 session 都在 `feat/power-plant-glow` branch 上；taipei-gis-analytics `a44f6f3` 也未 push。需用戶決定：
-  1. `feat/power-plant-glow` 是否含 bloom + memory + sidebar 三批不同 scope commits，要不要拆
-  2. taipei-gis-analytics 何時 push（有本地 3 天工作 + memory + pipeline）
-
-## 上一個 session（2026-06-29 ~ 07-01）
-
-見前一版 STATUS 已 memory commit `cac1a66`：警政司法 17 layer + 警察 isochrone × overlap_count 全台 5 區跑完 → dissolve by count + PI-1 記待辦。
+## 上一個 session（2026-07-01 → 02 凌晨）
+PI-1 派出所 isochrone 區界斷裂 + 山區偏移 2 bugs 修好 + sidebar 分區調位。詳 INCIDENTS 2026-07-01/02 + PLAYBOOKS PB-24。
 
 ---
 
-_本 session 8 memory commits_：`d6582a9 d52724b f6901c4 c06351b 670f02c b3c3fdd 67c869c` + 本檔
+_本 session memory commits_：INCIDENTS / PRINCIPLES / REFLECTIONS / GLOSSARY / DATA_SCOPE / PLAYBOOKS PB-25 / BACKLOG + 本檔


### PR DESCRIPTION
## Summary
- 本 session（全球氣候整包 + 颱風修正/增強 + 分支大整合）的記憶留檔，8 個 atomic memory commit

## Changes
- INCIDENTS +4 / PRINCIPLES +5 / REFLECTIONS +4 / GLOSSARY / DATA_SCOPE / PLAYBOOKS PB-25 / BACKLOG / STATUS rewrite

🤖 Generated with [Claude Code](https://claude.com/claude-code)