### PR TITLE
fix: Supabase client 韌性 — 併發上限 + timeout + retry (AR-01)

### DIFF
--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -37,8 +37,113 @@ function createStubClient(): SupabaseClient {
   } as unknown as SupabaseClient;
 }
 
+// ── AR-01: 韌性 fetch wrapper（併發上限 / timeout / retry） ──
+//
+// DB 變慢時用戶重整會讓瀏覽器同時射出數十個 RPC 雪崩，故：
+// 1. 全域同時進行請求上限 8，超過進 FIFO queue
+// 2. 每請求 30s timeout（AbortController；與 caller 自帶 signal 合成）
+// 3. 網路層錯誤（fetch TypeError）與 5xx / 429 最多 retry 2 次
+//    （backoff 500ms / 1500ms + jitter）；caller 主動 abort、timeout 不 retry
+// 4. 寫入類 RPC 一律不 retry（重送會重複寫入）
+// 錯誤最終仍 throw / 交給 supabase-js 轉成 { error } 給 caller —— 不吞錯，
+// loadingRegistry 錯誤態依賴這點。
+
+const MAX_CONCURRENT_REQUESTS = 8;
+const REQUEST_TIMEOUT_MS = 30_000;
+const MAX_RETRIES = 2;
+const RETRY_BACKOFF_MS = [500, 1500] as const;
+
+/** 寫入類 RPC denylist（2026-07 盤點：全 repo 僅 log_session_events 會寫入） */
+const WRITE_RPC_DENYLIST = ["log_session_events"] as const;
+
+let activeRequests = 0;
+const waitQueue: Array<() => void> = [];
+
+function acquireSlot(): Promise<void> {
+  if (activeRequests < MAX_CONCURRENT_REQUESTS) {
+    activeRequests++;
+    return Promise.resolve();
+  }
+  return new Promise((resolve) => {
+    waitQueue.push(() => {
+      activeRequests++;
+      resolve();
+    });
+  });
+}
+
+function releaseSlot(): void {
+  activeRequests--;
+  waitQueue.shift()?.();
+}
+
+function requestUrl(input: RequestInfo | URL): string {
+  if (typeof input === "string") return input;
+  if (input instanceof URL) return input.href;
+  return input.url;
+}
+
+function isWriteRpc(input: RequestInfo | URL): boolean {
+  const url = requestUrl(input);
+  return WRITE_RPC_DENYLIST.some((name) => url.includes(`/rpc/${name}`));
+}
+
+function backoffDelay(attempt: number): number {
+  const base = RETRY_BACKOFF_MS[attempt] ?? RETRY_BACKOFF_MS[RETRY_BACKOFF_MS.length - 1]!;
+  return base + Math.random() * 250; // jitter
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+async function resilientFetch(input: RequestInfo | URL, init?: RequestInit): Promise<Response> {
+  const callerSignal = init?.signal ?? (input instanceof Request ? input.signal : null);
+  const retryable = !isWriteRpc(input);
+
+  for (let attempt = 0; ; attempt++) {
+    await acquireSlot();
+    const timeoutCtrl = new AbortController();
+    const timer = setTimeout(
+      () =>
+        timeoutCtrl.abort(
+          new DOMException(`Supabase request timeout (${REQUEST_TIMEOUT_MS}ms)`, "TimeoutError"),
+        ),
+      REQUEST_TIMEOUT_MS,
+    );
+    const signal = callerSignal
+      ? AbortSignal.any([callerSignal, timeoutCtrl.signal])
+      : timeoutCtrl.signal;
+
+    let retryDelay: number | null = null;
+    try {
+      const res = await fetch(input, { ...init, signal });
+      if (retryable && attempt < MAX_RETRIES && (res.status >= 500 || res.status === 429)) {
+        void res.body?.cancel().catch(() => {});
+        retryDelay = backoffDelay(attempt);
+      } else {
+        return res;
+      }
+    } catch (err) {
+      // abort（caller 主動或 timeout）拋的是 DOMException，不是 TypeError → 不 retry
+      const isNetworkError = err instanceof TypeError;
+      if (retryable && isNetworkError && !callerSignal?.aborted && attempt < MAX_RETRIES) {
+        retryDelay = backoffDelay(attempt);
+      } else {
+        throw err;
+      }
+    } finally {
+      clearTimeout(timer);
+      releaseSlot();
+    }
+    await sleep(retryDelay ?? 0);
+  }
+}
+
 export const supabase: SupabaseClient = supabaseConfigured
-  ? createClient(SUPABASE_URL!, SUPABASE_ANON_KEY!)
+  ? createClient(SUPABASE_URL!, SUPABASE_ANON_KEY!, {
+      global: { fetch: resilientFetch },
+    })
   : createStubClient();
 
 /** 取得台灣時間的今天日期 YYYY-MM-DD */


### PR DESCRIPTION
## Summary
- `src/lib/supabase.ts` 裸 `createClient` 加上韌性 fetch wrapper：全域併發上限 8（FIFO queue）+ 30s timeout + 讀取類請求最多 retry 2 次，DB 變慢時用戶重整不再雪崩。

## Changes
- `src/lib/supabase.ts`（+106/-1，單檔）：
  - `resilientFetch` 經 `createClient` 的 `global.fetch` 注入，不動任何 caller
  - 併發上限 8：超過的請求進 FIFO queue，完成後依序放行
  - 30s timeout：AbortController；caller 自帶 signal（如 `useShipData` / `useAirspaceData`）用 `AbortSignal.any` 合成，caller 主動 abort 原樣拋回、不 retry
  - Retry 最多 2 次（backoff 500ms / 1500ms + 0~250ms jitter），僅網路層錯誤（fetch `TypeError`）與 5xx / 429 觸發；timeout / abort 不 retry
  - 寫入 RPC denylist `WRITE_RPC_DENYLIST = ["log_session_events"]`：全 repo 盤點 `.rpc(` 僅此一個寫入 RPC；`.from(` 4 處皆為 select、無 insert/update 直寫
  - 錯誤最終仍 throw / 由 supabase-js 轉 `{ error }` 給 caller，loadingRegistry 錯誤態不受影響

## Test
- [x] npx tsc -b 通過
- [x] pnpm test 通過（15 files / 161 tests）
- [ ] Browser 驗收（devtools throttle 模擬慢 RPC：不雪崩、UI 有錯誤態）

## Risk / Rollback
- 風險：所有 Supabase 請求都經過 wrapper——若 queue 邏輯有誤可能造成請求卡住；timeout 30s 對極慢 RPC 會提早砍掉（原本無上限）。`sessionTracker.flushViaBeacon` 走原生 fetch keepalive，不受影響。
- 回滾：revert 本 commit 即回到裸 `createClient`，單檔無其他依賴。

## Related
- Proposal: docs/proposal/architecture-overhaul-plan.md AR-01（proposal 原寫 15s timeout，本 PR 依任務規格採 30s）

🤖 Generated with [Claude Code](https://claude.com/claude-code)