### PR TITLE
feat: BYOK AI 對話助手 — 三家直連 + 地圖聯動 + 白名單資料問答

### DIFF
--- a/docs/features/byok-chat/README.md
+++ b/docs/features/byok-chat/README.md
@@ -1,0 +1,51 @@
+# BYOK AI 對話助手
+
+> **Slug**：`byok-chat`
+> **狀態**：dev（PR 審核中）
+> **Owner**：migu
+> **上線日期**：TBD
+> **相關 PR**：#TBD
+
+## 一句話說明
+
+使用者自帶 LLM API key（Anthropic / OpenAI / Google 三選）在瀏覽器直連對話，
+LLM 透過白名單 tools 操作地圖（開圖層 / 飛行 / 標記）與查資料（靜態 geojson 統計 /
+H3 人口 join / 薄 RPC），key 零經手我方伺服器。
+
+## 架構要點（詳見 `docs/proposal/member-byok-chat-plan.md`）
+
+- **BYOK 直連**：Anthropic 帶 `anthropic-dangerous-direct-browser-access` header；
+  三層儲存（memory / sessionStorage 預設 / localStorage opt-in）；CORS 被封則揭露不做 proxy
+- **Agent loop**：Vercel AI SDK v7（`streamText` + `stopWhen: stepCountIs(10)`），瀏覽器內執行
+- **安全邊界**：LLM 只能呼叫白名單 tools；`supabase.rpc` 全 codebase 單一出口
+  （`rpcTools.callWhitelistedRpc`，白名單外拒絕）；tool 回傳一律過 `capToolResult` 截斷鐵則
+- **Agentic 人體工學**：查詢 0 筆 / 欄位不存在回 availableFields + 樣本值 + hint 供模型自我修正
+
+## 圖層 / 元件
+
+| 元件 | 類型 | 說明 |
+|---|---|---|
+| ChatPanel | 浮層 panel | 桌機右上錨定 max 55vh（popup 開啟時讓位縮 45vh）；手機底部上拉 60vh |
+| KeySettings | 面板內頁 | provider/model 選擇 + key 三層儲存 + 測試連線 |
+| chatHighlight | featureInfo 條目 | AI 標記點的 popup + halo |
+
+## 關鍵檔案
+
+- 契約：`src/chat/types.ts`（MapBridge / RunChatTurn / KeyVault，改動需同步 UI+邏輯兩側）
+- 引擎：`src/chat/agent.ts`（loop + abort/finish/空回覆防護）、`providers.ts`、`systemPrompt.ts`
+- Tools：`src/chat/tools/`（mapTools / catalogTools / dataTools / rpcTools / datasets / truncate）
+- UI：`src/components/chat/`、`src/state/chatStore.ts`、`src/lib/keyVault.ts`
+- 接線：`src/App.tsx`（chatBridge useMemo + 觸發按鈕）
+
+## 資料契約摘要
+
+無上游新契約——全部使用既有靜態 geojson（13 個白名單 dataset）與既有 anon RPC
+（10 支白名單）。無 taipei-gis-analytics handoff。詳見 [handoff.md](./handoff.md)。
+
+## 已知限制 / 注意
+
+- 輕量檔模型（Haiku/Flash）在多步任務可能偷懶，設定頁已加提示引導進階檔
+- `police_stations` URL 帶日期戳（`_20260626`），上游換版需同步 `datasets.ts`
+- 掩埋場等廢棄物設施是 RPC 動態資料，計數走 `get_waste_facility_counts`
+- IME（注音）Enter 已守門（isComposing / keyCode 229）
+- 部署前置：CSP header `connect-src` 需含三家 LLM 域名；隱私頁 BYOK 揭露

--- a/docs/features/byok-chat/backlog.md
+++ b/docs/features/byok-chat/backlog.md
@@ -13,6 +13,8 @@
   （含匿名 session_id，已拍板）+ 對話歷史跨裝置；依賴 BC-1
 - [ ] **BC-3**：預設模型檔位是否從最便宜檔改中階檔（Flash/Sonnet 級）— 用戶待決
 - [ ] **BC-4**：部署前置 — CSP header（connect-src 三家 LLM 域名）+ 隱私頁 BYOK 揭露
+  + **OAuth 網域切換**：Supabase Site URL 改正式網域、Redirect URLs 加正式網域、
+    Google Console「已授權的 JavaScript 來源」加正式網域（測試期全走 localhost，2026-07-03 拍板）
 - [ ] **BC-5**：`police_stations_20260626` 日期戳 URL 改吃 manifest 或 latest 別名（上游換版免同步）
 - [ ] **BC-6**：（選配）Anthropic 進階檔開 extended thinking（AI SDK providerOptions）
 - [ ] **BC-7**：Phase 4 選項 — 站方付費免費額度（Edge Function + 單 key，AR-43 原案）／

--- a/docs/features/byok-chat/backlog.md
+++ b/docs/features/byok-chat/backlog.md
@@ -1,0 +1,26 @@
+# Backlog — byok-chat
+
+> 全站對應：`.claude/memory/BACKLOG.md` 之後加 BC 系列。規劃 SSOT：`docs/proposal/member-byok-chat-plan.md`。
+
+## 進行中
+
+- [ ] **BC-1**：P0 會員系統（Supabase Auth Google OAuth）— 等 OAuth 憑證備妥，
+  migration（profiles + RLS + trigger）+ `src/lib/auth.ts` + Avatar；分支 `feat/member-auth`
+
+## 待辦
+
+- [ ] **BC-2**：P3 會員加值 — `user_favorites`（圖層狀態快照收藏）+ `chat_logs`
+  （含匿名 session_id，已拍板）+ 對話歷史跨裝置；依賴 BC-1
+- [ ] **BC-3**：預設模型檔位是否從最便宜檔改中階檔（Flash/Sonnet 級）— 用戶待決
+- [ ] **BC-4**：部署前置 — CSP header（connect-src 三家 LLM 域名）+ 隱私頁 BYOK 揭露
+- [ ] **BC-5**：`police_stations_20260626` 日期戳 URL 改吃 manifest 或 latest 別名（上游換版免同步）
+- [ ] **BC-6**：（選配）Anthropic 進階檔開 extended thinking（AI SDK providerOptions）
+- [ ] **BC-7**：Phase 4 選項 — 站方付費免費額度（Edge Function + 單 key，AR-43 原案）／
+  對話結果 pin 成 Monitor 面板（AR-44）／P2 layer manifest 落地後 tool 目錄來源切換
+
+## 已完成（近期）
+
+- [x] P1 對話 MVP（BYOK 三家直連 + 地圖 tools + UI）— PR #TBD, 2026-07-02
+- [x] P2 資料問答（13 dataset + 10 RPC 白名單 + h3 人口 join）— 同 PR, 2026-07-03
+- [x] 高度讓位（popup 開啟自動縮 45vh）— 同 PR, 2026-07-03
+- [x] FX-1~5 驗收回饋修正（IME / 對話記憶 / 顧問式 tools / 檔位 hint / agentic 人體工學 + abort 真修）— 同 PR, 2026-07-03

--- a/docs/features/byok-chat/changelog.md
+++ b/docs/features/byok-chat/changelog.md
@@ -1,0 +1,15 @@
+# Changelog — byok-chat
+
+> 逐 PR 變更紀錄。最新在上。
+
+## 2026-07-03 — PR #TBD（待 squash 後補 hash）
+
+- P1 對話 MVP：BYOK 三家瀏覽器直連（key 零經手）、AI SDK v7 agent loop、
+  5 地圖 tools + 2 目錄 tools、ChatPanel/KeySettings（design token 全合規）、App.tsx 接線
+- P2 資料問答：query_dataset（13 靜態資料集）/ rank_by_population（h3 res7）/
+  call_rpc（10 支白名單）/ get_layer_details
+- UX：高度讓位（popup 開啟縮 45vh）、chatHighlight popup 條目
+- FX 驗收修正：IME composition 守門、tool 摘要進對話歷史、廢棄物計數 RPC、
+  顧問式 system prompt、教學性工具錯誤（availableFields+hint）、filterContains op、
+  abort part 正確處理（AI SDK v7 不 throw）、空回覆防護、maxSteps 10
+- 測試：+29（truncate/geojsonQuery/h3/RPC 白名單/layerDetails/教學回饋），共 190

--- a/docs/features/byok-chat/handoff.md
+++ b/docs/features/byok-chat/handoff.md
@@ -1,0 +1,18 @@
+# Handoff — byok-chat（下游視角）
+
+> **無上游新契約**：本 feature 純前端，消費既有資產，無 taipei-gis-analytics handoff。
+> 規劃 SSOT：`docs/proposal/member-byok-chat-plan.md`。
+
+## 消費的既有資產
+
+| 類型 | 內容 | 契約點 |
+|---|---|---|
+| 靜態 geojson | `DATASET_WHITELIST` 13 個（police_stations / fire_stations / schools / wasteStopsStatic…） | URL 沿用 overlayRegistry sourceUrl；`police_stations_20260626` 帶日期戳（BC-5） |
+| H3 人口 | `public/h3/h3_population_res7.json`（8345 格，d/n 欄位） | resolution 從 metadata 動態取 |
+| anon RPC | `RPC_WHITELIST` 10 支（data_catalog×2 / fire×2 / h3×2 / source_health / news_trending / waste_counts×2） | 參數名對齊 migration 簽名；pooler 2min timeout 適用 |
+| 外部 API | api.anthropic.com / api.openai.com / generativelanguage.googleapis.com | 瀏覽器直連（CORS）；Anthropic 需 dangerous-direct-browser-access header |
+
+## 下游（未來 P0/P3）依賴本 feature 的點
+
+- `chat_logs`（P3）將記錄 question / tool_calls / usage —— schema 見 plan §6.2
+- 會員收藏的 state_snapshot 與 chat 的 `MapBridge.getVisibleLayerKeys()` 共用圖層 key 語彙

--- a/docs/proposal/member-byok-chat-plan.md
+++ b/docs/proposal/member-byok-chat-plan.md
@@ -1,0 +1,308 @@
+# 會員系統 + BYOK 空間問答 — 系統架構規劃
+
+> 建立：2026-07-02 · 狀態：規劃完成、待拍板開工
+> 需求來源：用戶三大需求 —— (1) BYOK 金鑰管理與資安 (2) Google 登入會員 + 查詢記錄 (3) 空間資訊問答 + 地圖聯動
+
+---
+
+## 0. 一句話結論
+
+**會員走 Supabase Auth（= 落地 AR-42），問答走「純前端 BYOK agent loop」（= AR-43 的變體）：
+使用者的 LLM key 只存在瀏覽器、直連三家 API，永不經過我方伺服器；
+LLM 透過白名單 tools 操作地圖與查資料，絕不生 SQL 直打 DB。**
+
+---
+
+## 1. 與既有規劃的關係（先讀，避免重造）
+
+| 既有文件 | 關係 |
+|---|---|
+| `architecture-overhaul-plan.md` AR-42 | 會員系統已規劃（Supabase Auth + user_profiles + RLS）→ **本計畫直接落地它** |
+| `architecture-overhaul-plan.md` AR-43 | 對話介面已規劃，但走「後端 Edge Function + 單一 key」→ **本計畫改走 BYOK**（差異見 §1.1）|
+| `architecture-overhaul-plan.md` AR-41 / audit D3 | 收窄 Exposed schemas 到 public only → **上 Auth 前的硬前置** |
+| worktree `mini-taiwan-pulse-auth/docs/auth-membership-plan.md`（2026-06-25，未 commit） | 已拍板：Google OAuth only、GA4 為主的使用監測、收藏延後 → **Phase 0 骨架照抄、GA4 分工結論沿用**，本檔取代它成為 SSOT |
+| `worldmonitor-taiwan-vision.md` A3 | 「AI Brief 每 30 分鐘後端 Haiku」→ 與本計畫獨立不衝突，屬未來免費 tier 素材（Phase 4）|
+| `monitor-mode.md` / `alerts-integration-impl.md` | 其 pre-aggregate 薄 RPC（news/alert 系列）= 問答 tool 的現成白名單成員 |
+| P2 layer manifest（未做） | AR-43 原本依賴 manifest 當 tool schema 來源 → **本計畫不等它**：先用 `layerCatalog.ts` THEMES 當目錄（它本來就是 sidebar SSOT），tool 層設計成目錄來源可抽換，manifest 落地後一行切換 |
+
+### 1.1 拍板點：BYOK vs 後端單 key
+
+兩者**不互斥**，是分層策略：
+
+| | BYOK（本計畫主體） | 後端單 key（AR-43 原案，延後為 Phase 4 選項）|
+|---|---|---|
+| 費用 | 使用者自付 | 站方付（Haiku/Flash 級便宜模型）|
+| Key 風險 | 站方零經手 | 站方管一把 key（Edge Function 隔離）|
+| 用途 | 主要問答功能，無限量 | 未來「免登入試用 N 次」的免費額度 |
+
+---
+
+## 2. 總體架構
+
+```
+┌────────────────────────── Browser（信任邊界內只有使用者自己）──────────────────────────┐
+│                                                                                        │
+│  ChatPanel ──> chatStore（satelliteConsoleStore pattern）                              │
+│      │                                                                                 │
+│      ▼                                                                                 │
+│  Agent Loop（Vercel AI SDK，maxSteps tool-calling）                                    │
+│      │  ├─ apiKey ◄── KeyVault（memory / sessionStorage / opt-in localStorage）       │
+│      │  └─ 直連：api.anthropic.com / api.openai.com / generativelanguage.googleapis.com│
+│      ▼                                                                                 │
+│  Tool Registry（白名單，兩類）                                                          │
+│   ├─ 地圖操作：set_layers / fly_to / jump_to_place / highlight_point / all_off        │
+│   │            （直接綁 App.tsx 既有 handler，零新增地圖邏輯）                          │
+│   └─ 資料查詢：query_geojson_dataset（靜態檔記憶體統計）                                │
+│                query_h3_population（h3-js 空間 join）                                  │
+│                call_rpc（Supabase anon RPC 白名單）                                    │
+│                get_data_catalog（metadata.data_catalog 現成 RPC）                      │
+│                                                                                        │
+│  Auth：supabase.auth（Google OAuth）──> profiles / user_favorites / chat_logs（RLS）  │
+└────────────────────────────────────────────────────────────────────────────────────────┘
+         ▲ 靜態 geojson/PMTiles（S3/CDN）        ▲ Supabase gis-platform（public RPC only）
+```
+
+LLM key 的資料流只有一條：`使用者輸入 → 瀏覽器記憶體/storage → 直連 LLM API`。
+我方伺服器（Supabase / Zeabur / S3）**在這條路徑上完全不存在**。
+
+---
+
+## 3. 子系統 A：BYOK 金鑰管理（需求 1）
+
+### 3.1 為什麼「瀏覽器直連」可行
+
+| Provider | 瀏覽器 CORS | 做法 |
+|---|---|---|
+| Anthropic | ✅ 官方支援 | request header `anthropic-dangerous-direct-browser-access: true`（官方為 BYOK 場景設計；SDK 對應 `dangerouslyAllowBrowser: true`）|
+| OpenAI | ✅ 允許 | 直接 fetch，官方警示「勿曝露自己的 key」不適用於 BYOK（key 是使用者自己的）|
+| Google Gemini | ✅ 允許 | `@google/genai` 支援瀏覽器執行 |
+
+這是 TypingMind / Chatbox / big-AGI 等 BYOK 工具的業界標準做法。
+
+### 3.2 儲存策略（誠實版）
+
+| 層級 | 存放 | 生命週期 | 預設 |
+|---|---|---|---|
+| L1 | React state（記憶體） | 分頁關閉即消失 | ✅ 永遠 |
+| L2 | sessionStorage | 分頁存活期間 | ✅ 預設勾選「本分頁記住」 |
+| L3 | localStorage | 永久，需一鍵刪除 | ⬜ opt-in「在此瀏覽器記住」+ 風險說明 |
+
+**不做 passphrase 加密**（WebCrypto AES-GCM）：加密 key 若同存瀏覽器只是 obfuscation；
+若要求每次輸入 passphrase 則摩擦等同重貼 key。XSS 場景下運行時記憶體一樣讀得到，加密不改變威脅模型。
+
+### 3.3 真正的防線（XSS 防護 + 洩漏面歸零）
+
+1. **CSP header**（Zeabur/Cloudflare 設）：`script-src 'self'`；`connect-src` 白名單 =
+   supabase + 三家 LLM API + mapbox + S3/CDN 域名。第三方 script 一律不引入。
+2. **洩漏面歸零守則**（code review 檢查點）：
+   - key 絕不進 `chat_logs` / GA4 event / console.log / 錯誤訊息（catch 時 strip）
+   - key 絕不放 URL / query string
+   - UI 欄位 masked，只顯示尾 4 碼，附「測試連線」與「刪除」按鈕
+3. **使用者端建議**（設定頁文案）：建議建立**專用低額度 key**
+   （OpenAI project key + 月花費上限 / Anthropic workspace key / Gemini 免費 tier）。
+4. **費用透明**：每則回答下方顯示該輪 token 用量與估算成本。
+
+### 3.4 模型選單
+
+各家提供 2 檔：預設輕量檔（tool-calling 夠用、便宜）+ 進階檔。
+實作時以各家當時最新型號為準，方向：Anthropic `claude-haiku-4-5`（$1/$5 per MTok）起步、
+OpenAI mini 級、Gemini Flash 級；進階檔給 Sonnet / GPT 主力 / Gemini Pro 級。
+
+---
+
+## 4. 子系統 B：對話引擎
+
+### 4.1 Provider 抽象
+
+用 **Vercel AI SDK**（`ai` + `@ai-sdk/anthropic` / `@ai-sdk/openai` / `@ai-sdk/google`）：
+- 統一三家的 tool-calling 格式與 streaming（自刻要維護三套差異極大的 wire format）
+- 純 fetch、可在瀏覽器跑；Anthropic provider 帶 §3.1 的 header
+- agent loop 用 `maxSteps`（建議 5-8），LLM 可連續呼叫多個 tool 再作答
+
+### 4.2 System prompt 組成（順序即快取順序，穩定在前）
+
+1. 站台簡介 + 回答規範（繁中、簡潔、引用資料日期）
+2. **主題索引**：只放 19 個主題名 + 一行說明（~300 tokens）；完整圖層目錄**不進 prompt**，
+   LLM 需要時呼叫 `list_layers` / `search_layers` tool 查（§5.1；2026-07-02 拍板改 tool 模式）
+3. tool 使用規範（先查目錄再開圖層；查數字用 query tool 不要瞎猜；回答附資料來源）
+4. 動態尾段：當前開啟圖層、timeline 時間、地圖視角（每輪更新，放最後不破壞快取）
+
+### 4.3 前端掛法（照既有 pattern，改動最小）
+
+| 新檔 | Pattern 來源 |
+|---|---|
+| `src/state/chatStore.ts` | 照抄 `satelliteConsoleStore.ts`（useSyncExternalStore）|
+| `src/components/chat/ChatPanel.tsx` | 仿 `MonitorPanel` 浮層掛法（absolute + zIndex + open state）|
+| `src/components/chat/KeySettings.tsx` | 設定頁（provider/model 選擇 + key 輸入）|
+| `src/chat/agent.ts` | agent loop + provider 工廠 |
+| `src/chat/tools/registry.ts` | tool schema + 執行體綁定 |
+
+App.tsx 只加：一顆觸發按鈕 + `<ChatPanel …/>`，把既有 handler 當 props 傳入
+（`handleBulkSetVisibility` / `handleAllOff` / `handleLocationJump` / `setFeatureInfo` / `mapRef`）。
+
+---
+
+## 5. 子系統 C：Tool 層（安全邊界所在）
+
+**原則：LLM 只能呼叫白名單 tool；絕不讓 LLM 產生 SQL；DB 暴露面 = 既有 anon RPC，零新增。**
+
+### 5.1 地圖操作 tools（既有 handler 直綁，幾乎零成本）
+
+| Tool | 綁定 | 出處 |
+|---|---|---|
+| `set_layers(keys[], visible)` | `handleBulkSetVisibility` | App.tsx:1497 |
+| `all_layers_off()` | `handleAllOff` | App.tsx:1487 |
+| `fly_to(lng, lat, zoom?)` | `mapRef.current.flyTo` | 範例 App.tsx:1807 |
+| `jump_to_place(presetId)` | `handleLocationJump` + `cameraPresets.ts`（具名地點目錄）| App.tsx:1514 |
+| `highlight_point(lng, lat, layerType?, properties?)` | `setFeatureInfo` → 自動觸發 halo（useSelectedFeatureHalo）+ popup（PANEL_REGISTRY）| App.tsx:687 |
+| `list_layers(theme)` | `THEMES`（layerCatalog.ts）依主題回傳 key + 中文名 | layerCatalog.ts:321 |
+| `search_layers(query)` | `LAYER_LABELS` 中英文關鍵字比對，回前 10 筆 | layerCatalog.ts:1034 |
+
+### 5.2 資料查詢 tools
+
+| Tool | 實作 | 回答什麼 |
+|---|---|---|
+| `query_geojson_dataset(datasetId, op)` | fetch 靜態 geojson（datasetId → sourceUrl 白名單，起步 ~15 個常問資料集）→ 記憶體 count / groupBy / filter / nearest | 「全台幾個警察局？分類？」→ `police_stations` 2065 點 groupBy `facility_subtype`（7 類）|
+| `query_h3_population(points, res)` | h3-js `latLngToCell` × `public/h3/h3_population_res8.json`（日/夜間人口）| 「哪些消防分隊附近人口密度最高」|
+| `call_rpc(name, params)` | **白名單** anon RPC：`get_data_catalog_by_theme` / `get_fire_events_by_year` / `get_h3_demographics_yearly` / news・alert 系列薄 RPC…（起步 ~10 支，全部已存在）| 時序/事件類問題 |
+| `get_data_catalog(theme)` | 現成 `metadata.data_catalog` RPC（migration 269）| 「有哪些消防相關圖層/資料？」|
+
+### 5.3 護欄
+
+- **回傳截斷（鐵則，2026-07-02 拍板確認）**：任何 tool **永不回傳全量資料**——一律回統計值、
+  top N 示範案例（如 top 20 + 總數 + 欄位摘要）或合理範圍內的節錄；防灌爆 context 與費用
+- **loadingRegistry**：資料類 tool 執行包 `withLoading`（守 CLAUDE.md 規則 3）
+- **Prompt injection 天花板**：tools 全部唯讀查詢 + 前端視覺操作，最壞情況 = 亂開圖層亂飛視角，無資料寫入面（chat_logs insert 由前端程式碼做，不是 tool）
+- **2min pooler timeout** 同樣適用 tool 的 RPC 呼叫（白名單只收薄 RPC）
+
+### 5.4 範例走查
+
+1. **「目前全臺灣有多少個警察局？分類有哪些？」**
+   `query_geojson_dataset('policeStations', {op:'groupBy', field:'facility_subtype'})`
+   → 2065 點 / substation・precinct・police_dept・specialized・headquarters・security・other
+   → 作答 + `set_layers(['policeStation'], true)` 讓答案上圖。
+2. **「臺北市消防局與警察局的分佈與服務範圍」**
+   `set_layers(['fireStations','policeStation','fireIsochroneCoverage'], true)` + `fly_to(121.56, 25.04, 11)`
+   → 消防服務範圍用現成救援等時圈 PMTiles；警局服務範圍用現成 `policeIso*` 三層等時圈。
+3. **「哪些消防分隊附近人口密度最高？」**
+   `query_geojson_dataset('fireStations')` 取 716 點 → `query_h3_population(points, 8)` join 夜間人口
+   → 排名 top 10 文字作答 + `highlight_point` 第一名 + 開 `fireStations` + h3 人口圖層疊圖。
+
+---
+
+## 6. 子系統 D：會員系統（需求 2）
+
+### 6.1 Auth
+
+- Supabase Auth + **Google OAuth only**（沿用舊計畫拍板）；gis-platform Dashboard 開 provider，
+  redirect URL 白名單：`localhost:3721` + 正式域名
+- `src/lib/supabase.ts` 補 auth options（persistSession / detectSessionInUrl）
+- 新增 `src/lib/auth.ts`（signInWithGoogle / signOut / useUser hook）+ 右上 Avatar 元件
+- **硬前置 AR-41/D3**：確認 Supabase Exposed schemas 只留 `public`，再開 Auth
+
+### 6.2 資料表（gis-platform migration，全新 — 現有 270 個 migration 中零 auth 相關）
+
+```sql
+profiles        (id uuid PK FK auth.users, display_name, avatar_url,
+                 tier text default 'free', created_at)          -- + signup trigger 自動建列
+user_favorites  (id, user_id FK, name, state_snapshot jsonb,    -- 圖層 keys + 時間 + 相機視角
+                 created_at)
+chat_logs       (id, user_id uuid NULL, session_id text,        -- 匿名用 sessionTracker id
+                 provider text, model text, question text,
+                 answer_summary text, tool_calls jsonb,
+                 latency_ms int, created_at)                     -- ⚠️ 絕不含 API key
+```
+
+RLS（本專案首批 authenticated 政策）：
+- `profiles` / `user_favorites`：本人 CRUD
+- `chat_logs`：本人 insert + select 自己的；後台用 service role / Dashboard SQL 看全量
+- 匿名 chat_logs：`user_id NULL` + anon insert 允許（掛 session_id），量大再加 rate limit
+
+### 6.3 監測分工（沿用 2026-06-25 GA4 結論）
+
+- 通用行為（DAU / layer_toggle / popup_open）→ GA4；登入後 `gtag('set', {user_id})`
+- **對話內容與 tool 軌跡** → Supabase `chat_logs`（內容型資料，GA4 放不下也不該放）
+- 後台掌握使用狀況：初期 Dashboard SQL 即可，不先刻 admin UI
+
+### 6.4 匿名 vs 登入
+
+| | 匿名 | 登入 |
+|---|---|---|
+| 瀏覽全部圖層 | ✅ | ✅ |
+| BYOK 問答 | ✅（自帶 key 即可） | ✅ |
+| 查詢記錄歸戶 | session 級 | 帳號級（可跨裝置看歷史）|
+| 我的最愛圖層（狀態快照） | ❌ | ✅ |
+| 未來免費額度 / plus tier | ❌ | 預留 `tier` 欄位 |
+
+---
+
+## 7. Phase 切分與跨 repo 順序
+
+> 跨 repo 順序照規：**gis-platform 先動（migration + OAuth），mini-taiwan-pulse 後接**；
+> 開工時在 `taipei-gis-analytics/docs/handoff/member-byok-chat.md` 建 handoff。
+
+| Phase | 內容 | 依賴 | 規模 |
+|---|---|---|---|
+| **P0 會員基礎** | AR-41 schema 收窄確認 → OAuth provider → `profiles` migration → auth.ts + Avatar | 無 | 1-2 天 |
+| **P1 BYOK 對話 MVP** | KeySettings + KeyVault → AI SDK provider 層 → ChatPanel/chatStore → 地圖操作 5 tools → system prompt 目錄 → CSP header | 無（可與 P0 平行）| 3-5 天 |
+| **P2 資料問答** | query_geojson_dataset（15 資料集白名單）→ h3 join → call_rpc 白名單 → 回傳截斷護欄 | P1 | 3-5 天 |
+| ~~P2b 警局服務範圍~~ | **免做（2026-07-03 確認）**：master 已有 `policeIsoSubstation` / `policeIsoPrecinct` / `policeIsoCityDept` 三層警局等時圈 PMTiles（PR #44），chat 開圖層即可回答 | — | 0 |
+| **P3 會員加值** | `user_favorites` + `chat_logs` migration → 收藏 UI → 對話記錄寫入 + 歷史同步 → GA4 接線 | P0+P1 | 2-3 天 |
+| **P4 延後選項** | 免費額度（Edge Function + 站方 Haiku key = AR-43 原案）／對話 pin 成 Monitor 面板（AR-44）／tool 目錄切到 layer manifest（P2 overhaul 完成後）| P1-P3 | 另議 |
+
+分支：`feat/member-auth`（P0/P3，worktree 已在）+ `feat/byok-chat`（P1/P2），各自 PR squash 進 master。
+
+---
+
+## 8. 風險與待拍板
+
+1. **第三方 CORS 政策可變**（OpenAI/Gemini 非契約保證；Anthropic 是官方明文支援）。
+   **拍板（2026-07-02）：不做 proxy 備援、不降級**——「key 零經手」的信任模型永不妥協。
+   若某家封鎖瀏覽器直連：UI 誠實揭露「該 provider 暫不支援」，引導切換其他家；
+   公開站屬附贈性質，本地開發不受影響。
+2. **localStorage 的殘餘風險**要在 UI 明說（同機惡意程式 / 共用電腦）；預設 sessionStorage。
+3. **匿名 chat_logs 濫寫**：anon insert 開放後可能被灌；先靠前端節流 + 量大再上 DB 端 rate limit。
+4. ~~圖層目錄 token 成本~~ **已解決（2026-07-02 拍板）**：目錄改 `list_layers` / `search_layers`
+   tool 模式（§4.2 / §5.1），system prompt 只留主題索引 ~300 tokens。
+5. **待拍板**：(a) P0/P1 先做哪個（建議平行，見 §7 註）；(c) GA4 property 歸屬（舊計畫遺留問題）。
+6. **已拍板**（2026-07-02）：(b) 匿名使用者**也記** chat_logs，`user_id NULL` + sessionTracker 的匿名 session_id。
+
+---
+
+## 9. 驗收回饋修正清單（2026-07-03 凌晨，用戶實測後；預計 04:30 chain 派工）
+
+> 現況：P1+P2+高度讓位已完成並通過審查，worktree `mini-taiwan-pulse-byok` **未 commit**，
+> dev server 3799 運行中。用戶端到端實測通過，回饋以下修正。
+
+### FX-1 IME 中文輸入 Enter 誤送出 + 送出後文字殘留（P0，同一根因）
+`ChatPanel.tsx` 的 `handleKeyDown` 沒有處理 IME composition：注音/拼音選字按 Enter 會被當成送出
+（送出當下組字未完成 → `setDraft("")` 清了 state 但 IME 之後才 commit 文字回 textarea → 看起來沒清掉）。
+修法：`if (e.nativeEvent.isComposing || e.keyCode === 229) return;` 於 Enter 分支前。
+
+### FX-2 對話記憶強化：tool 結果進歷史（P1）
+現況 `agent.ts` 的 `toModelMessages` 只送文字 content，前輪 tool 執行結果不在歷史裡
+→ 追問「你有開啟嗎？」模型只能重跑工具。修法：assistant 歷史訊息若有 `toolCalls`，
+把 summaries 併進 content（如附註「[已執行：開啟 2 個圖層]」），輕量且不撐爆 context。
+
+### FX-3 顧問式深對話（「垃圾清運有哪些圖層、你建議怎麼做、他們的關係」）（P1）
+1. 新 tool `get_layer_details(keys[])`：彙整 layerCatalog（主題/分區）+ `get_data_catalog_for_layer`
+   （上游來源/更新頻率）回富 metadata，讓模型能講「圖層之間的關係」
+2. `DATASET_WHITELIST` 擴充廢棄物主題（掩埋場/焚化廠等靜態 geojson，先盤 public/ 有什麼）
+   ——用戶實測「總共幾個掩埋場」因白名單沒有而答不了
+3. system prompt 加顧問段：被問「建議/怎麼做/關係」時，先 list_layers + get_layer_details
+   蒐集脈絡再給結構化建議（開哪些圖層、疊圖順序、時間軸怎麼用）
+
+### FX-4（順帶）model 檔位切換提醒
+顧問式問題建議引導用戶用進階檔（Sonnet 級）；輕量檔（Haiku 級）容易偷懶。
+低成本做法：KeySettings 的模型下拉 hint 文案補一句。
+
+### FX-5 Agentic 工具人體工學（2026-07-03 上午，用戶實測 Haiku 躺平後加）
+1. `query_dataset` 查 0 筆 / 欄位不存在 → 回可用欄位 + 樣本值 + 建議下一步（讓模型自我修正）
+2. 新增 op `filterContains`（address 等文字欄模糊比對）——解「台北的派出所」類問題
+3. 空回覆 bug：錯誤必須 surface 到 UI；content 空且無 error 時補 fallback；systemPrompt 加「工具失敗也必須文字總結」
+4. maxSteps 6 → 10
+5. 架構結論（盤點後拍板）：**不引入** Agent SDK（需後端、Anthropic-only）與 Dify（key 進伺服器、
+   tools 在瀏覽器架構錯位）；維持瀏覽器內 AI SDK loop。模型因素實證：Gemini 2.5 Pro 表現佳。
+
+### 收尾（修正完成後）
+`docs/features/byok-chat/`（從 _TEMPLATE）→ 分批 commit → PR（模板）→ 用戶 squash merge。

--- a/package.json
+++ b/package.json
@@ -18,12 +18,16 @@
     "pillars:generate": "python3 scripts/preprocess/generate-station-pillars.py"
   },
   "dependencies": {
+    "@ai-sdk/anthropic": "^4.0.5",
+    "@ai-sdk/google": "^4.0.6",
+    "@ai-sdk/openai": "^4.0.5",
     "@aws-sdk/client-s3": "^3.995.0",
     "@deck.gl/core": "^9.2.10",
     "@deck.gl/geo-layers": "^9.2.10",
     "@deck.gl/layers": "^9.2.10",
     "@deck.gl/mapbox": "^9.2.10",
     "@supabase/supabase-js": "^2.101.1",
+    "ai": "^7.0.11",
     "dotenv": "^17.3.1",
     "h3-js": "^4.4.0",
     "lucide-react": "^0.576.0",
@@ -33,7 +37,8 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "satellite.js": "^5.0.0",
-    "three": "^0.172.0"
+    "three": "^0.172.0",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@types/react": "^19.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,0 +1,3763 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      '@ai-sdk/anthropic':
+        specifier: ^4.0.5
+        version: 4.0.5(zod@4.4.3)
+      '@ai-sdk/google':
+        specifier: ^4.0.6
+        version: 4.0.6(zod@4.4.3)
+      '@ai-sdk/openai':
+        specifier: ^4.0.5
+        version: 4.0.5(zod@4.4.3)
+      '@aws-sdk/client-s3':
+        specifier: ^3.995.0
+        version: 3.1078.0
+      '@deck.gl/core':
+        specifier: ^9.2.10
+        version: 9.3.5
+      '@deck.gl/geo-layers':
+        specifier: ^9.2.10
+        version: 9.3.5(@deck.gl/core@9.3.5)(@deck.gl/extensions@9.3.5(@deck.gl/core@9.3.5)(@luma.gl/core@9.3.5)(@luma.gl/engine@9.3.5(@luma.gl/core@9.3.5)(@luma.gl/shadertools@9.3.5(@luma.gl/core@9.3.5))))(@deck.gl/layers@9.3.5(@deck.gl/core@9.3.5)(@loaders.gl/core@4.4.3)(@luma.gl/core@9.3.5)(@luma.gl/engine@9.3.5(@luma.gl/core@9.3.5)(@luma.gl/shadertools@9.3.5(@luma.gl/core@9.3.5))))(@deck.gl/mesh-layers@9.3.5(@deck.gl/core@9.3.5)(@loaders.gl/core@4.4.3)(@luma.gl/core@9.3.5)(@luma.gl/engine@9.3.5(@luma.gl/core@9.3.5)(@luma.gl/shadertools@9.3.5(@luma.gl/core@9.3.5)))(@luma.gl/gltf@9.3.5(@luma.gl/core@9.3.5)(@luma.gl/engine@9.3.5(@luma.gl/core@9.3.5)(@luma.gl/shadertools@9.3.5(@luma.gl/core@9.3.5)))(@luma.gl/shadertools@9.3.5(@luma.gl/core@9.3.5)))(@luma.gl/shadertools@9.3.5(@luma.gl/core@9.3.5)))(@loaders.gl/core@4.4.3)(@luma.gl/core@9.3.5)(@luma.gl/engine@9.3.5(@luma.gl/core@9.3.5)(@luma.gl/shadertools@9.3.5(@luma.gl/core@9.3.5)))
+      '@deck.gl/layers':
+        specifier: ^9.2.10
+        version: 9.3.5(@deck.gl/core@9.3.5)(@loaders.gl/core@4.4.3)(@luma.gl/core@9.3.5)(@luma.gl/engine@9.3.5(@luma.gl/core@9.3.5)(@luma.gl/shadertools@9.3.5(@luma.gl/core@9.3.5)))
+      '@deck.gl/mapbox':
+        specifier: ^9.2.10
+        version: 9.3.5(@deck.gl/core@9.3.5)(@luma.gl/core@9.3.5)(@math.gl/web-mercator@4.1.0)
+      '@supabase/supabase-js':
+        specifier: ^2.101.1
+        version: 2.105.4
+      ai:
+        specifier: ^7.0.11
+        version: 7.0.11(zod@4.4.3)
+      dotenv:
+        specifier: ^17.3.1
+        version: 17.4.2
+      h3-js:
+        specifier: ^4.4.0
+        version: 4.5.0
+      lucide-react:
+        specifier: ^0.576.0
+        version: 0.576.0(react@19.2.6)
+      mapbox-gl:
+        specifier: ^3.9.0
+        version: 3.23.1
+      mapbox-pmtiles:
+        specifier: ^1.0.56
+        version: 1.0.56
+      pmtiles:
+        specifier: ^4.4.1
+        version: 4.4.1
+      react:
+        specifier: ^19.0.0
+        version: 19.2.6
+      react-dom:
+        specifier: ^19.0.0
+        version: 19.2.6(react@19.2.6)
+      satellite.js:
+        specifier: ^5.0.0
+        version: 5.0.0
+      three:
+        specifier: ^0.172.0
+        version: 0.172.0
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
+    devDependencies:
+      '@types/react':
+        specifier: ^19.0.0
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: ^19.0.0
+        version: 19.2.3(@types/react@19.2.14)
+      '@types/three':
+        specifier: ^0.172.0
+        version: 0.172.0
+      '@vitejs/plugin-react':
+        specifier: ^4.3.0
+        version: 4.7.0(vite@6.4.2(@types/node@25.9.1)(tsx@4.21.0))
+      tsx:
+        specifier: ^4.21.0
+        version: 4.21.0
+      typescript:
+        specifier: ~5.7.0
+        version: 5.7.3
+      vite:
+        specifier: ^6.1.0
+        version: 6.4.2(@types/node@25.9.1)(tsx@4.21.0)
+      vitest:
+        specifier: ^3.2.6
+        version: 3.2.6(@types/node@25.9.1)(tsx@4.21.0)
+
+packages:
+
+  '@ai-sdk/anthropic@4.0.5':
+    resolution: {integrity: sha512-JyJYKWGYz8vfoQ1pCm48a9zgX3Gvb2/6iGHb+8pEelpqnOiUq3aDHVq+nYMf9VepqcjCuH0JSOwBrKiPg/PD9w==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/gateway@4.0.8':
+    resolution: {integrity: sha512-esHzojMp+LllqOnEu6sYa6NKOmPcE5UObPV61LE6L2QAzCH6WHMgTS+Q/HF5HU3lVUWsHtkDzN7TNqMfv/ecCg==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/google@4.0.6':
+    resolution: {integrity: sha512-YJnWlHVqG6Lq3NY5Z0hs1+8+P4GFTBLPkmnuFIGdsYi19qB7C36IpK2JOzdkyE47waVJuu6tq/d0rFyHZzY2MQ==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/openai@4.0.5':
+    resolution: {integrity: sha512-a9cYQNAKAbkMTt6bHAvDuLv3klwtJT9m0A6x7s8EZlf1ebcxadg/1CONaYh1GA80ZRA9UQHJUS2wHoOphkQQkg==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider-utils@5.0.3':
+    resolution: {integrity: sha512-El0JOXXGcHFe6+owJ1UV0VgB9XtdivP8vcZni+rUIt6lt+cBHCnUdddaA6LE2avJGJ5AD0uXSY+uAvRL2tSvgw==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider@4.0.1':
+    resolution: {integrity: sha512-6p3C/vGqVIjcptBu1DnVd/BZJ2wWmV9TUv9192vT6ZvT9KNED8EwRTqyqFpoQZKgSbMDSvBSq3dqR524Nt/Crw==}
+    engines: {node: '>=22'}
+
+  '@aws-sdk/checksums@3.1000.11':
+    resolution: {integrity: sha512-nW5kNBJBwVxkvBqygBYksS8WUFDO8Ad8OSfsVa+f5KFRRTrHL1rnWZNsWBwc5fC9YvZbET/57+X4hym/jKfV+g==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/client-s3@3.1078.0':
+    resolution: {integrity: sha512-uQMPma3CzTXPKrRfTkhdKLfXocGoEJwBePcI/ca9iWF+re2gbFSDVV9EIcOrK8ke1OV3Jw4ejNmfmgRVlI5b9A==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/core@3.974.26':
+    resolution: {integrity: sha512-wRj7Pthvjk3anees97pUWlxlTa0DUjeGrEQU5fKDZVdWZV0ekaprbof0df2uaE9g8u67t035v2j+ne2AW2UMkA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-env@3.972.52':
+    resolution: {integrity: sha512-sxuaHZGHqOgKB8OdL3doXa1NJjqmO60FPfyTnYVKGjX9taRsIEGS9pd+2yALmo06hijZ8L94uSK0kfXZsRmVyA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-http@3.972.54':
+    resolution: {integrity: sha512-e6yz52nq3SpR1oPLcvfsDM7H7k2gIYk/NSn/rwsFqzGXEwr3g0mRMlPbLaKCPCGNZJMU/gZg6/64B3eSam+gBw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-ini@3.972.59':
+    resolution: {integrity: sha512-9Um/UpruN76AdpiLnvwChVkJJwJ9Vx9ykk/2AeLxxSCM/YYRD8Kkq2towUk9fZQLV7dd9ATlsi87U7hKs0z/iQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-login@3.972.58':
+    resolution: {integrity: sha512-H3q96qF8/DJsPsXMVtMRqSWOc85K5O4zos32untdw+vE5vw0f3a6qJo1YqbND4BsEIKd4iZmzzVUq9kV4LjbHg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-node@3.972.61':
+    resolution: {integrity: sha512-2U2KHMRCt1dlZoLU3KZR5g5EL4b0h2HHw96SkaUBK7qvEXPZj5rGRO/3ZTeJmh37dIYQuCnA2273rZOQvmsiHw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-process@3.972.52':
+    resolution: {integrity: sha512-Aff9Ebs42lz+Ep1wkS+Nlwh5S0eahakpyskPsuKGjiBJ6ExOjNtxbfKJTKovQtQNgJ7oG1BH6esJwGrbs7qgSA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-sso@3.972.58':
+    resolution: {integrity: sha512-syloC58mXOacUqM2toPNfwd7X3jT+tWj0F/cN7qdW1FQyI0q41J0tPf6DIZ56BF0x82iS9j3ALP45MoBz79YuQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-web-identity@3.972.58':
+    resolution: {integrity: sha512-pTBImKzcGK+pcMKjL0fAJbnYzzYd1c0UDc7BSIOGNQhF9Nuk66vWlIXfYTYyzNSs+w8Q/vfbbNDDU8zdrouwLg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-sdk-s3@3.972.57':
+    resolution: {integrity: sha512-E7tRmmUb64LlsoI6pZZRTov21K74Fr/MVgYBeNFfBkFzpF8e2tuJkKd4YGmcNwz0UjDs8fMoS0v/MGgHASIx+Q==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/nested-clients@3.997.26':
+    resolution: {integrity: sha512-Lwe3F6K7bs+jEubp1LbrvzeMBYb5fMazJ1IxV9TtKWPF8CSh67Fmwyq9fLz3NL/k55Dfpuph5Dimw76JFgr+SA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/signature-v4-multi-region@3.996.38':
+    resolution: {integrity: sha512-C379Sk+MiFZCfWZphKlMyLHKxV22OjoGM5KJjj5IJNJcOCWL4IGIpnEGzv1FQiRwhYXfq55SJMfxlqPE08JJ9g==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/token-providers@3.1078.0':
+    resolution: {integrity: sha512-/uyXLBGu3Lw1GbBA2X66hcOMnKtMcqAIF+3/eHfxBQmUeXF2sdqozDPrTfEr/TnSd0D6deZar+eVyhEqqWu29w==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/types@3.973.15':
+    resolution: {integrity: sha512-IULn8uBV/SMtmOIANsm4WHXIOtVPBWfOWs3WGL0j/sI+KhaYehvOw0ET+9urnn8MBpiijuU/0JOpuwKOE451PQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/xml-builder@3.972.33':
+    resolution: {integrity: sha512-ezbwz9WpuLctm6o7P2t2naDhVVPI5jFGrVefVybhcKGjU57VIyT46pQVO0RI2RYkUdhdj2Z9uSIlAzGZE9NW9A==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws/lambda-invoke-store@0.2.4':
+    resolution: {integrity: sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@babel/code-frame@7.29.0':
+    resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/compat-data@7.29.3':
+    resolution: {integrity: sha512-LIVqM46zQWZhj17qA8wb4nW/ixr2y1Nw+r1etiAWgRM6U1IqP+LNhL1yg440jYZR72jCWcWbLWzIosH+uP1fqg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/core@7.29.0':
+    resolution: {integrity: sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/generator@7.29.1':
+    resolution: {integrity: sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-compilation-targets@7.28.6':
+    resolution: {integrity: sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-globals@7.28.0':
+    resolution: {integrity: sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-imports@7.28.6':
+    resolution: {integrity: sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-transforms@7.28.6':
+    resolution: {integrity: sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
+  '@babel/helper-plugin-utils@7.28.6':
+    resolution: {integrity: sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-string-parser@7.27.1':
+    resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.28.5':
+    resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-option@7.27.1':
+    resolution: {integrity: sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helpers@7.29.2':
+    resolution: {integrity: sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/parser@7.29.3':
+    resolution: {integrity: sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/plugin-transform-react-jsx-self@7.27.1':
+    resolution: {integrity: sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-react-jsx-source@7.27.1':
+    resolution: {integrity: sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/template@7.28.6':
+    resolution: {integrity: sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/traverse@7.29.0':
+    resolution: {integrity: sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/types@7.29.0':
+    resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
+    engines: {node: '>=6.9.0'}
+
+  '@deck.gl/core@9.3.5':
+    resolution: {integrity: sha512-15qYTYbP2GJaiJ+N9XPUYK5HkpCGQypNYRfWFrtKLLYPNXJPxBVXKhjEV350z2i8nRd25CapMLpFaQaaVORZGw==}
+
+  '@deck.gl/extensions@9.3.5':
+    resolution: {integrity: sha512-mx5S0iIA/QC492u2h29pdpjfe1PuX65OBh2gJYhDlPA3y/PHTBE4KR+SwXiIIa26VbzUXe0FBV+MVnWM/dutEQ==}
+    peerDependencies:
+      '@deck.gl/core': ~9.3.0
+      '@luma.gl/core': ~9.3.3
+      '@luma.gl/engine': ~9.3.3
+
+  '@deck.gl/geo-layers@9.3.5':
+    resolution: {integrity: sha512-3rrNsV2DzdMxjTkBOKRSt6GVIJYJhTaj6Jpz6TlWeqmhGI5pj4ONPcCYobF6BvhxmaIRSVeN3kt6ZppF6VEbjQ==}
+    peerDependencies:
+      '@deck.gl/core': ~9.3.0
+      '@deck.gl/extensions': ~9.3.0
+      '@deck.gl/layers': ~9.3.0
+      '@deck.gl/mesh-layers': ~9.3.0
+      '@loaders.gl/core': ^4.4.3
+      '@luma.gl/core': ~9.3.3
+      '@luma.gl/engine': ~9.3.3
+
+  '@deck.gl/layers@9.3.5':
+    resolution: {integrity: sha512-zTtvm+neP82Uixm+c4V1PUqVNGiz075MwYCyId80DouK/FWbUPSIzvSbQT+EKjVRojvU6JYObhR/aT0zNcv/lQ==}
+    peerDependencies:
+      '@deck.gl/core': ~9.3.0
+      '@loaders.gl/core': ^4.4.3
+      '@luma.gl/core': ~9.3.3
+      '@luma.gl/engine': ~9.3.3
+
+  '@deck.gl/mapbox@9.3.5':
+    resolution: {integrity: sha512-odm+QfVslgJOI0c0NwzmWyKVtYy7yPVyZ8mz/xuDmA4QvdskpfcDaczaEpFEf4wT2senF6AOnnRcw5MGTu+FHw==}
+    peerDependencies:
+      '@deck.gl/core': ~9.3.0
+      '@luma.gl/core': ~9.3.3
+      '@math.gl/web-mercator': ^4.1.0
+
+  '@deck.gl/mesh-layers@9.3.5':
+    resolution: {integrity: sha512-avzXBqBp1U8BOi6C2mtSRDpBkd0iG46b+XRBykxQwx0VPAcx+r5tLRtMMQWx/KhwZ5SFofjt4nG9sAOiT5qhGQ==}
+    peerDependencies:
+      '@deck.gl/core': ~9.3.0
+      '@luma.gl/core': ~9.3.3
+      '@luma.gl/engine': ~9.3.3
+      '@luma.gl/gltf': ~9.3.3
+      '@luma.gl/shadertools': ~9.3.3
+
+  '@esbuild/aix-ppc64@0.25.12':
+    resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/aix-ppc64@0.27.7':
+    resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.25.12':
+    resolution: {integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm64@0.27.7':
+    resolution: {integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.25.12':
+    resolution: {integrity: sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-arm@0.27.7':
+    resolution: {integrity: sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.25.12':
+    resolution: {integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/android-x64@0.27.7':
+    resolution: {integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.25.12':
+    resolution: {integrity: sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-arm64@0.27.7':
+    resolution: {integrity: sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.25.12':
+    resolution: {integrity: sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.27.7':
+    resolution: {integrity: sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.25.12':
+    resolution: {integrity: sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-arm64@0.27.7':
+    resolution: {integrity: sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.25.12':
+    resolution: {integrity: sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.27.7':
+    resolution: {integrity: sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.25.12':
+    resolution: {integrity: sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm64@0.27.7':
+    resolution: {integrity: sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.25.12':
+    resolution: {integrity: sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.27.7':
+    resolution: {integrity: sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.25.12':
+    resolution: {integrity: sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.27.7':
+    resolution: {integrity: sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.25.12':
+    resolution: {integrity: sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.27.7':
+    resolution: {integrity: sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.25.12':
+    resolution: {integrity: sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.27.7':
+    resolution: {integrity: sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.25.12':
+    resolution: {integrity: sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.27.7':
+    resolution: {integrity: sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.25.12':
+    resolution: {integrity: sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.27.7':
+    resolution: {integrity: sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.25.12':
+    resolution: {integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.27.7':
+    resolution: {integrity: sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.25.12':
+    resolution: {integrity: sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.27.7':
+    resolution: {integrity: sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.25.12':
+    resolution: {integrity: sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.27.7':
+    resolution: {integrity: sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.25.12':
+    resolution: {integrity: sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.27.7':
+    resolution: {integrity: sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.25.12':
+    resolution: {integrity: sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/openharmony-arm64@0.27.7':
+    resolution: {integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.25.12':
+    resolution: {integrity: sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/sunos-x64@0.27.7':
+    resolution: {integrity: sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.25.12':
+    resolution: {integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-arm64@0.27.7':
+    resolution: {integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.25.12':
+    resolution: {integrity: sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.27.7':
+    resolution: {integrity: sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.25.12':
+    resolution: {integrity: sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.27.7':
+    resolution: {integrity: sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@jridgewell/gen-mapping@0.3.13':
+    resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
+
+  '@jridgewell/remapping@2.3.5':
+    resolution: {integrity: sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==}
+
+  '@jridgewell/resolve-uri@3.1.2':
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@loaders.gl/3d-tiles@4.4.3':
+    resolution: {integrity: sha512-trKDXRYE7xIyH0g2tvDG0SHo/J5sCUhOec70Ne1a5t64/yY+yifQ4B67n4AnSOnZ+l4sxjUypjxhHUqoAeWieQ==}
+    peerDependencies:
+      '@loaders.gl/core': ~4.4.0
+
+  '@loaders.gl/compression@4.4.3':
+    resolution: {integrity: sha512-v3feEE48FblxBPaILwejV48plcLmjvOh2yBQrgvKvLCaQdQ9bVz7PzhrUdLW0VDVlGnoR1NUJtI833627U8Heg==}
+    peerDependencies:
+      '@loaders.gl/core': ~4.4.0
+
+  '@loaders.gl/core@4.4.3':
+    resolution: {integrity: sha512-D6kXFdpUtYwoqS5OQLLaLELkHlS3qIdcSgzVvsh/MinRteeVIITJojqEc/lmDx1zVR3j6WND7yPGF4i4aOwiOg==}
+
+  '@loaders.gl/crypto@4.4.3':
+    resolution: {integrity: sha512-zratEvtj/Mdbu0NwwwzdbP1oyY4FNxLcOY2JRcYqe3wzw+0kyeK7THdaVPcduZAnQ06HtpwHls61ONZunjMtXA==}
+    peerDependencies:
+      '@loaders.gl/core': ~4.4.0
+
+  '@loaders.gl/draco@4.4.3':
+    resolution: {integrity: sha512-YNI1MUDDIbrJBamgU1emLBC2kQUbESNIOZv9bcS8xwxr9SNMfnAMZWgdUJkYcC5xzV2q6ty2I/b2eGhXQkd9EQ==}
+    peerDependencies:
+      '@loaders.gl/core': ~4.4.0
+
+  '@loaders.gl/geoarrow@4.4.3':
+    resolution: {integrity: sha512-P0TSbtsw1UI1rZnp1tGHuqPVHcH7Yc14q9jZLIcrjhQOzol55YDI0/hYSXpA73794nR6o8ALxNwiy7/4HlBlcA==}
+    peerDependencies:
+      '@loaders.gl/core': ~4.4.0
+
+  '@loaders.gl/gis@4.4.3':
+    resolution: {integrity: sha512-2dhhzfCT1cXQQLZ1lMtb2Y+pX414qaeLL8Wpx7FJu/ar1HJfKL6Fb3juTR+2WzMybkAOX5zLxYh6+y7LqiPjgA==}
+    peerDependencies:
+      '@loaders.gl/core': ~4.4.0
+
+  '@loaders.gl/gltf@4.4.3':
+    resolution: {integrity: sha512-OYE/0nGLYm3weiCb78+ROwdNVyuLS8IZwN8NvGqctqt0HS4ZD40biu7b9L8xkFbVTZQkQZXDpyZ61n5PSQeU1A==}
+    peerDependencies:
+      '@loaders.gl/core': ~4.4.0
+
+  '@loaders.gl/images@4.4.3':
+    resolution: {integrity: sha512-a4C6x+4GZUchf+IwpdBOvyGeLGSbGOVob+WSWfGUezEQ4gqu1zS1pn3lCX3ZTL5P+Ch3v6KKwPGdO5YdTd52Ew==}
+    peerDependencies:
+      '@loaders.gl/core': ~4.4.0
+
+  '@loaders.gl/loader-utils@4.4.3':
+    resolution: {integrity: sha512-5yt1OqZPYR3d+xFAqtzSKO24Hd7019KqN+iOWp7XBKPQBS+sAEhAnmSTnO1axo45IEi14J3FhMDk+ndqBoSKEQ==}
+
+  '@loaders.gl/math@4.4.3':
+    resolution: {integrity: sha512-EdEsZGqo1AX3sqgXt8bSBmdo+8ncURXjWucyQ8eeIJ2h0VIqM3bLkOGKk/D1ngeqK4hJXcjiturYHBW1B286lw==}
+    peerDependencies:
+      '@loaders.gl/core': ~4.4.0
+
+  '@loaders.gl/mvt@4.4.3':
+    resolution: {integrity: sha512-s2R8GRlaWDfZ7oKDFiY0c5EJ8elkf2VbPvdC0eoh69DN71y+AKngDSB+7h4veH/oueLEjmV7tNlF0+Snv58CPw==}
+    peerDependencies:
+      '@loaders.gl/core': ~4.4.0
+
+  '@loaders.gl/schema-utils@4.4.3':
+    resolution: {integrity: sha512-TggzQWkzf9pIYbj8I9RlTk33kwXslvDkY1nnw/OL/hika6qTls1G127qK5m9skiAjElk5ZkvQLQcwhOboZXZeA==}
+    peerDependencies:
+      '@loaders.gl/core': ~4.4.0
+
+  '@loaders.gl/schema@4.4.3':
+    resolution: {integrity: sha512-tDb/rOn44nHWvMFSOaAk1/pQcQcusxirGCM1O5BMJR0PQ71UrCHey56rsbcf7/wGhvyRwPtX+oiMzlJ9TmN8vQ==}
+
+  '@loaders.gl/terrain@4.4.3':
+    resolution: {integrity: sha512-wu7O3FVXE6D1kSm5inRu8M8V1Vv5AYlnlNB0EJIOSSXBLhfNbPL5oHjlD2wIlag0gSxOVlhWjCUcWS3/Nb0P8Q==}
+    peerDependencies:
+      '@loaders.gl/core': ~4.4.0
+
+  '@loaders.gl/textures@4.4.3':
+    resolution: {integrity: sha512-QNC+anwJJcHsLsaAzXozJ+IUNxBnqWsZLUMkUZIorVey+XQcp2hcYng5iOmUQnCZdIR9gYe53VJa0j1C0JXRSg==}
+    peerDependencies:
+      '@loaders.gl/core': ~4.4.0
+
+  '@loaders.gl/tiles@4.4.3':
+    resolution: {integrity: sha512-8ZkPMe+daMV5mHKTEU591mJSp6pswdWliI+PcNhSOkpeuvyjecaYKSzuzMFMmaywfgOLpYl+lpfzKUEmCcE5vQ==}
+    peerDependencies:
+      '@loaders.gl/core': ~4.4.0
+
+  '@loaders.gl/wms@4.4.3':
+    resolution: {integrity: sha512-fKYCdIp6xQcucbm42bztprlfMJ5SZKx5f2ZwWLcj+kwv53U7hjcbIl04uMAk/i/7Xw/I4QEyA/XnPnxquuIFHQ==}
+    peerDependencies:
+      '@loaders.gl/core': ~4.4.0
+
+  '@loaders.gl/worker-utils@4.4.3':
+    resolution: {integrity: sha512-RZt/NwFXm6Kx3Fn/rqiW3Alse9Z0XtBktH/EFAp8W6LvsKuxpRMjULqGfybTu2waRXRYUNYZ6zGs9aOWbtDRLw==}
+    peerDependencies:
+      '@loaders.gl/core': ~4.4.0
+
+  '@loaders.gl/xml@4.4.3':
+    resolution: {integrity: sha512-/CtpIWaPKBs/AaX7MqUGSSE1OAhq78nDrJ5xPExYdIQAw5gl5OSmLZobUSSxV5FGaqkJRVbtC/sj5sUpci7doA==}
+    peerDependencies:
+      '@loaders.gl/core': ~4.4.0
+
+  '@loaders.gl/zip@4.4.3':
+    resolution: {integrity: sha512-HH/JLulJJVyqmbQYp4e/9MPjaTnUFnWfhgza8sMGIBYZ/YuZXOc6Ad2vvmyFQHvNbVr+NLrRZODASEjNZQ5rfQ==}
+    peerDependencies:
+      '@loaders.gl/core': ~4.4.0
+
+  '@luma.gl/core@9.3.5':
+    resolution: {integrity: sha512-wWQNH9eZiaW4fYV8s30al8Ofe5S6UCyqdXC4qwIk0lAoz00jicWDVFW/EOU1Mu1lVUkPQaT5yfUgcy1gOSMprQ==}
+
+  '@luma.gl/engine@9.3.5':
+    resolution: {integrity: sha512-YdtCBPh2TcFRblBZTguFBgynLfAoqBI8u7Nb4jux2hZX8E8PIaDWzS+dWiNSJ8Um67EFXyKlMf1k2CEkmNiZIQ==}
+    peerDependencies:
+      '@luma.gl/core': ~9.3.0
+      '@luma.gl/shadertools': ~9.3.0
+
+  '@luma.gl/gltf@9.3.5':
+    resolution: {integrity: sha512-uLzXk2hDyzocME3SJquDHDZDm5HALRV2C+TnEXmKnp1Y6XNNR5aQF7n5DbvdCMQppgtVrMwRaMAvSgNs83nEYQ==}
+    peerDependencies:
+      '@luma.gl/core': ~9.3.0
+      '@luma.gl/engine': ~9.3.0
+      '@luma.gl/shadertools': ~9.3.0
+
+  '@luma.gl/shadertools@9.3.5':
+    resolution: {integrity: sha512-fQNsGijMAT/daYhddjUmoAya69/yW6aOk+mGrLytWEmXGJLCJKMyWx6N+/kNSoMHfonXRIlkryoQ6jZJJnV3Wg==}
+    peerDependencies:
+      '@luma.gl/core': ~9.3.0
+
+  '@luma.gl/webgl@9.3.5':
+    resolution: {integrity: sha512-dxx7rsDI1fx3rzCLrdbAmG0ILejvpYEyKtqbTRAsSuPY/4gKnsXGi8n5GdlxJigA/3d4DbVRM8U7RV7l/PqmlA==}
+    peerDependencies:
+      '@luma.gl/core': ~9.3.0
+
+  '@mapbox/mapbox-gl-supported@3.0.0':
+    resolution: {integrity: sha512-2XghOwu16ZwPJLOFVuIOaLbN0iKMn867evzXFyf0P22dqugezfJwLmdanAgU25ITvz1TvOfVP4jsDImlDJzcWg==}
+
+  '@mapbox/martini@0.2.0':
+    resolution: {integrity: sha512-7hFhtkb0KTLEls+TRw/rWayq5EeHtTaErgm/NskVoXmtgAQu/9D299aeyj6mzAR/6XUnYRp2lU+4IcrYRFjVsQ==}
+
+  '@mapbox/point-geometry@0.1.0':
+    resolution: {integrity: sha512-6j56HdLTwWGO0fJPlrZtdU/B13q8Uwmo18Ck2GnGgN9PCFyKTZ3UbXeEdRFh18i9XQ92eH2VdtpJHpBD3aripQ==}
+
+  '@mapbox/point-geometry@1.1.0':
+    resolution: {integrity: sha512-YGcBz1cg4ATXDCM/71L9xveh4dynfGmcLDqufR+nQQy3fKwsAZsWd/x4621/6uJaeB9mwOHE6hPeDgXz9uViUQ==}
+
+  '@mapbox/tiny-sdf@2.2.0':
+    resolution: {integrity: sha512-LVL4wgI9YAum5V+LNVQO6QgFBPw7/MIIY4XJPNsPDMrjEwcE+JfKk1LuIl8GnF197ejVdC9QdPaxrx5gfgdGXg==}
+
+  '@mapbox/unitbezier@0.0.1':
+    resolution: {integrity: sha512-nMkuDXFv60aBr9soUG5q+GvZYL+2KZHVvsqFCzqnkGEf46U2fvmytHaEVc1/YZbiLn8X+eR3QzX1+dwDO1lxlw==}
+
+  '@mapbox/vector-tile@1.3.1':
+    resolution: {integrity: sha512-MCEddb8u44/xfQ3oD+Srl/tNcQoqTw3goGk2oLsrFxOTc3dUp+kAnby3PvAeeBYSMSjSPD1nd1AJA6W49WnoUw==}
+
+  '@mapbox/vector-tile@2.0.4':
+    resolution: {integrity: sha512-AkOLcbgGTdXScosBWwmmD7cDlvOjkg/DetGva26pIRiZPdeJYjYKarIlb4uxVzi6bwHO6EWH82eZ5Nuv4T5DUg==}
+
+  '@math.gl/core@4.1.0':
+    resolution: {integrity: sha512-FrdHBCVG3QdrworwrUSzXIaK+/9OCRLscxI2OUy6sLOHyHgBMyfnEGs99/m3KNvs+95BsnQLWklVfpKfQzfwKA==}
+
+  '@math.gl/culling@4.1.0':
+    resolution: {integrity: sha512-jFmjFEACnP9kVl8qhZxFNhCyd47qPfSVmSvvjR0/dIL6R9oD5zhR1ub2gN16eKDO/UM7JF9OHKU3EBIfeR7gtg==}
+
+  '@math.gl/geospatial@4.1.0':
+    resolution: {integrity: sha512-BzsUhpVvnmleyYF6qdqJIip6FtIzJmnWuPTGhlBuPzh7VBHLonCFSPtQpbkRuoyAlbSyaGXcVt6p6lm9eK2vtg==}
+
+  '@math.gl/polygon@4.1.0':
+    resolution: {integrity: sha512-YA/9PzaCRHbIP5/0E9uTYrqe+jsYTQoqoDWhf6/b0Ixz8bPZBaGDEafLg3z7ffBomZLacUty9U3TlPjqMtzPjA==}
+
+  '@math.gl/sun@4.1.0':
+    resolution: {integrity: sha512-i3q6OCBLSZ5wgZVhXg+X7gsjY/TUtuFW/2KBiq/U1ypLso3S4sEykoU/MGjxUv1xiiGtr+v8TeMbO1OBIh/HmA==}
+
+  '@math.gl/types@4.1.0':
+    resolution: {integrity: sha512-clYZdHcmRvMzVK5fjeDkQlHUzXQSNdZ7s4xOqC3nJPgz4C/TZkUecTo9YS4PruZqtDda/ag4erndP0MIn40dGA==}
+
+  '@math.gl/web-mercator@4.1.0':
+    resolution: {integrity: sha512-HZo3vO5GCMkXJThxRJ5/QYUYRr3XumfT8CzNNCwoJfinxy5NtKUd7dusNTXn7yJ40UoB8FMIwkVwNlqaiRZZAw==}
+
+  '@nodable/entities@2.2.0':
+    resolution: {integrity: sha512-9uGyhaQavEUMC8AIddIjau4NsnsXhou+j5sBAGojCM1oxmQpVKTWR/9JxABD6UAv12vpIms55fPZKFQEhG6uBg==}
+
+  '@probe.gl/env@4.1.1':
+    resolution: {integrity: sha512-+68seNDMVsEegRB47pFA/Ws1Fjy8agcFYXxzorKToyPcD6zd+gZ5uhwoLd7TzsSw6Ydns//2KEszWn+EnNHTbA==}
+
+  '@probe.gl/log@4.1.1':
+    resolution: {integrity: sha512-kcZs9BT44pL7hS1OkRGKYRXI/SN9KejUlPD+BY40DguRLzdC5tLG/28WGMyfKdn/51GT4a0p+0P8xvDn1Ez+Kg==}
+
+  '@probe.gl/stats@4.1.1':
+    resolution: {integrity: sha512-4VpAyMHOqydSvPlEyHwXaE+AkIdR03nX+Qhlxsk2D/IW4OVmDZgIsvJB1cDzyEEtcfKcnaEbfXeiPgejBceT6g==}
+
+  '@rolldown/pluginutils@1.0.0-beta.27':
+    resolution: {integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==}
+
+  '@rollup/rollup-android-arm-eabi@4.60.3':
+    resolution: {integrity: sha512-x35CNW/ANXG3hE/EZpRU8MXX1JDN86hBb2wMGAtltkz7pc6cxgjpy1OMMfDosOQ+2hWqIkag/fGok1Yady9nGw==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.60.3':
+    resolution: {integrity: sha512-xw3xtkDApIOGayehp2+Rz4zimfkaX65r4t47iy+ymQB2G4iJCBBfj0ogVg5jpvjpn8UWn/+q9tprxleYeNp3Hw==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.60.3':
+    resolution: {integrity: sha512-vo6Y5Qfpx7/5EaamIwi0WqW2+zfiusVihKatLvtN1VFVy3D13uERk/6gZLU1UiHRL6fDXqj/ELIeVRGnvcTE1g==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.60.3':
+    resolution: {integrity: sha512-D+0QGcZhBzTN82weOnsSlY7V7+RMmPuF1CkbxyMAGE8+ZHeUjyb76ZiWmBlCu//AQQONvxcqRbwZTajZKqjuOw==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.60.3':
+    resolution: {integrity: sha512-6HnvHCT7fDyj6R0Ph7A6x8dQS/S38MClRWeDLqc0MdfWkxjiu1HSDYrdPhqSILzjTIC/pnXbbJbo+ft+gy/9hQ==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.60.3':
+    resolution: {integrity: sha512-KHLgC3WKlUYW3ShFKnnosZDOJ0xjg9zp7au3sIm2bs/tGBeC2ipmvRh/N7JKi0t9Ue20C0dpEshi8WUubg+cnA==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.60.3':
+    resolution: {integrity: sha512-DV6fJoxEYWJOvaZIsok7KrYl0tPvga5OZ2yvKHNNYyk/2roMLqQAbGhr78EQ5YhHpnhLKJD3S1WFusAkmUuV5g==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.60.3':
+    resolution: {integrity: sha512-mQKoJAzvuOs6F+TZybQO4GOTSMUu7v0WdxEk24krQ/uUxXoPTtHjuaUuPmFhtBcM4K0ons8nrE3JyhTuCFtT/w==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-gnu@4.60.3':
+    resolution: {integrity: sha512-Whjj2qoiJ6+OOJMGptTYazaJvjOJm+iKHpXQM1P3LzGjt7Ff++Tp7nH4N8J/BUA7R9IHfDyx4DJIflifwnbmIA==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-musl@4.60.3':
+    resolution: {integrity: sha512-4YTNHKqGng5+yiZt3mg77nmyuCfmNfX4fPmyUapBcIk+BdwSwmCWGXOUxhXbBEkFHtoN5boLj/5NON+u5QC9tg==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-gnu@4.60.3':
+    resolution: {integrity: sha512-SU3kNlhkpI4UqlUc2VXPGK9o886ZsSeGfMAX2ba2b8DKmMXq4AL7KUrkSWVbb7koVqx41Yczx6dx5PNargIrEA==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-musl@4.60.3':
+    resolution: {integrity: sha512-6lDLl5h4TXpB1mTf2rQWnAk/LcXrx9vBfu/DT5TIPhvMhRWaZ5MxkIc8u4lJAmBo6klTe1ywXIUHFjylW505sg==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.60.3':
+    resolution: {integrity: sha512-BMo8bOw8evlup/8G+cj5xWtPyp93xPdyoSN16Zy90Q2QZ0ZYRhCt6ZJSwbrRzG9HApFabjwj2p25TUPDWrhzqQ==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-musl@4.60.3':
+    resolution: {integrity: sha512-E0L8X1dZN1/Rph+5VPF6Xj2G7JJvMACVXtamTJIDrVI44Y3K+G8gQaMEAavbqCGTa16InptiVrX6eM6pmJ+7qA==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.60.3':
+    resolution: {integrity: sha512-oZJ/WHaVfHUiRAtmTAeo3DcevNsVvH8mbvodjZy7D5QKvCefO371SiKRpxoDcCxB3PTRTLayWBkvmDQKTcX/sw==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-musl@4.60.3':
+    resolution: {integrity: sha512-Dhbyh7j9FybM3YaTgaHmVALwA8AkUwTPccyCQ79TG9AJUsMQqgN1DDEZNr4+QUfwiWvLDumW5vdwzoeUF+TNxQ==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-s390x-gnu@4.60.3':
+    resolution: {integrity: sha512-cJd1X5XhHHlltkaypz1UcWLA8AcoIi1aWhsvaWDskD1oz2eKCypnqvTQ8ykMNI0RSmm7NkTdSqSSD7zM0xa6Ig==}
+    cpu: [s390x]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-gnu@4.60.3':
+    resolution: {integrity: sha512-DAZDBHQfG2oQuhY7mc6I3/qB4LU2fQCjRvxbDwd/Jdvb9fypP4IJ4qmtu6lNjes6B531AI8cg1aKC2di97bUxA==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-musl@4.60.3':
+    resolution: {integrity: sha512-cRxsE8c13mZOh3vP+wLDxpQBRrOHDIGOWyDL93Sy0Ga8y515fBcC2pjUfFwUe5T7tqvTvWbCpg1URM/AXdWIXA==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-openbsd-x64@4.60.3':
+    resolution: {integrity: sha512-QaWcIgRxqEdQdhJqW4DJctsH6HCmo5vHxY0krHSX4jMtOqfzC+dqDGuHM87bu4H8JBeibWx7jFz+h6/4C8wA5Q==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.60.3':
+    resolution: {integrity: sha512-AaXwSvUi3QIPtroAUw1t5yHGIyqKEXwH54WUocFolZhpGDruJcs8c+xPNDRn4XiQsS7MEwnYsHW2l0MBLDMkWg==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.60.3':
+    resolution: {integrity: sha512-65LAKM/bAWDqKNEelHlcHvm2V+Vfb8C6INFxQXRHCvaVN1rJfwr4NvdP4FyzUaLqWfaCGaadf6UbTm8xJeYfEg==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.60.3':
+    resolution: {integrity: sha512-EEM2gyhBF5MFnI6vMKdX1LAosE627RGBzIoGMdLloPZkXrUN0Ckqgr2Qi8+J3zip/8NVVro3/FjB+tjhZUgUHA==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.60.3':
+    resolution: {integrity: sha512-E5Eb5H/DpxaoXH++Qkv28RcUJboMopmdDUALBczvHMf7hNIxaDZqwY5lK12UK1BHacSmvupoEWGu+n993Z0y1A==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.60.3':
+    resolution: {integrity: sha512-hPt/bgL5cE+Qp+/TPHBqptcAgPzgj46mPcg/16zNUmbQk0j+mOEQV/+Lqu8QRtDV3Ek95Q6FeFITpuhl6OTsAA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@smithy/core@3.29.0':
+    resolution: {integrity: sha512-sEvpvkBVoMxjoek35XyJFn2ZD3EJ1RpiZrT47WaZodxzAIWS44zkdvbqGE/ZlugtjiQp62cffYZ9ldyRkjAGnA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/credential-provider-imds@4.4.5':
+    resolution: {integrity: sha512-LnjUTNG0GgQlKIq7IioeOrPaEmC5xOd1WtAz24TLSiYQnWX2uHr53GrFuQhkrJBktPYCMga/NbUOW7hFbSA2Cg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/fetch-http-handler@5.6.2':
+    resolution: {integrity: sha512-q96PSDOAGw+X+nuELd7Cjebps0SYr+YlPbviEX9sLVw+VM4M7VV8hn1nL1mGS6urDu33eQ5A7WhlphaDO6kUyQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/node-http-handler@4.9.2':
+    resolution: {integrity: sha512-s0yAIRj6TVfHgl+QzVyqal1KMGZ9B5512IrxKc6+dOpw8fUmFL3CvuAhjv0J+aNjUPfVZ2IhqPEDvkB5Ncx9oA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/signature-v4@5.6.1':
+    resolution: {integrity: sha512-SqvuP75p/DmgWWI7jv4kf/UW+V4LFmlUn19s604SgAcRuJRB1vDnWwzZMYCLUcmKxko9wDn6iLgGEIpTNgZbIQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/types@4.15.1':
+    resolution: {integrity: sha512-x3L0XSACF6UYzKpa9biqiRMgvH5+wnFFew9Tm/grFYqgaupPwx/+ojDPpPJM8dZON3S9tjz5U+PQYsCBd1Mw5Q==}
+    engines: {node: '>=18.0.0'}
+
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@supabase/auth-js@2.105.4':
+    resolution: {integrity: sha512-Ejfa37M5xoIwoxVebxRahnwubPo8g22qkXQ4p50+N9MIvU9UZoN+A8dwVPtczzGf8oV/YXN80ZPxK4aWXuSN/A==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/functions-js@2.105.4':
+    resolution: {integrity: sha512-JVNKbBft3Qkja+WlGaE026AJ2AH9K0UTsxsfvEIHgd4zFrBor4BYRCrYFrv9IDsvVqkF72wKDsODJl5GY/C4tA==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/phoenix@0.4.2':
+    resolution: {integrity: sha512-YSAGnmDAfuleFCVt3CeurQZAhxRfXWeZIIkwp7NhYzQ1UwW6ePSnzsFAiUm/mbCkfoCf70QQHKW/K6RKh52a4A==}
+
+  '@supabase/postgrest-js@2.105.4':
+    resolution: {integrity: sha512-SppIyLo/kTwIlz1qpv2HN1EQqBg0GVktrDDFsXygYROha3MgVn4rT7p5EjFHFqXQm2rdRGb/BI7bc+jr10m91w==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/realtime-js@2.105.4':
+    resolution: {integrity: sha512-6ov6c59+8D9h7q4M4Gy/uDJlC0Akxl9/714Y+6vJ+Sijuc16TS/p5DwhfRCLNcIhNiej1gEt+CQUwsjiPt4PxQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/storage-js@2.105.4':
+    resolution: {integrity: sha512-Jx+pzMP1Whjof2PWHoVBUA75/p7PQE9CqKBzn1oXVyJDOggMLSH2OzVWwsXYaxEpdC1K/KltwmOX44nL3LHl9g==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/supabase-js@2.105.4':
+    resolution: {integrity: sha512-cEnx+k49knU+qdIP7rXwR6fqEXPHZs+74xFK1R0S8MgQ7v9tbePVdGxvO03n3bPympMdJWVLadARBfU4TgNHCQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@swc/helpers@0.5.23':
+    resolution: {integrity: sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==}
+
+  '@turf/boolean-clockwise@5.1.5':
+    resolution: {integrity: sha512-FqbmEEOJ4rU4/2t7FKx0HUWmjFEVqR+NJrFP7ymGSjja2SQ7Q91nnBihGuT+yuHHl6ElMjQ3ttsB/eTmyCycxA==}
+
+  '@turf/clone@5.1.5':
+    resolution: {integrity: sha512-//pITsQ8xUdcQ9pVb4JqXiSqG4dos5Q9N4sYFoWghX21tfOV2dhc5TGqYOhnHrQS7RiKQL1vQ48kIK34gQ5oRg==}
+
+  '@turf/helpers@5.1.5':
+    resolution: {integrity: sha512-/lF+JR+qNDHZ8bF9d+Cp58nxtZWJ3sqFe6n3u3Vpj+/0cqkjk4nXKYBSY0azm+GIYB5mWKxUXvuP/m0ZnKj1bw==}
+
+  '@turf/invariant@5.2.0':
+    resolution: {integrity: sha512-28RCBGvCYsajVkw2EydpzLdcYyhSA77LovuOvgCJplJWaNVyJYH6BOR3HR9w50MEkPqb/Vc/jdo6I6ermlRtQA==}
+
+  '@turf/meta@5.2.0':
+    resolution: {integrity: sha512-ZjQ3Ii62X9FjnK4hhdsbT+64AYRpaI8XMBMcyftEOGSmPMUVnkbvuv3C9geuElAXfQU7Zk1oWGOcrGOD9zr78Q==}
+
+  '@turf/rewind@5.1.5':
+    resolution: {integrity: sha512-Gdem7JXNu+G4hMllQHXRFRihJl3+pNl7qY+l4qhQFxq+hiU1cQoVFnyoleIqWKIrdK/i2YubaSwc3SCM7N5mMw==}
+
+  '@tweenjs/tween.js@23.1.3':
+    resolution: {integrity: sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA==}
+
+  '@types/babel__core@7.20.5':
+    resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
+
+  '@types/babel__generator@7.27.0':
+    resolution: {integrity: sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==}
+
+  '@types/babel__template@7.4.4':
+    resolution: {integrity: sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==}
+
+  '@types/babel__traverse@7.28.0':
+    resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
+
+  '@types/brotli@1.3.5':
+    resolution: {integrity: sha512-9xoNr+bcxT236/7ZgcWw/6Pb2RRetE13p4bFy1xYSckKwyOiRfmInay8baUWZgH7/284Wl6IPe7+nOI9+OQg/A==}
+
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/command-line-args@5.2.3':
+    resolution: {integrity: sha512-uv0aG6R0Y8WHZLTamZwtfsDLVRnOa+n+n5rEvFWL5Na5gZ8V2Teab/duDPFzIIIhs9qizDpcavCusCLJZu62Kw==}
+
+  '@types/command-line-usage@5.0.4':
+    resolution: {integrity: sha512-BwR5KP3Es/CSht0xqBcUXS3qCAUVXwpRKsV2+arxeb65atasuXG9LykC9Ab10Cw3s2raH92ZqOeILaQbsB2ACg==}
+
+  '@types/crypto-js@4.2.2':
+    resolution: {integrity: sha512-sDOLlVbHhXpAUAL0YHDUUwDZf3iN4Bwi4W6a0W0b+QcAezUbRtH4FVb+9J4h+XFPW7l/gQ9F8qC7P+Ec4k8QVQ==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
+  '@types/estree@1.0.8':
+    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/estree@1.0.9':
+    resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
+
+  '@types/geojson-vt@3.2.5':
+    resolution: {integrity: sha512-qDO7wqtprzlpe8FfQ//ClPV9xiuoh2nkIgiouIptON9w5jvD/fA4szvP9GBlDVdJ5dldAl0kX/sy3URbWwLx0g==}
+
+  '@types/geojson@7946.0.16':
+    resolution: {integrity: sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==}
+
+  '@types/leaflet@1.9.21':
+    resolution: {integrity: sha512-TbAd9DaPGSnzp6QvtYngntMZgcRk+igFELwR2N99XZn7RXUdKgsXMR+28bUO0rPsWp8MIu/f47luLIQuSLYv/w==}
+
+  '@types/mapbox-gl@2.7.21':
+    resolution: {integrity: sha512-Dx9MuF2kKgT/N22LsMUB4b3acFZh9clVqz9zv1fomoiPoBrJolwYxpWA/9LPO/2N0xWbKi4V+pkjTaFkkx/4wA==}
+
+  '@types/node@24.12.4':
+    resolution: {integrity: sha512-GUUEShf+PBCGW2KaXwcIt3Yk+e3pkKwWKb9GSyM9WQVE+ep2jzmHdGsHzu4wgcZy5fN9FBdVzjpBQsYlpfpgLA==}
+
+  '@types/node@25.9.1':
+    resolution: {integrity: sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==}
+
+  '@types/offscreencanvas@2019.7.3':
+    resolution: {integrity: sha512-ieXiYmgSRXUDeOntE1InxjWyvEelZGP63M+cGuquuRLuIKKT1osnkXjxev9B7d1nXSug5vpunx+gNlbVxMlC9A==}
+
+  '@types/pako@1.0.7':
+    resolution: {integrity: sha512-YBtzT2ztNF6R/9+UXj2wTGFnC9NklAnASt3sC0h2m1bbH7G6FyBIkt4AN8ThZpNfxUo1b2iMVO0UawiJymEt8A==}
+
+  '@types/pbf@3.0.5':
+    resolution: {integrity: sha512-j3pOPiEcWZ34R6a6mN07mUkM4o4Lwf6hPNt8eilOeZhTFbxFXmKhvXl9Y28jotFPaI1bpPDJsbCprUoNke6OrA==}
+
+  '@types/react-dom@19.2.3':
+    resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
+    peerDependencies:
+      '@types/react': ^19.2.0
+
+  '@types/react@19.2.14':
+    resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
+
+  '@types/stats.js@0.17.4':
+    resolution: {integrity: sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA==}
+
+  '@types/supercluster@7.1.3':
+    resolution: {integrity: sha512-Z0pOY34GDFl3Q6hUFYf3HkTwKEE02e7QgtJppBt+beEAxnyOpJua+voGFvxINBHa06GwLFFym7gRPY2SiKIfIA==}
+
+  '@types/three@0.172.0':
+    resolution: {integrity: sha512-LrUtP3FEG26Zg5WiF0nbg8VoXiKokBLTcqM2iLvM9vzcfEiYmmBAPGdBgV0OYx9fvWlY3R/3ERTZcD9X5sc0NA==}
+
+  '@types/webxr@0.5.24':
+    resolution: {integrity: sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg==}
+
+  '@vercel/oidc@3.2.0':
+    resolution: {integrity: sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==}
+    engines: {node: '>= 20'}
+
+  '@vitejs/plugin-react@4.7.0':
+    resolution: {integrity: sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+    peerDependencies:
+      vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
+
+  '@vitest/expect@3.2.6':
+    resolution: {integrity: sha512-1+7q9BtaKzEmO+fmNT3kYvoNn5Y71XWAx2Q5HRim4tTVRQVRv4uJFAQ5FbK0OPUeNP/WmVCpxYxoJdvuHVjzBQ==}
+
+  '@vitest/mocker@3.2.6':
+    resolution: {integrity: sha512-EZOrpDbkKotFAP7wPAQV1UIyoGOk4oX7ynWhBhLB7v+meMHbQhU16oPpIYGTTe4oFlhpryGpgpcZP/sin3hYuw==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0-0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@3.2.6':
+    resolution: {integrity: sha512-lb7XXXzmm2h2ASzFnRvQpDo6onT1NmMJA3tkGTWiBFtRJ9lxGY3d3mm/Apt36gej2bkkOVLL/yTOtufDaFa/jA==}
+
+  '@vitest/runner@3.2.6':
+    resolution: {integrity: sha512-HYcoSj1w5tcgUnzoF0HcyaAQjpA1gj9ftUJ7iSJSuipc02jW9gKkigwZbjFldAfYHA1fa8UZVRftdMY5msWM9Q==}
+
+  '@vitest/snapshot@3.2.6':
+    resolution: {integrity: sha512-H+ZjNTWGpObenh0YnlBctAPnJSI20P81PL8BPzWpx54YXLLTm8hEsWawtcYLMrwvpK48hGxLLbCS+1KRXhsKhw==}
+
+  '@vitest/spy@3.2.6':
+    resolution: {integrity: sha512-oq6BbH68WzcWmwtBrU9nqLeaXTR4XwJF7FSLkKEZo4i6eoXcrxjcwSuTvWBIRUTC6VC72nXYunzqgZA+IKdtxg==}
+
+  '@vitest/utils@3.2.6':
+    resolution: {integrity: sha512-lI23nIs4bnT3T8NIoh+vFaz5s2/DdP0Jgt2jxwgWljvwn82cLJtyi/If+fjFyoLMGIOz0U/fKvWE0d4jsNQEfg==}
+
+  '@webgpu/types@0.1.71':
+    resolution: {integrity: sha512-mMy8/ODcKhab808co15eW+yN+HgXoQxRQHTiBV9Mrvl1r0ufnid7YOcI+gi4eUWSWl9ezD6TW2KXccrL8HCh2A==}
+
+  '@workflow/serde@4.1.0':
+    resolution: {integrity: sha512-pav4F2BoirECWR7Nf1TKt+2eETcBj7jj4cBefQ8VXQCA6NPkaKeLfj/zMgi+3zYV5ZIBT4GuUiphsj0/b9hPQQ==}
+
+  a5-js@0.7.3:
+    resolution: {integrity: sha512-3aoMwHmNkyuMDHS4q6GRRInpOawamen2pokIbc0MQmR9cqG0Y9+B0bZpzswwetjrSG2ckbYtShH+nKru6+3O5Q==}
+
+  ai@7.0.11:
+    resolution: {integrity: sha512-ecCtume1NKJG/8oIkV8G26KL9jmFJRx6+Gjx2260FcDZqIUGPiF1uBoNeGy4S1vxbHmFxUul4D7axqiXZZ1XuA==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  ansi-styles@4.3.0:
+    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
+    engines: {node: '>=8'}
+
+  anynum@1.0.1:
+    resolution: {integrity: sha512-N6//FLET/tXYNM/F6ABca1oH6fWB+KlTt909Le28WMDBk8oaT4vY17DCrwg2MvmuqUKt3Ni4N5dGJ/EoBgcO6A==}
+
+  apache-arrow@21.1.0:
+    resolution: {integrity: sha512-kQrYLxhC+NTVVZ4CCzGF6L/uPVOzJmD1T3XgbiUnP7oTeVFOFgEUu6IKNwCDkpFoBVqDKQivlX4RUFqqnWFlEA==}
+    hasBin: true
+
+  argparse@1.0.10:
+    resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
+
+  array-back@6.2.3:
+    resolution: {integrity: sha512-SGDvmg6QTYiTxCBkYVmThcoa67uLl35pyzRHdpCGBOcqFy6BtwnphoFPk7LhJshD+Yk1Kt35WGWeZPTgwR4Fhw==}
+    engines: {node: '>=12.17'}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
+  base64-js@1.5.1:
+    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+
+  baseline-browser-mapping@2.10.29:
+    resolution: {integrity: sha512-Asa2krT+XTPZINCS+2QcyS8WTkObE77RwkydwF7h6DmnKqbvlalz93m/dnphUyCa6SWSP51VgtEUf2FN+gelFQ==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  bowser@2.14.1:
+    resolution: {integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==}
+
+  brotli@1.3.3:
+    resolution: {integrity: sha512-oTKjJdShmDuGW94SyyaoQvAjf30dZaHnjJ8uAF+u2/vGJkJbJPJAT1gDiOJP5v1Zb6f9KEyW/1HpuaWIXtGHPg==}
+
+  browserslist@4.28.2:
+    resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
+    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
+    hasBin: true
+
+  buf-compare@1.0.1:
+    resolution: {integrity: sha512-Bvx4xH00qweepGc43xFvMs5BKASXTbHaHm6+kDYIK9p/4iFwjATQkmPKHQSgJZzKbAymhztRbXUf1Nqhzl73/Q==}
+    engines: {node: '>=0.10.0'}
+
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+
+  caniuse-lite@1.0.30001792:
+    resolution: {integrity: sha512-hVLMUZFgR4JJ6ACt1uEESvQN1/dBVqPAKY0hgrV70eN3391K6juAfTjKZLKvOMsx8PxA7gsY1/tLMMTcfFLLpw==}
+
+  chai@5.3.3:
+    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+    engines: {node: '>=18'}
+
+  chalk-template@0.4.0:
+    resolution: {integrity: sha512-/ghrgmhfY8RaSdeo43hNXxpoHAtxdbskUHjPpfqUWGttFgycUhYPGx3YZBCnUCvOa7Doivn1IZec3DEGFoMgLg==}
+    engines: {node: '>=12'}
+
+  chalk@4.1.2:
+    resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
+    engines: {node: '>=10'}
+
+  charenc@0.0.2:
+    resolution: {integrity: sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==}
+
+  cheap-ruler@4.0.0:
+    resolution: {integrity: sha512-0BJa8f4t141BYKQyn9NSQt1PguFQXMXwZiA5shfoaBYHAb2fFk2RAX+tiWMoQU+Agtzt3mdt0JtuyshAXqZ+Vw==}
+
+  check-error@2.1.3:
+    resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
+    engines: {node: '>= 16'}
+
+  color-convert@2.0.1:
+    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
+    engines: {node: '>=7.0.0'}
+
+  color-name@1.1.4:
+    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  command-line-args@6.0.2:
+    resolution: {integrity: sha512-AIjYVxrV9X752LmPDLbVYv8aMCuHPSLZJXEo2qo/xJfv+NYhaZ4sMSF01rM+gHPaMgvPM0l5D/F+Qx+i2WfSmQ==}
+    engines: {node: '>=12.20'}
+    peerDependencies:
+      '@75lb/nature': latest
+    peerDependenciesMeta:
+      '@75lb/nature':
+        optional: true
+
+  command-line-usage@7.0.4:
+    resolution: {integrity: sha512-85UdvzTNx/+s5CkSgBm/0hzP80RFHAa7PsfeADE5ezZF3uHz3/Tqj9gIKGT9PTtpycc3Ua64T0oVulGfKxzfqg==}
+    engines: {node: '>=12.20.0'}
+
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  core-assert@0.2.1:
+    resolution: {integrity: sha512-IG97qShIP+nrJCXMCgkNZgH7jZQ4n8RpPyPeXX++T6avR/KhLhgLiHKoEn5Rc1KjfycSfA9DMa6m+4C4eguHhw==}
+    engines: {node: '>=0.10.0'}
+
+  core-util-is@1.0.3:
+    resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
+
+  crypt@0.0.2:
+    resolution: {integrity: sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==}
+
+  csscolorparser@1.0.3:
+    resolution: {integrity: sha512-umPSgYwZkdFoUrH5hIq5kf0wPSXiro51nPw0j2K/c83KflkPSTBGMz6NJvMB+07VlL0y7VPo6QJcDjcgKTTm3w==}
+
+  csstype@3.2.3:
+    resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    engines: {node: '>=6'}
+
+  deep-strict-equal@0.2.0:
+    resolution: {integrity: sha512-3daSWyvZ/zwJvuMGlzG1O+Ow0YSadGfb3jsh9xoCutv2tWyB9dA4YvR9L9/fSdDZa2dByYQe+TqapSGUrjnkoA==}
+    engines: {node: '>=0.10.0'}
+
+  dotenv@17.4.2:
+    resolution: {integrity: sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==}
+    engines: {node: '>=12'}
+
+  draco3d@1.5.7:
+    resolution: {integrity: sha512-m6WCKt/erDXcw+70IJXnG7M3awwQPAsZvJGX5zY7beBqpELw6RDGkYVU0W43AFxye4pDZ5i2Lbyc/NNGqwjUVQ==}
+
+  earcut@2.2.4:
+    resolution: {integrity: sha512-/pjZsA1b4RPHbeWZQn66SWS8nZZWLQQ23oE3Eam7aroEFGEvwKAsJfZ9ytiEMycfzXWpca4FA9QIOehf7PocBQ==}
+
+  earcut@3.0.2:
+    resolution: {integrity: sha512-X7hshQbLyMJ/3RPhyObLARM2sNxxmRALLKx1+NVFFnQ9gKzmCrxm9+uLIAdBcvc8FNLpctqlQ2V6AE92Ol9UDQ==}
+
+  electron-to-chromium@1.5.355:
+    resolution: {integrity: sha512-LUPZhKzZPYSPme1jEYohpkA+ybYCJztr1quAdBd7E7h3+VOBVcKkwwtBJu41nrjawrRzfb8mtMfzWozoaK0ZIQ==}
+
+  es-module-lexer@1.7.0:
+    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
+  esbuild@0.25.12:
+    resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  esbuild@0.27.7:
+    resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  escalade@3.2.0:
+    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
+    engines: {node: '>=6'}
+
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  eventsource-parser@3.1.0:
+    resolution: {integrity: sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==}
+    engines: {node: '>=18.0.0'}
+
+  expect-type@1.4.0:
+    resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
+    engines: {node: '>=12.0.0'}
+
+  fast-xml-builder@1.2.0:
+    resolution: {integrity: sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==}
+
+  fast-xml-parser@5.9.3:
+    resolution: {integrity: sha512-brCNCeScma/kqa54J4PIDriSSSLssRkuYaUCpvHJulGc3HGI/xxKUCTDcYkAdqJsyb//ydpbxecjC3hB9+tb/g==}
+    hasBin: true
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
+  fflate@0.7.4:
+    resolution: {integrity: sha512-5u2V/CDW15QM1XbbgS+0DfPxVB+jUKhWEKuuFuHncbk3tEEqzmoXL+2KyOFuKGqOnmdIy0/davWF1CkuwtibCw==}
+
+  fflate@0.8.3:
+    resolution: {integrity: sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==}
+
+  find-replace@5.0.2:
+    resolution: {integrity: sha512-Y45BAiE3mz2QsrN2fb5QEtO4qb44NcS7en/0y9PEVsg351HsLeVclP8QPMH79Le9sH3rs5RSwJu99W0WPZO43Q==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@75lb/nature': latest
+    peerDependenciesMeta:
+      '@75lb/nature':
+        optional: true
+
+  flatbuffers@25.9.23:
+    resolution: {integrity: sha512-MI1qs7Lo4Syw0EOzUl0xjs2lsoeqFku44KpngfIduHBYvzm8h2+7K8YMQh1JtVVVrUvhLpNwqVi4DERegUJhPQ==}
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  gensync@1.0.0-beta.2:
+    resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
+    engines: {node: '>=6.9.0'}
+
+  geojson-vt@4.0.2:
+    resolution: {integrity: sha512-AV9ROqlNqoZEIJGfm1ncNjEXfkz2hdFlZf0qkVfmkwdKa8vj7H16YUOT81rJw1rdFhyEDlN2Tds91p/glzbl5A==}
+
+  get-tsconfig@4.14.0:
+    resolution: {integrity: sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==}
+
+  gl-matrix@3.4.4:
+    resolution: {integrity: sha512-latSnyDNt/8zYUB6VIJ6PCh2jBjJX6gnDsoCZ7LyW7GkqrD51EWwa9qCoGixj8YqBtETQK/xY7OmpTF8xz1DdQ==}
+
+  grid-index@1.1.0:
+    resolution: {integrity: sha512-HZRwumpOGUrHyxO5bqKZL0B0GlUpwtCAzZ42sgxUPniu33R1LSFH5yrIcBCHjkctCAh3mtWKcKd9J4vDDdeVHA==}
+
+  h3-js@4.5.0:
+    resolution: {integrity: sha512-uKmdPc+DuarnR+XqZxEuWOMw7KzzKROrx3MLeJpFnMOs78S9M5eZ+X5RieS9UcSFQqbeXzbfWuX/W9Pyajinqw==}
+    engines: {node: '>=4', npm: '>=3', yarn: '>=1.3.0'}
+
+  has-flag@4.0.0:
+    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
+    engines: {node: '>=8'}
+
+  iceberg-js@0.8.1:
+    resolution: {integrity: sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==}
+    engines: {node: '>=20.0.0'}
+
+  ieee754@1.2.1:
+    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
+
+  image-size@0.7.5:
+    resolution: {integrity: sha512-Hiyv+mXHfFEP7LzUL/llg9RwFxxY+o9N3JVLIeG5E7iFIFAalxvRU9UZthBdYDEVnzHMgjnKJPPpay5BWf1g9g==}
+    engines: {node: '>=6.9.0'}
+    hasBin: true
+
+  immediate@3.0.6:
+    resolution: {integrity: sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==}
+
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  is-buffer@1.1.6:
+    resolution: {integrity: sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==}
+
+  is-error@2.2.2:
+    resolution: {integrity: sha512-IOQqts/aHWbiisY5DuPJQ0gcbvaLFCa7fBa9xoLfxBZvQ+ZI/Zh9xoI7Gk+G64N0FdK4AbibytHht2tWgpJWLg==}
+
+  is-unsafe@1.0.1:
+    resolution: {integrity: sha512-CLK2+VdgERgD96EYm5lUQssZYlRg2tkZnbsxZoacmSiRxiFJ4Nk4SzjCl+Ur+v3kXIY9dTIdb3IH22y1mZ56LA==}
+
+  isarray@1.0.0:
+    resolution: {integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==}
+
+  js-tokens@4.0.0:
+    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
+  js-tokens@9.0.1:
+    resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
+
+  jsesc@3.1.0:
+    resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
+    engines: {node: '>=6'}
+    hasBin: true
+
+  json-bignum@0.0.3:
+    resolution: {integrity: sha512-2WHyXj3OfHSgNyuzDbSxI1w2jgw5gkWSWhS7Qg4bWXx1nLk3jnbwfUeS0PSba3IzpTUWdHxBieELUzXRjQB2zg==}
+    engines: {node: '>=0.8'}
+
+  json-schema@0.4.0:
+    resolution: {integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==}
+
+  json5@2.2.3:
+    resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
+    engines: {node: '>=6'}
+    hasBin: true
+
+  jszip@3.10.1:
+    resolution: {integrity: sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==}
+
+  kdbush@4.0.2:
+    resolution: {integrity: sha512-WbCVYJ27Sz8zi9Q7Q0xHC+05iwkm3Znipc2XTlrnJbsHMYktW4hPhXUE8Ys1engBrvffoSCqbil1JQAa7clRpA==}
+
+  ktx-parse@0.7.1:
+    resolution: {integrity: sha512-FeA3g56ksdFNwjXJJsc1CCc7co+AJYDp6ipIp878zZ2bU8kWROatLYf39TQEd4/XRSUvBXovQ8gaVKWPXsCLEQ==}
+
+  lie@3.3.0:
+    resolution: {integrity: sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==}
+
+  lodash.camelcase@4.3.0:
+    resolution: {integrity: sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==}
+
+  long@3.2.0:
+    resolution: {integrity: sha512-ZYvPPOMqUwPoDsbJaR10iQJYnMuZhRTvHYl62ErLIEX7RgFlziSBUUvrt3OVfc47QlHHpzPZYP17g3Fv7oeJkg==}
+    engines: {node: '>=0.6'}
+
+  long@5.3.2:
+    resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
+
+  loupe@3.2.1:
+    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
+
+  lru-cache@5.1.1:
+    resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+
+  lucide-react@0.576.0:
+    resolution: {integrity: sha512-koNxU14BXrxUfZQ9cUaP0ES1uyPZKYDjk31FQZB6dQ/x+tXk979sVAn9ppZ/pVeJJyOxVM8j1E+8QEuSc02Vug==}
+    peerDependencies:
+      react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  lz4js@0.2.0:
+    resolution: {integrity: sha512-gY2Ia9Lm7Ep8qMiuGRhvUq0Q7qUereeldZPP1PMEJxPtEWHJLqw9pgX68oHajBH0nzJK4MaZEA/YNV3jT8u8Bg==}
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  mapbox-gl@3.23.1:
+    resolution: {integrity: sha512-J5M32GunL5KcxvV3ZyLJdr7xtcQ3afAO3VjitLW0v2UVfHjXhq9NO4tkTpn4Dknqwq/pXZG7j1WBfmddLCA26w==}
+
+  mapbox-pmtiles@1.0.56:
+    resolution: {integrity: sha512-DcMj0ZpDypMskqU4WSNTlt+2ACTihK/qjtWnyVnJF51f5F5fDLxFUWzRgEn4utSvSuynm5+vlJt+k8U83xuVsQ==}
+    engines: {node: '>=18.x.x <=22.x.x', npm: '>=10.0.0'}
+
+  martinez-polygon-clipping@0.8.1:
+    resolution: {integrity: sha512-9PLLMzMPI6ihHox4Ns6LpVBLpRc7sbhULybZ/wyaY8sY3ECNe2+hxm1hA2/9bEEpRrdpjoeduBuZLg2aq1cSIQ==}
+
+  md5@2.3.0:
+    resolution: {integrity: sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==}
+
+  meshoptimizer@0.18.1:
+    resolution: {integrity: sha512-ZhoIoL7TNV4s5B6+rx5mC//fw8/POGyNxS/DZyCJeiZ12ScLfVwRE/GfsxwiTkMYYD5DmK2/JXnEVXqL4rF+Sw==}
+
+  mjolnir.js@3.0.0:
+    resolution: {integrity: sha512-siX3YCG7N2HnmN1xMH3cK4JkUZJhbkhRFJL+G5N1vH0mh1t5088rJknIoqDFWDIU6NPGvRRgLnYW3ZHjSMEBLA==}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  murmurhash-js@1.0.0:
+    resolution: {integrity: sha512-TvmkNhkv8yct0SVBSy+o8wYzXjE4Zz3PCesbfs8HiCXXdcTuocApFv11UWlNFWKYsP2okqrhb7JNlSm9InBhIw==}
+
+  nanoid@3.3.12:
+    resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  node-releases@2.0.44:
+    resolution: {integrity: sha512-5WUyunoPMsvvEhS8AxHtRzP+oA8UCkJ7YRxatWKjngndhDGLiqEVAQKWjFAiAiuL8zMRGzGSJxFnLetoa43qGQ==}
+
+  pako@1.0.11:
+    resolution: {integrity: sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==}
+
+  path-expression-matcher@1.6.1:
+    resolution: {integrity: sha512-h7bxdzhHk8Knyc4Tj+jMaa7fEEoUJy7p1qtbVgkYg1Uhpe5Np5VuGXCRZnkZvU+Q42M1vStt0ifa3ueykRJPmQ==}
+    engines: {node: '>=14.0.0'}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  pathval@2.0.1:
+    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
+    engines: {node: '>= 14.16'}
+
+  pbf@3.3.0:
+    resolution: {integrity: sha512-XDF38WCH3z5OV/OVa8GKUNtLAyneuzbCisx7QUCF8Q6Nutx0WnJrQe5O+kOtBlLfRNUws98Y58Lblp+NJG5T4Q==}
+    hasBin: true
+
+  pbf@4.0.1:
+    resolution: {integrity: sha512-SuLdBvS42z33m8ejRbInMapQe8n0D3vN/Xd5fmWM3tufNgRQFBpaW2YVJxQZV4iPNqb0vEFvssMEo5w9c6BTIA==}
+    hasBin: true
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
+    engines: {node: '>=12'}
+
+  pmtiles@3.2.1:
+    resolution: {integrity: sha512-3R4fBwwoli5mw7a6t1IGwOtfmcSAODq6Okz0zkXhS1zi9sz1ssjjIfslwPvcWw5TNhdjNBUg9fgfPLeqZlH6ng==}
+
+  pmtiles@4.4.1:
+    resolution: {integrity: sha512-5oTeQc/yX/ft1evbpIlnoCZugQuug/iYIAj/ZTqIqzdGek4uZEho99En890EE6NOSI3JTI3IG8R7r8+SltphxA==}
+
+  postcss@8.5.14:
+    resolution: {integrity: sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  potpack@2.1.0:
+    resolution: {integrity: sha512-pcaShQc1Shq0y+E7GqJqvZj8DTthWV1KeHGdi0Z6IAin2Oi3JnLCOfwnCo84qc+HAp52wT9nK9H7FAJp5a44GQ==}
+
+  process-nextick-args@2.0.1:
+    resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
+
+  protocol-buffers-schema@3.6.1:
+    resolution: {integrity: sha512-VG2K63Igkiv9p76tk1lilczEK1cT+kCjKtkdhw1dQZV3k3IXJbd3o6Ho8b9zJZaHSnT2hKe4I+ObmX9w6m5SmQ==}
+
+  quickselect@3.0.0:
+    resolution: {integrity: sha512-XdjUArbK4Bm5fLLvlm5KpTFOiOThgfWWI4axAZDWg4E/0mKdZyI9tNEfds27qCi1ze/vwTR16kvmmGhRra3c2g==}
+
+  react-dom@19.2.6:
+    resolution: {integrity: sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==}
+    peerDependencies:
+      react: ^19.2.6
+
+  react-refresh@0.17.0:
+    resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
+    engines: {node: '>=0.10.0'}
+
+  react@19.2.6:
+    resolution: {integrity: sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==}
+    engines: {node: '>=0.10.0'}
+
+  readable-stream@2.3.8:
+    resolution: {integrity: sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==}
+
+  resolve-pkg-maps@1.0.0:
+    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+
+  resolve-protobuf-schema@2.1.0:
+    resolution: {integrity: sha512-kI5ffTiZWmJaS/huM8wZfEMer1eRd7oJQhDuxeCLe3t7N7mX3z94CN0xPxBQxFYQTSNz9T0i+v6inKqSdK8xrQ==}
+
+  robust-predicates@2.0.4:
+    resolution: {integrity: sha512-l4NwboJM74Ilm4VKfbAtFeGq7aEjWL+5kVFcmgFA2MrdnQWx9iE/tUGvxY5HyMI7o/WpSIUFLbC5fbeaHgSCYg==}
+
+  rollup@4.60.3:
+    resolution: {integrity: sha512-pAQK9HalE84QSm4Po3EmWIZPd3FnjkShVkiMlz1iligWYkWQ7wHYd1PF/T7QZ5TVSD6uSTon5gBVMSM4JfBV+A==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
+  safe-buffer@5.1.2:
+    resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
+
+  satellite.js@5.0.0:
+    resolution: {integrity: sha512-ie3yiJ2LJAJIhVUKdYhgp7V0btXKAMImDjRnuaNfJGl8rjwP2HwVIh4HLFcpiXYEiYwXc5fqh5+yZqCe6KIwWw==}
+
+  scheduler@0.27.0:
+    resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
+
+  semver@6.3.1:
+    resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
+    hasBin: true
+
+  setimmediate@1.0.5:
+    resolution: {integrity: sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==}
+
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  snappyjs@0.6.1:
+    resolution: {integrity: sha512-YIK6I2lsH072UE0aOFxxY1dPDCS43I5ktqHpeAsuLNYWkE5pGxRGWfDM4/vSUfNzXjC1Ivzt3qx31PCLmc9yqg==}
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
+  splaytree@0.1.4:
+    resolution: {integrity: sha512-D50hKrjZgBzqD3FT2Ek53f2dcDLAQT8SSGrzj3vidNH5ISRgceeGVJ2dQIthKOuayqFXfFjXheHNo4bbt9LhRQ==}
+
+  sprintf-js@1.0.3:
+    resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@3.10.0:
+    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
+
+  string_decoder@1.1.1:
+    resolution: {integrity: sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==}
+
+  strip-literal@3.1.0:
+    resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
+
+  strnum@2.4.1:
+    resolution: {integrity: sha512-M9eUSMT2dCB2cTNPG7UYj6KuK7RJR2SN2+yCV/fTW3xzTCS6EaGZ5pSMgDIjB7r8zSfTGk+dvvn9rTjpVS9Mwg==}
+
+  supercluster@8.0.1:
+    resolution: {integrity: sha512-IiOea5kJ9iqzD2t7QJq/cREyLHTtSmUT6gQsweojg9WH2sYJqZK9SswTu6jrscO6D1G5v5vYZ9ru/eq85lXeZQ==}
+
+  supports-color@7.2.0:
+    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
+    engines: {node: '>=8'}
+
+  table-layout@4.1.1:
+    resolution: {integrity: sha512-iK5/YhZxq5GO5z8wb0bY1317uDF3Zjpha0QFFLA8/trAoiLbQD0HUbMesEaxyzUgDxi2QlcbM8IvqOlEjgoXBA==}
+    engines: {node: '>=12.17'}
+
+  texture-compressor@1.0.2:
+    resolution: {integrity: sha512-dStVgoaQ11mA5htJ+RzZ51ZxIZqNOgWKAIvtjLrW1AliQQLCmrDqNzQZ8Jh91YealQ95DXt4MEduLzJmbs6lig==}
+    hasBin: true
+
+  three@0.172.0:
+    resolution: {integrity: sha512-6HMgMlzU97MsV7D/tY8Va38b83kz8YJX+BefKjspMNAv0Vx6dxMogHOrnRl/sbMIs3BPUKijPqDqJ/+UwJbIow==}
+
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
+  tinyglobby@0.2.16:
+    resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
+    engines: {node: '>=12.0.0'}
+
+  tinypool@1.1.1:
+    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+
+  tinyqueue@3.0.0:
+    resolution: {integrity: sha512-gRa9gwYU3ECmQYv3lslts5hxuIa90veaEcxDYuu3QGOIAEM2mOZkVHp48ANJuu1CURtRdHKUBY5Lm1tHV+sD4g==}
+
+  tinyrainbow@2.0.0:
+    resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@4.0.4:
+    resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
+    engines: {node: '>=14.0.0'}
+
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  tsx@4.21.0:
+    resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
+  typescript@5.7.3:
+    resolution: {integrity: sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  typical@7.3.0:
+    resolution: {integrity: sha512-ya4mg/30vm+DOWfBg4YK3j2WD6TWtRkCbasOJr40CseYENzCUby/7rIvXA99JGsQHeNxLbnXdyLLxKSv3tauFw==}
+    engines: {node: '>=12.17'}
+
+  undici-types@7.16.0:
+    resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
+
+  undici-types@7.24.6:
+    resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
+
+  update-browserslist-db@1.2.3:
+    resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
+    hasBin: true
+    peerDependencies:
+      browserslist: '>= 4.21.0'
+
+  util-deprecate@1.0.2:
+    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  vite-node@3.2.4:
+    resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+
+  vite@6.4.2:
+    resolution: {integrity: sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      jiti: '>=1.21.0'
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      sass-embedded: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@3.2.6:
+    resolution: {integrity: sha512-xejya+bT/j/+R/AGa1XOfRxLmNUlLtlwjRsFUILF+xHfzElmGcmFydy2gqqIrd62ptIEfwVMofd19uNWD9L7Nw==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/debug': ^4.1.12
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      '@vitest/browser': 3.2.6
+      '@vitest/ui': 3.2.6
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/debug':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
+
+  wordwrapjs@5.1.1:
+    resolution: {integrity: sha512-0yweIbkINJodk27gX9LBGMzyQdBDan3s/dEAiwBOj+Mf0PPyWL6/rikalkv8EeD0E8jm4o5RXEOrFTP3NXbhJg==}
+    engines: {node: '>=12.17'}
+
+  xml-naming@0.1.0:
+    resolution: {integrity: sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==}
+    engines: {node: '>=16.0.0'}
+
+  yallist@3.1.1:
+    resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
+
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
+
+  zstd-codec@0.1.5:
+    resolution: {integrity: sha512-v3fyjpK8S/dpY/X5WxqTK3IoCnp/ZOLxn144GZVlNUjtwAchzrVo03h+oMATFhCIiJ5KTr4V3vDQQYz4RU684g==}
+
+snapshots:
+
+  '@ai-sdk/anthropic@4.0.5(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 4.0.1
+      '@ai-sdk/provider-utils': 5.0.3(zod@4.4.3)
+      zod: 4.4.3
+
+  '@ai-sdk/gateway@4.0.8(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 4.0.1
+      '@ai-sdk/provider-utils': 5.0.3(zod@4.4.3)
+      '@vercel/oidc': 3.2.0
+      zod: 4.4.3
+
+  '@ai-sdk/google@4.0.6(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 4.0.1
+      '@ai-sdk/provider-utils': 5.0.3(zod@4.4.3)
+      zod: 4.4.3
+
+  '@ai-sdk/openai@4.0.5(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 4.0.1
+      '@ai-sdk/provider-utils': 5.0.3(zod@4.4.3)
+      zod: 4.4.3
+
+  '@ai-sdk/provider-utils@5.0.3(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 4.0.1
+      '@standard-schema/spec': 1.1.0
+      '@workflow/serde': 4.1.0
+      eventsource-parser: 3.1.0
+      zod: 4.4.3
+
+  '@ai-sdk/provider@4.0.1':
+    dependencies:
+      json-schema: 0.4.0
+
+  '@aws-sdk/checksums@3.1000.11':
+    dependencies:
+      '@aws-sdk/core': 3.974.26
+      '@aws-sdk/types': 3.973.15
+      '@smithy/core': 3.29.0
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
+  '@aws-sdk/client-s3@3.1078.0':
+    dependencies:
+      '@aws-sdk/checksums': 3.1000.11
+      '@aws-sdk/core': 3.974.26
+      '@aws-sdk/credential-provider-node': 3.972.61
+      '@aws-sdk/middleware-sdk-s3': 3.972.57
+      '@aws-sdk/signature-v4-multi-region': 3.996.38
+      '@aws-sdk/types': 3.973.15
+      '@smithy/core': 3.29.0
+      '@smithy/fetch-http-handler': 5.6.2
+      '@smithy/node-http-handler': 4.9.2
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
+  '@aws-sdk/core@3.974.26':
+    dependencies:
+      '@aws-sdk/types': 3.973.15
+      '@aws-sdk/xml-builder': 3.972.33
+      '@aws/lambda-invoke-store': 0.2.4
+      '@smithy/core': 3.29.0
+      '@smithy/signature-v4': 5.6.1
+      '@smithy/types': 4.15.1
+      bowser: 2.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-env@3.972.52':
+    dependencies:
+      '@aws-sdk/core': 3.974.26
+      '@aws-sdk/types': 3.973.15
+      '@smithy/core': 3.29.0
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-http@3.972.54':
+    dependencies:
+      '@aws-sdk/core': 3.974.26
+      '@aws-sdk/types': 3.973.15
+      '@smithy/core': 3.29.0
+      '@smithy/fetch-http-handler': 5.6.2
+      '@smithy/node-http-handler': 4.9.2
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-ini@3.972.59':
+    dependencies:
+      '@aws-sdk/core': 3.974.26
+      '@aws-sdk/credential-provider-env': 3.972.52
+      '@aws-sdk/credential-provider-http': 3.972.54
+      '@aws-sdk/credential-provider-login': 3.972.58
+      '@aws-sdk/credential-provider-process': 3.972.52
+      '@aws-sdk/credential-provider-sso': 3.972.58
+      '@aws-sdk/credential-provider-web-identity': 3.972.58
+      '@aws-sdk/nested-clients': 3.997.26
+      '@aws-sdk/types': 3.973.15
+      '@smithy/core': 3.29.0
+      '@smithy/credential-provider-imds': 4.4.5
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-login@3.972.58':
+    dependencies:
+      '@aws-sdk/core': 3.974.26
+      '@aws-sdk/nested-clients': 3.997.26
+      '@aws-sdk/types': 3.973.15
+      '@smithy/core': 3.29.0
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-node@3.972.61':
+    dependencies:
+      '@aws-sdk/credential-provider-env': 3.972.52
+      '@aws-sdk/credential-provider-http': 3.972.54
+      '@aws-sdk/credential-provider-ini': 3.972.59
+      '@aws-sdk/credential-provider-process': 3.972.52
+      '@aws-sdk/credential-provider-sso': 3.972.58
+      '@aws-sdk/credential-provider-web-identity': 3.972.58
+      '@aws-sdk/types': 3.973.15
+      '@smithy/core': 3.29.0
+      '@smithy/credential-provider-imds': 4.4.5
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-process@3.972.52':
+    dependencies:
+      '@aws-sdk/core': 3.974.26
+      '@aws-sdk/types': 3.973.15
+      '@smithy/core': 3.29.0
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-sso@3.972.58':
+    dependencies:
+      '@aws-sdk/core': 3.974.26
+      '@aws-sdk/nested-clients': 3.997.26
+      '@aws-sdk/token-providers': 3.1078.0
+      '@aws-sdk/types': 3.973.15
+      '@smithy/core': 3.29.0
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-web-identity@3.972.58':
+    dependencies:
+      '@aws-sdk/core': 3.974.26
+      '@aws-sdk/nested-clients': 3.997.26
+      '@aws-sdk/types': 3.973.15
+      '@smithy/core': 3.29.0
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-sdk-s3@3.972.57':
+    dependencies:
+      '@aws-sdk/core': 3.974.26
+      '@aws-sdk/signature-v4-multi-region': 3.996.38
+      '@aws-sdk/types': 3.973.15
+      '@smithy/core': 3.29.0
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
+  '@aws-sdk/nested-clients@3.997.26':
+    dependencies:
+      '@aws-sdk/core': 3.974.26
+      '@aws-sdk/signature-v4-multi-region': 3.996.38
+      '@aws-sdk/types': 3.973.15
+      '@smithy/core': 3.29.0
+      '@smithy/fetch-http-handler': 5.6.2
+      '@smithy/node-http-handler': 4.9.2
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
+  '@aws-sdk/signature-v4-multi-region@3.996.38':
+    dependencies:
+      '@aws-sdk/types': 3.973.15
+      '@smithy/signature-v4': 5.6.1
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
+  '@aws-sdk/token-providers@3.1078.0':
+    dependencies:
+      '@aws-sdk/core': 3.974.26
+      '@aws-sdk/nested-clients': 3.997.26
+      '@aws-sdk/types': 3.973.15
+      '@smithy/core': 3.29.0
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
+  '@aws-sdk/types@3.973.15':
+    dependencies:
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
+  '@aws-sdk/xml-builder@3.972.33':
+    dependencies:
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
+  '@aws/lambda-invoke-store@0.2.4': {}
+
+  '@babel/code-frame@7.29.0':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.28.5
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
+  '@babel/compat-data@7.29.3': {}
+
+  '@babel/core@7.29.0':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/generator': 7.29.1
+      '@babel/helper-compilation-targets': 7.28.6
+      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0)
+      '@babel/helpers': 7.29.2
+      '@babel/parser': 7.29.3
+      '@babel/template': 7.28.6
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
+      '@jridgewell/remapping': 2.3.5
+      convert-source-map: 2.0.0
+      debug: 4.4.3
+      gensync: 1.0.0-beta.2
+      json5: 2.2.3
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/generator@7.29.1':
+    dependencies:
+      '@babel/parser': 7.29.3
+      '@babel/types': 7.29.0
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+      jsesc: 3.1.0
+
+  '@babel/helper-compilation-targets@7.28.6':
+    dependencies:
+      '@babel/compat-data': 7.29.3
+      '@babel/helper-validator-option': 7.27.1
+      browserslist: 4.28.2
+      lru-cache: 5.1.1
+      semver: 6.3.1
+
+  '@babel/helper-globals@7.28.0': {}
+
+  '@babel/helper-module-imports@7.28.6':
+    dependencies:
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-module-transforms@7.28.6(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-module-imports': 7.28.6
+      '@babel/helper-validator-identifier': 7.28.5
+      '@babel/traverse': 7.29.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-plugin-utils@7.28.6': {}
+
+  '@babel/helper-string-parser@7.27.1': {}
+
+  '@babel/helper-validator-identifier@7.28.5': {}
+
+  '@babel/helper-validator-option@7.27.1': {}
+
+  '@babel/helpers@7.29.2':
+    dependencies:
+      '@babel/template': 7.28.6
+      '@babel/types': 7.29.0
+
+  '@babel/parser@7.29.3':
+    dependencies:
+      '@babel/types': 7.29.0
+
+  '@babel/plugin-transform-react-jsx-self@7.27.1(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/plugin-transform-react-jsx-source@7.27.1(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/template@7.28.6':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/parser': 7.29.3
+      '@babel/types': 7.29.0
+
+  '@babel/traverse@7.29.0':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/generator': 7.29.1
+      '@babel/helper-globals': 7.28.0
+      '@babel/parser': 7.29.3
+      '@babel/template': 7.28.6
+      '@babel/types': 7.29.0
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/types@7.29.0':
+    dependencies:
+      '@babel/helper-string-parser': 7.27.1
+      '@babel/helper-validator-identifier': 7.28.5
+
+  '@deck.gl/core@9.3.5':
+    dependencies:
+      '@loaders.gl/core': 4.4.3
+      '@loaders.gl/images': 4.4.3(@loaders.gl/core@4.4.3)
+      '@luma.gl/core': 9.3.5
+      '@luma.gl/engine': 9.3.5(@luma.gl/core@9.3.5)(@luma.gl/shadertools@9.3.5(@luma.gl/core@9.3.5))
+      '@luma.gl/shadertools': 9.3.5(@luma.gl/core@9.3.5)
+      '@luma.gl/webgl': 9.3.5(@luma.gl/core@9.3.5)
+      '@math.gl/core': 4.1.0
+      '@math.gl/sun': 4.1.0
+      '@math.gl/types': 4.1.0
+      '@math.gl/web-mercator': 4.1.0
+      '@probe.gl/env': 4.1.1
+      '@probe.gl/log': 4.1.1
+      '@probe.gl/stats': 4.1.1
+      '@types/offscreencanvas': 2019.7.3
+      gl-matrix: 3.4.4
+      mjolnir.js: 3.0.0
+    transitivePeerDependencies:
+      - '@75lb/nature'
+
+  '@deck.gl/extensions@9.3.5(@deck.gl/core@9.3.5)(@luma.gl/core@9.3.5)(@luma.gl/engine@9.3.5(@luma.gl/core@9.3.5)(@luma.gl/shadertools@9.3.5(@luma.gl/core@9.3.5)))':
+    dependencies:
+      '@deck.gl/core': 9.3.5
+      '@luma.gl/core': 9.3.5
+      '@luma.gl/engine': 9.3.5(@luma.gl/core@9.3.5)(@luma.gl/shadertools@9.3.5(@luma.gl/core@9.3.5))
+      '@luma.gl/shadertools': 9.3.5(@luma.gl/core@9.3.5)
+      '@luma.gl/webgl': 9.3.5(@luma.gl/core@9.3.5)
+      '@math.gl/core': 4.1.0
+
+  '@deck.gl/geo-layers@9.3.5(@deck.gl/core@9.3.5)(@deck.gl/extensions@9.3.5(@deck.gl/core@9.3.5)(@luma.gl/core@9.3.5)(@luma.gl/engine@9.3.5(@luma.gl/core@9.3.5)(@luma.gl/shadertools@9.3.5(@luma.gl/core@9.3.5))))(@deck.gl/layers@9.3.5(@deck.gl/core@9.3.5)(@loaders.gl/core@4.4.3)(@luma.gl/core@9.3.5)(@luma.gl/engine@9.3.5(@luma.gl/core@9.3.5)(@luma.gl/shadertools@9.3.5(@luma.gl/core@9.3.5))))(@deck.gl/mesh-layers@9.3.5(@deck.gl/core@9.3.5)(@loaders.gl/core@4.4.3)(@luma.gl/core@9.3.5)(@luma.gl/engine@9.3.5(@luma.gl/core@9.3.5)(@luma.gl/shadertools@9.3.5(@luma.gl/core@9.3.5)))(@luma.gl/gltf@9.3.5(@luma.gl/core@9.3.5)(@luma.gl/engine@9.3.5(@luma.gl/core@9.3.5)(@luma.gl/shadertools@9.3.5(@luma.gl/core@9.3.5)))(@luma.gl/shadertools@9.3.5(@luma.gl/core@9.3.5)))(@luma.gl/shadertools@9.3.5(@luma.gl/core@9.3.5)))(@loaders.gl/core@4.4.3)(@luma.gl/core@9.3.5)(@luma.gl/engine@9.3.5(@luma.gl/core@9.3.5)(@luma.gl/shadertools@9.3.5(@luma.gl/core@9.3.5)))':
+    dependencies:
+      '@deck.gl/core': 9.3.5
+      '@deck.gl/extensions': 9.3.5(@deck.gl/core@9.3.5)(@luma.gl/core@9.3.5)(@luma.gl/engine@9.3.5(@luma.gl/core@9.3.5)(@luma.gl/shadertools@9.3.5(@luma.gl/core@9.3.5)))
+      '@deck.gl/layers': 9.3.5(@deck.gl/core@9.3.5)(@loaders.gl/core@4.4.3)(@luma.gl/core@9.3.5)(@luma.gl/engine@9.3.5(@luma.gl/core@9.3.5)(@luma.gl/shadertools@9.3.5(@luma.gl/core@9.3.5)))
+      '@deck.gl/mesh-layers': 9.3.5(@deck.gl/core@9.3.5)(@loaders.gl/core@4.4.3)(@luma.gl/core@9.3.5)(@luma.gl/engine@9.3.5(@luma.gl/core@9.3.5)(@luma.gl/shadertools@9.3.5(@luma.gl/core@9.3.5)))(@luma.gl/gltf@9.3.5(@luma.gl/core@9.3.5)(@luma.gl/engine@9.3.5(@luma.gl/core@9.3.5)(@luma.gl/shadertools@9.3.5(@luma.gl/core@9.3.5)))(@luma.gl/shadertools@9.3.5(@luma.gl/core@9.3.5)))(@luma.gl/shadertools@9.3.5(@luma.gl/core@9.3.5))
+      '@loaders.gl/3d-tiles': 4.4.3(@loaders.gl/core@4.4.3)
+      '@loaders.gl/core': 4.4.3
+      '@loaders.gl/gis': 4.4.3(@loaders.gl/core@4.4.3)
+      '@loaders.gl/loader-utils': 4.4.3(@loaders.gl/core@4.4.3)
+      '@loaders.gl/mvt': 4.4.3(@loaders.gl/core@4.4.3)
+      '@loaders.gl/schema': 4.4.3
+      '@loaders.gl/terrain': 4.4.3(@loaders.gl/core@4.4.3)
+      '@loaders.gl/tiles': 4.4.3(@loaders.gl/core@4.4.3)
+      '@loaders.gl/wms': 4.4.3(@loaders.gl/core@4.4.3)
+      '@luma.gl/core': 9.3.5
+      '@luma.gl/engine': 9.3.5(@luma.gl/core@9.3.5)(@luma.gl/shadertools@9.3.5(@luma.gl/core@9.3.5))
+      '@luma.gl/gltf': 9.3.5(@luma.gl/core@9.3.5)(@luma.gl/engine@9.3.5(@luma.gl/core@9.3.5)(@luma.gl/shadertools@9.3.5(@luma.gl/core@9.3.5)))(@luma.gl/shadertools@9.3.5(@luma.gl/core@9.3.5))
+      '@luma.gl/shadertools': 9.3.5(@luma.gl/core@9.3.5)
+      '@math.gl/core': 4.1.0
+      '@math.gl/culling': 4.1.0
+      '@math.gl/web-mercator': 4.1.0
+      '@types/geojson': 7946.0.16
+      a5-js: 0.7.3
+      h3-js: 4.5.0
+      long: 3.2.0
+    transitivePeerDependencies:
+      - '@75lb/nature'
+
+  '@deck.gl/layers@9.3.5(@deck.gl/core@9.3.5)(@loaders.gl/core@4.4.3)(@luma.gl/core@9.3.5)(@luma.gl/engine@9.3.5(@luma.gl/core@9.3.5)(@luma.gl/shadertools@9.3.5(@luma.gl/core@9.3.5)))':
+    dependencies:
+      '@deck.gl/core': 9.3.5
+      '@loaders.gl/core': 4.4.3
+      '@loaders.gl/images': 4.4.3(@loaders.gl/core@4.4.3)
+      '@loaders.gl/schema': 4.4.3
+      '@luma.gl/core': 9.3.5
+      '@luma.gl/engine': 9.3.5(@luma.gl/core@9.3.5)(@luma.gl/shadertools@9.3.5(@luma.gl/core@9.3.5))
+      '@luma.gl/shadertools': 9.3.5(@luma.gl/core@9.3.5)
+      '@mapbox/tiny-sdf': 2.2.0
+      '@math.gl/core': 4.1.0
+      '@math.gl/polygon': 4.1.0
+      '@math.gl/web-mercator': 4.1.0
+      earcut: 2.2.4
+    transitivePeerDependencies:
+      - '@75lb/nature'
+
+  '@deck.gl/mapbox@9.3.5(@deck.gl/core@9.3.5)(@luma.gl/core@9.3.5)(@math.gl/web-mercator@4.1.0)':
+    dependencies:
+      '@deck.gl/core': 9.3.5
+      '@luma.gl/core': 9.3.5
+      '@math.gl/web-mercator': 4.1.0
+
+  '@deck.gl/mesh-layers@9.3.5(@deck.gl/core@9.3.5)(@loaders.gl/core@4.4.3)(@luma.gl/core@9.3.5)(@luma.gl/engine@9.3.5(@luma.gl/core@9.3.5)(@luma.gl/shadertools@9.3.5(@luma.gl/core@9.3.5)))(@luma.gl/gltf@9.3.5(@luma.gl/core@9.3.5)(@luma.gl/engine@9.3.5(@luma.gl/core@9.3.5)(@luma.gl/shadertools@9.3.5(@luma.gl/core@9.3.5)))(@luma.gl/shadertools@9.3.5(@luma.gl/core@9.3.5)))(@luma.gl/shadertools@9.3.5(@luma.gl/core@9.3.5))':
+    dependencies:
+      '@deck.gl/core': 9.3.5
+      '@loaders.gl/gltf': 4.4.3(@loaders.gl/core@4.4.3)
+      '@loaders.gl/schema': 4.4.3
+      '@luma.gl/core': 9.3.5
+      '@luma.gl/engine': 9.3.5(@luma.gl/core@9.3.5)(@luma.gl/shadertools@9.3.5(@luma.gl/core@9.3.5))
+      '@luma.gl/gltf': 9.3.5(@luma.gl/core@9.3.5)(@luma.gl/engine@9.3.5(@luma.gl/core@9.3.5)(@luma.gl/shadertools@9.3.5(@luma.gl/core@9.3.5)))(@luma.gl/shadertools@9.3.5(@luma.gl/core@9.3.5))
+      '@luma.gl/shadertools': 9.3.5(@luma.gl/core@9.3.5)
+    transitivePeerDependencies:
+      - '@75lb/nature'
+      - '@loaders.gl/core'
+
+  '@esbuild/aix-ppc64@0.25.12':
+    optional: true
+
+  '@esbuild/aix-ppc64@0.27.7':
+    optional: true
+
+  '@esbuild/android-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/android-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/android-arm@0.25.12':
+    optional: true
+
+  '@esbuild/android-arm@0.27.7':
+    optional: true
+
+  '@esbuild/android-x64@0.25.12':
+    optional: true
+
+  '@esbuild/android-x64@0.27.7':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/darwin-x64@0.25.12':
+    optional: true
+
+  '@esbuild/darwin-x64@0.27.7':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.25.12':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-arm@0.25.12':
+    optional: true
+
+  '@esbuild/linux-arm@0.27.7':
+    optional: true
+
+  '@esbuild/linux-ia32@0.25.12':
+    optional: true
+
+  '@esbuild/linux-ia32@0.27.7':
+    optional: true
+
+  '@esbuild/linux-loong64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-loong64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.25.12':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.27.7':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-s390x@0.25.12':
+    optional: true
+
+  '@esbuild/linux-s390x@0.27.7':
+    optional: true
+
+  '@esbuild/linux-x64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-x64@0.27.7':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.25.12':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.25.12':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/sunos-x64@0.25.12':
+    optional: true
+
+  '@esbuild/sunos-x64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/win32-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-ia32@0.25.12':
+    optional: true
+
+  '@esbuild/win32-ia32@0.27.7':
+    optional: true
+
+  '@esbuild/win32-x64@0.25.12':
+    optional: true
+
+  '@esbuild/win32-x64@0.27.7':
+    optional: true
+
+  '@jridgewell/gen-mapping@0.3.13':
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/remapping@2.3.5':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/resolve-uri@3.1.2': {}
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@loaders.gl/3d-tiles@4.4.3(@loaders.gl/core@4.4.3)':
+    dependencies:
+      '@loaders.gl/compression': 4.4.3(@loaders.gl/core@4.4.3)
+      '@loaders.gl/core': 4.4.3
+      '@loaders.gl/crypto': 4.4.3(@loaders.gl/core@4.4.3)
+      '@loaders.gl/draco': 4.4.3(@loaders.gl/core@4.4.3)
+      '@loaders.gl/gltf': 4.4.3(@loaders.gl/core@4.4.3)
+      '@loaders.gl/images': 4.4.3(@loaders.gl/core@4.4.3)
+      '@loaders.gl/loader-utils': 4.4.3(@loaders.gl/core@4.4.3)
+      '@loaders.gl/math': 4.4.3(@loaders.gl/core@4.4.3)
+      '@loaders.gl/tiles': 4.4.3(@loaders.gl/core@4.4.3)
+      '@loaders.gl/zip': 4.4.3(@loaders.gl/core@4.4.3)
+      '@math.gl/core': 4.1.0
+      '@math.gl/culling': 4.1.0
+      '@math.gl/geospatial': 4.1.0
+      '@probe.gl/log': 4.1.1
+      long: 5.3.2
+    transitivePeerDependencies:
+      - '@75lb/nature'
+
+  '@loaders.gl/compression@4.4.3(@loaders.gl/core@4.4.3)':
+    dependencies:
+      '@loaders.gl/core': 4.4.3
+      '@loaders.gl/loader-utils': 4.4.3(@loaders.gl/core@4.4.3)
+      '@loaders.gl/worker-utils': 4.4.3(@loaders.gl/core@4.4.3)
+      '@types/pako': 1.0.7
+      fflate: 0.7.4
+      pako: 1.0.11
+      snappyjs: 0.6.1
+    optionalDependencies:
+      '@types/brotli': 1.3.5
+      brotli: 1.3.3
+      lz4js: 0.2.0
+      zstd-codec: 0.1.5
+    transitivePeerDependencies:
+      - '@75lb/nature'
+
+  '@loaders.gl/core@4.4.3':
+    dependencies:
+      '@loaders.gl/loader-utils': 4.4.3(@loaders.gl/core@4.4.3)
+      '@loaders.gl/schema': 4.4.3
+      '@loaders.gl/schema-utils': 4.4.3(@loaders.gl/core@4.4.3)
+      '@loaders.gl/worker-utils': 4.4.3(@loaders.gl/core@4.4.3)
+      '@probe.gl/log': 4.1.1
+    transitivePeerDependencies:
+      - '@75lb/nature'
+
+  '@loaders.gl/crypto@4.4.3(@loaders.gl/core@4.4.3)':
+    dependencies:
+      '@loaders.gl/core': 4.4.3
+      '@loaders.gl/loader-utils': 4.4.3(@loaders.gl/core@4.4.3)
+      '@loaders.gl/worker-utils': 4.4.3(@loaders.gl/core@4.4.3)
+      '@types/crypto-js': 4.2.2
+    transitivePeerDependencies:
+      - '@75lb/nature'
+
+  '@loaders.gl/draco@4.4.3(@loaders.gl/core@4.4.3)':
+    dependencies:
+      '@loaders.gl/core': 4.4.3
+      '@loaders.gl/loader-utils': 4.4.3(@loaders.gl/core@4.4.3)
+      '@loaders.gl/schema': 4.4.3
+      '@loaders.gl/schema-utils': 4.4.3(@loaders.gl/core@4.4.3)
+      '@loaders.gl/worker-utils': 4.4.3(@loaders.gl/core@4.4.3)
+      draco3d: 1.5.7
+    transitivePeerDependencies:
+      - '@75lb/nature'
+
+  '@loaders.gl/geoarrow@4.4.3(@loaders.gl/core@4.4.3)':
+    dependencies:
+      '@loaders.gl/core': 4.4.3
+      '@math.gl/polygon': 4.1.0
+      apache-arrow: 21.1.0
+    transitivePeerDependencies:
+      - '@75lb/nature'
+
+  '@loaders.gl/gis@4.4.3(@loaders.gl/core@4.4.3)':
+    dependencies:
+      '@loaders.gl/core': 4.4.3
+      '@loaders.gl/geoarrow': 4.4.3(@loaders.gl/core@4.4.3)
+      '@loaders.gl/loader-utils': 4.4.3(@loaders.gl/core@4.4.3)
+      '@loaders.gl/schema': 4.4.3
+      '@loaders.gl/schema-utils': 4.4.3(@loaders.gl/core@4.4.3)
+      '@mapbox/vector-tile': 1.3.1
+      '@math.gl/polygon': 4.1.0
+      pbf: 3.3.0
+    transitivePeerDependencies:
+      - '@75lb/nature'
+
+  '@loaders.gl/gltf@4.4.3(@loaders.gl/core@4.4.3)':
+    dependencies:
+      '@loaders.gl/core': 4.4.3
+      '@loaders.gl/draco': 4.4.3(@loaders.gl/core@4.4.3)
+      '@loaders.gl/images': 4.4.3(@loaders.gl/core@4.4.3)
+      '@loaders.gl/loader-utils': 4.4.3(@loaders.gl/core@4.4.3)
+      '@loaders.gl/schema': 4.4.3
+      '@loaders.gl/textures': 4.4.3(@loaders.gl/core@4.4.3)
+      '@math.gl/core': 4.1.0
+    transitivePeerDependencies:
+      - '@75lb/nature'
+
+  '@loaders.gl/images@4.4.3(@loaders.gl/core@4.4.3)':
+    dependencies:
+      '@loaders.gl/core': 4.4.3
+      '@loaders.gl/loader-utils': 4.4.3(@loaders.gl/core@4.4.3)
+    transitivePeerDependencies:
+      - '@75lb/nature'
+
+  '@loaders.gl/loader-utils@4.4.3(@loaders.gl/core@4.4.3)':
+    dependencies:
+      '@loaders.gl/schema': 4.4.3
+      '@loaders.gl/worker-utils': 4.4.3(@loaders.gl/core@4.4.3)
+      '@probe.gl/log': 4.1.1
+      '@probe.gl/stats': 4.1.1
+    transitivePeerDependencies:
+      - '@75lb/nature'
+      - '@loaders.gl/core'
+
+  '@loaders.gl/math@4.4.3(@loaders.gl/core@4.4.3)':
+    dependencies:
+      '@loaders.gl/core': 4.4.3
+      '@math.gl/core': 4.1.0
+
+  '@loaders.gl/mvt@4.4.3(@loaders.gl/core@4.4.3)':
+    dependencies:
+      '@loaders.gl/core': 4.4.3
+      '@loaders.gl/gis': 4.4.3(@loaders.gl/core@4.4.3)
+      '@loaders.gl/images': 4.4.3(@loaders.gl/core@4.4.3)
+      '@loaders.gl/loader-utils': 4.4.3(@loaders.gl/core@4.4.3)
+      '@loaders.gl/schema': 4.4.3
+      '@math.gl/polygon': 4.1.0
+      '@probe.gl/stats': 4.1.1
+      pbf: 3.3.0
+    transitivePeerDependencies:
+      - '@75lb/nature'
+
+  '@loaders.gl/schema-utils@4.4.3(@loaders.gl/core@4.4.3)':
+    dependencies:
+      '@loaders.gl/core': 4.4.3
+      '@loaders.gl/schema': 4.4.3
+      '@types/geojson': 7946.0.16
+      apache-arrow: 21.1.0
+    transitivePeerDependencies:
+      - '@75lb/nature'
+
+  '@loaders.gl/schema@4.4.3':
+    dependencies:
+      '@types/geojson': 7946.0.16
+      apache-arrow: 21.1.0
+    transitivePeerDependencies:
+      - '@75lb/nature'
+
+  '@loaders.gl/terrain@4.4.3(@loaders.gl/core@4.4.3)':
+    dependencies:
+      '@loaders.gl/core': 4.4.3
+      '@loaders.gl/images': 4.4.3(@loaders.gl/core@4.4.3)
+      '@loaders.gl/loader-utils': 4.4.3(@loaders.gl/core@4.4.3)
+      '@loaders.gl/schema': 4.4.3
+      '@mapbox/martini': 0.2.0
+    transitivePeerDependencies:
+      - '@75lb/nature'
+
+  '@loaders.gl/textures@4.4.3(@loaders.gl/core@4.4.3)':
+    dependencies:
+      '@loaders.gl/core': 4.4.3
+      '@loaders.gl/images': 4.4.3(@loaders.gl/core@4.4.3)
+      '@loaders.gl/loader-utils': 4.4.3(@loaders.gl/core@4.4.3)
+      '@loaders.gl/schema': 4.4.3
+      '@loaders.gl/worker-utils': 4.4.3(@loaders.gl/core@4.4.3)
+      '@math.gl/types': 4.1.0
+      ktx-parse: 0.7.1
+      texture-compressor: 1.0.2
+    transitivePeerDependencies:
+      - '@75lb/nature'
+
+  '@loaders.gl/tiles@4.4.3(@loaders.gl/core@4.4.3)':
+    dependencies:
+      '@loaders.gl/core': 4.4.3
+      '@loaders.gl/loader-utils': 4.4.3(@loaders.gl/core@4.4.3)
+      '@loaders.gl/math': 4.4.3(@loaders.gl/core@4.4.3)
+      '@math.gl/core': 4.1.0
+      '@math.gl/culling': 4.1.0
+      '@math.gl/geospatial': 4.1.0
+      '@math.gl/web-mercator': 4.1.0
+      '@probe.gl/stats': 4.1.1
+    transitivePeerDependencies:
+      - '@75lb/nature'
+
+  '@loaders.gl/wms@4.4.3(@loaders.gl/core@4.4.3)':
+    dependencies:
+      '@loaders.gl/core': 4.4.3
+      '@loaders.gl/images': 4.4.3(@loaders.gl/core@4.4.3)
+      '@loaders.gl/loader-utils': 4.4.3(@loaders.gl/core@4.4.3)
+      '@loaders.gl/schema': 4.4.3
+      '@loaders.gl/xml': 4.4.3(@loaders.gl/core@4.4.3)
+      '@turf/rewind': 5.1.5
+      deep-strict-equal: 0.2.0
+    transitivePeerDependencies:
+      - '@75lb/nature'
+
+  '@loaders.gl/worker-utils@4.4.3(@loaders.gl/core@4.4.3)':
+    dependencies:
+      '@loaders.gl/core': 4.4.3
+
+  '@loaders.gl/xml@4.4.3(@loaders.gl/core@4.4.3)':
+    dependencies:
+      '@loaders.gl/core': 4.4.3
+      '@loaders.gl/loader-utils': 4.4.3(@loaders.gl/core@4.4.3)
+      '@loaders.gl/schema': 4.4.3
+      fast-xml-parser: 5.9.3
+    transitivePeerDependencies:
+      - '@75lb/nature'
+
+  '@loaders.gl/zip@4.4.3(@loaders.gl/core@4.4.3)':
+    dependencies:
+      '@loaders.gl/compression': 4.4.3(@loaders.gl/core@4.4.3)
+      '@loaders.gl/core': 4.4.3
+      '@loaders.gl/crypto': 4.4.3(@loaders.gl/core@4.4.3)
+      '@loaders.gl/loader-utils': 4.4.3(@loaders.gl/core@4.4.3)
+      jszip: 3.10.1
+      md5: 2.3.0
+    transitivePeerDependencies:
+      - '@75lb/nature'
+
+  '@luma.gl/core@9.3.5':
+    dependencies:
+      '@math.gl/types': 4.1.0
+      '@probe.gl/env': 4.1.1
+      '@probe.gl/log': 4.1.1
+      '@probe.gl/stats': 4.1.1
+      '@types/offscreencanvas': 2019.7.3
+
+  '@luma.gl/engine@9.3.5(@luma.gl/core@9.3.5)(@luma.gl/shadertools@9.3.5(@luma.gl/core@9.3.5))':
+    dependencies:
+      '@luma.gl/core': 9.3.5
+      '@luma.gl/shadertools': 9.3.5(@luma.gl/core@9.3.5)
+      '@math.gl/core': 4.1.0
+      '@math.gl/types': 4.1.0
+      '@probe.gl/log': 4.1.1
+      '@probe.gl/stats': 4.1.1
+
+  '@luma.gl/gltf@9.3.5(@luma.gl/core@9.3.5)(@luma.gl/engine@9.3.5(@luma.gl/core@9.3.5)(@luma.gl/shadertools@9.3.5(@luma.gl/core@9.3.5)))(@luma.gl/shadertools@9.3.5(@luma.gl/core@9.3.5))':
+    dependencies:
+      '@loaders.gl/core': 4.4.3
+      '@loaders.gl/gltf': 4.4.3(@loaders.gl/core@4.4.3)
+      '@loaders.gl/textures': 4.4.3(@loaders.gl/core@4.4.3)
+      '@luma.gl/core': 9.3.5
+      '@luma.gl/engine': 9.3.5(@luma.gl/core@9.3.5)(@luma.gl/shadertools@9.3.5(@luma.gl/core@9.3.5))
+      '@luma.gl/shadertools': 9.3.5(@luma.gl/core@9.3.5)
+      '@math.gl/core': 4.1.0
+    transitivePeerDependencies:
+      - '@75lb/nature'
+
+  '@luma.gl/shadertools@9.3.5(@luma.gl/core@9.3.5)':
+    dependencies:
+      '@luma.gl/core': 9.3.5
+      '@math.gl/core': 4.1.0
+      '@math.gl/types': 4.1.0
+
+  '@luma.gl/webgl@9.3.5(@luma.gl/core@9.3.5)':
+    dependencies:
+      '@luma.gl/core': 9.3.5
+      '@math.gl/types': 4.1.0
+      '@probe.gl/env': 4.1.1
+
+  '@mapbox/mapbox-gl-supported@3.0.0': {}
+
+  '@mapbox/martini@0.2.0': {}
+
+  '@mapbox/point-geometry@0.1.0': {}
+
+  '@mapbox/point-geometry@1.1.0': {}
+
+  '@mapbox/tiny-sdf@2.2.0': {}
+
+  '@mapbox/unitbezier@0.0.1': {}
+
+  '@mapbox/vector-tile@1.3.1':
+    dependencies:
+      '@mapbox/point-geometry': 0.1.0
+
+  '@mapbox/vector-tile@2.0.4':
+    dependencies:
+      '@mapbox/point-geometry': 1.1.0
+      '@types/geojson': 7946.0.16
+      pbf: 4.0.1
+
+  '@math.gl/core@4.1.0':
+    dependencies:
+      '@math.gl/types': 4.1.0
+
+  '@math.gl/culling@4.1.0':
+    dependencies:
+      '@math.gl/core': 4.1.0
+      '@math.gl/types': 4.1.0
+
+  '@math.gl/geospatial@4.1.0':
+    dependencies:
+      '@math.gl/core': 4.1.0
+      '@math.gl/types': 4.1.0
+
+  '@math.gl/polygon@4.1.0':
+    dependencies:
+      '@math.gl/core': 4.1.0
+
+  '@math.gl/sun@4.1.0': {}
+
+  '@math.gl/types@4.1.0': {}
+
+  '@math.gl/web-mercator@4.1.0':
+    dependencies:
+      '@math.gl/core': 4.1.0
+
+  '@nodable/entities@2.2.0': {}
+
+  '@probe.gl/env@4.1.1': {}
+
+  '@probe.gl/log@4.1.1':
+    dependencies:
+      '@probe.gl/env': 4.1.1
+
+  '@probe.gl/stats@4.1.1': {}
+
+  '@rolldown/pluginutils@1.0.0-beta.27': {}
+
+  '@rollup/rollup-android-arm-eabi@4.60.3':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.60.3':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.60.3':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.60.3':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.60.3':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.60.3':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.60.3':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.60.3':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.60.3':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.60.3':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.60.3':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.60.3':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.60.3':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.60.3':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.60.3':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.60.3':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.60.3':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.60.3':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.60.3':
+    optional: true
+
+  '@rollup/rollup-openbsd-x64@4.60.3':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.60.3':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.60.3':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.60.3':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.60.3':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.60.3':
+    optional: true
+
+  '@smithy/core@3.29.0':
+    dependencies:
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
+  '@smithy/credential-provider-imds@4.4.5':
+    dependencies:
+      '@smithy/core': 3.29.0
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
+  '@smithy/fetch-http-handler@5.6.2':
+    dependencies:
+      '@smithy/core': 3.29.0
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
+  '@smithy/node-http-handler@4.9.2':
+    dependencies:
+      '@smithy/core': 3.29.0
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
+  '@smithy/signature-v4@5.6.1':
+    dependencies:
+      '@smithy/core': 3.29.0
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
+  '@smithy/types@4.15.1':
+    dependencies:
+      tslib: 2.8.1
+
+  '@standard-schema/spec@1.1.0': {}
+
+  '@supabase/auth-js@2.105.4':
+    dependencies:
+      tslib: 2.8.1
+
+  '@supabase/functions-js@2.105.4':
+    dependencies:
+      tslib: 2.8.1
+
+  '@supabase/phoenix@0.4.2': {}
+
+  '@supabase/postgrest-js@2.105.4':
+    dependencies:
+      tslib: 2.8.1
+
+  '@supabase/realtime-js@2.105.4':
+    dependencies:
+      '@supabase/phoenix': 0.4.2
+      tslib: 2.8.1
+
+  '@supabase/storage-js@2.105.4':
+    dependencies:
+      iceberg-js: 0.8.1
+      tslib: 2.8.1
+
+  '@supabase/supabase-js@2.105.4':
+    dependencies:
+      '@supabase/auth-js': 2.105.4
+      '@supabase/functions-js': 2.105.4
+      '@supabase/postgrest-js': 2.105.4
+      '@supabase/realtime-js': 2.105.4
+      '@supabase/storage-js': 2.105.4
+
+  '@swc/helpers@0.5.23':
+    dependencies:
+      tslib: 2.8.1
+
+  '@turf/boolean-clockwise@5.1.5':
+    dependencies:
+      '@turf/helpers': 5.1.5
+      '@turf/invariant': 5.2.0
+
+  '@turf/clone@5.1.5':
+    dependencies:
+      '@turf/helpers': 5.1.5
+
+  '@turf/helpers@5.1.5': {}
+
+  '@turf/invariant@5.2.0':
+    dependencies:
+      '@turf/helpers': 5.1.5
+
+  '@turf/meta@5.2.0':
+    dependencies:
+      '@turf/helpers': 5.1.5
+
+  '@turf/rewind@5.1.5':
+    dependencies:
+      '@turf/boolean-clockwise': 5.1.5
+      '@turf/clone': 5.1.5
+      '@turf/helpers': 5.1.5
+      '@turf/invariant': 5.2.0
+      '@turf/meta': 5.2.0
+
+  '@tweenjs/tween.js@23.1.3': {}
+
+  '@types/babel__core@7.20.5':
+    dependencies:
+      '@babel/parser': 7.29.3
+      '@babel/types': 7.29.0
+      '@types/babel__generator': 7.27.0
+      '@types/babel__template': 7.4.4
+      '@types/babel__traverse': 7.28.0
+
+  '@types/babel__generator@7.27.0':
+    dependencies:
+      '@babel/types': 7.29.0
+
+  '@types/babel__template@7.4.4':
+    dependencies:
+      '@babel/parser': 7.29.3
+      '@babel/types': 7.29.0
+
+  '@types/babel__traverse@7.28.0':
+    dependencies:
+      '@babel/types': 7.29.0
+
+  '@types/brotli@1.3.5':
+    dependencies:
+      '@types/node': 25.9.1
+    optional: true
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/command-line-args@5.2.3': {}
+
+  '@types/command-line-usage@5.0.4': {}
+
+  '@types/crypto-js@4.2.2': {}
+
+  '@types/deep-eql@4.0.2': {}
+
+  '@types/estree@1.0.8': {}
+
+  '@types/estree@1.0.9': {}
+
+  '@types/geojson-vt@3.2.5':
+    dependencies:
+      '@types/geojson': 7946.0.16
+
+  '@types/geojson@7946.0.16': {}
+
+  '@types/leaflet@1.9.21':
+    dependencies:
+      '@types/geojson': 7946.0.16
+
+  '@types/mapbox-gl@2.7.21':
+    dependencies:
+      '@types/geojson': 7946.0.16
+
+  '@types/node@24.12.4':
+    dependencies:
+      undici-types: 7.16.0
+
+  '@types/node@25.9.1':
+    dependencies:
+      undici-types: 7.24.6
+    optional: true
+
+  '@types/offscreencanvas@2019.7.3': {}
+
+  '@types/pako@1.0.7': {}
+
+  '@types/pbf@3.0.5': {}
+
+  '@types/react-dom@19.2.3(@types/react@19.2.14)':
+    dependencies:
+      '@types/react': 19.2.14
+
+  '@types/react@19.2.14':
+    dependencies:
+      csstype: 3.2.3
+
+  '@types/stats.js@0.17.4': {}
+
+  '@types/supercluster@7.1.3':
+    dependencies:
+      '@types/geojson': 7946.0.16
+
+  '@types/three@0.172.0':
+    dependencies:
+      '@tweenjs/tween.js': 23.1.3
+      '@types/stats.js': 0.17.4
+      '@types/webxr': 0.5.24
+      '@webgpu/types': 0.1.71
+      fflate: 0.8.3
+      meshoptimizer: 0.18.1
+
+  '@types/webxr@0.5.24': {}
+
+  '@vercel/oidc@3.2.0': {}
+
+  '@vitejs/plugin-react@4.7.0(vite@6.4.2(@types/node@25.9.1)(tsx@4.21.0))':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.29.0)
+      '@rolldown/pluginutils': 1.0.0-beta.27
+      '@types/babel__core': 7.20.5
+      react-refresh: 0.17.0
+      vite: 6.4.2(@types/node@25.9.1)(tsx@4.21.0)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@vitest/expect@3.2.6':
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/spy': 3.2.6
+      '@vitest/utils': 3.2.6
+      chai: 5.3.3
+      tinyrainbow: 2.0.0
+
+  '@vitest/mocker@3.2.6(vite@6.4.2(@types/node@25.9.1)(tsx@4.21.0))':
+    dependencies:
+      '@vitest/spy': 3.2.6
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 6.4.2(@types/node@25.9.1)(tsx@4.21.0)
+
+  '@vitest/pretty-format@3.2.6':
+    dependencies:
+      tinyrainbow: 2.0.0
+
+  '@vitest/runner@3.2.6':
+    dependencies:
+      '@vitest/utils': 3.2.6
+      pathe: 2.0.3
+      strip-literal: 3.1.0
+
+  '@vitest/snapshot@3.2.6':
+    dependencies:
+      '@vitest/pretty-format': 3.2.6
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@3.2.6':
+    dependencies:
+      tinyspy: 4.0.4
+
+  '@vitest/utils@3.2.6':
+    dependencies:
+      '@vitest/pretty-format': 3.2.6
+      loupe: 3.2.1
+      tinyrainbow: 2.0.0
+
+  '@webgpu/types@0.1.71': {}
+
+  '@workflow/serde@4.1.0': {}
+
+  a5-js@0.7.3:
+    dependencies:
+      gl-matrix: 3.4.4
+
+  ai@7.0.11(zod@4.4.3):
+    dependencies:
+      '@ai-sdk/gateway': 4.0.8(zod@4.4.3)
+      '@ai-sdk/provider': 4.0.1
+      '@ai-sdk/provider-utils': 5.0.3(zod@4.4.3)
+      zod: 4.4.3
+
+  ansi-styles@4.3.0:
+    dependencies:
+      color-convert: 2.0.1
+
+  anynum@1.0.1: {}
+
+  apache-arrow@21.1.0:
+    dependencies:
+      '@swc/helpers': 0.5.23
+      '@types/command-line-args': 5.2.3
+      '@types/command-line-usage': 5.0.4
+      '@types/node': 24.12.4
+      command-line-args: 6.0.2
+      command-line-usage: 7.0.4
+      flatbuffers: 25.9.23
+      json-bignum: 0.0.3
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - '@75lb/nature'
+
+  argparse@1.0.10:
+    dependencies:
+      sprintf-js: 1.0.3
+
+  array-back@6.2.3: {}
+
+  assertion-error@2.0.1: {}
+
+  base64-js@1.5.1:
+    optional: true
+
+  baseline-browser-mapping@2.10.29: {}
+
+  bowser@2.14.1: {}
+
+  brotli@1.3.3:
+    dependencies:
+      base64-js: 1.5.1
+    optional: true
+
+  browserslist@4.28.2:
+    dependencies:
+      baseline-browser-mapping: 2.10.29
+      caniuse-lite: 1.0.30001792
+      electron-to-chromium: 1.5.355
+      node-releases: 2.0.44
+      update-browserslist-db: 1.2.3(browserslist@4.28.2)
+
+  buf-compare@1.0.1: {}
+
+  cac@6.7.14: {}
+
+  caniuse-lite@1.0.30001792: {}
+
+  chai@5.3.3:
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.3
+      deep-eql: 5.0.2
+      loupe: 3.2.1
+      pathval: 2.0.1
+
+  chalk-template@0.4.0:
+    dependencies:
+      chalk: 4.1.2
+
+  chalk@4.1.2:
+    dependencies:
+      ansi-styles: 4.3.0
+      supports-color: 7.2.0
+
+  charenc@0.0.2: {}
+
+  cheap-ruler@4.0.0: {}
+
+  check-error@2.1.3: {}
+
+  color-convert@2.0.1:
+    dependencies:
+      color-name: 1.1.4
+
+  color-name@1.1.4: {}
+
+  command-line-args@6.0.2:
+    dependencies:
+      array-back: 6.2.3
+      find-replace: 5.0.2
+      lodash.camelcase: 4.3.0
+      typical: 7.3.0
+
+  command-line-usage@7.0.4:
+    dependencies:
+      array-back: 6.2.3
+      chalk-template: 0.4.0
+      table-layout: 4.1.1
+      typical: 7.3.0
+
+  convert-source-map@2.0.0: {}
+
+  core-assert@0.2.1:
+    dependencies:
+      buf-compare: 1.0.1
+      is-error: 2.2.2
+
+  core-util-is@1.0.3: {}
+
+  crypt@0.0.2: {}
+
+  csscolorparser@1.0.3: {}
+
+  csstype@3.2.3: {}
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  deep-eql@5.0.2: {}
+
+  deep-strict-equal@0.2.0:
+    dependencies:
+      core-assert: 0.2.1
+
+  dotenv@17.4.2: {}
+
+  draco3d@1.5.7: {}
+
+  earcut@2.2.4: {}
+
+  earcut@3.0.2: {}
+
+  electron-to-chromium@1.5.355: {}
+
+  es-module-lexer@1.7.0: {}
+
+  esbuild@0.25.12:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.25.12
+      '@esbuild/android-arm': 0.25.12
+      '@esbuild/android-arm64': 0.25.12
+      '@esbuild/android-x64': 0.25.12
+      '@esbuild/darwin-arm64': 0.25.12
+      '@esbuild/darwin-x64': 0.25.12
+      '@esbuild/freebsd-arm64': 0.25.12
+      '@esbuild/freebsd-x64': 0.25.12
+      '@esbuild/linux-arm': 0.25.12
+      '@esbuild/linux-arm64': 0.25.12
+      '@esbuild/linux-ia32': 0.25.12
+      '@esbuild/linux-loong64': 0.25.12
+      '@esbuild/linux-mips64el': 0.25.12
+      '@esbuild/linux-ppc64': 0.25.12
+      '@esbuild/linux-riscv64': 0.25.12
+      '@esbuild/linux-s390x': 0.25.12
+      '@esbuild/linux-x64': 0.25.12
+      '@esbuild/netbsd-arm64': 0.25.12
+      '@esbuild/netbsd-x64': 0.25.12
+      '@esbuild/openbsd-arm64': 0.25.12
+      '@esbuild/openbsd-x64': 0.25.12
+      '@esbuild/openharmony-arm64': 0.25.12
+      '@esbuild/sunos-x64': 0.25.12
+      '@esbuild/win32-arm64': 0.25.12
+      '@esbuild/win32-ia32': 0.25.12
+      '@esbuild/win32-x64': 0.25.12
+
+  esbuild@0.27.7:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.27.7
+      '@esbuild/android-arm': 0.27.7
+      '@esbuild/android-arm64': 0.27.7
+      '@esbuild/android-x64': 0.27.7
+      '@esbuild/darwin-arm64': 0.27.7
+      '@esbuild/darwin-x64': 0.27.7
+      '@esbuild/freebsd-arm64': 0.27.7
+      '@esbuild/freebsd-x64': 0.27.7
+      '@esbuild/linux-arm': 0.27.7
+      '@esbuild/linux-arm64': 0.27.7
+      '@esbuild/linux-ia32': 0.27.7
+      '@esbuild/linux-loong64': 0.27.7
+      '@esbuild/linux-mips64el': 0.27.7
+      '@esbuild/linux-ppc64': 0.27.7
+      '@esbuild/linux-riscv64': 0.27.7
+      '@esbuild/linux-s390x': 0.27.7
+      '@esbuild/linux-x64': 0.27.7
+      '@esbuild/netbsd-arm64': 0.27.7
+      '@esbuild/netbsd-x64': 0.27.7
+      '@esbuild/openbsd-arm64': 0.27.7
+      '@esbuild/openbsd-x64': 0.27.7
+      '@esbuild/openharmony-arm64': 0.27.7
+      '@esbuild/sunos-x64': 0.27.7
+      '@esbuild/win32-arm64': 0.27.7
+      '@esbuild/win32-ia32': 0.27.7
+      '@esbuild/win32-x64': 0.27.7
+
+  escalade@3.2.0: {}
+
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.9
+
+  eventsource-parser@3.1.0: {}
+
+  expect-type@1.4.0: {}
+
+  fast-xml-builder@1.2.0:
+    dependencies:
+      path-expression-matcher: 1.6.1
+      xml-naming: 0.1.0
+
+  fast-xml-parser@5.9.3:
+    dependencies:
+      '@nodable/entities': 2.2.0
+      fast-xml-builder: 1.2.0
+      is-unsafe: 1.0.1
+      path-expression-matcher: 1.6.1
+      strnum: 2.4.1
+      xml-naming: 0.1.0
+
+  fdir@6.5.0(picomatch@4.0.4):
+    optionalDependencies:
+      picomatch: 4.0.4
+
+  fflate@0.7.4: {}
+
+  fflate@0.8.3: {}
+
+  find-replace@5.0.2: {}
+
+  flatbuffers@25.9.23: {}
+
+  fsevents@2.3.3:
+    optional: true
+
+  gensync@1.0.0-beta.2: {}
+
+  geojson-vt@4.0.2: {}
+
+  get-tsconfig@4.14.0:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
+
+  gl-matrix@3.4.4: {}
+
+  grid-index@1.1.0: {}
+
+  h3-js@4.5.0: {}
+
+  has-flag@4.0.0: {}
+
+  iceberg-js@0.8.1: {}
+
+  ieee754@1.2.1: {}
+
+  image-size@0.7.5: {}
+
+  immediate@3.0.6: {}
+
+  inherits@2.0.4: {}
+
+  is-buffer@1.1.6: {}
+
+  is-error@2.2.2: {}
+
+  is-unsafe@1.0.1: {}
+
+  isarray@1.0.0: {}
+
+  js-tokens@4.0.0: {}
+
+  js-tokens@9.0.1: {}
+
+  jsesc@3.1.0: {}
+
+  json-bignum@0.0.3: {}
+
+  json-schema@0.4.0: {}
+
+  json5@2.2.3: {}
+
+  jszip@3.10.1:
+    dependencies:
+      lie: 3.3.0
+      pako: 1.0.11
+      readable-stream: 2.3.8
+      setimmediate: 1.0.5
+
+  kdbush@4.0.2: {}
+
+  ktx-parse@0.7.1: {}
+
+  lie@3.3.0:
+    dependencies:
+      immediate: 3.0.6
+
+  lodash.camelcase@4.3.0: {}
+
+  long@3.2.0: {}
+
+  long@5.3.2: {}
+
+  loupe@3.2.1: {}
+
+  lru-cache@5.1.1:
+    dependencies:
+      yallist: 3.1.1
+
+  lucide-react@0.576.0(react@19.2.6):
+    dependencies:
+      react: 19.2.6
+
+  lz4js@0.2.0:
+    optional: true
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  mapbox-gl@3.23.1:
+    dependencies:
+      '@mapbox/mapbox-gl-supported': 3.0.0
+      '@mapbox/point-geometry': 1.1.0
+      '@mapbox/tiny-sdf': 2.2.0
+      '@mapbox/unitbezier': 0.0.1
+      '@mapbox/vector-tile': 2.0.4
+      '@types/geojson': 7946.0.16
+      '@types/geojson-vt': 3.2.5
+      '@types/pbf': 3.0.5
+      '@types/supercluster': 7.1.3
+      cheap-ruler: 4.0.0
+      csscolorparser: 1.0.3
+      earcut: 3.0.2
+      geojson-vt: 4.0.2
+      gl-matrix: 3.4.4
+      grid-index: 1.1.0
+      kdbush: 4.0.2
+      martinez-polygon-clipping: 0.8.1
+      murmurhash-js: 1.0.0
+      pbf: 4.0.1
+      potpack: 2.1.0
+      quickselect: 3.0.0
+      supercluster: 8.0.1
+      tinyqueue: 3.0.0
+
+  mapbox-pmtiles@1.0.56:
+    dependencies:
+      '@types/mapbox-gl': 2.7.21
+      mapbox-gl: 3.23.1
+      pmtiles: 3.2.1
+
+  martinez-polygon-clipping@0.8.1:
+    dependencies:
+      robust-predicates: 2.0.4
+      splaytree: 0.1.4
+      tinyqueue: 3.0.0
+
+  md5@2.3.0:
+    dependencies:
+      charenc: 0.0.2
+      crypt: 0.0.2
+      is-buffer: 1.1.6
+
+  meshoptimizer@0.18.1: {}
+
+  mjolnir.js@3.0.0: {}
+
+  ms@2.1.3: {}
+
+  murmurhash-js@1.0.0: {}
+
+  nanoid@3.3.12: {}
+
+  node-releases@2.0.44: {}
+
+  pako@1.0.11: {}
+
+  path-expression-matcher@1.6.1: {}
+
+  pathe@2.0.3: {}
+
+  pathval@2.0.1: {}
+
+  pbf@3.3.0:
+    dependencies:
+      ieee754: 1.2.1
+      resolve-protobuf-schema: 2.1.0
+
+  pbf@4.0.1:
+    dependencies:
+      resolve-protobuf-schema: 2.1.0
+
+  picocolors@1.1.1: {}
+
+  picomatch@4.0.4: {}
+
+  pmtiles@3.2.1:
+    dependencies:
+      '@types/leaflet': 1.9.21
+      fflate: 0.8.3
+
+  pmtiles@4.4.1:
+    dependencies:
+      fflate: 0.8.3
+
+  postcss@8.5.14:
+    dependencies:
+      nanoid: 3.3.12
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  potpack@2.1.0: {}
+
+  process-nextick-args@2.0.1: {}
+
+  protocol-buffers-schema@3.6.1: {}
+
+  quickselect@3.0.0: {}
+
+  react-dom@19.2.6(react@19.2.6):
+    dependencies:
+      react: 19.2.6
+      scheduler: 0.27.0
+
+  react-refresh@0.17.0: {}
+
+  react@19.2.6: {}
+
+  readable-stream@2.3.8:
+    dependencies:
+      core-util-is: 1.0.3
+      inherits: 2.0.4
+      isarray: 1.0.0
+      process-nextick-args: 2.0.1
+      safe-buffer: 5.1.2
+      string_decoder: 1.1.1
+      util-deprecate: 1.0.2
+
+  resolve-pkg-maps@1.0.0: {}
+
+  resolve-protobuf-schema@2.1.0:
+    dependencies:
+      protocol-buffers-schema: 3.6.1
+
+  robust-predicates@2.0.4: {}
+
+  rollup@4.60.3:
+    dependencies:
+      '@types/estree': 1.0.8
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.60.3
+      '@rollup/rollup-android-arm64': 4.60.3
+      '@rollup/rollup-darwin-arm64': 4.60.3
+      '@rollup/rollup-darwin-x64': 4.60.3
+      '@rollup/rollup-freebsd-arm64': 4.60.3
+      '@rollup/rollup-freebsd-x64': 4.60.3
+      '@rollup/rollup-linux-arm-gnueabihf': 4.60.3
+      '@rollup/rollup-linux-arm-musleabihf': 4.60.3
+      '@rollup/rollup-linux-arm64-gnu': 4.60.3
+      '@rollup/rollup-linux-arm64-musl': 4.60.3
+      '@rollup/rollup-linux-loong64-gnu': 4.60.3
+      '@rollup/rollup-linux-loong64-musl': 4.60.3
+      '@rollup/rollup-linux-ppc64-gnu': 4.60.3
+      '@rollup/rollup-linux-ppc64-musl': 4.60.3
+      '@rollup/rollup-linux-riscv64-gnu': 4.60.3
+      '@rollup/rollup-linux-riscv64-musl': 4.60.3
+      '@rollup/rollup-linux-s390x-gnu': 4.60.3
+      '@rollup/rollup-linux-x64-gnu': 4.60.3
+      '@rollup/rollup-linux-x64-musl': 4.60.3
+      '@rollup/rollup-openbsd-x64': 4.60.3
+      '@rollup/rollup-openharmony-arm64': 4.60.3
+      '@rollup/rollup-win32-arm64-msvc': 4.60.3
+      '@rollup/rollup-win32-ia32-msvc': 4.60.3
+      '@rollup/rollup-win32-x64-gnu': 4.60.3
+      '@rollup/rollup-win32-x64-msvc': 4.60.3
+      fsevents: 2.3.3
+
+  safe-buffer@5.1.2: {}
+
+  satellite.js@5.0.0: {}
+
+  scheduler@0.27.0: {}
+
+  semver@6.3.1: {}
+
+  setimmediate@1.0.5: {}
+
+  siginfo@2.0.0: {}
+
+  snappyjs@0.6.1: {}
+
+  source-map-js@1.2.1: {}
+
+  splaytree@0.1.4: {}
+
+  sprintf-js@1.0.3: {}
+
+  stackback@0.0.2: {}
+
+  std-env@3.10.0: {}
+
+  string_decoder@1.1.1:
+    dependencies:
+      safe-buffer: 5.1.2
+
+  strip-literal@3.1.0:
+    dependencies:
+      js-tokens: 9.0.1
+
+  strnum@2.4.1:
+    dependencies:
+      anynum: 1.0.1
+
+  supercluster@8.0.1:
+    dependencies:
+      kdbush: 4.0.2
+
+  supports-color@7.2.0:
+    dependencies:
+      has-flag: 4.0.0
+
+  table-layout@4.1.1:
+    dependencies:
+      array-back: 6.2.3
+      wordwrapjs: 5.1.1
+
+  texture-compressor@1.0.2:
+    dependencies:
+      argparse: 1.0.10
+      image-size: 0.7.5
+
+  three@0.172.0: {}
+
+  tinybench@2.9.0: {}
+
+  tinyexec@0.3.2: {}
+
+  tinyglobby@0.2.16:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+
+  tinypool@1.1.1: {}
+
+  tinyqueue@3.0.0: {}
+
+  tinyrainbow@2.0.0: {}
+
+  tinyspy@4.0.4: {}
+
+  tslib@2.8.1: {}
+
+  tsx@4.21.0:
+    dependencies:
+      esbuild: 0.27.7
+      get-tsconfig: 4.14.0
+    optionalDependencies:
+      fsevents: 2.3.3
+
+  typescript@5.7.3: {}
+
+  typical@7.3.0: {}
+
+  undici-types@7.16.0: {}
+
+  undici-types@7.24.6:
+    optional: true
+
+  update-browserslist-db@1.2.3(browserslist@4.28.2):
+    dependencies:
+      browserslist: 4.28.2
+      escalade: 3.2.0
+      picocolors: 1.1.1
+
+  util-deprecate@1.0.2: {}
+
+  vite-node@3.2.4(@types/node@25.9.1)(tsx@4.21.0):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 2.0.3
+      vite: 6.4.2(@types/node@25.9.1)(tsx@4.21.0)
+    transitivePeerDependencies:
+      - '@types/node'
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
+  vite@6.4.2(@types/node@25.9.1)(tsx@4.21.0):
+    dependencies:
+      esbuild: 0.25.12
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+      postcss: 8.5.14
+      rollup: 4.60.3
+      tinyglobby: 0.2.16
+    optionalDependencies:
+      '@types/node': 25.9.1
+      fsevents: 2.3.3
+      tsx: 4.21.0
+
+  vitest@3.2.6(@types/node@25.9.1)(tsx@4.21.0):
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/expect': 3.2.6
+      '@vitest/mocker': 3.2.6(vite@6.4.2(@types/node@25.9.1)(tsx@4.21.0))
+      '@vitest/pretty-format': 3.2.6
+      '@vitest/runner': 3.2.6
+      '@vitest/snapshot': 3.2.6
+      '@vitest/spy': 3.2.6
+      '@vitest/utils': 3.2.6
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.16
+      tinypool: 1.1.1
+      tinyrainbow: 2.0.0
+      vite: 6.4.2(@types/node@25.9.1)(tsx@4.21.0)
+      vite-node: 3.2.4(@types/node@25.9.1)(tsx@4.21.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 25.9.1
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
+
+  wordwrapjs@5.1.1: {}
+
+  xml-naming@0.1.0: {}
+
+  yallist@3.1.1: {}
+
+  zod@4.4.3: {}
+
+  zstd-codec@0.1.5:
+    optional: true

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { COLORS, FONT_DATA, RADIUS, FONT_SIZE } from "./styles/designTokens";
 import type { Map as MapboxMap } from "mapbox-gl";
-import type { ViewMode, RenderMode, DisplayMode, Flight, ExpandableLayerKey, LayerVisibility, AppMode } from "./types";
+import type { ViewMode, RenderMode, DisplayMode, Flight, ExpandableLayerKey, LayerVisibility, AppMode, FeatureInfo } from "./types";
 import type { StationPillarData } from "./three/StationPillarScene";
 import { MapView } from "./map/MapView";
 import { useAirspaceData } from "./hooks/useAirspaceData";
@@ -130,6 +130,11 @@ import { StyleSelector, getStyleUrl } from "./components/StyleSelector";
 import { MobileBottomSheet } from "./components/MobileBottomSheet";
 import { InfoModal } from "./components/InfoModal";
 import { FeatureInfoPanel } from "./components/FeatureInfoPanel";
+import { HEADER_LABELS } from "./components/featureInfo/registry";
+import { ChatPanel } from "./components/chat/ChatPanel";
+import { runChatTurn, testKey } from "./chat/agent";
+import type { MapBridge } from "./chat/types";
+import { MessageSquare } from "lucide-react";
 import { LegendPanel } from "./components/LegendPanel";
 import { LoadingIndicator } from "./components/LoadingIndicator";
 import { LoadingScreen } from "./components/LoadingScreen";
@@ -334,6 +339,7 @@ export default function App() {
   const [displayMode, setDisplayMode] = useState<DisplayMode>("status");
   const [captureMode, setCaptureMode] = useState(false);
   const [showInfo, setShowInfo] = useState(false);
+  const [chatOpen, setChatOpen] = useState(false);
   const [sidebarWidth, setSidebarWidth] = useState(56); // rail only by default
   const handleSidebarWidthChange = useCallback((w: number) => setSidebarWidth(w), []);
   const [cameraInfo, setCameraInfo] = useState({ lng: 0, lat: 0, zoom: 0, pitch: 0, bearing: 0 });
@@ -1531,6 +1537,40 @@ export default function App() {
     }
   }, [timelineSeek, timelineSetSpeed, timelinePlay, setLayerVisibility]);
 
+  // BYOK 對話 agent 的地圖操作橋接：把既有 handler 注入白名單 tool（無新增地圖邏輯）。
+  const chatBridge = useMemo<MapBridge>(() => ({
+    bulkSetVisibility: (keys, visible) =>
+      handleBulkSetVisibility(keys as (keyof LayerVisibility)[], visible),
+    allOff: handleAllOff,
+    flyTo: (lng, lat, zoom) =>
+      mapRef.current?.flyTo({ center: [lng, lat], zoom: zoom ?? 11, speed: 1.2 }),
+    jumpToPlace: (presetId) => {
+      if (!getPresetById(presetId)) return false;
+      handleLocationJump(presetId);
+      return true;
+    },
+    highlightPoint: (lng, lat, layerType, properties) => {
+      // 已知 layerType → 走該圖層專屬 popup；未知（含 chat 標記）→ 通用 chatHighlight
+      const known = typeof layerType === "string" && layerType in HEADER_LABELS;
+      const lt = known ? (layerType as FeatureInfo["layerType"]) : "chatHighlight";
+      const props = known ? (properties ?? {}) : { ...(properties ?? {}), lng, lat };
+      setFeatureInfo({ layerType: lt, properties: props, coords: [lng, lat] });
+    },
+    getVisibleLayerKeys: () =>
+      Object.entries(layerVisibilityRef.current)
+        .filter(([, v]) => v)
+        .map(([k]) => k),
+    getCurrentTimeISO: () => new Date(timeStore.getTime() * 1000).toISOString(),
+    getCamera: () => {
+      const map = mapRef.current;
+      if (!map) {
+        return { lng: DEFAULT_CAMERA.center[0], lat: DEFAULT_CAMERA.center[1], zoom: DEFAULT_CAMERA.zoom };
+      }
+      const c = map.getCenter();
+      return { lng: c.lng, lat: c.lat, zoom: map.getZoom() };
+    },
+  }), [handleBulkSetVisibility, handleAllOff, handleLocationJump, setFeatureInfo, layerVisibilityRef]);
+
   // ── Render ──
 
   // LoadingScreen 改為 overlay（fixed, zIndex 9999）蓋在主 UI 上，
@@ -1983,6 +2023,31 @@ export default function App() {
                 BETA
               </span>
             </button>
+            <button
+              onClick={() => setChatOpen((v) => !v)}
+              title="AI 助手 BYOK Chat"
+              style={{
+                display: "inline-flex",
+                alignItems: "center",
+                gap: 6,
+                padding: "6px 14px",
+                background: chatOpen
+                  ? "#64aaff"
+                  : (isDarkTheme ? "rgba(80,140,255,0.25)" : "rgba(80,140,255,0.15)"),
+                border: `1px solid ${chatOpen ? "#64aaff" : "rgba(80,140,255,0.5)"}`,
+                borderRadius: RADIUS.lg,
+                color: chatOpen ? "#04121f" : (isDarkTheme ? "#fff" : "#333"),
+                fontSize: FONT_SIZE.md,
+                fontFamily: FONT_DATA,
+                fontWeight: chatOpen ? 700 : 400,
+                cursor: "pointer",
+                backdropFilter: "blur(8px)",
+                letterSpacing: 1,
+              }}
+            >
+              <MessageSquare size={13} />
+              AI
+            </button>
           </div>
 
           {/* 右上角第二排 */}
@@ -2145,6 +2210,25 @@ export default function App() {
               }}
             >
               Capture
+            </button>
+
+            <button
+              onClick={() => setChatOpen((v) => !v)}
+              title="AI 助手"
+              style={{
+                width: 36,
+                height: 36,
+                borderRadius: RADIUS.xl,
+                background: chatOpen ? "#64aaff" : "rgba(80,140,255,0.25)",
+                border: `1px solid ${chatOpen ? "#64aaff" : "rgba(80,140,255,0.5)"}`,
+                color: chatOpen ? "#04121f" : "#fff",
+                cursor: "pointer",
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+              }}
+            >
+              <MessageSquare size={16} />
             </button>
 
             <button
@@ -2623,6 +2707,16 @@ export default function App() {
 
       {/* ── Info Modal ── */}
       <InfoModal open={showInfo} onClose={() => setShowInfo(false)} isMobile={isMobile} />
+
+      {/* ── BYOK 對話浮層（桌機右側 / 手機底部上拉，自帶 mobile 版型）── */}
+      <ChatPanel
+        open={chatOpen}
+        onClose={() => setChatOpen(false)}
+        bridge={chatBridge}
+        runChatTurn={runChatTurn}
+        onTestKey={testKey}
+        compact={featureInfo !== null}
+      />
 
       {/* ── 資料來源總覽（Step 4 SSOT bridge UI，右下浮動按鈕）── */}
       <DataSourceBrowser />

--- a/src/chat/agent.ts
+++ b/src/chat/agent.ts
@@ -1,0 +1,219 @@
+// 對話引擎 — streamText + tool loop（上限 10 步），瀏覽器直連。
+// 錯誤一律轉成固定的中文訊息，絕不把 apiKey / 原始錯誤細節外洩。
+
+import { streamText, generateText, stepCountIs } from "ai";
+import type { ModelMessage } from "ai";
+import type {
+  AgentRunOptions,
+  ChatMessage,
+  ChatProviderId,
+  ChatToolCallSummary,
+  RunChatTurn,
+} from "./types";
+import { createChatModel } from "./providers";
+import { buildSystemPrompt } from "./systemPrompt";
+import { buildTools } from "./tools/registry";
+
+const MAX_STEPS = 10;
+
+function genId(): string {
+  return `a-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+/**
+ * 把任意錯誤轉成使用者可讀、且不含機敏資訊的固定訊息。
+ * 只有 401/403 判為金鑰問題；網路 / CORS 判為直連失敗；其餘為通用錯誤。
+ */
+function classifyError(err: unknown): string {
+  const e = err as { statusCode?: number; status?: number; name?: string; message?: string };
+  const status = e?.statusCode ?? e?.status;
+  const msg = String(e?.message ?? "");
+  const name = String(e?.name ?? "");
+
+  if (
+    status === 401 ||
+    status === 403 ||
+    /\b401\b|\b403\b|unauthorized|invalid[\s_-]?api[\s_-]?key|permission denied|authentication/i.test(msg)
+  ) {
+    return "金鑰無效或無權限";
+  }
+  if (
+    name === "TypeError" ||
+    /failed to fetch|load failed|network error|networkerror|fetch failed|\bcors\b|econnrefused|err_network/i.test(msg)
+  ) {
+    return "無法直連該服務商（可能為網路或 CORS 限制），請改用其他家";
+  }
+  return "對話發生錯誤，請稍後再試";
+}
+
+/** 使用者主動中斷（AbortController.abort）產生的錯誤，不當成失敗。 */
+function isAbortError(err: unknown): boolean {
+  if (err instanceof DOMException && err.name === "AbortError") return true;
+  const name = (err as { name?: string } | null | undefined)?.name;
+  return name === "AbortError";
+}
+
+/**
+ * 只保留有內容的歷史訊息，並轉成 AI SDK 的 ModelMessage。
+ * assistant 訊息若有 toolCalls，把摘要併進 content 尾端（例如
+ * 「[已執行工具：開啟 2 個圖層；搜尋「掩埋場」找到 2 筆]」），讓模型追問
+ * 時知道前輪已經做過什麼、不必重跑工具；只有 toolCalls、content 為空的
+ * 訊息也保留（否則整輪工具執行紀錄會從歷史消失）。刻意不塞工具原始回傳，
+ * 保持歷史輕量。
+ */
+function toModelMessages(history: ChatMessage[], userText: string): ModelMessage[] {
+  const msgs: ModelMessage[] = [];
+  for (const m of history) {
+    const hasToolCalls = m.role === "assistant" && !!m.toolCalls?.length;
+    if (!m.content.trim() && !hasToolCalls) continue;
+
+    let content = m.content;
+    if (hasToolCalls) {
+      const toolNote = `[已執行工具：${m.toolCalls!.map((c) => c.summary).join("；")}]`;
+      content = content.trim() ? `${content}\n${toolNote}` : toolNote;
+    }
+
+    msgs.push(
+      m.role === "assistant"
+        ? { role: "assistant", content }
+        : { role: "user", content },
+    );
+  }
+  msgs.push({ role: "user", content: userText });
+  return msgs;
+}
+
+export const runChatTurn: RunChatTurn = async (opts: AgentRunOptions): Promise<ChatMessage> => {
+  const { provider, model, apiKey, history, userText, bridge, onDelta, onToolCall, abortSignal } = opts;
+
+  const toolCalls: ChatToolCallSummary[] = [];
+  let content = "";
+  let errorMsg: string | undefined;
+  let aborted = false;
+
+  try {
+    const result = streamText({
+      model: createChatModel(provider, model, apiKey),
+      system: buildSystemPrompt(bridge),
+      messages: toModelMessages(history, userText),
+      tools: buildTools(bridge),
+      stopWhen: stepCountIs(MAX_STEPS),
+      abortSignal,
+    });
+
+    for await (const part of result.fullStream) {
+      switch (part.type) {
+        case "text-delta": {
+          content += part.text;
+          onDelta?.(part.text);
+          break;
+        }
+        case "tool-result": {
+          const out = part.output as { summary?: unknown } | null | undefined;
+          const summary =
+            typeof out?.summary === "string" ? out.summary : `已執行 ${part.toolName}`;
+          const call: ChatToolCallSummary = { name: part.toolName, summary };
+          toolCalls.push(call);
+          onToolCall?.(call);
+          break;
+        }
+        case "tool-error": {
+          const call: ChatToolCallSummary = {
+            name: part.toolName,
+            summary: `工具 ${part.toolName} 執行失敗`,
+          };
+          toolCalls.push(call);
+          onToolCall?.(call);
+          break;
+        }
+        case "error": {
+          errorMsg = classifyError(part.error);
+          break;
+        }
+        // AI SDK 在 abortSignal 觸發時不會 throw，而是正常收尾並送一個 abort part
+        // （見 node_modules/ai/dist/index.js pull() 的 abort() helper）；漏接這個
+        // part 會讓中斷後的部分內容被當成「正常完成」回傳，使用者看不出是中斷的。
+        case "abort": {
+          aborted = true;
+          break;
+        }
+        // finishReason 可能是 'error'（模型端出錯但沒有先送 error part），這裡兜底
+        // 確保這種錯誤形態也會 surface，不會被當成一般正常結束。
+        case "finish": {
+          if (part.finishReason === "error" && !errorMsg) {
+            errorMsg = classifyError(undefined);
+          }
+          break;
+        }
+        default:
+          break;
+      }
+    }
+
+    let usage: ChatMessage["usage"];
+    try {
+      const u = await result.usage;
+      usage = { inputTokens: u.inputTokens ?? 0, outputTokens: u.outputTokens ?? 0 };
+    } catch {
+      // usage 取不到不影響主回覆
+    }
+
+    if (aborted) {
+      content = content ? `${content}（已中斷）` : "（已中斷）";
+    } else if (!content.trim() && !errorMsg) {
+      // 空回覆防護：不能讓使用者看到完全空白的回覆卻不知道發生什麼事。
+      if (toolCalls.length) {
+        content = "（模型未提供文字總結，以下為工具執行結果）";
+      } else {
+        errorMsg = "模型未產生回覆，請重試或改用進階檔模型";
+      }
+    }
+
+    return {
+      id: genId(),
+      role: "assistant",
+      content,
+      toolCalls: toolCalls.length ? toolCalls : undefined,
+      usage,
+      error: errorMsg,
+      createdAt: Date.now(),
+    };
+  } catch (err) {
+    // 使用者主動中斷：保留已累積內容，不視為錯誤（尾端標記已中斷）
+    if (isAbortError(err)) {
+      return {
+        id: genId(),
+        role: "assistant",
+        content: content ? `${content}（已中斷）` : "（已中斷）",
+        toolCalls: toolCalls.length ? toolCalls : undefined,
+        createdAt: Date.now(),
+      };
+    }
+    return {
+      id: genId(),
+      role: "assistant",
+      content,
+      toolCalls: toolCalls.length ? toolCalls : undefined,
+      error: errorMsg ?? classifyError(err),
+      createdAt: Date.now(),
+    };
+  }
+};
+
+/** 用最小成本 ping 驗證金鑰是否可用。回傳結果不含任何機敏資訊。 */
+export async function testKey(
+  provider: ChatProviderId,
+  model: string,
+  apiKey: string,
+): Promise<{ ok: boolean; message: string }> {
+  try {
+    await generateText({
+      model: createChatModel(provider, model, apiKey),
+      prompt: "ping",
+      maxOutputTokens: 1,
+    });
+    return { ok: true, message: "金鑰驗證成功" };
+  } catch (err) {
+    return { ok: false, message: classifyError(err) };
+  }
+}

--- a/src/chat/providers.ts
+++ b/src/chat/providers.ts
@@ -1,0 +1,34 @@
+// 供應商工廠 — 全部瀏覽器直連（BYOK），不經任何我方 proxy。
+// key 只在此處交給官方 SDK，絕不落 log。
+
+import { createAnthropic } from "@ai-sdk/anthropic";
+import { createOpenAI } from "@ai-sdk/openai";
+import { createGoogleGenerativeAI } from "@ai-sdk/google";
+import type { LanguageModel } from "ai";
+import type { ChatProviderId } from "./types";
+
+/**
+ * 依 provider 建立 AI SDK LanguageModel。
+ * anthropic 需 `anthropic-dangerous-direct-browser-access` header 才能從瀏覽器直打。
+ */
+export function createChatModel(
+  provider: ChatProviderId,
+  model: string,
+  apiKey: string,
+): LanguageModel {
+  switch (provider) {
+    case "anthropic":
+      return createAnthropic({
+        apiKey,
+        headers: { "anthropic-dangerous-direct-browser-access": "true" },
+      })(model);
+    case "openai":
+      return createOpenAI({ apiKey })(model);
+    case "google":
+      return createGoogleGenerativeAI({ apiKey })(model);
+    default: {
+      const exhaustive: never = provider;
+      throw new Error(`未知的供應商：${String(exhaustive)}`);
+    }
+  }
+}

--- a/src/chat/systemPrompt.ts
+++ b/src/chat/systemPrompt.ts
@@ -1,0 +1,55 @@
+// System prompt 組裝。
+// 靜態段放最前（同 prefix → 利 prompt cache），動態段（現況）放最後。
+// 完整圖層清單（231 個）絕不進 prompt，只給 19 個主題索引，細節指示模型用 tool 查。
+
+import type { MapBridge } from "./types";
+import { THEMES } from "../components/sidebar/layerCatalog";
+
+// ── 靜態段（一次算好，跨 turn 不變）──
+const THEME_INDEX = THEMES.map(
+  (t) => `- ${t.title}：${t.groups.map((g) => g.title).join("、")}`,
+).join("\n");
+
+const STATIC_PROMPT = `你是「Mini Taiwan Pulse」的地圖助手。這是一個把台灣多種即時 / 時序資料（交通、環境、災害、能源…）疊在 3D 地圖上的視覺化站台，你可以依使用者需求開關圖層、移動鏡頭、查詢圖層目錄。
+
+# 回答規範
+- 一律用繁體中文，簡潔、口語、不囉嗦。
+- 不知道就查（用工具），不要憑空猜測或杜撰數字 / 圖層名。
+- 回答盡量附上資料脈絡（例如來自哪個主題、目前開了哪些圖層）。
+
+# 圖層主題索引（共 ${THEMES.length} 個主題，每行為主題 → 子群）
+完整圖層清單很長，不在此列出。要拿到某主題底下的圖層 key 請用 list_layers；用關鍵字找圖層請用 search_layers。
+${THEME_INDEX}
+
+# 工具使用規範
+- 開 / 關圖層前，先用 list_layers 或 search_layers 取得正確的圖層 key，再呼叫 set_layers（keys 是 key 不是顯示名）。
+- list_layers / search_layers 只是查詢，不會改變地圖；查到 key 之後必須實際呼叫 set_layers，圖層才會開啟。任何地圖動作（開關圖層、飛行、標記）都必須真的呼叫對應工具後，才能在回覆中聲稱完成；絕不可聲稱未執行的動作已完成。
+- 涉及數量、統計、「有幾筆 / 哪些 / 分幾類」的問題，用 query_dataset（靜態點位資料集：警消、學校、醫院、法院、超商…）實際查，不可瞎猜。
+- 「哪些點位附近人口最多 / 人口密度最高」用 rank_by_population（資料集點位 × H3 人口網格）。
+- 時序 / 事件 / 資料目錄 / 來源類問題（火災年份、熱門新聞、某圖層資料哪來的、資料源新不新）用 call_rpc，只能呼叫白名單內的 RPC。
+- 服務範圍 / 可達性類問題（「消防 / 警局服務範圍」「幾分鐘到得了」）不用自己算距離，直接用 search_layers 找等時圈圖層再 set_layers 開啟：消防「fireIsochrone」、警局「policeIsoSubstation / policeIsoPrecinct / policeIsoCityDept」三層、醫療「medIsochrone」。
+- 工具回傳若標示 truncated（僅示範前 N 筆），請以其中的 total 統計值回答，不要逐筆列舉樣本。
+- 需要移動視角時：具名地點（城市 / 機場 / 場景）用 jump_to_place，任意座標用 fly_to（限台灣範圍）。
+- 工具查詢失敗或 0 筆時，不可放棄：讀取回饋中的 availableFields / hint 換方式重查（換欄位、換 op、改用 filterContains 模糊比對）；最終仍需以文字總結回覆使用者，即使是說明查不到。
+
+# 顧問式提問（被問「建議 / 怎麼做 / 關係 / 分析什麼」時）
+遇到開放式諮詢（例如「跟垃圾清運有關的圖層有哪些？你建議怎麼做？它們的關係？」）：
+1. 先用 list_layers / search_layers 找齊該主題底下所有相關圖層。
+2. 用 get_layer_details 拿這些圖層的資料來源與所屬子群，理清彼此關係（哪些是即時、哪些是設施點位、哪些是投放點）。
+3. 給結構化建議：建議開哪些圖層＋為什麼、合理的疊圖順序、可搭配的時間軸操作。
+4. 最後主動呼叫 set_layers 把建議的圖層組合實際開起來，讓建議上圖。`;
+
+// ── 動態段（每 turn 依現況組）──
+function buildDynamicContext(bridge: MapBridge): string {
+  const visible = bridge.getVisibleLayerKeys();
+  const cam = bridge.getCamera();
+  const timeISO = bridge.getCurrentTimeISO();
+  return `# 目前地圖現況
+- 已開啟圖層 key（${visible.length} 個）：${visible.length ? visible.join(", ") : "（無，畫面乾淨）"}
+- 時間軸目前時刻：${timeISO}
+- 相機位置：lng ${cam.lng.toFixed(3)}, lat ${cam.lat.toFixed(3)}, zoom ${cam.zoom.toFixed(1)}`;
+}
+
+export function buildSystemPrompt(bridge: MapBridge): string {
+  return `${STATIC_PROMPT}\n\n${buildDynamicContext(bridge)}`;
+}

--- a/src/chat/tools/__tests__/dataQuery.test.ts
+++ b/src/chat/tools/__tests__/dataQuery.test.ts
@@ -1,0 +1,297 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { latLngToCell } from "h3-js";
+import {
+  groupByField,
+  filterEqField,
+  filterContainsField,
+  nearestPoints,
+  countDataset,
+  fetchDataset,
+  clearDatasetCache,
+  type GeoFeature,
+} from "../geojsonQuery";
+import { capToolResult, type CappedResult } from "../truncate";
+import { rankPointsByPopulation, clearH3PopulationCache } from "../h3Population";
+import { callWhitelistedRpc, RPC_WHITELIST } from "../rpcTools";
+
+// ── 小 GeoJSON fixture ──
+function pt(lng: number, lat: number, props: Record<string, unknown>): GeoFeature {
+  return { type: "Feature", geometry: { type: "Point", coordinates: [lng, lat] }, properties: props };
+}
+
+const FIRE_FIXTURE: GeoFeature[] = [
+  pt(121.5, 25.04, { name: "台北中隊", cat: "分隊", county: "臺北市" }),
+  pt(121.51, 25.05, { name: "大安分隊", cat: "分隊", county: "臺北市" }),
+  pt(121.56, 25.03, { name: "第一大隊", cat: "大隊", county: "臺北市" }),
+  pt(120.3, 22.6, { name: "高雄分駐所", cat: "分駐所", county: "高雄市" }),
+];
+
+describe("geojsonQuery.groupByField", () => {
+  it("counts by field, sorted desc", () => {
+    const r = groupByField(FIRE_FIXTURE, "cat");
+    expect("groups" in r).toBe(true);
+    const groups = (r as { groups: { value: string; count: number }[] }).groups;
+    expect(groups[0]).toEqual({ value: "分隊", count: 2 });
+    expect((r as unknown as { distinct: number }).distinct).toBe(3);
+  });
+
+  it("returns availableFields when field is absent", () => {
+    const r = groupByField(FIRE_FIXTURE, "nonexistent") as {
+      error: string;
+      availableFields: string[];
+    };
+    expect(r.error).toContain("nonexistent");
+    expect(r.availableFields).toContain("cat");
+  });
+});
+
+// ── FX-5: 教學性工具回饋（0 筆 / 欄位不存在 → availableFields + fieldSamples + hint） ──
+describe("geojsonQuery.filterEqField (FX-5)", () => {
+  it("returns matched sample when value exists", () => {
+    const r = filterEqField(FIRE_FIXTURE, "cat", "分隊") as { matched: number };
+    expect(r.matched).toBe(2);
+  });
+
+  it("returns availableFields + fieldSamples + hint on 0 matches with a valid field", () => {
+    const r = filterEqField(FIRE_FIXTURE, "cat", "不存在的分類") as {
+      matched: number;
+      error?: string;
+      hint: string;
+      availableFields: string[];
+      fieldSamples: Record<string, string[]>;
+    };
+    expect(r.matched).toBe(0);
+    expect(r.error).toBeUndefined(); // 欄位本身存在，只是值查不到
+    expect(r.hint).toBeTruthy();
+    expect(r.availableFields).toEqual(expect.arrayContaining(["name", "cat", "county"]));
+    expect(r.fieldSamples.cat).toEqual(expect.arrayContaining(["分隊"]));
+  });
+
+  it("flags the field itself as missing (欄位不存在) with the same feedback shape", () => {
+    const r = filterEqField(FIRE_FIXTURE, "district", "隨便") as {
+      matched: number;
+      error: string;
+      hint: string;
+      availableFields: string[];
+      fieldSamples: Record<string, string[]>;
+    };
+    expect(r.matched).toBe(0);
+    expect(r.error).toContain("district");
+    expect(r.error).toContain("不存在");
+    expect(r.hint).toBeTruthy();
+    expect(r.availableFields).toEqual(expect.arrayContaining(["name", "cat", "county"]));
+  });
+});
+
+describe("geojsonQuery.filterContainsField (FX-5)", () => {
+  const ADDRESS_FIXTURE: GeoFeature[] = [
+    pt(121.5, 25.04, { name: "台北一號", address: "臺北市中正區重慶南路一段" }),
+    pt(121.51, 25.05, { name: "台北二號", address: "Taipei City Da-an District" }),
+    pt(120.3, 22.6, { name: "高雄一號", address: "高雄市苓雅區" }),
+  ];
+
+  it("matches by substring (Traditional Chinese)", () => {
+    const r = filterContainsField(ADDRESS_FIXTURE, "address", "臺北市") as {
+      matched: number;
+      sample: unknown;
+    };
+    expect(r.matched).toBe(1);
+  });
+
+  it("matches case-insensitively for ASCII text", () => {
+    const upper = filterContainsField(ADDRESS_FIXTURE, "address", "TAIPEI") as { matched: number };
+    const lower = filterContainsField(ADDRESS_FIXTURE, "address", "taipei") as { matched: number };
+    expect(upper.matched).toBe(1);
+    expect(lower.matched).toBe(1);
+  });
+
+  it("returns availableFields + fieldSamples + hint on 0 matches", () => {
+    const r = filterContainsField(ADDRESS_FIXTURE, "address", "不存在的地址片段") as {
+      matched: number;
+      hint: string;
+      availableFields: string[];
+      fieldSamples: Record<string, string[]>;
+    };
+    expect(r.matched).toBe(0);
+    expect(r.hint).toBeTruthy();
+    expect(r.availableFields).toContain("address");
+    expect(r.fieldSamples.address?.length).toBeGreaterThan(0);
+  });
+
+  it("flags a nonexistent field as 不存在", () => {
+    const r = filterContainsField(ADDRESS_FIXTURE, "county", "台北") as {
+      matched: number;
+      error: string;
+    };
+    expect(r.matched).toBe(0);
+    expect(r.error).toContain("不存在");
+  });
+});
+
+describe("geojsonQuery fieldSamples 抽樣上限 (FX-5)", () => {
+  it("only samples the first 200 features when building fieldSamples", () => {
+    const features: GeoFeature[] = Array.from({ length: 250 }, (_, i) =>
+      i < 200
+        ? pt(121.5, 25.0, { name: `pt-${i}`, tag: "early" })
+        : pt(121.5, 25.0, { name: `pt-${i}`, tag: "early", onlyLate: "late-value" }),
+    );
+    const r = filterEqField(features, "tag", "查無此值") as {
+      matched: number;
+      fieldSamples: Record<string, string[]>;
+    };
+    expect(r.matched).toBe(0);
+    expect(r.fieldSamples.tag).toContain("early");
+    // onlyLate 只出現在第 200 筆之後，超過抽樣上限應該完全掃不到
+    expect(r.fieldSamples.onlyLate).toBeUndefined();
+  });
+});
+
+describe("geojsonQuery.nearestPoints", () => {
+  it("returns k nearest points ordered by distance", () => {
+    const r = nearestPoints(FIRE_FIXTURE, 121.5, 25.04, 2);
+    const points = r.points as { name: string; distanceKm: number }[];
+    expect(points).toHaveLength(2);
+    expect(points[0]!.name).toBe("台北中隊"); // same coord → ~0 km
+    expect(points[0]!.distanceKm).toBeLessThanOrEqual(points[1]!.distanceKm);
+  });
+
+  it("distances are in km (Haversine sanity)", () => {
+    const r = nearestPoints(FIRE_FIXTURE, 121.5, 25.04, 4);
+    const kaohsiung = (r.points as { name: string; distanceKm: number }[]).find(
+      (p) => p.name === "高雄分駐所",
+    )!;
+    // 台北→高雄 直線約 300km 量級
+    expect(kaohsiung.distanceKm).toBeGreaterThan(250);
+    expect(kaohsiung.distanceKm).toBeLessThan(360);
+  });
+});
+
+describe("truncate.capToolResult", () => {
+  it("returns array unchanged when under limits", () => {
+    const data = [1, 2, 3];
+    expect(capToolResult(data)).toBe(data);
+  });
+
+  it("truncates by maxItems", () => {
+    const data = Array.from({ length: 50 }, (_, i) => ({ i }));
+    const r = capToolResult(data, { maxItems: 20 }) as CappedResult<{ i: number }>;
+    expect(r.truncated).toBe(true);
+    expect(r.total).toBe(50);
+    expect(r.sample).toHaveLength(20);
+  });
+
+  it("truncates further by maxChars", () => {
+    const data = Array.from({ length: 20 }, (_, i) => ({ blob: "x".repeat(500), i }));
+    const r = capToolResult(data, { maxItems: 20, maxChars: 1000 }) as CappedResult<unknown>;
+    expect(r.truncated).toBe(true);
+    expect(JSON.stringify(r.sample).length).toBeLessThanOrEqual(1000);
+  });
+});
+
+describe("geojsonQuery.fetchDataset", () => {
+  beforeEach(() => clearDatasetCache());
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("fetches a whitelisted dataset and caches it", async () => {
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({ type: "FeatureCollection", features: FIRE_FIXTURE }),
+    }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const a = await fetchDataset("fireStations");
+    const b = await fetchDataset("fireStations");
+    expect(a).toBe(b); // cache hit → same array reference
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(countDataset(a).total).toBe(4);
+  });
+
+  it("rejects an unauthorized dataset id", async () => {
+    await expect(fetchDataset("__not_whitelisted__")).rejects.toThrow(/未授權/);
+  });
+});
+
+describe("h3Population.rankPointsByPopulation", () => {
+  beforeEach(() => clearH3PopulationCache());
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("joins points to H3 cells and ranks by night population", async () => {
+    const res = 7;
+    const points = [
+      { lng: 121.5, lat: 25.04, name: "A" },
+      { lng: 120.3, lat: 22.6, name: "B" },
+      { lng: 121.0, lat: 23.5, name: "C-no-cell" },
+    ];
+    // 只給 A、B 建 cell（C 對不到 → population 0）
+    const cells = [
+      { h: latLngToCell(points[0]!.lat, points[0]!.lng, res), d: 5000, n: 8000 },
+      { h: latLngToCell(points[1]!.lat, points[1]!.lng, res), d: 3000, n: 2000 },
+    ];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({
+        ok: true,
+        status: 200,
+        json: async () => ({ metadata: { resolution: res, value_columns: ["d", "n"] }, cells }),
+      })),
+    );
+
+    const r = await rankPointsByPopulation(points, 10, "night");
+    const ranked = r.ranked as { name: string; population: number }[];
+    expect(r.metric).toBe("night");
+    expect(ranked[0]!.name).toBe("A"); // 夜間 8000 最高
+    expect(ranked[0]!.population).toBe(8000);
+    expect(ranked[1]!.name).toBe("B");
+    expect(ranked[2]!.population).toBe(0); // 對不到 cell
+  });
+
+  it("switches to day population when metric=day", async () => {
+    const res = 7;
+    const points = [
+      { lng: 121.5, lat: 25.04, name: "A" },
+      { lng: 120.3, lat: 22.6, name: "B" },
+    ];
+    const cells = [
+      { h: latLngToCell(points[0]!.lat, points[0]!.lng, res), d: 1000, n: 9000 },
+      { h: latLngToCell(points[1]!.lat, points[1]!.lng, res), d: 9000, n: 1000 },
+    ];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({
+        ok: true,
+        status: 200,
+        json: async () => ({ metadata: { resolution: res }, cells }),
+      })),
+    );
+
+    const r = await rankPointsByPopulation(points, 10, "day");
+    const ranked = r.ranked as { name: string }[];
+    expect(ranked[0]!.name).toBe("B"); // 日間 B 較高
+  });
+});
+
+describe("rpcTools.callWhitelistedRpc", () => {
+  it("rejects an unknown RPC name without hitting the network", async () => {
+    const r = await callWhitelistedRpc("drop_table_users", {});
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toContain("未授權");
+  });
+
+  it("rejects when params fail schema validation", async () => {
+    // get_fire_events_by_year 需要 target_year:number
+    const r = await callWhitelistedRpc("get_fire_events_by_year", { target_year: "not-a-number" });
+    expect(r.ok).toBe(false);
+  });
+
+  it("whitelist includes the required RPCs", () => {
+    for (const name of [
+      "get_data_catalog_by_theme",
+      "get_data_catalog_for_layer",
+      "get_fire_events_by_year",
+      "get_h3_demographics_yearly",
+    ]) {
+      expect(RPC_WHITELIST[name]).toBeTruthy();
+    }
+  });
+});

--- a/src/chat/tools/__tests__/layerDetails.test.ts
+++ b/src/chat/tools/__tests__/layerDetails.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { MapBridge } from "../../types";
+import { DATASET_WHITELIST } from "../datasets";
+import { RPC_WHITELIST } from "../rpcTools";
+
+// mock 掉 RPC 層（避免打網路），保留 RPC_WHITELIST 真值
+vi.mock("../rpcTools", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../rpcTools")>();
+  return { ...actual, callWhitelistedRpc: vi.fn() };
+});
+
+import { collectLayerDetails } from "../catalogTools";
+import { callWhitelistedRpc } from "../rpcTools";
+
+const mockBridge = (visible: string[] = []): MapBridge => ({
+  bulkSetVisibility: () => {},
+  allOff: () => {},
+  flyTo: () => {},
+  jumpToPlace: () => true,
+  highlightPoint: () => {},
+  getVisibleLayerKeys: () => visible,
+  getCurrentTimeISO: () => "2026-07-03T00:00:00Z",
+  getCamera: () => ({ lng: 121, lat: 24, zoom: 7 }),
+});
+
+const mockedRpc = vi.mocked(callWhitelistedRpc);
+
+beforeEach(() => {
+  mockedRpc.mockReset();
+  mockedRpc.mockResolvedValue({
+    ok: true,
+    result: [{ source_agency: "環境部", license: "CC BY 4.0" }],
+  });
+});
+
+describe("catalogTools.collectLayerDetails", () => {
+  it("aggregates label + theme + group + source for a known layer key", async () => {
+    const r = await collectLayerDetails(["wfLandfill"], mockBridge(["wfLandfill"]));
+    expect(r.requested).toBe(1);
+    expect(r.truncatedKeys).toBe(false);
+    const details = r.details as Array<{
+      found: boolean;
+      label: string;
+      theme: string;
+      group: string;
+      visibleNow: boolean;
+      source: unknown;
+    }>;
+    expect(details[0]!.found).toBe(true);
+    expect(details[0]!.label).toContain("掩埋場");
+    expect(details[0]!.theme).toContain("廢棄物");
+    expect(details[0]!.group).toBe("處理設施");
+    expect(details[0]!.visibleNow).toBe(true);
+    expect(details[0]!.source).toBeTruthy();
+    expect(mockedRpc).toHaveBeenCalledWith("get_data_catalog_for_layer", {
+      p_layer_key: "wfLandfill",
+    });
+  });
+
+  it("caps at 5 keys and flags truncation", async () => {
+    const keys = [
+      "wfLandfill",
+      "wfIncinerator",
+      "wfRecycling",
+      "wfTransfer",
+      "wfMedical",
+      "wfMonitoring",
+      "wfScrapYard",
+    ];
+    const r = await collectLayerDetails(keys, mockBridge());
+    expect(r.requested).toBe(7);
+    expect(r.truncatedKeys).toBe(true);
+    expect(r.details as unknown[]).toHaveLength(5);
+    expect(mockedRpc).toHaveBeenCalledTimes(5); // 只對前 5 個打 RPC
+  });
+
+  it("marks unknown keys as not found without calling the RPC", async () => {
+    const r = await collectLayerDetails(["__nope__"], mockBridge());
+    const details = r.details as Array<{ found: boolean; note?: string }>;
+    expect(details[0]!.found).toBe(false);
+    expect(details[0]!.note).toContain("__nope__");
+    expect(mockedRpc).not.toHaveBeenCalled();
+  });
+
+  it("degrades gracefully when the catalog RPC fails", async () => {
+    mockedRpc.mockResolvedValue({ ok: false, error: "boom" });
+    const r = await collectLayerDetails(["wfLandfill"], mockBridge());
+    const details = r.details as Array<{ found: boolean; label: string; source: string }>;
+    expect(details[0]!.found).toBe(true); // catalog 資訊仍在
+    expect(details[0]!.label).toContain("掩埋場");
+    expect(String(details[0]!.source)).toContain("boom");
+  });
+});
+
+describe("DATASET_WHITELIST waste entry", () => {
+  it("includes wasteStopsStatic pointing to a static geojson", () => {
+    const w = DATASET_WHITELIST.wasteStopsStatic;
+    expect(w).toBeTruthy();
+    expect(w!.url).toMatch(/\.geojson$/);
+    expect(w!.label).toBeTruthy();
+    expect(w!.description.length).toBeGreaterThan(20);
+  });
+
+  it("every whitelist entry has a well-formed url / label / description", () => {
+    for (const [id, meta] of Object.entries(DATASET_WHITELIST)) {
+      expect(meta.url, id).toMatch(/^\.\//);
+      expect(meta.label, id).toBeTruthy();
+      expect(meta.description, id).toBeTruthy();
+    }
+  });
+});
+
+describe("RPC_WHITELIST waste count RPCs", () => {
+  it("exposes the lightweight waste count RPCs used for 「幾個掩埋場」", () => {
+    for (const name of ["get_waste_facility_counts", "get_waste_disposal_point_counts"]) {
+      expect(RPC_WHITELIST[name]).toBeTruthy();
+      expect(RPC_WHITELIST[name]!.description).toBeTruthy();
+    }
+  });
+});

--- a/src/chat/tools/catalogTools.ts
+++ b/src/chat/tools/catalogTools.ts
@@ -1,0 +1,152 @@
+// 圖層目錄查詢工具 — 讓模型按需查 key/label，避免把 231 個圖層塞進 system prompt。
+// 清單類回傳一律過 capToolResult。
+
+import { tool } from "ai";
+import { z } from "zod";
+import type { MapBridge } from "../types";
+import { THEMES, LAYER_LABELS } from "../../components/sidebar/layerCatalog";
+import { capToolResult } from "./truncate";
+import { callWhitelistedRpc } from "./rpcTools";
+
+interface LayerRef {
+  key: string;
+  label: string;
+}
+
+function themeLayers(theme: (typeof THEMES)[number]): LayerRef[] {
+  return theme.groups.flatMap((g) => g.layers.map((l) => ({ key: l.key, label: l.label })));
+}
+
+// ── get_layer_details 用：從 THEMES 反查圖層所屬主題 / 子群 ──
+interface LayerDetail {
+  key: string;
+  found: boolean;
+  label?: string;
+  theme?: string;
+  group?: string;
+  visibleNow?: boolean;
+  /** 上游資料來源（get_data_catalog_for_layer 的結果；查不到時回說明字串）*/
+  source?: unknown;
+  note?: string;
+}
+
+function locateLayer(key: string): { label: string; theme: string; group: string } | null {
+  for (const t of THEMES) {
+    for (const g of t.groups) {
+      const l = g.layers.find((layer) => layer.key === key);
+      if (l) return { label: l.label, theme: t.title, group: g.title };
+    }
+  }
+  return null;
+}
+
+const MAX_DETAIL_KEYS = 5;
+
+/**
+ * 彙整一組圖層的細節（label + 主題/子群 + 上游資料來源）。
+ * 上游來源透過白名單 RPC get_data_catalog_for_layer 取得，失敗時 graceful 降級只回 catalog 資訊。
+ * keys 超過 MAX_DETAIL_KEYS 個自動截斷。抽成 export 供測試。
+ */
+export async function collectLayerDetails(keys: string[], bridge: MapBridge) {
+  const use = keys.slice(0, MAX_DETAIL_KEYS);
+  const truncatedKeys = keys.length > MAX_DETAIL_KEYS;
+  const visible = new Set(bridge.getVisibleLayerKeys());
+  const details = await Promise.all(
+    use.map(async (key): Promise<LayerDetail> => {
+      const loc = locateLayer(key);
+      if (!loc) {
+        return { key, found: false, note: `找不到圖層 key「${key}」，請先用 search_layers 確認` };
+      }
+      const r = await callWhitelistedRpc("get_data_catalog_for_layer", { p_layer_key: key });
+      return {
+        key,
+        found: true,
+        label: loc.label,
+        theme: loc.theme,
+        group: loc.group,
+        visibleNow: visible.has(key),
+        source: r.ok ? r.result : `（查無上游來源：${r.error}）`,
+      };
+    }),
+  );
+  const foundCount = details.filter((d) => d.found).length;
+  return {
+    summary: `已彙整 ${foundCount}/${use.length} 個圖層細節${
+      truncatedKeys ? `（keys 超過 ${MAX_DETAIL_KEYS} 個，僅取前 ${MAX_DETAIL_KEYS}）` : ""
+    }`,
+    truncatedKeys,
+    requested: keys.length,
+    details: capToolResult(details, { maxItems: MAX_DETAIL_KEYS }),
+  };
+}
+
+export function catalogTools(bridge: MapBridge) {
+  return {
+    list_layers: tool({
+      description:
+        "列出某個主題底下的所有圖層（回 {key,label}）。theme 用主題名，可只給中文或英文片段，例如「交通」「Water」。",
+      inputSchema: z.object({
+        theme: z.string().describe("主題名片段，例如「水資源」「Hazard」"),
+      }),
+      execute: ({ theme }) => {
+        const q = theme.trim().toLowerCase();
+        const matched = THEMES.find((t) => t.title.toLowerCase().includes(q));
+        if (!matched) {
+          return {
+            summary: `找不到主題「${theme}」`,
+            themes: THEMES.map((t) => t.title),
+            note: "theme 不符，請從 themes 清單挑一個重試",
+          };
+        }
+        const layers = themeLayers(matched);
+        const visible = new Set(bridge.getVisibleLayerKeys());
+        const visibleNow = layers.filter((l) => visible.has(l.key)).map((l) => l.key);
+        return {
+          summary: `主題「${matched.title}」共 ${layers.length} 個圖層，目前開啟 ${visibleNow.length} 個`,
+          theme: matched.title,
+          total: layers.length,
+          layers: capToolResult(layers),
+          visibleNow,
+        };
+      },
+    }),
+
+    search_layers: tool({
+      description: "以中英文關鍵字模糊搜尋圖層名稱，回前 10 筆 {key,label}。",
+      inputSchema: z.object({
+        query: z.string().describe("關鍵字，例如「消防」「flood」「bus」"),
+      }),
+      execute: ({ query }) => {
+        const q = query.trim().toLowerCase();
+        const hits: LayerRef[] = [];
+        for (const [key, label] of Object.entries(LAYER_LABELS)) {
+          if (!label) continue;
+          if (key.toLowerCase().includes(q) || label.toLowerCase().includes(q)) {
+            hits.push({ key, label });
+          }
+        }
+        const results = hits.slice(0, 10);
+        const visible = new Set(bridge.getVisibleLayerKeys());
+        const visibleNow = results.filter((l) => visible.has(l.key)).map((l) => l.key);
+        return {
+          summary: `搜尋「${query}」找到 ${hits.length} 筆${hits.length > 10 ? "（顯示前 10）" : ""}`,
+          query,
+          total: hits.length,
+          results: capToolResult(results, { maxItems: 10 }),
+          visibleNow,
+        };
+      },
+    }),
+
+    get_layer_details: tool({
+      description:
+        "彙整一組圖層的細節：中文名、所屬主題 / 子群、上游資料來源、是否已開啟。回答『圖層之間的關係』『資料哪來的』『建議怎麼用 / 怎麼疊圖』之前，先用這支拿脈絡。keys 上限 5 個（超過自動截斷）。",
+      inputSchema: z.object({
+        keys: z
+          .array(z.string())
+          .describe("圖層 key 陣列（先用 list_layers / search_layers 找），上限 5 個"),
+      }),
+      execute: ({ keys }) => collectLayerDetails(keys, bridge),
+    }),
+  };
+}

--- a/src/chat/tools/dataTools.ts
+++ b/src/chat/tools/dataTools.ts
@@ -1,0 +1,178 @@
+// 資料查詢工具 — 組裝 query_dataset / rank_by_population / call_rpc 給 agent。
+// 照 mapTools.ts 的 tool() 寫法；每個回傳都含繁中 summary（UI chip 用）。
+// 安全邊界：資料集 / RPC 皆白名單，LLM 不產 SQL；清單類輸出全過 capToolResult。
+
+import { tool } from "ai";
+import { z } from "zod";
+import type { MapBridge } from "../types";
+import { DATASET_WHITELIST } from "./datasets";
+import {
+  fetchDataset,
+  countDataset,
+  groupByField,
+  filterEqField,
+  filterContainsField,
+  nearestPoints,
+  pointOf,
+  nameOf,
+} from "./geojsonQuery";
+import { rankPointsByPopulation } from "./h3Population";
+import { RPC_WHITELIST, callWhitelistedRpc } from "./rpcTools";
+
+const DATASET_LIST = Object.entries(DATASET_WHITELIST)
+  .map(([id, m]) => `  - ${id}：${m.description}`)
+  .join("\n");
+
+const RPC_LIST = Object.entries(RPC_WHITELIST)
+  .map(([name, s]) => `  - ${name}：${s.description}`)
+  .join("\n");
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export function dataTools(_bridge: MapBridge) {
+  return {
+    query_dataset: tool({
+      description:
+        "查詢靜態點位資料集的統計（數量 / 分類佔比 / 篩選 / 最近點）。回答「全台幾個 X」「X 分哪幾類、各多少」「離某地最近的 X」等。\n" +
+        "op：count（總數 + 可用欄位）、groupBy（依 field 分類計數，需 field）、filterEq（field==value 精確比對的筆數，需 field+value）、filterContains（field 文字包含 value，不分大小寫，需 field+value）、nearest（離 lng,lat 最近 k 個，需 lng+lat）。\n" +
+        "地址/名稱類篩選用 filterContains（例：address 含 臺北市）；精確分類值用 filterEq；不確定值域先 groupBy。\n" +
+        "查 0 筆或欄位不存在時，回傳會附 availableFields / fieldSamples / hint，請依此換欄位或換 op 再查一次，不要放棄。\n" +
+        `可用 datasetId：\n${DATASET_LIST}`,
+      inputSchema: z.object({
+        datasetId: z.string().describe("白名單資料集 id，例如 policeStations"),
+        op: z.enum(["count", "groupBy", "filterEq", "filterContains", "nearest"]),
+        field: z.string().optional().describe("groupBy / filterEq / filterContains 用的欄位名"),
+        value: z.string().optional().describe("filterEq / filterContains 的比對值"),
+        lng: z.number().optional().describe("nearest 的原點經度"),
+        lat: z.number().optional().describe("nearest 的原點緯度"),
+        k: z.number().optional().describe("nearest 取幾個，預設 5"),
+      }),
+      execute: async ({ datasetId, op, field, value, lng, lat, k }) => {
+        const meta = DATASET_WHITELIST[datasetId];
+        if (!meta) {
+          return {
+            summary: `未授權資料集：${datasetId}`,
+            error: `datasetId「${datasetId}」不在白名單`,
+            available: Object.keys(DATASET_WHITELIST),
+          };
+        }
+        let features;
+        try {
+          features = await fetchDataset(datasetId);
+        } catch (e) {
+          return { summary: `載入 ${meta.label} 失敗`, error: (e as Error).message };
+        }
+
+        switch (op) {
+          case "count": {
+            const r = countDataset(features);
+            return { summary: `${meta.label} 共 ${r.total} 筆`, datasetId, ...r };
+          }
+          case "groupBy": {
+            if (!field) return { summary: "groupBy 需要 field 參數" };
+            const r = groupByField(features, field);
+            const distinct = "distinct" in r ? r.distinct : 0;
+            return {
+              summary:
+                "error" in r
+                  ? `${meta.label}：${r.error}`
+                  : `${meta.label} 依 ${field} 分 ${distinct} 類（共 ${features.length} 筆）`,
+              datasetId,
+              ...r,
+            };
+          }
+          case "filterEq": {
+            if (!field || value === undefined)
+              return { summary: "filterEq 需要 field 與 value 參數" };
+            const r = filterEqField(features, field, value);
+            return {
+              summary:
+                "error" in r
+                  ? `${meta.label}：${r.error}`
+                  : `${meta.label} 中 ${field}=${value} 共 ${r.matched} 筆`,
+              datasetId,
+              ...r,
+            };
+          }
+          case "filterContains": {
+            if (!field || value === undefined)
+              return { summary: "filterContains 需要 field 與 value 參數" };
+            const r = filterContainsField(features, field, value);
+            return {
+              summary:
+                "error" in r
+                  ? `${meta.label}：${r.error}`
+                  : `${meta.label} 中 ${field} 含「${value}」共 ${r.matched} 筆`,
+              datasetId,
+              ...r,
+            };
+          }
+          case "nearest": {
+            if (lng === undefined || lat === undefined)
+              return { summary: "nearest 需要 lng 與 lat 參數" };
+            const r = nearestPoints(features, lng, lat, k ?? 5);
+            return { summary: `${meta.label}：已找出最近 ${k ?? 5} 個點`, datasetId, ...r };
+          }
+        }
+      },
+    }),
+
+    rank_by_population: tool({
+      description:
+        "把某資料集的點位對到 H3 人口網格，依「附近人口密度」排名。回答「哪些消防分隊 / 醫院附近人口最多」這類問題。metric：day 日間人口 / night 夜間人口（預設 night）。",
+      inputSchema: z.object({
+        datasetId: z.string().describe("白名單資料集 id，例如 fireStations"),
+        topN: z.number().optional().describe("回前幾名，預設 10"),
+        metric: z.enum(["day", "night"]).optional().describe("day 日間 / night 夜間人口"),
+      }),
+      execute: async ({ datasetId, topN, metric }) => {
+        const meta = DATASET_WHITELIST[datasetId];
+        if (!meta) {
+          return {
+            summary: `未授權資料集：${datasetId}`,
+            error: `datasetId「${datasetId}」不在白名單`,
+            available: Object.keys(DATASET_WHITELIST),
+          };
+        }
+        let features;
+        try {
+          features = await fetchDataset(datasetId);
+        } catch (e) {
+          return { summary: `載入 ${meta.label} 失敗`, error: (e as Error).message };
+        }
+        const points = features
+          .map((f) => {
+            const pt = pointOf(f);
+            return pt ? { lng: pt[0], lat: pt[1], name: nameOf(f.properties ?? {}) } : null;
+          })
+          .filter((p): p is { lng: number; lat: number; name: string } => p !== null);
+
+        const n = topN ?? 10;
+        const m = metric ?? "night";
+        const r = await rankPointsByPopulation(points, n, m);
+        return {
+          summary: `${meta.label} 依${m === "day" ? "日" : "夜"}間人口密度排名（top ${n}）`,
+          datasetId,
+          ...r,
+        };
+      },
+    }),
+
+    call_rpc: tool({
+      description:
+        "呼叫白名單內的 Supabase 唯讀 RPC，回答時序 / 事件 / 資料目錄類問題。name 必須在白名單內，params 依該 RPC 需求給。\n" +
+        `可用 RPC：\n${RPC_LIST}`,
+      inputSchema: z.object({
+        name: z.string().describe("白名單 RPC 名稱，例如 get_data_catalog_by_theme"),
+        params: z.record(z.string(), z.unknown()).optional().describe("該 RPC 的參數物件"),
+      }),
+      execute: async ({ name, params }) => {
+        const r = await callWhitelistedRpc(name, params ?? {});
+        return {
+          summary: r.ok ? `已呼叫 RPC ${name}` : `RPC ${name} 失敗：${r.error}`,
+          name,
+          ...r,
+        };
+      },
+    }),
+  };
+}

--- a/src/chat/tools/datasets.ts
+++ b/src/chat/tools/datasets.ts
@@ -1,0 +1,108 @@
+// 靜態 GeoJSON 資料集白名單 — query_dataset / rank_by_population 只能查這裡列的資料集。
+// url 沿用 overlayRegistry.ts 的 sourceUrl（同一份生產路徑；相對路徑會相對於站台 base）。
+// description 給 LLM 看：說明有哪些欄位可 groupBy / filterEq（county 幾乎每個都有，適合縣市統計）。
+//
+// 只收「點狀 + 有分類欄位 + 常被問」的資料集。動態資料（加油站 / 充電站 / 火災事件…走 RPC）
+// 與 PMTiles（醫療 5 類 medical_poi、消防栓…無法當 GeoJSON fetch）不在此。
+
+export interface DatasetMeta {
+  url: string;
+  label: string;
+  /** 給 LLM 的欄位提示：可 groupBy / filterEq 的欄位與大致取值 */
+  description: string;
+}
+
+export const DATASET_WHITELIST: Record<string, DatasetMeta> = {
+  // ── 治安 / 司法（police_justice，全國）──
+  policeStations: {
+    url: "./police_justice/police_stations/police_stations_20260626.geojson",
+    label: "警察機關",
+    description:
+      "全國警察機關點位（約 2000+）。欄位 facility_subtype（substation 派出所 / precinct 分局 / police_dept 警察局 / headquarters 總部 / specialized 專業警察 / security 保安 / other）、county（縣市）。",
+  },
+  courts: {
+    url: "./police_justice/courts/courts_20260626.geojson",
+    label: "法院",
+    description: "全國各級法院點位。欄位 court_type（法院層級）、county（縣市）。",
+  },
+  prosecutorsOffices: {
+    url: "./police_justice/prosecutors_offices/prosecutors_offices_20260626.geojson",
+    label: "檢察署",
+    description: "全國各級檢察署點位。欄位 pros_type（檢察署層級）、county（縣市）。",
+  },
+  correctionalFacilities: {
+    url: "./police_justice/correctional_facilities/correctional_facilities_20260626.geojson",
+    label: "矯正機關",
+    description:
+      "全國矯正機關點位（監獄 / 看守所 / 少年觀護所等）。欄位 facility_type（機關類型）、county（縣市）。",
+  },
+  coastGuardStations: {
+    url: "./police_justice/coast_guard_stations/coast_guard_stations_20260626.geojson",
+    label: "海巡機關",
+    description: "全國海巡機關點位。欄位 facility_subtype（機關類型）、county（縣市）。",
+  },
+  speedCameras: {
+    url: "./police_justice/speed_cameras/speed_cameras_20260626.geojson",
+    label: "測速照相",
+    description:
+      "全國固定式測速照相點位。欄位 facility_subtype（種類）、limit_kph（速限）、county（縣市）。",
+  },
+
+  // ── 消防 / 救護（全國 22 縣市）──
+  fireStations: {
+    url: "./geo/fire_stations.geojson",
+    label: "消防分隊",
+    description:
+      "全國消防機關點位（約 700+）。欄位 cat（大隊 / 分隊 / 分駐所）、county（縣市）、township（鄉鎮）。",
+  },
+
+  // ── 教育 ──
+  schools: {
+    url: "./geo/schools.geojson",
+    label: "學校",
+    description:
+      "全國各級學校點位。欄位 school_level（國民小學 / 國民中學 / 高級中等學校 / 大專校院 / 特殊教育學校 等）。",
+  },
+
+  // ── 醫療 ──
+  medHospitals: {
+    url: "./geo/medical_hospitals.geojson",
+    label: "醫院",
+    description: "全國醫院點位（健保特約）。欄位 county（縣市），適合依縣市統計醫院數。",
+  },
+
+  // ── 交通 / 監視 ──
+  cctv: {
+    url: "./geo/cctv.geojson",
+    label: "道路 CCTV",
+    description: "全國道路監視器（約 6000+）。欄位 source（freeway 國道 / highway 省道 / city 市區）。",
+  },
+
+  // ── 基礎設施 ──
+  landingStations: {
+    url: "./geo/landing_stations.geojson",
+    label: "海纜登陸站",
+    description: "海底電纜登陸站。欄位 station_type（國際樞紐 / 區域節點 / 端點）。",
+  },
+  waterMonitorStations: {
+    url: "./geo/water_monitor_stations.geojson",
+    label: "水文監測站",
+    description: "全國水文監測站。欄位 station_type（測站類型）、county（縣市）。",
+  },
+  convenienceStores: {
+    url: "./geo/convenience_stores.geojson",
+    label: "超商",
+    description:
+      "全國連鎖超商點位。欄位 brand（7-ELEVEN / 全家 FamilyMart / 萊爾富 Hi-Life / OK）、county（縣市）。",
+  },
+
+  // ── 廢棄物 / 清運（Waste，全國 22 縣市）──
+  wasteStopsStatic: {
+    url: "./geo/waste_stops_static.geojson",
+    label: "全台垃圾車清運點位",
+    description:
+      "全台垃圾車 / 廚餘車清運停靠點（約 7.3 萬筆，檔案較大）。欄位 city（縣市，涵蓋全 22 縣市）、district（行政區）、vehicle_type（garbage 一般垃圾 / kitchen 廚餘）、routes_count（該點經過的清運路線數）。問「XX 市有幾個清運點 / 各縣市清運點分佈」用 groupBy city。注意：掩埋場 / 焚化爐 / 資收廠等『處理設施』與衣物回收箱等『投放點』不在此靜態檔，其數量請改用 call_rpc 的 get_waste_facility_counts / get_waste_disposal_point_counts。",
+  },
+};
+
+export type DatasetId = keyof typeof DATASET_WHITELIST;

--- a/src/chat/tools/geojsonQuery.ts
+++ b/src/chat/tools/geojsonQuery.ts
@@ -1,0 +1,235 @@
+// 記憶體 GeoJSON 查詢引擎 — 靜態資料集只 fetch 一次、快取，之後在記憶體做統計。
+// 絕不把整份 features 回給 LLM：所有清單類輸出都過 capToolResult。
+
+import { withLoading } from "../../lib/loadingRegistry";
+import { DATASET_WHITELIST } from "./datasets";
+import { capToolResult } from "./truncate";
+
+export interface GeoFeature {
+  type: "Feature";
+  geometry: { type: string; coordinates: unknown } | null;
+  properties: Record<string, unknown>;
+}
+interface FeatureCollection {
+  features?: GeoFeature[];
+}
+
+// ── module-level 快取（同 fireLoader pattern）──
+const cache = new Map<string, GeoFeature[]>();
+
+/** fetch 白名單資料集 → features 陣列，含快取 + withLoading。未授權 id 直接 throw。 */
+export async function fetchDataset(id: string): Promise<GeoFeature[]> {
+  const cached = cache.get(id);
+  if (cached) return cached;
+
+  const meta = DATASET_WHITELIST[id];
+  if (!meta) throw new Error(`未授權的資料集：${id}`);
+
+  const features = await withLoading(
+    `chat-dataset:${id}`,
+    `載入 ${meta.label}`,
+    fetchFeatures(meta.url),
+  );
+  cache.set(id, features);
+  return features;
+}
+
+async function fetchFeatures(url: string): Promise<GeoFeature[]> {
+  const res = await fetch(url);
+  if (!res.ok) throw new Error(`載入資料失敗（${res.status}）：${url}`);
+  const gj = (await res.json()) as FeatureCollection;
+  return gj.features ?? [];
+}
+
+/** 測試 / 重載用 */
+export function clearDatasetCache(): void {
+  cache.clear();
+}
+
+// ── 純函式（可直接餵 features 做單元測試）──
+
+/** 取點座標 [lng, lat]；非 Point geometry 回 null。 */
+export function pointOf(f: GeoFeature): [number, number] | null {
+  if (!f.geometry || f.geometry.type !== "Point") return null;
+  const c = f.geometry.coordinates;
+  if (!Array.isArray(c) || c.length < 2) return null;
+  const lng = Number(c[0]);
+  const lat = Number(c[1]);
+  if (!Number.isFinite(lng) || !Number.isFinite(lat)) return null;
+  return [lng, lat];
+}
+
+const NAME_KEYS = ["name", "NAME", "Name", "title", "名稱", "站名", "場站名稱", "機關名稱"];
+/** 盡量取一個可讀名稱。 */
+export function nameOf(props: Record<string, unknown>): string {
+  for (const k of NAME_KEYS) {
+    const v = props[k];
+    if (typeof v === "string" && v.trim()) return v.trim();
+  }
+  return "";
+}
+
+/** count：回總數 + 首筆的可用欄位（讓 LLM 知道能 groupBy / filter 哪些欄位）。 */
+export function countDataset(features: GeoFeature[]): {
+  total: number;
+  availableFields: string[];
+} {
+  const availableFields = features[0] ? Object.keys(features[0].properties ?? {}) : [];
+  return { total: features.length, availableFields };
+}
+
+// ── 教學性工具回饋（FX-5）──
+// 查 0 筆 / 欄位不存在時，回可用欄位 + 樣本值 + 建議下一步，讓 LLM 能自我修正
+// 而不是放棄。抽樣上限 SAMPLE_SIZE 筆，避免大資料集拖慢。
+
+const SAMPLE_SIZE = 200;
+const SAMPLE_VALUES_PER_FIELD = 3;
+
+/** 抽前 SAMPLE_SIZE 筆，算每個欄位的前 SAMPLE_VALUES_PER_FIELD 個 distinct 值。 */
+function sampleFieldValues(features: GeoFeature[]): Record<string, string[]> {
+  const seen = new Map<string, Set<string>>();
+  for (const f of features.slice(0, SAMPLE_SIZE)) {
+    for (const [k, v] of Object.entries(f.properties ?? {})) {
+      if (v === null || v === undefined || v === "") continue;
+      let set = seen.get(k);
+      if (!set) {
+        set = new Set();
+        seen.set(k, set);
+      }
+      if (set.size < SAMPLE_VALUES_PER_FIELD) set.add(String(v));
+    }
+  }
+  const result: Record<string, string[]> = {};
+  for (const [k, set] of seen) result[k] = [...set];
+  return result;
+}
+
+/** 可用欄位（首筆的欄位名）+ 各欄位樣本值，供查 0 筆 / 欄位不存在時附在回傳裡。 */
+function fieldFeedback(features: GeoFeature[]) {
+  return {
+    availableFields: features[0] ? Object.keys(features[0].properties ?? {}) : [],
+    fieldSamples: sampleFieldValues(features),
+  };
+}
+
+/** 欄位是否存在於資料集（只要有一筆帶這個 key 就算存在）。 */
+function fieldExists(features: GeoFeature[], field: string): boolean {
+  return features.some((f) => field in (f.properties ?? {}));
+}
+
+/** groupBy：依欄位分組計數，由多到少排序。欄位不存在時回 availableFields + 樣本值 + hint 讓 LLM 改用。 */
+export function groupByField(features: GeoFeature[], field: string) {
+  const counts = new Map<string, number>();
+  let missing = 0;
+  for (const f of features) {
+    const props = f.properties ?? {};
+    if (!(field in props)) missing++;
+    const raw = props[field];
+    const key = raw === null || raw === undefined || raw === "" ? "(未填)" : String(raw);
+    counts.set(key, (counts.get(key) ?? 0) + 1);
+  }
+  if (missing === features.length && features[0]) {
+    return {
+      field,
+      error: `欄位「${field}」不存在`,
+      hint: "欄位不存在，可用欄位見 availableFields，或改用 filterContains 模糊比對地址/名稱類欄位",
+      ...fieldFeedback(features),
+    };
+  }
+  const groups = [...counts.entries()]
+    .map(([value, count]) => ({ value, count }))
+    .sort((a, b) => b.count - a.count);
+  return { field, distinct: groups.length, total: features.length, groups: capToolResult(groups) };
+}
+
+/** filterEq：欄位 == 值 的筆數 + 前 N 筆樣本（name + 座標）。0 筆或欄位不存在時回可用欄位 + 樣本值 + hint。 */
+export function filterEqField(features: GeoFeature[], field: string, value: string) {
+  if (features.length && !fieldExists(features, field)) {
+    return {
+      field,
+      value,
+      matched: 0,
+      error: `欄位「${field}」不存在`,
+      hint: "欄位不存在，可用欄位見 availableFields，或改用 filterContains 模糊比對",
+      ...fieldFeedback(features),
+    };
+  }
+  const matched = features.filter((f) => String((f.properties ?? {})[field]) === String(value));
+  if (matched.length === 0) {
+    return {
+      field,
+      value,
+      matched: 0,
+      hint: "欄位或值可能不對，可改用 groupBy 探索值域，或用 filterContains 模糊比對",
+      ...fieldFeedback(features),
+    };
+  }
+  const sample = matched.map((f) => {
+    const pt = pointOf(f);
+    return { name: nameOf(f.properties ?? {}), lng: pt?.[0], lat: pt?.[1] };
+  });
+  return { field, value, matched: matched.length, sample: capToolResult(sample) };
+}
+
+/** filterContains：欄位值（轉字串）包含 value 的筆數 + 前 N 筆樣本，不分大小寫。0 筆或欄位不存在時同 filterEq 回饋。 */
+export function filterContainsField(features: GeoFeature[], field: string, value: string) {
+  if (features.length && !fieldExists(features, field)) {
+    return {
+      field,
+      value,
+      matched: 0,
+      error: `欄位「${field}」不存在`,
+      hint: "欄位不存在，可用欄位見 availableFields，或改用 groupBy 探索值域",
+      ...fieldFeedback(features),
+    };
+  }
+  const needle = value.toLowerCase();
+  const matched = features.filter((f) => {
+    const raw = (f.properties ?? {})[field];
+    return raw !== null && raw !== undefined && String(raw).toLowerCase().includes(needle);
+  });
+  if (matched.length === 0) {
+    return {
+      field,
+      value,
+      matched: 0,
+      hint: "值可能不對，可改用 groupBy 探索值域",
+      ...fieldFeedback(features),
+    };
+  }
+  const sample = matched.map((f) => {
+    const pt = pointOf(f);
+    return { name: nameOf(f.properties ?? {}), lng: pt?.[0], lat: pt?.[1] };
+  });
+  return { field, value, matched: matched.length, sample: capToolResult(sample) };
+}
+
+/** Haversine 距離（km）。 */
+export function haversineKm(lng1: number, lat1: number, lng2: number, lat2: number): number {
+  const R = 6371;
+  const toRad = (d: number) => (d * Math.PI) / 180;
+  const dLat = toRad(lat2 - lat1);
+  const dLng = toRad(lng2 - lng1);
+  const a =
+    Math.sin(dLat / 2) ** 2 +
+    Math.cos(toRad(lat1)) * Math.cos(toRad(lat2)) * Math.sin(dLng / 2) ** 2;
+  return 2 * R * Math.asin(Math.min(1, Math.sqrt(a)));
+}
+
+/** nearest：離 (lng,lat) 最近的 k 個點，回距離 km（由近到遠）。 */
+export function nearestPoints(features: GeoFeature[], lng: number, lat: number, k: number) {
+  const scored: { name: string; lng: number; lat: number; distanceKm: number }[] = [];
+  for (const f of features) {
+    const pt = pointOf(f);
+    if (!pt) continue;
+    scored.push({
+      name: nameOf(f.properties ?? {}),
+      lng: pt[0],
+      lat: pt[1],
+      distanceKm: Math.round(haversineKm(lng, lat, pt[0], pt[1]) * 100) / 100,
+    });
+  }
+  scored.sort((a, b) => a.distanceKm - b.distanceKm);
+  const top = scored.slice(0, Math.max(1, k));
+  return { origin: { lng, lat }, k, points: capToolResult(top, { maxItems: k }) };
+}

--- a/src/chat/tools/h3Population.ts
+++ b/src/chat/tools/h3Population.ts
@@ -1,0 +1,76 @@
+// H3 人口密度空間 join — 把任意點位對到 H3 網格，取日 / 夜間人口做排名。
+// 資料：public/h3/h3_population_res*.json（{metadata:{resolution,value_columns:["d","n"]}, cells:[{h,d,n}]}）。
+// 注意：目前線上只有 res7（原規劃 res8 尚未產出），resolution 直接讀 metadata，不寫死。
+
+import { latLngToCell } from "h3-js";
+import { withLoading } from "../../lib/loadingRegistry";
+import { capToolResult } from "./truncate";
+
+const H3_POP_URL = "./h3/h3_population_res7.json";
+
+interface PopCell {
+  h: string;
+  d: number; // 日間人口
+  n: number; // 夜間人口
+}
+interface PopFile {
+  metadata: { resolution: number; value_columns?: string[] };
+  cells: PopCell[];
+}
+
+let popCache: { resolution: number; byCell: Map<string, PopCell> } | null = null;
+
+async function loadH3Population() {
+  if (popCache) return popCache;
+  const file = await withLoading("chat-h3-population", "載入人口密度網格", fetchPop());
+  const byCell = new Map<string, PopCell>();
+  for (const c of file.cells ?? []) byCell.set(c.h, c);
+  popCache = { resolution: file.metadata?.resolution ?? 7, byCell };
+  return popCache;
+}
+
+async function fetchPop(): Promise<PopFile> {
+  const res = await fetch(H3_POP_URL);
+  if (!res.ok) throw new Error(`載入人口網格失敗（${res.status}）`);
+  return (await res.json()) as PopFile;
+}
+
+/** 測試 / 重載用 */
+export function clearH3PopulationCache(): void {
+  popCache = null;
+}
+
+export interface RankInputPoint {
+  lng: number;
+  lat: number;
+  name: string;
+}
+export interface RankedPoint extends RankInputPoint {
+  population: number;
+  h3: string;
+}
+
+/**
+ * 把點位對到 H3 格、取日 / 夜間人口後由高到低排名，回前 topN。
+ * @param dayOrNight "day" = 日間人口(d)，"night" = 夜間人口(n)
+ */
+export async function rankPointsByPopulation(
+  points: RankInputPoint[],
+  topN = 10,
+  dayOrNight: "day" | "night" = "night",
+) {
+  const { resolution, byCell } = await loadH3Population();
+  const ranked: RankedPoint[] = points.map((p) => {
+    const h3 = latLngToCell(p.lat, p.lng, resolution);
+    const cell = byCell.get(h3);
+    const population = cell ? (dayOrNight === "day" ? cell.d : cell.n) : 0;
+    return { ...p, h3, population: Math.round(population) };
+  });
+  ranked.sort((a, b) => b.population - a.population);
+  const top = ranked.slice(0, Math.max(1, topN));
+  return {
+    metric: dayOrNight,
+    resolution,
+    ranked: capToolResult(top, { maxItems: topN }),
+  };
+}

--- a/src/chat/tools/mapTools.ts
+++ b/src/chat/tools/mapTools.ts
@@ -1,0 +1,100 @@
+// 地圖操作工具 — 執行體全部打 MapBridge（App.tsx 注入）。
+// 只做「動作」，不回傳大資料，故不需 capToolResult。
+
+import { tool } from "ai";
+import { z } from "zod";
+import type { MapBridge } from "../types";
+import { LAYER_LABELS } from "../../components/sidebar/layerCatalog";
+import { ALL_PRESETS, getPresetById } from "../../map/cameraPresets";
+
+// 台灣範圍（含外島：金門 118.36 / 馬祖 26.2 / 澎湖 / 綠島）
+const LNG_MIN = 118;
+const LNG_MAX = 123;
+const LAT_MIN = 21.5;
+const LAT_MAX = 26.5;
+
+const PRESET_LIST = ALL_PRESETS.map((p) => `${p.id}（${p.name}）`).join("、");
+
+export function mapTools(bridge: MapBridge) {
+  return {
+    set_layers: tool({
+      description:
+        "開啟或關閉指定圖層。keys 必須是圖層 key（非顯示名）；不確定 key 時先用 list_layers 或 search_layers 查。",
+      inputSchema: z.object({
+        keys: z.array(z.string()).describe("圖層 key 陣列，例如 ['countyBoundary']"),
+        visible: z.boolean().describe("true = 開啟，false = 關閉"),
+      }),
+      execute: ({ keys, visible }) => {
+        const valid = new Set(Object.keys(LAYER_LABELS));
+        const applied = keys.filter((k) => valid.has(k));
+        const invalid = keys.filter((k) => !valid.has(k));
+        if (applied.length > 0) bridge.bulkSetVisibility(applied, visible);
+        const action = visible ? "開啟" : "關閉";
+        const summary =
+          applied.length > 0
+            ? `${action} ${applied.length} 個圖層${invalid.length ? `（${invalid.length} 個無效 key 已略過）` : ""}`
+            : `無有效 key 可${action}${invalid.length ? `（${invalid.join("、")} 皆無效）` : ""}`;
+        return { summary, applied, invalid, visible };
+      },
+    }),
+
+    all_layers_off: tool({
+      description: "關閉目前所有已開啟的圖層，回到乾淨畫面。",
+      inputSchema: z.object({}),
+      execute: () => {
+        bridge.allOff();
+        return { summary: "已關閉所有圖層" };
+      },
+    }),
+
+    fly_to: tool({
+      description: "把地圖鏡頭飛到指定經緯度（僅限台灣範圍）；zoom 省略則用預設。",
+      inputSchema: z.object({
+        lng: z.number().describe("經度 118–123"),
+        lat: z.number().describe("緯度 21.5–26.5"),
+        zoom: z.number().optional().describe("縮放 6–16，省略用預設"),
+      }),
+      execute: ({ lng, lat, zoom }) => {
+        if (lng < LNG_MIN || lng > LNG_MAX || lat < LAT_MIN || lat > LAT_MAX) {
+          return { ok: false, summary: `座標 (${lng}, ${lat}) 超出台灣範圍，已拒絕` };
+        }
+        bridge.flyTo(lng, lat, zoom);
+        return { ok: true, summary: `已飛往 (${lng.toFixed(3)}, ${lat.toFixed(3)})` };
+      },
+    }),
+
+    jump_to_place: tool({
+      description: `跳到具名地點（城市 / 機場 / 時空場景）。可用 presetId：${PRESET_LIST}`,
+      inputSchema: z.object({
+        presetId: z.string().describe("預設地點 id，例如 taipei、RCTP、scene-penghu-fishing"),
+      }),
+      execute: ({ presetId }) => {
+        const ok = bridge.jumpToPlace(presetId);
+        const preset = getPresetById(presetId);
+        return ok
+          ? { ok: true, summary: `已跳至 ${preset ? preset.name : presetId}` }
+          : { ok: false, summary: `找不到地點 id：${presetId}` };
+      },
+    }),
+
+    highlight_point: tool({
+      description: "在地圖上標記一個點位（含選填文字標籤）。",
+      inputSchema: z.object({
+        lng: z.number().describe("經度"),
+        lat: z.number().describe("緯度"),
+        label: z.string().optional().describe("標籤文字"),
+      }),
+      execute: ({ lng, lat, label }) => {
+        bridge.highlightPoint(
+          lng,
+          lat,
+          label ? "chat-highlight" : undefined,
+          label ? { label } : undefined,
+        );
+        return {
+          summary: `已標記${label ? `「${label}」` : "座標"} (${lng.toFixed(3)}, ${lat.toFixed(3)})`,
+        };
+      },
+    }),
+  };
+}

--- a/src/chat/tools/registry.ts
+++ b/src/chat/tools/registry.ts
@@ -1,0 +1,14 @@
+// 匯集全部 chat tools 給 agent 的 streamText 使用。
+
+import type { MapBridge } from "../types";
+import { mapTools } from "./mapTools";
+import { catalogTools } from "./catalogTools";
+import { dataTools } from "./dataTools";
+
+export function buildTools(bridge: MapBridge) {
+  return {
+    ...catalogTools(bridge),
+    ...mapTools(bridge),
+    ...dataTools(bridge),
+  };
+}

--- a/src/chat/tools/rpcTools.ts
+++ b/src/chat/tools/rpcTools.ts
@@ -1,0 +1,118 @@
+// Supabase RPC 白名單 — call_rpc 只能呼叫這裡列的薄 RPC，白名單外一律拒絕。
+// 全部走 public schema 既有 anon RPC，零新增 DB 暴露面；回傳過 capToolResult。
+// 參數 schema 用 zod；param 名稱對齊 migration 的 function 參數名（前端 supabase.rpc 具名傳參）。
+
+import { z } from "zod";
+import { supabase } from "../../lib/supabase";
+import { withLoading } from "../../lib/loadingRegistry";
+import { capToolResult } from "./truncate";
+
+export interface RpcSpec {
+  params: z.ZodType<Record<string, unknown>>;
+  label: string;
+  /** 給 LLM：這支 RPC 何時用 */
+  description: string;
+}
+
+export const RPC_WHITELIST: Record<string, RpcSpec> = {
+  // ── 資料目錄（migration 269）──
+  get_data_catalog_by_theme: {
+    params: z.object({ p_theme: z.string().nullish() }),
+    label: "資料目錄（主題）",
+    description:
+      "查某主題底下有哪些上游資料集（來源機關 / 授權 / 更新頻率）。p_theme 省略則回全部。回答「有哪些 X 相關的資料 / 來源」。",
+  },
+  get_data_catalog_for_layer: {
+    params: z.object({ p_layer_key: z.string() }),
+    label: "資料目錄（圖層）",
+    description:
+      "查某個圖層 key 對應的上游資料來源。p_layer_key 為圖層 key（先用 search_layers 找）。回答「這個圖層的資料哪來的」。",
+  },
+
+  // ── 火災事件（migration 064）──
+  get_fire_event_years: {
+    params: z.object({}),
+    label: "火災年份",
+    description:
+      "回可用的火災事件年份與每年筆數（極輕量）。回答火災「哪幾年有資料 / 每年幾件」優先用這支，不要拉全部事件。",
+  },
+  get_fire_events_by_year: {
+    params: z.object({ target_year: z.number().int() }),
+    label: "火災事件",
+    description:
+      "取某民國年的火災事件（一年約 1.6 萬筆，回傳會被截斷成樣本 + 總數）。需要縣市 / 成因 / 時段細節時才用；純數量請改用 get_fire_event_years。",
+  },
+
+  // ── H3 年度人口指標（migration 020）──
+  get_h3_demographics_yearly: {
+    params: z.object({
+      target_year: z.number().int(),
+      target_resolution: z.number().int().optional(),
+    }),
+    label: "H3 年度人口",
+    description:
+      "取某年 H3 六角格人口統計（人口 / 戶數 / 性別比 / 扶養比 / 老化指數等，res 預設 7）。資料量大會被截斷；適合抓某年概況。",
+  },
+  get_h3_demographics_years: {
+    params: z.object({}),
+    label: "H3 人口年份",
+    description: "回 H3 年度人口有哪些年份 / 解析度（極輕量）。挑年份前先問這支。",
+  },
+
+  // ── 廢棄物設施數量（薄計數，全國）──
+  get_waste_facility_counts: {
+    params: z.object({}),
+    label: "廢棄物處理設施數量",
+    description:
+      "回各類廢棄物『處理設施』的數量（facility_type × n）：incinerator 焚化爐 / landfill 衛生掩埋場 / landfill_coastal 濱海掩埋場 / transfer 轉運站 / medical 醫療廢棄物 / monitoring 地下水監測井 / recycling 資源回收廠 / scrap 廢車廢金屬 / other 其他事廢。回答「全台幾個掩埋場 / 焚化爐」用這支（極輕量，不要拉全部點位）。",
+  },
+  get_waste_disposal_point_counts: {
+    params: z.object({}),
+    label: "廢棄物投放點數量",
+    description:
+      "回各類回收 / 垃圾『投放點』數量（point_type × source × n）：衣物回收箱 / 混合投放點 / 街頭資收桶 / 電池回收 等。回答「全台幾個衣物回收箱 / 投放點」用這支（極輕量）。",
+  },
+
+  // ── 資料源健康 ──
+  get_source_health: {
+    params: z.object({}),
+    label: "資料源健康",
+    description: "各動態資料源的最新更新時間 / 健康狀態。回答「資料新不新 / 哪些源掛了」。",
+  },
+
+  // ── 熱門新聞事件 ──
+  get_news_trending: {
+    params: z.object({
+      p_window_hours: z.number().int().positive(),
+      p_limit: z.number().int().positive(),
+    }),
+    label: "熱門新聞",
+    description:
+      "取近 p_window_hours 小時內的熱門新聞事件（p_limit 筆）。回答「最近在關注什麼 / 熱門事件」。",
+  },
+};
+
+export async function callWhitelistedRpc(
+  name: string,
+  params: unknown,
+): Promise<
+  | { ok: true; result: unknown }
+  | { ok: false; error: string }
+> {
+  const spec = RPC_WHITELIST[name];
+  if (!spec) {
+    return { ok: false, error: `未授權的 RPC：${name}（僅允許白名單內的查詢）` };
+  }
+  const parsed = spec.params.safeParse(params ?? {});
+  if (!parsed.success) {
+    return { ok: false, error: `參數不符：${parsed.error.issues.map((i) => i.message).join("; ")}` };
+  }
+  const { data, error } = await withLoading(
+    `chat-rpc:${name}`,
+    spec.label,
+    supabase.rpc(name, parsed.data as Record<string, unknown>),
+  );
+  if (error) return { ok: false, error: error.message };
+  const rows = Array.isArray(data) ? data : data == null ? [] : [data];
+  return { ok: true, result: capToolResult(rows as unknown[]) };
+}

--- a/src/chat/tools/truncate.ts
+++ b/src/chat/tools/truncate.ts
@@ -1,0 +1,53 @@
+// 截斷鐵則 — 任何 tool 回傳給 LLM 的清單資料都必須先過這裡，
+// 避免把數千筆 row 塞進 context。超上限時只回前 N 筆樣本 + 統計值。
+
+export interface CapOptions {
+  maxItems?: number;
+  maxChars?: number;
+}
+
+export interface CappedResult<T> {
+  truncated: true;
+  total: number;
+  sample: T[];
+  note: string;
+}
+
+const DEFAULT_MAX_ITEMS = 20;
+const DEFAULT_MAX_CHARS = 4000;
+
+/**
+ * 若 data 在上限內 → 原樣回傳陣列；
+ * 超過 maxItems 或序列化後超過 maxChars → 回 { truncated, total, sample, note }。
+ */
+export function capToolResult<T>(
+  data: T[],
+  opts: CapOptions = {},
+): T[] | CappedResult<T> {
+  const maxItems = opts.maxItems ?? DEFAULT_MAX_ITEMS;
+  const maxChars = opts.maxChars ?? DEFAULT_MAX_CHARS;
+
+  const total = data.length;
+  let sample = data;
+  let truncated = false;
+
+  if (total > maxItems) {
+    sample = data.slice(0, maxItems);
+    truncated = true;
+  }
+
+  // 再依字元預算收斂（避免單筆過大撐爆 context）
+  while (sample.length > 0 && JSON.stringify(sample).length > maxChars) {
+    sample = sample.slice(0, sample.length - 1);
+    truncated = true;
+  }
+
+  if (!truncated) return data;
+
+  return {
+    truncated: true,
+    total,
+    sample,
+    note: `僅示範前 ${sample.length} 筆（共 ${total} 筆），請以統計值回答，不要逐筆列舉`,
+  };
+}

--- a/src/chat/types.ts
+++ b/src/chat/types.ts
@@ -1,0 +1,69 @@
+// BYOK 對話功能 — UI 層（Task A）/ 邏輯層（Task B）共用契約
+// 由 orchestrator 定稿：兩邊各自實作，不要擅改此檔；發現契約不足先在此檔加註 TODO。
+
+export type ChatProviderId = "anthropic" | "openai" | "google";
+
+export interface ChatModelOption {
+  id: string; // 送 API 的 model id
+  label: string; // UI 顯示名
+  tier: "default" | "advanced";
+}
+
+export interface ChatToolCallSummary {
+  name: string;
+  /** 給 UI chip 顯示的一行摘要，例如「開啟 2 個圖層」「查詢 police_stations：2065 筆」 */
+  summary: string;
+}
+
+export interface ChatMessage {
+  id: string;
+  role: "user" | "assistant";
+  content: string; // markdown
+  toolCalls?: ChatToolCallSummary[];
+  usage?: { inputTokens: number; outputTokens: number };
+  error?: string;
+  createdAt: number;
+}
+
+/** App.tsx 既有 handler 的注入面。整合時由 App.tsx 綁定，兩個任務都不要實作它。 */
+export interface MapBridge {
+  bulkSetVisibility(keys: string[], visible: boolean): void;
+  allOff(): void;
+  flyTo(lng: number, lat: number, zoom?: number): void;
+  /** cameraPresets 具名地點；回傳 false 表示 preset 不存在 */
+  jumpToPlace(presetId: string): boolean;
+  highlightPoint(
+    lng: number,
+    lat: number,
+    layerType?: string,
+    properties?: Record<string, unknown>,
+  ): void;
+  getVisibleLayerKeys(): string[];
+  getCurrentTimeISO(): string;
+  getCamera(): { lng: number; lat: number; zoom: number };
+}
+
+/** key 只存瀏覽器：memory 永遠有；persist 決定是否落 sessionStorage / localStorage。絕不 log。 */
+export interface KeyVault {
+  get(provider: ChatProviderId): string | null;
+  set(provider: ChatProviderId, key: string, persist: "memory" | "session" | "local"): void;
+  clear(provider: ChatProviderId): void;
+  presence(): Record<ChatProviderId, boolean>;
+}
+
+export interface AgentRunOptions {
+  provider: ChatProviderId;
+  model: string;
+  apiKey: string;
+  history: ChatMessage[]; // 不含本輪 user 訊息
+  userText: string;
+  bridge: MapBridge;
+  /** streaming 文字增量 */
+  onDelta?: (text: string) => void;
+  /** tool 呼叫即時回報（UI 顯示 chip 用） */
+  onToolCall?: (call: ChatToolCallSummary) => void;
+  abortSignal?: AbortSignal;
+}
+
+/** Task B 在 src/chat/agent.ts 實作並 export const runChatTurn: RunChatTurn */
+export type RunChatTurn = (opts: AgentRunOptions) => Promise<ChatMessage>;

--- a/src/components/chat/ChatPanel.tsx
+++ b/src/components/chat/ChatPanel.tsx
@@ -1,0 +1,408 @@
+/**
+ * ChatPanel — BYOK 對話浮層主面板
+ *
+ * 仿 MonitorPanel/IntelPanel 浮層 pattern：fixed 定位 + zIndex + 深色底。
+ * 桌機右側浮層寬 ~380px；手機底部上拉全寬。
+ * 訊息 / provider / model / settingsOpen 狀態走 chatStore（useSyncExternalStore）。
+ * key 讀取一律透過 keyVault，本檔不直接碰 storage。
+ */
+import { useEffect, useRef, useState } from "react";
+import { X, Send, Settings, Square, RotateCcw, CornerDownLeft } from "lucide-react";
+import type { ChatMessage, ChatProviderId, MapBridge, RunChatTurn } from "../../chat/types";
+import { chatStore, useChatStore } from "../../state/chatStore";
+import { keyVault } from "../../lib/keyVault";
+import { KeySettings, MODEL_OPTIONS } from "./KeySettings";
+import { useIsMobile } from "../../hooks/useIsMobile";
+import {
+  SURFACE, COLORS, BORDER, RADIUS, FONT_SIZE, FONT_CJK, FONT_DATA, ELEVATION, WHITE_ALPHA,
+} from "../../styles/designTokens";
+
+export interface ChatPanelProps {
+  open: boolean;
+  onClose: () => void;
+  bridge: MapBridge;
+  /** 依賴注入，Task B（src/chat/agent.ts）的實作由整合層綁進來 */
+  runChatTurn: RunChatTurn;
+  /** 呼叫由整合層綁定的測試連線函式（本元件不實作） */
+  onTestKey: (
+    provider: ChatProviderId,
+    model: string,
+    key: string,
+  ) => Promise<{ ok: boolean; message: string }>;
+  /** 右下 stack（FeatureInfoPanel popup / LegendPanel）有東西時傳 true，面板縮高度讓位 */
+  compact?: boolean;
+}
+
+const PROVIDER_LABELS: Record<ChatProviderId, string> = {
+  anthropic: "Anthropic",
+  openai: "OpenAI",
+  google: "Google Gemini",
+};
+
+function actionButtonStyle(): React.CSSProperties {
+  return {
+    display: "inline-flex", alignItems: "center", gap: 4,
+    padding: "5px 10px", borderRadius: RADIUS.lg, cursor: "pointer",
+    background: WHITE_ALPHA[4], border: `1px solid ${BORDER.mid}`,
+    color: COLORS.textDefault, fontFamily: FONT_CJK, fontSize: FONT_SIZE.base,
+    whiteSpace: "nowrap",
+  };
+}
+
+function ToolChip({ summary }: { summary: string }) {
+  return (
+    <span
+      style={{
+        padding: "2px 8px", borderRadius: RADIUS.pill,
+        background: WHITE_ALPHA[4], border: `1px solid ${BORDER.mid}`,
+        fontFamily: FONT_DATA, fontSize: FONT_SIZE.xs, color: COLORS.textMuted,
+      }}
+    >
+      {summary}
+    </span>
+  );
+}
+
+function MessageBubble({
+  msg,
+  streamingPlaceholder,
+}: {
+  msg: ChatMessage;
+  streamingPlaceholder: boolean;
+}) {
+  const isUser = msg.role === "user";
+  return (
+    <div style={{ display: "flex", justifyContent: isUser ? "flex-end" : "flex-start" }}>
+      <div
+        style={{
+          maxWidth: "86%", display: "flex", flexDirection: "column", gap: 4,
+          alignItems: isUser ? "flex-end" : "flex-start",
+        }}
+      >
+        <div
+          style={{
+            padding: "8px 12px", borderRadius: RADIUS.lg,
+            background: isUser ? COLORS.accentFaint : WHITE_ALPHA[4],
+            border: `1px solid ${isUser ? COLORS.accentSoft : BORDER.soft}`,
+            color: COLORS.textDefault, fontFamily: FONT_CJK, fontSize: FONT_SIZE.md,
+            lineHeight: 1.6, whiteSpace: "pre-wrap", wordBreak: "break-word",
+          }}
+        >
+          {msg.content || (streamingPlaceholder ? "…" : "")}
+        </div>
+        {!isUser && msg.toolCalls && msg.toolCalls.length > 0 && (
+          <div style={{ display: "flex", gap: 6, flexWrap: "wrap" }}>
+            {msg.toolCalls.map((call, idx) => (
+              <ToolChip key={`${msg.id}-tool-${idx}`} summary={call.summary} />
+            ))}
+          </div>
+        )}
+        {!isUser && msg.usage && (
+          <span style={{ fontFamily: FONT_DATA, fontSize: FONT_SIZE.xs, color: COLORS.textFaint }}>
+            輸入 {msg.usage.inputTokens} ・ 輸出 {msg.usage.outputTokens} tokens
+          </span>
+        )}
+        {msg.error && (
+          <span style={{ fontFamily: FONT_CJK, fontSize: FONT_SIZE.sm, color: COLORS.statusErr }}>
+            {msg.error}
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export function ChatPanel({ open, onClose, bridge, runChatTurn, onTestKey, compact = false }: ChatPanelProps) {
+  const { messages, status, provider, model, settingsOpen } = useChatStore();
+  const { isMobile } = useIsMobile();
+  const [draft, setDraft] = useState("");
+  const listRef = useRef<HTMLDivElement>(null);
+  const abortRef = useRef<AbortController | null>(null);
+
+  // provider 切換後 model 永遠對到合法選項（即使使用者從沒開過設定頁）
+  useEffect(() => {
+    const options = MODEL_OPTIONS[provider];
+    if (!options.some((m) => m.id === model)) {
+      chatStore.setModel(options[0]!.id);
+    }
+  }, [provider, model]);
+
+  // 新訊息 / streaming 增量 → 自動捲到底
+  useEffect(() => {
+    const el = listRef.current;
+    if (el) el.scrollTop = el.scrollHeight;
+  }, [messages]);
+
+  // 面板關閉時若還在 streaming，中斷掉，避免背景繼續打 API
+  useEffect(() => {
+    if (!open && abortRef.current) {
+      abortRef.current.abort();
+      abortRef.current = null;
+    }
+  }, [open]);
+
+  if (!open) return null;
+
+  const hasKey = keyVault.presence()[provider];
+
+  const handleSend = async () => {
+    const text = draft.trim();
+    if (!text || status === "streaming") return;
+    const apiKey = keyVault.get(provider);
+    if (!apiKey) {
+      chatStore.setSettingsOpen(true);
+      return;
+    }
+
+    const history = chatStore.getState().messages; // 不含本輪 user 訊息
+    const userMsg: ChatMessage = {
+      id: crypto.randomUUID(), role: "user", content: text, createdAt: Date.now(),
+    };
+    const assistantMsg: ChatMessage = {
+      id: crypto.randomUUID(), role: "assistant", content: "", createdAt: Date.now(),
+    };
+    chatStore.appendMessage(userMsg);
+    chatStore.appendMessage(assistantMsg);
+    setDraft("");
+    chatStore.setStatus("streaming");
+
+    const controller = new AbortController();
+    abortRef.current = controller;
+
+    try {
+      const result = await runChatTurn({
+        provider,
+        model,
+        apiKey,
+        history,
+        userText: text,
+        bridge,
+        onDelta: (chunk) => {
+          const cur = chatStore.getState().messages;
+          const prev = cur[cur.length - 1];
+          chatStore.updateLastAssistant({ content: (prev?.content ?? "") + chunk });
+        },
+        onToolCall: (call) => {
+          const cur = chatStore.getState().messages;
+          const prev = cur[cur.length - 1];
+          chatStore.updateLastAssistant({ toolCalls: [...(prev?.toolCalls ?? []), call] });
+        },
+        abortSignal: controller.signal,
+      });
+      // 契約 RunChatTurn 只保證最終回傳「一則 ChatMessage」，未明講 toolCalls/usage
+      // 是否已含 streaming 期間累積的內容 → 保守合併：result 有值就用 result，
+      // 否則保留 streaming 累積的版本，避免被 undefined 蓋掉。
+      const streamed = chatStore.getState().messages;
+      const streamedLast = streamed[streamed.length - 1];
+      chatStore.updateLastAssistant({
+        content: result.content || streamedLast?.content || "",
+        toolCalls: result.toolCalls ?? streamedLast?.toolCalls,
+        usage: result.usage ?? streamedLast?.usage,
+        error: result.error,
+      });
+      chatStore.setStatus(result.error ? "error" : "idle");
+    } catch (err) {
+      const aborted = err instanceof DOMException && err.name === "AbortError";
+      if (aborted) {
+        chatStore.setStatus("idle");
+      } else {
+        const message = err instanceof Error ? err.message : "對話發生錯誤，請稍後再試";
+        chatStore.updateLastAssistant({ error: message });
+        chatStore.setStatus("error");
+      }
+    } finally {
+      abortRef.current = null;
+    }
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key === "Enter" && !e.shiftKey) {
+      // IME（注音/拼音）選字階段的 Enter 是「確認選字」，不是送出；
+      // isComposing 涵蓋大多數瀏覽器，keyCode 229 補 Safari/舊版判斷。
+      if (e.nativeEvent.isComposing || e.keyCode === 229) return;
+      e.preventDefault();
+      void handleSend();
+    }
+  };
+
+  const containerStyle: React.CSSProperties = isMobile
+    ? {
+        position: "fixed", left: 0, right: 0, bottom: 0, height: "60vh",
+        background: SURFACE.strong,
+        borderTop: `1px solid ${BORDER.panel}`,
+        borderRadius: "16px 16px 0 0",
+        zIndex: 60,
+        display: "flex", flexDirection: "column", overflow: "hidden",
+        boxShadow: ELEVATION.dock,
+        animation: "chatPanelRiseMobile .28s cubic-bezier(0.22,1,0.36,1)",
+        paddingBottom: "env(safe-area-inset-bottom, 0px)",
+        color: COLORS.textDefault,
+      }
+    : {
+        position: "fixed", top: 88, right: 14, width: 380,
+        height: compact ? "min(45vh, 520px)" : "min(55vh, 640px)",
+        opacity: compact ? 0.96 : 1,
+        transition: "height 200ms ease, opacity 200ms ease",
+        background: SURFACE.panel,
+        backdropFilter: "blur(16px)", WebkitBackdropFilter: "blur(16px)",
+        border: `1px solid ${BORDER.panel}`,
+        borderRadius: RADIUS.xl,
+        zIndex: 60,
+        display: "flex", flexDirection: "column", overflow: "hidden",
+        boxShadow: ELEVATION.lg,
+        animation: "chatPanelRise .22s ease-out",
+        color: COLORS.textDefault,
+      };
+
+  return (
+    <div style={containerStyle}>
+      {/* Header */}
+      <div
+        style={{
+          flexShrink: 0, display: "flex", alignItems: "center", gap: 8,
+          padding: "10px 14px", borderBottom: `1px solid ${BORDER.panel}`,
+        }}
+      >
+        <span style={{ fontFamily: FONT_CJK, fontSize: FONT_SIZE.lg, fontWeight: 700, color: COLORS.textStrong }}>
+          AI 助手
+        </span>
+        <span style={{ fontFamily: FONT_DATA, fontSize: FONT_SIZE.xs, letterSpacing: "2px", color: COLORS.textDim }}>
+          BYOK CHAT
+        </span>
+        <div style={{ flex: 1 }} />
+        {!settingsOpen && messages.length > 0 && (
+          <button onClick={() => chatStore.reset()} style={actionButtonStyle()} title="清空對話">
+            <RotateCcw size={13} /> 清空
+          </button>
+        )}
+        <button onClick={() => chatStore.setSettingsOpen(!settingsOpen)} style={actionButtonStyle()}>
+          <Settings size={13} /> {settingsOpen ? "對話" : "設定"}
+        </button>
+        <button onClick={onClose} style={actionButtonStyle()}>
+          <X size={14} />
+        </button>
+      </div>
+
+      {settingsOpen ? (
+        <KeySettings onTestKey={onTestKey} onDone={() => chatStore.setSettingsOpen(false)} />
+      ) : (
+        <>
+          {!hasKey && (
+            <div
+              style={{
+                margin: "10px 14px 0", padding: "8px 10px", borderRadius: RADIUS.lg,
+                background: SURFACE.subtle, border: `1px solid ${BORDER.soft}`,
+                display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap",
+              }}
+            >
+              <span style={{ fontFamily: FONT_CJK, fontSize: FONT_SIZE.sm, color: COLORS.textMuted, flex: 1 }}>
+                尚未設定 {PROVIDER_LABELS[provider]} 的 API key，請先到設定頁貼上金鑰。
+              </span>
+              <button onClick={() => chatStore.setSettingsOpen(true)} style={actionButtonStyle()}>
+                前往設定
+              </button>
+            </div>
+          )}
+
+          <div
+            ref={listRef}
+            className="mtp-scroll"
+            style={{
+              flex: 1, overflowY: "auto", padding: "12px 14px",
+              display: "flex", flexDirection: "column", gap: 12,
+            }}
+          >
+            {messages.length === 0 ? (
+              <div
+                style={{
+                  display: "flex", flexDirection: "column", alignItems: "center",
+                  justifyContent: "center", height: "100%", gap: 8, textAlign: "center", padding: 24,
+                }}
+              >
+                <span style={{ fontFamily: FONT_CJK, fontSize: FONT_SIZE.md, color: COLORS.textMuted }}>
+                  問我地圖上的資料，我可以幫你開圖層、飛到定點、查數字
+                </span>
+              </div>
+            ) : (
+              messages.map((m, idx) => (
+                <MessageBubble
+                  key={m.id}
+                  msg={m}
+                  streamingPlaceholder={
+                    status === "streaming" && idx === messages.length - 1 && m.role === "assistant"
+                  }
+                />
+              ))
+            )}
+          </div>
+
+          {/* Input */}
+          <div
+            style={{
+              flexShrink: 0, borderTop: `1px solid ${BORDER.panel}`,
+              padding: "10px 14px", display: "flex", flexDirection: "column", gap: 6,
+            }}
+          >
+            <div style={{ display: "flex", gap: 8, alignItems: "flex-end" }}>
+              <textarea
+                value={draft}
+                onChange={(e) => setDraft(e.target.value)}
+                onKeyDown={handleKeyDown}
+                placeholder={hasKey ? "輸入訊息…" : "請先到設定頁貼上 API key"}
+                rows={2}
+                style={{
+                  flex: 1, resize: "none", padding: "8px 10px", borderRadius: RADIUS.lg,
+                  background: WHITE_ALPHA[4], border: `1px solid ${BORDER.mid}`,
+                  color: COLORS.textDefault, fontFamily: FONT_CJK, fontSize: FONT_SIZE.md, lineHeight: 1.5,
+                }}
+              />
+              {status === "streaming" ? (
+                <button
+                  onClick={() => abortRef.current?.abort()}
+                  style={{ ...actionButtonStyle(), color: COLORS.statusErr }}
+                  title="中斷"
+                >
+                  <Square size={13} /> 中斷
+                </button>
+              ) : (
+                <button
+                  onClick={() => void handleSend()}
+                  disabled={!draft.trim()}
+                  style={{
+                    ...actionButtonStyle(),
+                    opacity: draft.trim() ? 1 : 0.5,
+                    cursor: draft.trim() ? "pointer" : "not-allowed",
+                  }}
+                >
+                  <Send size={13} /> 送出
+                </button>
+              )}
+            </div>
+            <span
+              style={{
+                display: "inline-flex", alignItems: "center", gap: 4,
+                fontFamily: FONT_DATA, fontSize: FONT_SIZE.xs, color: COLORS.textFaint,
+              }}
+            >
+              <CornerDownLeft size={10} /> 送出・Shift+Enter 換行
+            </span>
+          </div>
+        </>
+      )}
+
+      <style>{`
+        @keyframes chatPanelRise {
+          from { opacity: 0; transform: translateY(8px); }
+          to   { opacity: 1; transform: translateY(0); }
+        }
+        @keyframes chatPanelRiseMobile {
+          from { opacity: 0; transform: translateY(16px); }
+          to   { opacity: 1; transform: translateY(0); }
+        }
+        @media (prefers-reduced-motion: reduce) {
+          [style*="chatPanelRise"] { animation: none !important; transition: none !important; }
+        }
+      `}</style>
+    </div>
+  );
+}

--- a/src/components/chat/KeySettings.tsx
+++ b/src/components/chat/KeySettings.tsx
@@ -1,0 +1,291 @@
+/**
+ * KeySettings — BYOK 金鑰設定頁（內嵌在 ChatPanel 內的一頁）
+ *
+ * provider / model 選擇 + key 輸入（含儲存位置）+ 測試連線 + 刪除金鑰。
+ * key 讀寫一律透過 keyVault（src/lib/keyVault.ts），本檔不直接碰 storage。
+ */
+import { useEffect, useState } from "react";
+import { ArrowLeft, CheckCircle2, AlertTriangle, Info } from "lucide-react";
+import type { ChatModelOption, ChatProviderId } from "../../chat/types";
+import { chatStore, useChatStore, type PersistChoice } from "../../state/chatStore";
+import { keyVault } from "../../lib/keyVault";
+import {
+  SURFACE, COLORS, BORDER, RADIUS, FONT_SIZE, FONT_CJK, FONT_DATA, SPACING, WHITE_ALPHA,
+} from "../../styles/designTokens";
+
+/** 各家 2 檔：預設輕量 + 進階。id 為合理現役型號，之後可調整。 */
+export const MODEL_OPTIONS: Record<ChatProviderId, ChatModelOption[]> = {
+  anthropic: [
+    { id: "claude-haiku-4-5", label: "Claude Haiku 4.5（快速・預設）", tier: "default" },
+    { id: "claude-sonnet-5", label: "Claude Sonnet 5（進階）", tier: "advanced" },
+  ],
+  openai: [
+    { id: "gpt-5-mini", label: "GPT-5 mini（快速・預設）", tier: "default" },
+    { id: "gpt-5", label: "GPT-5（進階）", tier: "advanced" },
+  ],
+  google: [
+    { id: "gemini-2.5-flash", label: "Gemini 2.5 Flash（快速・預設）", tier: "default" },
+    { id: "gemini-2.5-pro", label: "Gemini 2.5 Pro（進階）", tier: "advanced" },
+  ],
+};
+
+const PROVIDER_OPTIONS: { id: ChatProviderId; label: string }[] = [
+  { id: "anthropic", label: "Anthropic" },
+  { id: "openai", label: "OpenAI" },
+  { id: "google", label: "Google Gemini" },
+];
+
+const PERSIST_OPTIONS: { id: PersistChoice; label: string; hint: string }[] = [
+  { id: "memory", label: "僅本次", hint: "重新整理頁面就會消失" },
+  { id: "session", label: "本分頁記住", hint: "分頁關閉前有效" },
+  { id: "local", label: "此瀏覽器記住", hint: "永久保存，需手動刪除" },
+];
+
+interface KeySettingsProps {
+  /** 呼叫由整合層綁定的測試連線函式（本元件不實作） */
+  onTestKey: (
+    provider: ChatProviderId,
+    model: string,
+    key: string,
+  ) => Promise<{ ok: boolean; message: string }>;
+  /** 返回聊天畫面 */
+  onDone: () => void;
+}
+
+function pillStyle(active: boolean): React.CSSProperties {
+  return {
+    padding: "6px 12px",
+    borderRadius: RADIUS.lg,
+    background: active ? COLORS.accentFaint : WHITE_ALPHA[4],
+    border: `1px solid ${active ? COLORS.accentSoft : BORDER.mid}`,
+    color: active ? COLORS.accent : COLORS.textMuted,
+    fontFamily: FONT_CJK,
+    fontSize: FONT_SIZE.md,
+    cursor: "pointer",
+    whiteSpace: "nowrap",
+  };
+}
+
+export function KeySettings({ onTestKey, onDone }: KeySettingsProps) {
+  const { provider, model, persistChoice } = useChatStore();
+  const [draftKey, setDraftKey] = useState(() => keyVault.get(provider) ?? "");
+  const [testing, setTesting] = useState(false);
+  const [testResult, setTestResult] = useState<{ ok: boolean; message: string } | null>(null);
+
+  // provider 切換 → 重新載入該 provider 已存的 key + 清掉舊測試結果
+  useEffect(() => {
+    setDraftKey(keyVault.get(provider) ?? "");
+    setTestResult(null);
+  }, [provider]);
+
+  const models = MODEL_OPTIONS[provider];
+  const activeModel = models.some((m) => m.id === model) ? model : models[0]!.id;
+
+  const handleKeyChange = (value: string) => {
+    setDraftKey(value);
+    setTestResult(null);
+    if (value) {
+      keyVault.set(provider, value, persistChoice);
+    } else {
+      keyVault.clear(provider);
+    }
+  };
+
+  const handlePersistChange = (next: PersistChoice) => {
+    chatStore.setPersistChoice(next);
+    if (draftKey) keyVault.set(provider, draftKey, next);
+  };
+
+  const handleDelete = () => {
+    keyVault.clear(provider);
+    setDraftKey("");
+    setTestResult(null);
+  };
+
+  const handleTest = async () => {
+    if (!draftKey || testing) return;
+    setTesting(true);
+    setTestResult(null);
+    try {
+      const result = await onTestKey(provider, activeModel, draftKey);
+      setTestResult(result);
+    } catch (err) {
+      setTestResult({
+        ok: false,
+        message: err instanceof Error ? err.message : "測試連線失敗",
+      });
+    } finally {
+      setTesting(false);
+    }
+  };
+
+  const last4 = draftKey.slice(-4);
+
+  return (
+    <div
+      style={{
+        display: "flex", flexDirection: "column", gap: SPACING.lg,
+        padding: "14px 16px 18px", overflowY: "auto",
+      }}
+    >
+      <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+        <span style={{ fontFamily: FONT_CJK, fontSize: FONT_SIZE.lg, fontWeight: 700, color: COLORS.textStrong }}>
+          金鑰設定
+        </span>
+        <div style={{ flex: 1 }} />
+        <button onClick={onDone} style={{ ...pillStyle(false), display: "inline-flex", alignItems: "center", gap: 4 }}>
+          <ArrowLeft size={13} /> 返回對話
+        </button>
+      </div>
+
+      {/* Provider 三選 */}
+      <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+        <span style={{ fontFamily: FONT_DATA, fontSize: FONT_SIZE.xs, letterSpacing: "1.5px", color: COLORS.textFaint }}>
+          PROVIDER
+        </span>
+        <div style={{ display: "flex", gap: 6, flexWrap: "wrap" }}>
+          {PROVIDER_OPTIONS.map((p) => (
+            <button
+              key={p.id}
+              onClick={() => chatStore.setProvider(p.id)}
+              style={pillStyle(provider === p.id)}
+            >
+              {p.label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* 模型下拉 */}
+      <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+        <span style={{ fontFamily: FONT_DATA, fontSize: FONT_SIZE.xs, letterSpacing: "1.5px", color: COLORS.textFaint }}>
+          MODEL
+        </span>
+        <select
+          value={activeModel}
+          onChange={(e) => chatStore.setModel(e.target.value)}
+          style={{
+            padding: "7px 10px", borderRadius: RADIUS.lg,
+            background: WHITE_ALPHA[4], border: `1px solid ${BORDER.mid}`,
+            color: COLORS.textDefault, fontFamily: FONT_CJK, fontSize: FONT_SIZE.md,
+          }}
+        >
+          {models.map((m) => (
+            <option key={m.id} value={m.id} style={{ background: SURFACE.app }}>
+              {m.label}
+            </option>
+          ))}
+        </select>
+        <span style={{ fontFamily: FONT_CJK, fontSize: FONT_SIZE.sm, color: COLORS.textFaint }}>
+          統計、比較、顧問式問題建議用進階檔；輕量檔快但可能偷懶。
+        </span>
+      </div>
+
+      {/* Key 輸入 */}
+      <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+        <span style={{ fontFamily: FONT_DATA, fontSize: FONT_SIZE.xs, letterSpacing: "1.5px", color: COLORS.textFaint }}>
+          API KEY
+        </span>
+        <input
+          type="password"
+          value={draftKey}
+          onChange={(e) => handleKeyChange(e.target.value)}
+          placeholder="貼上你的 API key"
+          autoComplete="off"
+          style={{
+            padding: "8px 10px", borderRadius: RADIUS.lg,
+            background: WHITE_ALPHA[4], border: `1px solid ${BORDER.mid}`,
+            color: COLORS.textDefault, fontFamily: FONT_DATA, fontSize: FONT_SIZE.md,
+          }}
+        />
+        {draftKey && (
+          <span style={{ fontFamily: FONT_DATA, fontSize: FONT_SIZE.sm, color: COLORS.textMuted }}>
+            已設定・末 4 碼 ****{last4}
+          </span>
+        )}
+      </div>
+
+      {/* 儲存位置 */}
+      <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+        <span style={{ fontFamily: FONT_DATA, fontSize: FONT_SIZE.xs, letterSpacing: "1.5px", color: COLORS.textFaint }}>
+          儲存位置
+        </span>
+        <div style={{ display: "flex", gap: 6, flexWrap: "wrap" }}>
+          {PERSIST_OPTIONS.map((opt) => (
+            <button
+              key={opt.id}
+              onClick={() => handlePersistChange(opt.id)}
+              title={opt.hint}
+              style={pillStyle(persistChoice === opt.id)}
+            >
+              {opt.label}
+            </button>
+          ))}
+        </div>
+        <span style={{ fontFamily: FONT_CJK, fontSize: FONT_SIZE.sm, color: COLORS.textFaint }}>
+          {PERSIST_OPTIONS.find((o) => o.id === persistChoice)?.hint}
+        </span>
+      </div>
+
+      {/* 測試連線 + 刪除 */}
+      <div style={{ display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap" }}>
+        <button
+          onClick={handleTest}
+          disabled={!draftKey || testing}
+          style={{
+            ...pillStyle(false),
+            opacity: !draftKey || testing ? 0.5 : 1,
+            cursor: !draftKey || testing ? "not-allowed" : "pointer",
+          }}
+        >
+          {testing ? "測試中…" : "測試連線"}
+        </button>
+        <button
+          onClick={handleDelete}
+          disabled={!draftKey}
+          style={{
+            ...pillStyle(false),
+            opacity: !draftKey ? 0.5 : 1,
+            cursor: !draftKey ? "not-allowed" : "pointer",
+            color: draftKey ? COLORS.statusErr : COLORS.textMuted,
+          }}
+        >
+          刪除金鑰
+        </button>
+        {testResult && (
+          <span style={{ display: "inline-flex", alignItems: "center", gap: 4 }}>
+            {testResult.ok ? (
+              <CheckCircle2 size={13} color={COLORS.statusLive} />
+            ) : (
+              <AlertTriangle size={13} color={COLORS.statusErr} />
+            )}
+            <span
+              style={{
+                fontFamily: FONT_CJK, fontSize: FONT_SIZE.sm,
+                color: testResult.ok ? COLORS.statusLive : COLORS.statusErr,
+              }}
+            >
+              {testResult.message}
+            </span>
+          </span>
+        )}
+      </div>
+
+      {/* 風險說明 */}
+      <div
+        style={{
+          padding: "10px 12px", borderRadius: RADIUS.lg,
+          background: SURFACE.subtle, border: `1px solid ${BORDER.soft}`,
+          display: "flex", gap: 8, alignItems: "flex-start",
+        }}
+      >
+        <Info size={14} color={COLORS.textFaint} style={{ marginTop: 2, flexShrink: 0 }} />
+        <span style={{ fontFamily: FONT_CJK, fontSize: FONT_SIZE.sm, color: COLORS.textFaint, lineHeight: 1.6 }}>
+          金鑰只存在你的瀏覽器（依上方選擇存在記憶體 / sessionStorage / localStorage），對話時直接連到對應服務商的
+          API，本站伺服器不會經手也不會記錄金鑰內容。建議另外申請一把使用額度較低的專用 key（例如 OpenAI 專案 key
+          設定月花費上限、Anthropic workspace key、或 Gemini 免費額度），降低外洩時的風險。
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/src/components/featureInfo/registry.tsx
+++ b/src/components/featureInfo/registry.tsx
@@ -55,6 +55,7 @@ import {
   DroneZonesPanel,
   PoliceIsoSubstationPanel, PoliceIsoPrecinctPanel, PoliceIsoCityDeptPanel,
 } from "./policeJusticePanels";
+import { ChatHighlightPanel } from "./shared";
 
 export interface PanelProps {
   props: Record<string, unknown>;
@@ -199,6 +200,8 @@ export const PANEL_REGISTRY: Partial<Record<FeatureInfo["layerType"], FC<PanelPr
   policeIsoSubstation: PoliceIsoSubstationPanel,
   policeIsoPrecinct: PoliceIsoPrecinctPanel,
   policeIsoCityDept: PoliceIsoCityDeptPanel,
+  // AI 助手標記點
+  chatHighlight: ChatHighlightPanel,
 };
 
 export const HEADER_LABELS: Record<FeatureInfo["layerType"], string> = {
@@ -343,4 +346,6 @@ export const HEADER_LABELS: Record<FeatureInfo["layerType"], string> = {
   policeIsoSubstation: "派出所等時圈",
   policeIsoPrecinct: "分局等時圈",
   policeIsoCityDept: "縣市警局等時圈",
+  // AI 助手標記點
+  chatHighlight: "地圖標記",
 };

--- a/src/components/featureInfo/shared.tsx
+++ b/src/components/featureInfo/shared.tsx
@@ -22,6 +22,24 @@ export function Row({ label, value, color }: { label: string; value: string; col
   );
 }
 
+/**
+ * AI 助手 highlight_point tool 的通用標記 panel。
+ * properties 期望帶：label（選填標籤）、lng / lat（座標）。
+ */
+export function ChatHighlightPanel({ props }: { props: Record<string, unknown> }) {
+  const label = typeof props.label === "string" ? props.label : "";
+  const lng = Number(props.lng);
+  const lat = Number(props.lat);
+  const hasCoords = Number.isFinite(lng) && Number.isFinite(lat);
+  return (
+    <div>
+      {label && <Row label="標記" value={label} />}
+      {hasCoords && <Row label="座標" value={`${lng.toFixed(4)}, ${lat.toFixed(4)}`} />}
+      {!label && !hasCoords && <Row label="標記" value="地圖標記點" />}
+    </div>
+  );
+}
+
 export function Badge({ label, on, color }: { label: string; on: boolean; color: string }) {
   return (
     <span style={{

--- a/src/lib/keyVault.ts
+++ b/src/lib/keyVault.ts
@@ -1,0 +1,89 @@
+/**
+ * BYOK Key Vault — 使用者 LLM API key 的三層瀏覽器儲存
+ *
+ * L1 module 記憶體：永遠寫，分頁/App 存活期間有效
+ * L2 sessionStorage：persist === "session" 時額外寫，分頁存活期間有效
+ * L3 localStorage：persist === "local" 時額外寫，永久（需使用者主動刪除）
+ *
+ * 鐵則：key 值絕不進 console.log / 錯誤訊息 / telemetry。本檔任何 catch 一律靜默，
+ * 不把 error 物件（可能夾帶呼叫參數）印出。
+ *
+ * 見 src/chat/types.ts 的 KeyVault 介面（契約，不可改）。
+ */
+import type { ChatProviderId, KeyVault } from "../chat/types";
+
+const STORAGE_PREFIX = "mtp_llm_key_";
+const PROVIDERS: ChatProviderId[] = ["anthropic", "openai", "google"];
+
+function storageKey(provider: ChatProviderId): string {
+  return `${STORAGE_PREFIX}${provider}`;
+}
+
+// L1：module 記憶體
+const memory = new Map<ChatProviderId, string>();
+
+function safeGet(storage: Storage, provider: ChatProviderId): string | null {
+  try {
+    return storage.getItem(storageKey(provider));
+  } catch {
+    // 隱私模式 / storage 被封鎖時靜默略過
+    return null;
+  }
+}
+
+function safeSet(storage: Storage, provider: ChatProviderId, value: string): void {
+  try {
+    storage.setItem(storageKey(provider), value);
+  } catch {
+    // 配額滿 / storage 被封鎖時靜默略過，key 仍留在 memory 可用
+  }
+}
+
+function safeRemove(storage: Storage, provider: ChatProviderId): void {
+  try {
+    storage.removeItem(storageKey(provider));
+  } catch {
+    // ignore
+  }
+}
+
+export const keyVault: KeyVault = {
+  get(provider) {
+    const inMemory = memory.get(provider);
+    if (inMemory) return inMemory;
+    const fromSession = safeGet(sessionStorage, provider);
+    if (fromSession) return fromSession;
+    const fromLocal = safeGet(localStorage, provider);
+    if (fromLocal) return fromLocal;
+    return null;
+  },
+
+  set(provider, key, persist) {
+    memory.set(provider, key);
+    // 只留使用者這次選擇的持久層，避免切換選項後殘留舊層的複本
+    if (persist === "session") {
+      safeSet(sessionStorage, provider, key);
+      safeRemove(localStorage, provider);
+    } else if (persist === "local") {
+      safeSet(localStorage, provider, key);
+      safeRemove(sessionStorage, provider);
+    } else {
+      safeRemove(sessionStorage, provider);
+      safeRemove(localStorage, provider);
+    }
+  },
+
+  clear(provider) {
+    memory.delete(provider);
+    safeRemove(sessionStorage, provider);
+    safeRemove(localStorage, provider);
+  },
+
+  presence() {
+    const result = {} as Record<ChatProviderId, boolean>;
+    for (const provider of PROVIDERS) {
+      result[provider] = keyVault.get(provider) !== null;
+    }
+    return result;
+  },
+};

--- a/src/state/chatStore.ts
+++ b/src/state/chatStore.ts
@@ -1,0 +1,108 @@
+/**
+ * Chat Store — BYOK 對話面板的外部 store（照 satelliteConsoleStore pattern）
+ *
+ * 用 useSyncExternalStore 訂閱；ChatPanel / KeySettings 跨元件共享狀態，不靠 prop drilling。
+ */
+import { useSyncExternalStore } from "react";
+import type { ChatMessage, ChatProviderId } from "../chat/types";
+
+export type ChatStatus = "idle" | "streaming" | "error";
+export type PersistChoice = "memory" | "session" | "local";
+
+interface ChatState {
+  /** 對話浮層是否開啟 */
+  open: boolean;
+  messages: ChatMessage[];
+  status: ChatStatus;
+  provider: ChatProviderId;
+  model: string;
+  /** key 儲存位置偏好（KeySettings 選取，套用到下一次 keyVault.set） */
+  persistChoice: PersistChoice;
+  /** 是否顯示 KeySettings 頁（內嵌在 ChatPanel 內） */
+  settingsOpen: boolean;
+}
+
+let state: ChatState = {
+  open: false,
+  messages: [],
+  status: "idle",
+  provider: "anthropic",
+  model: "",
+  persistChoice: "session",
+  settingsOpen: false,
+};
+
+const listeners = new Set<() => void>();
+
+function emit() {
+  for (const l of listeners) l();
+}
+
+export const chatStore = {
+  getState(): ChatState {
+    return state;
+  },
+  subscribe(cb: () => void): () => void {
+    listeners.add(cb);
+    return () => listeners.delete(cb);
+  },
+  open() {
+    if (state.open) return;
+    state = { ...state, open: true };
+    emit();
+  },
+  close() {
+    if (!state.open) return;
+    state = { ...state, open: false };
+    emit();
+  },
+  setSettingsOpen(settingsOpen: boolean) {
+    if (state.settingsOpen === settingsOpen) return;
+    state = { ...state, settingsOpen };
+    emit();
+  },
+  setProvider(provider: ChatProviderId) {
+    if (state.provider === provider) return;
+    state = { ...state, provider };
+    emit();
+  },
+  setModel(model: string) {
+    if (state.model === model) return;
+    state = { ...state, model };
+    emit();
+  },
+  setPersistChoice(persistChoice: PersistChoice) {
+    if (state.persistChoice === persistChoice) return;
+    state = { ...state, persistChoice };
+    emit();
+  },
+  setStatus(status: ChatStatus) {
+    if (state.status === status) return;
+    state = { ...state, status };
+    emit();
+  },
+  appendMessage(message: ChatMessage) {
+    state = { ...state, messages: [...state.messages, message] };
+    emit();
+  },
+  /** streaming 增量用：patch 最後一則訊息（呼叫方負責算好新內容，例如舊 content + delta） */
+  updateLastAssistant(patch: Partial<ChatMessage>) {
+    const { messages } = state;
+    const lastIdx = messages.length - 1;
+    const last = messages[lastIdx];
+    if (!last) return;
+    const nextMessages = messages.slice();
+    nextMessages[lastIdx] = { ...last, ...patch };
+    state = { ...state, messages: nextMessages };
+    emit();
+  },
+  /** 清空對話（不影響 provider / model / persistChoice 等使用者偏好） */
+  reset() {
+    state = { ...state, messages: [], status: "idle" };
+    emit();
+  },
+};
+
+export function useChatStore() {
+  return useSyncExternalStore(chatStore.subscribe, chatStore.getState);
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -650,7 +650,9 @@ export interface FeatureInfo {
     // 無人機禁/限航區（PMTiles polygon，filter 拆兩 layerType）
     | "droneNoFlyZone" | "droneRestrictedZone"
     // 警察覆蓋分析 (PMTiles, 帶 overlap_count)
-    | "policeIsoSubstation" | "policeIsoPrecinct" | "policeIsoCityDept";
+    | "policeIsoSubstation" | "policeIsoPrecinct" | "policeIsoCityDept"
+    // AI 助手 highlight_point tool 標記點（通用標籤 + 座標）
+    | "chatHighlight";
   properties: Record<string, unknown>;
   /** 點擊位置 (lng, lat)，給「選中光暈」用 */
   coords?: [number, number];


### PR DESCRIPTION
## Summary
- 使用者自帶 LLM key（Anthropic/OpenAI/Gemini）瀏覽器直連對話，LLM 透過白名單 tools 開圖層/飛行/標記/查資料，key 零經手伺服器

## Changes
- `src/chat/`：對話引擎（AI SDK v7 loop、abort/空回覆防護）、三家 provider、system prompt（主題索引 + 顧問段 + 反幻覺規範）、白名單 tools（地圖 5 + 目錄 3 + 資料 3；13 靜態資料集 + 10 RPC；截斷鐵則 + 教學性錯誤回饋）
- `src/components/chat/` + `src/state/chatStore.ts` + `src/lib/keyVault.ts`：ChatPanel（55vh 錨定 + popup 讓位 45vh + IME 守門）、KeySettings（三層 key 儲存 + 測試連線）、design token 全合規
- `src/App.tsx`：chatBridge 綁既有 handler（bulkSetVisibility/allOff/flyTo/locationJump/setFeatureInfo）+ 觸發按鈕；`featureInfo` 加 chatHighlight 條目
- `docs/`：feature 四件組 + member-byok-chat 規劃書（含 §9 驗收回饋軌跡）
- 依賴：+ai/@ai-sdk×3/zod

## Test
- [x] npx tsc -b 通過（rebase 後重驗）
- [x] pnpm test 通過：190/190（+29 新測試：截斷/查詢引擎/h3 join/RPC 白名單拒絕/教學回饋）
- [x] Browser 驗收：用戶實測三家 key 直連、開圖層、飛行、popup、中斷、IME、統計問答、顧問問答

## Risk / Rollback
- 風險：純新增功能（App.tsx +~100 行接線、featureInfo +2 行條目），不動既有 layer/loader 邏輯；OpenAI/Gemini 瀏覽器 CORS 屬第三方政策（已拍板：被封則 UI 揭露引導換家，不做 proxy）
- 回滾：revert 單一 squash commit 即可，無 migration、無資料契約變動

## Related
- Feature: docs/features/byok-chat/
- 規劃 SSOT: docs/proposal/member-byok-chat-plan.md
- Upstream handoff: 無（純前端，消費既有資產）

🤖 Generated with [Claude Code](https://claude.com/claude-code)