### PR TITLE
perf: freeway/temperature/youbikeH3 loader 套 loaderCache 第一批 (AR-02)

### DIFF
--- a/src/data/freewayLoader.ts
+++ b/src/data/freewayLoader.ts
@@ -1,5 +1,6 @@
 import { supabase } from "../lib/supabase";
 import { withLoading } from "../lib/loadingRegistry";
+import { cachedByKey } from "../lib/loaderCache";
 
 export interface FreewayDateInfo {
   date: string;
@@ -75,8 +76,7 @@ function parseLineString(geojsonStr: string): [number, number][] {
   }
 }
 
-/** 載入某一天全部路段 timeline */
-export async function fetchFreewayDay(date: string): Promise<FreewayDayData> {
+async function fetchFreewayDayUncached(date: string): Promise<FreewayDayData> {
   const t0 = performance.now();
   const { data, error } = await withLoading(
     `freeway:${date}`,
@@ -121,6 +121,13 @@ export async function fetchFreewayDay(date: string): Promise<FreewayDayData> {
       end: Number.isFinite(maxTs) ? maxTs : 0,
     },
   };
+}
+
+const fetchFreewayDayCached = cachedByKey(fetchFreewayDayUncached, 10 * 60_000);
+
+/** 載入某一天全部路段 timeline。10min TTL 快取，toggle 不重抓 */
+export function fetchFreewayDay(date: string): Promise<FreewayDayData> {
+  return fetchFreewayDayCached(date);
 }
 
 /** 等級 1~5 對應顏色（順暢 / 車多 / 略壅塞 / 壅塞 / 嚴重壅塞；0 = 無資料） */

--- a/src/data/temperatureLoader.ts
+++ b/src/data/temperatureLoader.ts
@@ -4,6 +4,7 @@
 
 import { supabase, todayTaiwan } from "../lib/supabase";
 import { withLoading } from "../lib/loadingRegistry";
+import { cachedOnce, cachedByKey } from "../lib/loaderCache";
 
 export interface TemperatureGridData {
   metadata: {
@@ -32,8 +33,6 @@ const GRID_BOTTOM_LAT = 21.88;
 const GRID_BOTTOM_LNG = 120.0;
 const GRID_RESOLUTION = 0.03;
 
-let cached: TemperatureGridData | null = null;
-
 /**
  * 從 grid_lat/grid_lng 計算在 full grid 中的 flat index
  */
@@ -43,22 +42,21 @@ function gridCoordsToIndex(lat: number, lng: number): number {
   return row * GRID_COLS + col;
 }
 
-export async function loadTemperatureGrid(): Promise<TemperatureGridData> {
-  if (cached) return cached;
-  const t0 = performance.now();
-
-  // 找最近有資料的日期
+/** 找最近有資料的日期。10min TTL 快取，toggle 不重打 get_temperature_dates */
+const resolveTargetDate = cachedOnce(async (): Promise<string> => {
   const { data: dates, error: datesErr } = await supabase.rpc("get_temperature_dates");
   if (datesErr) throw new Error(`get_temperature_dates: ${datesErr.message}`);
   if (!dates || dates.length === 0) throw new Error("No temperature data available");
 
   const today = todayTaiwan();
-  let targetDate = (dates as { date: string; frames: number; cells: number }[])
+  const targetDate = (dates as { date: string; frames: number; cells: number }[])
     .filter((d) => d.date <= today && d.frames >= 10)
     .pop()?.date;
-  if (!targetDate) {
-    targetDate = (dates as { date: string }[])[dates.length - 1]!.date;
-  }
+  return targetDate ?? (dates as { date: string }[])[dates.length - 1]!.date;
+}, 10 * 60_000);
+
+async function loadTemperatureGridForDateUncached(targetDate: string): Promise<TemperatureGridData> {
+  const t0 = performance.now();
 
   const [gridRes, framesRes] = await withLoading(
     `temperature:${targetDate}`,
@@ -100,7 +98,7 @@ export async function loadTemperatureGrid(): Promise<TemperatureGridData> {
     `[Temperature/Supabase] ${targetDate}: ${frames.length} frames, ${landIndices.length} cells, ${elapsed}ms`
   );
 
-  cached = {
+  return {
     metadata: {
       rows: GRID_ROWS,
       cols: GRID_COLS,
@@ -113,5 +111,12 @@ export async function loadTemperatureGrid(): Promise<TemperatureGridData> {
     landIndices,
     frames,
   };
-  return cached;
+}
+
+const loadTemperatureGridForDateCached = cachedByKey(loadTemperatureGridForDateUncached, 10 * 60_000);
+
+/** 載入最近有資料日的溫度網格。10min TTL + LRU 快取，toggle 不重抓 */
+export async function loadTemperatureGrid(): Promise<TemperatureGridData> {
+  const targetDate = await resolveTargetDate();
+  return loadTemperatureGridForDateCached(targetDate);
 }

--- a/src/data/youbikeH3Loader.ts
+++ b/src/data/youbikeH3Loader.ts
@@ -1,5 +1,6 @@
 import { supabase, todayTaiwan } from "../lib/supabase";
 import { withLoading } from "../lib/loadingRegistry";
+import { keyedThunkCache } from "../lib/loaderCache";
 
 export interface YoubikeH3CellData {
   h: string;   // H3 index
@@ -22,7 +23,8 @@ export interface YoubikeH3DataSet {
   snapshots: Record<string, YoubikeH3CellData[]>;  // "2026-03-28T08:00" → cells
 }
 
-const cache = new Map<string, YoubikeH3DataSet>();
+/** 10min TTL + LRU 快取（key = "res7:2026-04-03"），toggle / 重切同日期不重抓 */
+const dayCache = keyedThunkCache<YoubikeH3DataSet>(10 * 60_000);
 
 /** cache key = "res7:2026-04-03" */
 function cacheKey(resolution: number, date: string): string {
@@ -38,11 +40,11 @@ async function fetchAvailableDates(): Promise<string[]> {
   return (data as { date: string }[]).map((d) => d.date);
 }
 
-/** 從 Supabase RPC 載入單日 H3 聚合 */
+/** 從 Supabase RPC 載入單日 H3 聚合。失敗 / 空資料 throw（讓快取不留失敗結果） */
 async function fetchFromSupabase(
   resolution: number,
   date: string,
-): Promise<YoubikeH3DataSet | null> {
+): Promise<YoubikeH3DataSet> {
   const { data, error } = await withLoading(
     `youbike-h3:${date}:r${resolution}`,
     `YouBike ${date}`,
@@ -53,8 +55,9 @@ async function fetchFromSupabase(
   );
 
   if (error || !data || data.length === 0) {
-    console.warn(`[YouBike-H3] Supabase RPC failed for ${date} res${resolution}:`, error?.message);
-    return null;
+    throw new Error(
+      `get_youbike_h3_snapshots(${date}, res${resolution}): ${error?.message ?? "empty result"}`,
+    );
   }
 
   const rows = data as { time_key: string; cells: YoubikeH3CellData[] }[];
@@ -66,7 +69,12 @@ async function fetchFromSupabase(
     for (const c of row.cells) allCells.add(c.h);
   }
 
+  if (allCells.size === 0) {
+    throw new Error(`get_youbike_h3_snapshots(${date}, res${resolution}): 0 cells`);
+  }
+
   const timeKeys = Object.keys(snapshots).sort();
+  console.log(`[YouBike-H3] res${resolution} ${date}: ${allCells.size} cells, ${timeKeys.length} snapshots`);
   return {
     metadata: {
       resolution,
@@ -100,18 +108,13 @@ export async function loadYoubikeH3(
 
   const targetDate = date ?? todayTaiwan();
   const key = cacheKey(resolution, targetDate);
-  const cached = cache.get(key);
-  if (cached) return cached;
 
-  const dataset = await fetchFromSupabase(resolution, targetDate);
-  if (dataset && dataset.metadata.cell_count > 0) {
-    cache.set(key, dataset);
-    console.log(`[YouBike-H3] res${resolution} ${targetDate}: ${dataset.metadata.cell_count} cells, ${dataset.metadata.snapshot_count} snapshots`);
-    return dataset;
+  try {
+    return await dayCache(key, () => fetchFromSupabase(resolution, targetDate));
+  } catch (err) {
+    console.warn(`[YouBike-H3] Failed to load res${resolution} for ${targetDate}:`, err);
+    return empty;
   }
-
-  console.warn(`[YouBike-H3] Failed to load res${resolution} for ${targetDate}`);
-  return empty;
 }
 
 /**


### PR DESCRIPTION
## Summary
- audit 標紅的三個重聚合 loader（freeway / temperature / youbikeH3）套上 `src/lib/loaderCache.ts` 既有 factory，toggle off→on、重切同日期不再重打 DB。

## Changes
- `src/data/freewayLoader.ts`（+9/-2）：`fetchFreewayDay` 拆 uncached + `cachedByKey(date, 10min)`（原本完全無快取），沿用 groundwater / riverLevel 等既有 per-day pattern
- `src/data/temperatureLoader.ts`（+18/-13）：移除永久 module cache（無 TTL / 不分日期 / 無 in-flight 去重），拆成 `resolveTargetDate` `cachedOnce(10min)`（get_temperature_dates 不重打）+ 單日網格 `cachedByKey(date, 10min)`
- `src/data/youbikeH3Loader.ts`（+19/-16）：裸 `Map` cache（無 TTL / LRU / in-flight 去重）換 `keyedThunkCache(10min)`（key = `res{n}:{date}`，雙參數 key 正是此 factory 的設計用途）；`fetchFromSupabase` 失敗 / 0 cells 改 throw 讓快取自動驅逐失敗結果，`loadYoubikeH3` 外層 catch 維持原本「失敗回傳 empty dataset」契約
- `withLoading` 維持包在 uncached fetcher 內、cache 包外層 → cache hit 立即 resolve、不觸發 loading UI，與既有 cached loader 範例一致

## Test
- [x] npx tsc -b 通過
- [x] pnpm test 通過（15 files / 161 tests）
- [ ] Browser 驗收（Network tab：toggle off→on、重切同日期零重複請求）

## Risk / Rollback
- 風險：10min TTL 內看到的當日資料可能舊最多 10 分鐘（與其他 per-day loader 相同慣例）；temperature 原本「永久快取」改為 10min TTL，長 session 會多幾次重抓（換來跨日 / 新 frames 正確性）
- 回滾：revert 本 commit，三檔各自獨立、無跨檔依賴

## Related
- Proposal: docs/proposal/architecture-overhaul-plan.md AR-02（第一批；第二批其餘機械式 loader 另開 `perf/loader-cache-batch2`）

🤖 Generated with [Claude Code](https://claude.com/claude-code)