### PR TITLE
feat: 會員系統 P0 — Google OAuth 登入 + profiles + UserAvatar

### DIFF
--- a/docs/features/byok-chat/README.md
+++ b/docs/features/byok-chat/README.md
@@ -1,10 +1,10 @@
 # BYOK AI 對話助手
 
 > **Slug**：`byok-chat`
-> **狀態**：dev（PR 審核中）
+> **狀態**：shipped（BYOK chat + 會員 P0）
 > **Owner**：migu
-> **上線日期**：TBD
-> **相關 PR**：#TBD
+> **上線日期**：2026-07-03
+> **相關 PR**：#51（chat）#52 `pending`（member P0）
 
 ## 一句話說明
 

--- a/docs/features/byok-chat/backlog.md
+++ b/docs/features/byok-chat/backlog.md
@@ -4,8 +4,7 @@
 
 ## 進行中
 
-- [ ] **BC-1**：P0 會員系統（Supabase Auth Google OAuth）— 等 OAuth 憑證備妥，
-  migration（profiles + RLS + trigger）+ `src/lib/auth.ts` + Avatar；分支 `feat/member-auth`
+（無）
 
 ## 待辦
 
@@ -22,7 +21,9 @@
 
 ## 已完成（近期）
 
-- [x] P1 對話 MVP（BYOK 三家直連 + 地圖 tools + UI）— PR #TBD, 2026-07-02
-- [x] P2 資料問答（13 dataset + 10 RPC 白名單 + h3 人口 join）— 同 PR, 2026-07-03
-- [x] 高度讓位（popup 開啟自動縮 45vh）— 同 PR, 2026-07-03
-- [x] FX-1~5 驗收回饋修正（IME / 對話記憶 / 顧問式 tools / 檔位 hint / agentic 人體工學 + abort 真修）— 同 PR, 2026-07-03
+- [x] **BC-1**：P0 會員系統 — migration 270 + auth.ts + UserAvatar + OAuth 端到端實測 — PR #52, 2026-07-03
+
+- [x] P1 對話 MVP（BYOK 三家直連 + 地圖 tools + UI）— PR #51, 2026-07-02
+- [x] P2 資料問答（13 dataset + 10 RPC 白名單 + h3 人口 join）— PR #51, 2026-07-03
+- [x] 高度讓位（popup 開啟自動縮 45vh）— PR #51, 2026-07-03
+- [x] FX-1~5 驗收回饋修正（IME / 對話記憶 / 顧問式 tools / 檔位 hint / agentic 人體工學 + abort 真修）— PR #51, 2026-07-03

--- a/docs/features/byok-chat/changelog.md
+++ b/docs/features/byok-chat/changelog.md
@@ -2,7 +2,13 @@
 
 > 逐 PR 變更紀錄。最新在上。
 
-## 2026-07-03 — PR #TBD（待 squash 後補 hash）
+## 2026-07-03 — PR #52 `pending`（member P0）
+
+- 會員基礎：Google OAuth 登入（signInWithGoogle/signOut/useUser）+ UserAvatar（桌機+手機 header）
+- 上游：gis-platform migration 270（profiles + RLS + REVOKE default grants 修正 + signup trigger），已套用並實測
+- 登入端到端驗證：OAuth → trigger 自動建列（display_name/avatar 從 Google metadata）→ Avatar 顯示
+
+## 2026-07-03 — PR #51 `68f3df5`
 
 - P1 對話 MVP：BYOK 三家瀏覽器直連（key 零經手）、AI SDK v7 agent loop、
   5 地圖 tools + 2 目錄 tools、ChatPanel/KeySettings（design token 全合規）、App.tsx 接線

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -129,6 +129,7 @@ import { ModeToggle } from "./components/ModeToggle";
 import { StyleSelector, getStyleUrl } from "./components/StyleSelector";
 import { MobileBottomSheet } from "./components/MobileBottomSheet";
 import { InfoModal } from "./components/InfoModal";
+import { UserAvatar } from "./components/auth/UserAvatar";
 import { FeatureInfoPanel } from "./components/FeatureInfoPanel";
 import { HEADER_LABELS } from "./components/featureInfo/registry";
 import { ChatPanel } from "./components/chat/ChatPanel";
@@ -2079,6 +2080,7 @@ export default function App() {
             >
               Info
             </button>
+            <UserAvatar />
           </div>
 
           {/* 操作提示 */}
@@ -2250,6 +2252,8 @@ export default function App() {
             >
               {renderMode === "3d" ? "3D" : "2D"}
             </button>
+
+            <UserAvatar />
           </div>
 
           {/* Timeline */}

--- a/src/components/auth/UserAvatar.tsx
+++ b/src/components/auth/UserAvatar.tsx
@@ -1,0 +1,188 @@
+import { useEffect, useRef, useState } from "react";
+import { LogIn, LogOut, User as UserIcon } from "lucide-react";
+import { signInWithGoogle, signOut, useUser } from "../../lib/auth";
+import {
+  COLORS,
+  SURFACE,
+  BORDER,
+  RADIUS,
+  FONT_SIZE,
+  FONT_WEIGHT,
+  FONT_CJK,
+  SPACING,
+  ELEVATION,
+  WHITE_ALPHA,
+} from "../../styles/designTokens";
+
+/**
+ * 右上角會員入口（member-byok-chat-plan §6.1）。
+ * 未登入 → 「使用 Google 登入」按鈕；登入 → avatar + 名稱 + 下拉（登出）。
+ * 純元件、獨立掛載，App.tsx 接線待 byok-chat PR 併回 master 後再做。
+ */
+export function UserAvatar() {
+  const { user, loading } = useUser();
+  const [open, setOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  // 下拉開啟時，點擊外部關閉
+  useEffect(() => {
+    if (!open) return;
+    const onPointerDown = (e: MouseEvent) => {
+      if (!containerRef.current?.contains(e.target as Node)) setOpen(false);
+    };
+    document.addEventListener("mousedown", onPointerDown);
+    return () => document.removeEventListener("mousedown", onPointerDown);
+  }, [open]);
+
+  if (loading) return null;
+
+  // ── 未登入：登入按鈕 ──
+  if (!user) {
+    return (
+      <button
+        type="button"
+        onClick={() => {
+          void signInWithGoogle().catch((err) => console.error("[auth] signIn failed", err));
+        }}
+        style={{
+          display: "inline-flex",
+          alignItems: "center",
+          gap: SPACING.sm,
+          padding: `${SPACING.sm}px ${SPACING.lg}px`,
+          background: SURFACE.panel,
+          color: COLORS.textStrong,
+          border: `1px solid ${BORDER.mid}`,
+          borderRadius: RADIUS.md,
+          fontSize: FONT_SIZE.md,
+          fontWeight: FONT_WEIGHT.semibold,
+          fontFamily: FONT_CJK,
+          backdropFilter: "blur(8px)",
+          cursor: "pointer",
+        }}
+      >
+        <LogIn size={14} />
+        使用 Google 登入
+      </button>
+    );
+  }
+
+  // ── 已登入：avatar + 名稱 + 下拉 ──
+  const meta = user.user_metadata ?? {};
+  const displayName: string = meta.full_name ?? meta.name ?? user.email ?? "使用者";
+  const avatarUrl: string | null = meta.avatar_url ?? meta.picture ?? null;
+
+  return (
+    <div ref={containerRef} style={{ position: "relative" }}>
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        style={{
+          display: "inline-flex",
+          alignItems: "center",
+          gap: SPACING.sm,
+          padding: `${SPACING.xs}px ${SPACING.md}px`,
+          background: SURFACE.panel,
+          color: COLORS.textStrong,
+          border: `1px solid ${BORDER.mid}`,
+          borderRadius: RADIUS.pill,
+          fontSize: FONT_SIZE.md,
+          fontFamily: FONT_CJK,
+          backdropFilter: "blur(8px)",
+          cursor: "pointer",
+        }}
+      >
+        <Avatar url={avatarUrl} />
+        <span style={{ maxWidth: 120, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+          {displayName}
+        </span>
+      </button>
+
+      {open && (
+        <div
+          style={{
+            position: "absolute",
+            top: "calc(100% + 6px)",
+            right: 0,
+            minWidth: 160,
+            background: SURFACE.strong,
+            border: `1px solid ${BORDER.panel}`,
+            borderRadius: RADIUS.lg,
+            boxShadow: ELEVATION.lg,
+            backdropFilter: "blur(8px)",
+            overflow: "hidden",
+            zIndex: 10,
+          }}
+        >
+          <div
+            style={{
+              padding: `${SPACING.md}px ${SPACING.lg}px`,
+              borderBottom: `1px solid ${BORDER.soft}`,
+              fontSize: FONT_SIZE.sm,
+              fontFamily: FONT_CJK,
+              color: COLORS.textMuted,
+              overflow: "hidden",
+              textOverflow: "ellipsis",
+              whiteSpace: "nowrap",
+            }}
+          >
+            {user.email ?? displayName}
+          </div>
+          <button
+            type="button"
+            onClick={() => {
+              setOpen(false);
+              void signOut().catch((err) => console.error("[auth] signOut failed", err));
+            }}
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: SPACING.sm,
+              width: "100%",
+              padding: `${SPACING.md}px ${SPACING.lg}px`,
+              background: "transparent",
+              color: COLORS.textDefault,
+              border: "none",
+              fontSize: FONT_SIZE.md,
+              fontFamily: FONT_CJK,
+              textAlign: "left",
+              cursor: "pointer",
+            }}
+            onMouseEnter={(e) => (e.currentTarget.style.background = WHITE_ALPHA[8])}
+            onMouseLeave={(e) => (e.currentTarget.style.background = "transparent")}
+          >
+            <LogOut size={14} />
+            登出
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+/** 圓形頭像：有圖顯示圖，無圖顯示 fallback 人形 icon */
+function Avatar({ url }: { url: string | null }) {
+  const size = 22;
+  const common: React.CSSProperties = {
+    width: size,
+    height: size,
+    borderRadius: RADIUS.full,
+    flexShrink: 0,
+  };
+  if (url) {
+    return <img src={url} alt="" referrerPolicy="no-referrer" style={{ ...common, objectFit: "cover" }} />;
+  }
+  return (
+    <span
+      style={{
+        ...common,
+        display: "inline-flex",
+        alignItems: "center",
+        justifyContent: "center",
+        background: WHITE_ALPHA[12],
+        color: COLORS.textMuted,
+      }}
+    >
+      <UserIcon size={13} />
+    </span>
+  );
+}

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,0 +1,57 @@
+import { useEffect, useState } from "react";
+import type { User } from "@supabase/supabase-js";
+import { supabase } from "./supabase";
+
+/**
+ * 會員 Auth 薄封裝（member-byok-chat-plan §6.1）。
+ * Google OAuth only；session 持久化 / 自動刷新 / URL detect 皆走 supabase.ts
+ * 的 supabase-js v2 預設（persistSession / autoRefreshToken / detectSessionInUrl）。
+ */
+
+/** Google OAuth 登入：導向 Google，回跳後 detectSessionInUrl 自動接手 session */
+export async function signInWithGoogle(): Promise<void> {
+  const { error } = await supabase.auth.signInWithOAuth({
+    provider: "google",
+    options: { redirectTo: window.location.origin },
+  });
+  if (error) throw error;
+}
+
+/** 登出：清除本地 session */
+export async function signOut(): Promise<void> {
+  const { error } = await supabase.auth.signOut();
+  if (error) throw error;
+}
+
+/**
+ * 目前登入使用者。
+ * 初始以 getSession() 取一次，之後訂閱 onAuthStateChange 保持同步。
+ * loading = 尚未取得初始 session（避免 UI 先閃「未登入」再跳回）。
+ */
+export function useUser(): { user: User | null; loading: boolean } {
+  const [user, setUser] = useState<User | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let mounted = true;
+
+    void supabase.auth.getSession().then(({ data }) => {
+      if (!mounted) return;
+      setUser(data.session?.user ?? null);
+      setLoading(false);
+    });
+
+    const { data: sub } = supabase.auth.onAuthStateChange((_event, session) => {
+      if (!mounted) return;
+      setUser(session?.user ?? null);
+      setLoading(false);
+    });
+
+    return () => {
+      mounted = false;
+      sub.subscription.unsubscribe();
+    };
+  }, []);
+
+  return { user, loading };
+}


### PR DESCRIPTION
## Summary
- Supabase Auth（Google OAuth）會員基礎：登入/登出、profiles 自動建列、右上 Avatar（桌機+手機）——落地 AR-42 / member-byok-chat-plan §6

## Changes
- `src/lib/auth.ts`：signInWithGoogle（redirectTo=origin）/ signOut / useUser hook
- `src/components/auth/UserAvatar.tsx`：未登入→登入按鈕；登入→頭像+名字+登出 dropdown（design token 合規）
- `src/App.tsx`：桌機右上 + 手機 compact header 各掛一處（+4 行）
- docs：changelog/backlog 補 PR #51 資訊與 member 條目
- 上游（gis-platform，已套用+commit）：migration 270 — profiles 表 + RLS（本人讀/兩欄改）+ **REVOKE default grants**（修 tier 自升級漏洞）+ signup trigger（SECURITY DEFINER + 鎖 search_path）

## Test
- [x] npx tsc -b 通過（rebase 含 chat 的 master 後重驗）
- [x] pnpm test 190/190
- [x] Browser 驗收：用戶實測 Google 登入 → psql 驗證 profiles trigger 建列（display_name/avatar 自動帶入、tier=free）→ Avatar 顯示
- [x] DB grants 驗證：anon 零權限、authenticated 僅 SELECT + UPDATE(display_name, avatar_url)

## Risk / Rollback
- 風險：純新增（App.tsx +4 行）；未登入使用者完全不受影響（匿名全功能保留）
- 回滾：revert squash commit；DB 回滾 SQL 已寫在 migration 270 檔頭
- 注意：OAuth 憑證目前只設 localhost（正式網域切換已列 BC-4 部署清單）

## Related
- Feature: docs/features/byok-chat/
- 規劃 SSOT: docs/proposal/member-byok-chat-plan.md §6
- Upstream: gis-platform migrations/270_member_profiles.sql

🤖 Generated with [Claude Code](https://claude.com/claude-code)