### PR TITLE
fix: 補齊 17 處缺 loadingRegistry 的 Supabase 載入（AR-03/G009）

### DIFF
--- a/src/data/airspaceLoader.ts
+++ b/src/data/airspaceLoader.ts
@@ -57,7 +57,11 @@ function splitTrailByGap(path: TrailPoint[], maxGap: number = 1800): TrailPoint[
 
 /** 取得所有有航班資料的日期 */
 export async function fetchAirspaceDates(): Promise<AirspaceDateInfo[]> {
-  const { data, error } = await supabase.rpc("get_flight_dates");
+  const { data, error } = await withLoading(
+    "airspace:dates",
+    "航班日期",
+    supabase.rpc("get_flight_dates"),
+  );
   if (error) throw new Error(`Supabase get_flight_dates: ${error.message}`);
   return (data as { date: string; records: number; flights: number }[]).map((d) => ({
     date: d.date,

--- a/src/data/busLoader.ts
+++ b/src/data/busLoader.ts
@@ -12,6 +12,9 @@ import { dedupRpc } from "../lib/rpcDebounce";
 const cityRouteCache = new Map<BusCity, BusRouteData>();
 const cityRouteFetching = new Map<BusCity, Promise<BusRouteData>>();
 
+// 公車即時位置：只有初次載入顯示 loading，背景 30s tick 靜默（避免 loading UI 每次閃）
+const busCurrentLoadedOnce = new Set<string>();
+
 /** 載入指定城市的靜態路線幾何（lazy，有 per-city 快取） */
 export async function loadBusRoutesForCity(city: BusCity): Promise<BusRouteData> {
   if (cityRouteCache.has(city)) return cityRouteCache.get(city)!;
@@ -64,9 +67,14 @@ export async function fetchBusCurrent(cities: BusCity[]): Promise<BusPosition[]>
   if (cities.length === 0) return [];
 
   const dedupKey = `get_bus_current:${[...cities].sort().join(",")}`;
+  const firstLoad = !busCurrentLoadedOnce.has(dedupKey);
 
   return dedupRpc(dedupKey, async () => {
-    const { data, error } = await supabase.rpc("get_bus_current", { cities });
+    const rpc = supabase.rpc("get_bus_current", { cities });
+    const { data, error } = await (firstLoad
+      ? withLoading(dedupKey, `公車即時 ${cities.join("/")}`, rpc)
+      : rpc);
+    busCurrentLoadedOnce.add(dedupKey);
     if (error) {
       console.warn("[Bus] RPC error:", error.message);
       return [];
@@ -103,7 +111,11 @@ function parseTrail(trail: string): TrailPoint[] {
 /** 取得可用日期清單 */
 export async function fetchBusDates(): Promise<BusDateInfo[]> {
   if (!supabaseConfigured) return [];
-  const { data, error } = await supabase.rpc("get_bus_dates");
+  const { data, error } = await withLoading(
+    "bus:dates",
+    "公車日期",
+    supabase.rpc("get_bus_dates"),
+  );
   if (error) {
     console.warn("[Bus] get_bus_dates error:", error.message);
     return [];
@@ -206,11 +218,15 @@ export async function loadBusIntercityRoutes(): Promise<BusRouteData> {
 export async function fetchBusIntercityCurrent(): Promise<BusPosition[]> {
   if (!supabaseConfigured) return [];
 
+  const firstLoad = !busCurrentLoadedOnce.has("get_bus_intercity_current");
+
   return dedupRpc("get_bus_intercity_current", async () => {
     // 無 city 過濾：sub_authorities=NULL 取全部
-    const { data, error } = await supabase.rpc("get_bus_intercity_current", {
-      sub_authorities: null,
-    });
+    const rpc = supabase.rpc("get_bus_intercity_current", { sub_authorities: null });
+    const { data, error } = await (firstLoad
+      ? withLoading("get_bus_intercity_current", "公路客運即時", rpc)
+      : rpc);
+    busCurrentLoadedOnce.add("get_bus_intercity_current");
     if (error) {
       console.warn("[BusIntercity] RPC error:", error.message);
       return [];
@@ -234,7 +250,11 @@ export async function fetchBusIntercityCurrent(): Promise<BusPosition[]> {
 /** 取得公路客運可用日期清單 */
 export async function fetchBusIntercityDates(): Promise<BusDateInfo[]> {
   if (!supabaseConfigured) return [];
-  const { data, error } = await supabase.rpc("get_bus_intercity_dates");
+  const { data, error } = await withLoading(
+    "bus-intercity:dates",
+    "公路客運日期",
+    supabase.rpc("get_bus_intercity_dates"),
+  );
   if (error) {
     console.warn("[BusIntercity] get_bus_intercity_dates error:", error.message);
     return [];

--- a/src/data/disasterAlertLoader.ts
+++ b/src/data/disasterAlertLoader.ts
@@ -67,7 +67,11 @@ interface RawRow {
 const FAR_FUTURE = Number.MAX_SAFE_INTEGER;
 
 async function fetchDisasterAlertDatesUncached(): Promise<DisasterAlertDateInfo[]> {
-  const { data, error } = await supabase.rpc("get_disaster_alert_dates");
+  const { data, error } = await withLoading(
+    "disaster-alert:dates",
+    "災害示警日期",
+    supabase.rpc("get_disaster_alert_dates"),
+  );
   if (error) throw new Error(`get_disaster_alert_dates: ${error.message}`);
   return (data ?? []) as DisasterAlertDateInfo[];
 }

--- a/src/data/fireLoader.ts
+++ b/src/data/fireLoader.ts
@@ -71,7 +71,11 @@ export async function loadFireEventsByYear(year: number): Promise<FireEvent[]> {
 
 /** 取可用年份（前端可動態擴展 scrubber 範圍） */
 export async function loadFireEventYears(): Promise<{ year: number; n: number }[]> {
-  const { data, error } = await supabase.rpc("get_fire_event_years");
+  const { data, error } = await withLoading(
+    "fire:years",
+    "火災年份",
+    supabase.rpc("get_fire_event_years"),
+  );
   if (error || !data) {
     console.warn(`[Fire] get_fire_event_years error:`, error?.message);
     return [];

--- a/src/data/freewayLoader.ts
+++ b/src/data/freewayLoader.ts
@@ -37,7 +37,11 @@ export interface FreewayDayData {
 
 /** 取得可用日期 */
 export async function fetchFreewayDates(): Promise<FreewayDateInfo[]> {
-  const { data, error } = await supabase.rpc("get_freeway_dates");
+  const { data, error } = await withLoading(
+    "freeway:dates",
+    "國道日期",
+    supabase.rpc("get_freeway_dates"),
+  );
   if (error) throw new Error(`get_freeway_dates: ${error.message}`);
   return (data ?? []) as FreewayDateInfo[];
 }

--- a/src/data/h3Loader.ts
+++ b/src/data/h3Loader.ts
@@ -274,7 +274,11 @@ export async function loadH3DemographicsYearly(
 export async function loadH3DemographicsYears(): Promise<
   { year: number; resolution: number; cell_count: number }[]
 > {
-  const { data, error } = await supabase.rpc("get_h3_demographics_years");
+  const { data, error } = await withLoading(
+    "h3-demographics:years",
+    "人口網格年份",
+    supabase.rpc("get_h3_demographics_years"),
+  );
   if (error || !data) {
     console.warn(`[H3-DemoYearly] get_h3_demographics_years failed:`, error?.message);
     return [];

--- a/src/data/newsEventsLoader.ts
+++ b/src/data/newsEventsLoader.ts
@@ -139,7 +139,11 @@ const fetchStaticNewsEventsCached = cachedOnce(fetchStaticNewsEventsUncached, 15
 
 async function fetchNewsEventDatesUncached(): Promise<NewsEventDateInfo[]> {
   if (!supabaseConfigured) return [];
-  const { data, error } = await supabase.rpc("get_news_event_dates");
+  const { data, error } = await withLoading(
+    "news-events:dates",
+    "新聞事件日期",
+    supabase.rpc("get_news_event_dates"),
+  );
   if (error) throw new Error(`get_news_event_dates: ${error.message}`);
   return (data ?? []) as NewsEventDateInfo[];
 }

--- a/src/data/railScheduleLoader.ts
+++ b/src/data/railScheduleLoader.ts
@@ -63,7 +63,17 @@ export async function fetchSupabaseDates(
   days: number = 30,
 ): Promise<string[]> {
   if (!SUPABASE_URL || !SUPABASE_ANON_KEY) return [];
+  return withLoading(
+    `rail-dates:${system}`,
+    `鐵道時刻表日期 ${system.toUpperCase()}`,
+    fetchSupabaseDatesInner(system, days),
+  );
+}
 
+async function fetchSupabaseDatesInner(
+  system: string,
+  days: number,
+): Promise<string[]> {
   const params = new URLSearchParams({
     system: `eq.${system}_daily`,
     select: "schedule_date",

--- a/src/data/roadEventsLoader.ts
+++ b/src/data/roadEventsLoader.ts
@@ -65,7 +65,11 @@ interface RawRow {
 }
 
 async function fetchRoadEventDatesUncached(): Promise<RoadEventDateInfo[]> {
-  const { data, error } = await supabase.rpc("get_road_events_dates");
+  const { data, error } = await withLoading(
+    "road-events:dates",
+    "道路事件日期",
+    supabase.rpc("get_road_events_dates"),
+  );
   if (error) throw new Error(`get_road_events_dates: ${error.message}`);
   return (data ?? []) as RoadEventDateInfo[];
 }

--- a/src/data/shipLoader.ts
+++ b/src/data/shipLoader.ts
@@ -63,7 +63,11 @@ function parseTrail(trail: string): TrailPoint[] {
 
 /** 取得所有有船舶資料的日期 */
 export async function fetchShipDates(): Promise<ShipDateInfo[]> {
-  const { data, error } = await supabase.rpc("get_ship_dates");
+  const { data, error } = await withLoading(
+    "ship:dates",
+    "船舶日期",
+    supabase.rpc("get_ship_dates"),
+  );
   if (error) throw new Error(`Supabase get_ship_dates: ${error.message}`);
   return (data as { date: string; records: number; ships: number }[]).map((d) => ({
     date: d.date,

--- a/src/data/temperatureLoader.ts
+++ b/src/data/temperatureLoader.ts
@@ -44,7 +44,11 @@ function gridCoordsToIndex(lat: number, lng: number): number {
 
 /** 找最近有資料的日期。10min TTL 快取，toggle 不重打 get_temperature_dates */
 const resolveTargetDate = cachedOnce(async (): Promise<string> => {
-  const { data: dates, error: datesErr } = await supabase.rpc("get_temperature_dates");
+  const { data: dates, error: datesErr } = await withLoading(
+    "temperature:dates",
+    "氣溫日期",
+    supabase.rpc("get_temperature_dates"),
+  );
   if (datesErr) throw new Error(`get_temperature_dates: ${datesErr.message}`);
   if (!dates || dates.length === 0) throw new Error("No temperature data available");
 

--- a/src/data/wasteLoader.ts
+++ b/src/data/wasteLoader.ts
@@ -214,14 +214,22 @@ export function fetchWasteCleaningSquads(cities?: string[]): Promise<WasteCleani
 
 /** sidebar 顯示「焚化爐 30 筆」用 */
 export async function fetchWasteFacilityCounts(): Promise<WasteFacilityCount[]> {
-  const { data, error } = await supabase.rpc("get_waste_facility_counts");
+  const { data, error } = await withLoading(
+    "waste:facility-counts",
+    "垃圾處理設施數量",
+    supabase.rpc("get_waste_facility_counts"),
+  );
   if (error) throw new Error(`get_waste_facility_counts: ${error.message}`);
   return (data ?? []) as WasteFacilityCount[];
 }
 
 /** sidebar 顯示「衣物箱 utmap 6915 / tnepb 302 / osm 19」用 */
 export async function fetchWasteDisposalPointCounts(): Promise<WasteDisposalPointCount[]> {
-  const { data, error } = await supabase.rpc("get_waste_disposal_point_counts");
+  const { data, error } = await withLoading(
+    "waste:disposal-point-counts",
+    "垃圾投放點數量",
+    supabase.rpc("get_waste_disposal_point_counts"),
+  );
   if (error) throw new Error(`get_waste_disposal_point_counts: ${error.message}`);
   return (data ?? []) as WasteDisposalPointCount[];
 }

--- a/src/data/youbikeH3Loader.ts
+++ b/src/data/youbikeH3Loader.ts
@@ -35,7 +35,11 @@ function cacheKey(resolution: number, date: string): string {
 
 /** 取得可用日期清單 */
 async function fetchAvailableDates(): Promise<string[]> {
-  const { data, error } = await supabase.rpc("get_youbike_h3_dates");
+  const { data, error } = await withLoading(
+    "youbike-h3:dates",
+    "YouBike 網格日期",
+    supabase.rpc("get_youbike_h3_dates"),
+  );
   if (error || !data) return [];
   return (data as { date: string }[]).map((d) => d.date);
 }


### PR DESCRIPTION
## Summary
- 重新盤點全站 122 處 `.rpc(` 呼叫，補齊 17 處缺 loadingRegistry 的圖層資料載入（G009 原記 16 處，實測 17）；公車即時輪詢採「初次載入才顯示 loading」閘門，避免 30s tick 閃爍。

## Changes
- 14 處 metadata RPC（dates/counts 類）標準 `withLoading` 包裹（airspace/ship/disaster/roadEvents/news/fire/h3/freeway/temperature/youbikeH3/bus×2/waste×2）
- `busLoader.ts`：`get_bus_current` / `get_bus_intercity_current` 加 `busCurrentLoadedOnce` 閘門——per-key 初次載入有 loading、背景 tick 靜默（對齊 cwaImagery 的 silent 慣例）
- `railScheduleLoader.ts`：`fetchSupabaseDates` 拆 Inner 後包 withLoading（對齊同檔既有拆法）
- 刻意排除：popup/面板觸發的 `*_timeseries` ×7 與 info modal 類（非圖層載入）、lightning/nuclear/cwaImagery 既有前景/背景拆分（誤判）、sessionTracker 背景寫入

## Test
- [x] npx tsc -b 通過
- [x] pnpm test 15 files / 161 tests 通過
- [ ] Browser 驗收：開公車層應只在初次顯示 loading，之後 30s 更新不閃

## Risk / Rollback
- 風險低：只加 loading 註冊，不改資料流；錯誤仍照原路 throw
- Rollback：revert 單一 commit

## Related
- Plan: docs/proposal/architecture-overhaul-plan.md AR-03
- Backlog: G009

🤖 Generated with [Claude Code](https://claude.com/claude-code)