### PR TITLE
perf: loader 快取第二批——rail/reservoir/satellite 4 處（AR-02 batch2 完結）

### DIFF
--- a/src/data/railLoader.ts
+++ b/src/data/railLoader.ts
@@ -1,6 +1,7 @@
 import type { RailSystem, RailSchedule, RailData, RailStationTime, TraData, TraDeparture, TraSchedule } from "../types";
 import { fetchSupabaseSchedule } from "./railScheduleLoader";
 import { todayTaiwan } from "../lib/supabase";
+import { cachedOnce } from "../lib/loaderCache";
 
 // 系統定義：5 系統（不含 TRA，TRA 由 TraTrainEngine 獨立處理）
 const RAIL_SYSTEMS = [
@@ -350,9 +351,12 @@ async function loadFromLocalFiles(): Promise<{ systems: RailSystem[]; traData: T
 // ── 公開 API ──
 
 /**
- * 載入所有軌道系統資料（本地散檔 + Supabase 時刻表）
+ * 載入所有軌道系統資料（本地散檔 + Supabase 時刻表）。
+ * 10min TTL 快取：重新 toggle on 不重載數百個本地 geojson（含 StrictMode 雙跑去重）。
  */
-export async function loadAllRail(): Promise<RailData> {
+export const loadAllRail = cachedOnce(loadAllRailImpl, 10 * 60_000);
+
+async function loadAllRailImpl(): Promise<RailData> {
   const local = await loadFromLocalFiles();
   const { systems, traData } = local;
   const goldenCount = traData?.goldenTracks?.length ?? 0;

--- a/src/data/railScheduleLoader.ts
+++ b/src/data/railScheduleLoader.ts
@@ -4,9 +4,12 @@
  */
 
 import { withLoading } from "../lib/loadingRegistry";
+import { keyedThunkCache } from "../lib/loaderCache";
 
 const SUPABASE_URL = import.meta.env.VITE_SUPABASE_URL || "";
 const SUPABASE_ANON_KEY = import.meta.env.VITE_SUPABASE_ANON_KEY || "";
+
+const scheduleCache = keyedThunkCache<unknown | null>(10 * 60_000, 32);
 
 /**
  * 從 Supabase reference.daily_schedules 查詢時刻表
@@ -17,10 +20,13 @@ export async function fetchSupabaseSchedule(
   date: string,
 ): Promise<unknown | null> {
   if (!SUPABASE_URL || !SUPABASE_ANON_KEY) return null;
-  return withLoading(
-    `rail-schedule:${system}:${date}`,
-    `鐵道時刻表 ${system.toUpperCase()} ${date}`,
-    fetchSupabaseScheduleInner(system, date),
+  // 10min TTL 快取（key=system:date）：日期切換重選同日 / loadAllRail 各系統共用時不重打
+  return scheduleCache(`${system}:${date}`, () =>
+    withLoading(
+      `rail-schedule:${system}:${date}`,
+      `鐵道時刻表 ${system.toUpperCase()} ${date}`,
+      fetchSupabaseScheduleInner(system, date),
+    ),
   );
 }
 

--- a/src/data/reservoirOpsLoader.ts
+++ b/src/data/reservoirOpsLoader.ts
@@ -1,5 +1,6 @@
 import { supabase } from "../lib/supabase";
 import { withLoading } from "../lib/loadingRegistry";
+import { keyedThunkCache } from "../lib/loaderCache";
 
 /**
  * 水庫近期進/出流量聚合（for 3D 雙排日柱視覺化 — BL-5 方案 D）
@@ -40,10 +41,21 @@ function dateKeyTaipei(iso: string): string {
   return new Date(iso).toLocaleDateString("sv-SE", { timeZone: "Asia/Taipei" });
 }
 
-/** 近 N 日每日平均進/出流量 */
-export async function fetchReservoirOpsRecent(
+const opsCache = keyedThunkCache<ReservoirOpsRecent>(10 * 60_000);
+
+/** 近 N 日每日平均進/出流量。10min TTL 快取（key=id:days），重選同水庫不重打 */
+export function fetchReservoirOpsRecent(
   reservoirId: string,
   days = 5,
+): Promise<ReservoirOpsRecent> {
+  return opsCache(`${reservoirId}:${days}`, () =>
+    fetchReservoirOpsRecentUncached(reservoirId, days),
+  );
+}
+
+async function fetchReservoirOpsRecentUncached(
+  reservoirId: string,
+  days: number,
 ): Promise<ReservoirOpsRecent> {
   const to = new Date();
   const from = new Date(to.getTime() - days * 24 * 3600 * 1000);

--- a/src/data/satelliteHistoryLoader.ts
+++ b/src/data/satelliteHistoryLoader.ts
@@ -10,6 +10,7 @@
  */
 import { supabase, supabaseConfigured } from "../lib/supabase";
 import { withLoading } from "../lib/loadingRegistry";
+import { keyedThunkCache } from "../lib/loaderCache";
 
 export interface TleHistoryRow {
   norad_id: number;
@@ -28,17 +29,26 @@ export interface TlePair {
   curr: TleHistoryRow | null;
 }
 
-export async function fetchTleHistory(norad: number, days = 30): Promise<TleHistoryRow[]> {
-  if (!supabaseConfigured) return [];
+const tleHistoryCache = keyedThunkCache<TleHistoryRow[]>(10 * 60_000);
+
+/** 30 天 TLE 歷史。10min TTL 快取（key=norad:days），重選同衛星不重打（失敗不留快取） */
+export function fetchTleHistory(norad: number, days = 30): Promise<TleHistoryRow[]> {
+  if (!supabaseConfigured) return Promise.resolve([]);
+  return tleHistoryCache(`${norad}:${days}`, () => fetchTleHistoryUncached(norad, days)).catch(
+    (err) => {
+      console.warn(`[satconsole] get_satellite_tle_history(${norad}) failed:`, err);
+      return [] as TleHistoryRow[];
+    },
+  );
+}
+
+async function fetchTleHistoryUncached(norad: number, days: number): Promise<TleHistoryRow[]> {
   const { data, error } = await withLoading(
     `satellite:tle-history:${norad}`,
     `TLE 歷史 ${norad}`,
     supabase.rpc("get_satellite_tle_history", { p_norad: norad, p_days: days }),
   );
-  if (error) {
-    console.warn(`[satconsole] get_satellite_tle_history(${norad}) failed:`, error.message);
-    return [];
-  }
+  if (error) throw new Error(`get_satellite_tle_history(${norad}): ${error.message}`);
   return (data ?? []) as TleHistoryRow[];
 }
 


### PR DESCRIPTION
## Summary
- AR-02 batch2：盤點 batch1 後剩餘 ~20 個無快取 loader，判定僅 4 個該套（其餘 16 個屬 hook 已快取 / 輪詢即時性 / blob URL 生命週期等排除類，套了反而有害）。AR-02 至此完結。

## Changes
- `railLoader.loadAllRail` → `cachedOnce` 10min：重 toggle 不重載數百個本地 geojson
- `railScheduleLoader.fetchSupabaseSchedule` → `keyedThunkCache`（system:date）：重選同日不重打，並 dedup 各系統併發呼叫
- `reservoirOpsLoader.fetchReservoirOpsRecent` → keyed（id:days）：重選同水庫不重打
- `satelliteHistoryLoader.fetchTleHistory` → keyed（norad:days）：重選同衛星不重打；error 改 throw 讓失敗不留快取，外層 catch 維持原「失敗回 []」契約
- 16 個排除的完整決策表見 PR 討論脈絡（重點：aqi/cwa/precip 影像 loader 有 object URL revoke 生命週期，快取會回死連結——刻意不套）

## Test
- [x] npx tsc -b 通過
- [x] pnpm test 161 tests 全綠
- [ ] Browser：重 toggle 軌道層不重載、重選水庫/衛星不重打（Network tab）

## Risk / Rollback
- 低：4 處皆純 memo，無 abort 語意衝突；rollback = revert 單 commit

## Related
- Plan: docs/proposal/architecture-overhaul-plan.md AR-02
- 附帶發現：`h3Loader.loadH3DemographicsYears` 為 dead code（零 consumer），未動，列後續清理

🤖 Generated with [Claude Code](https://claude.com/claude-code)