### PR TITLE
fix(deploy): 修 13 個 PMTiles 圖層 prod 404 + BC-4 CSP/安全 header

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -126,6 +126,20 @@ server {
     # SPA fallback
     location / {
         try_files $uri $uri/ /index.html;
+
+        # ── BC-4 公開前置：安全 header（2026-07-04）────────────────────────────
+        # 立即生效（零破壞風險）：防點擊劫持 / 防 MIME 嗅探 / Referrer 收斂。
+        add_header X-Frame-Options "SAMEORIGIN" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+
+        # CSP：先上 Report-Only（不阻擋、violation 進瀏覽器 console 可觀察），零白畫面風險。
+        #   connect-src = BYOK 對話金鑰/資料只能送這些 host（三家 LLM + Supabase + Mapbox + CDN），
+        #   是 BYOK 防金鑰外洩的核心；img-src/frame-src 放寬 https: 因 CCTV/新聞圖/YouTube 直播是動態多來源。
+        # ⚠️ 切正式 enforcing 的步驟（browser 實測全功能無 violation 後）：
+        #   把下行 header 名稱 `Content-Security-Policy-Report-Only` 改成 `Content-Security-Policy` 即可。
+        add_header Content-Security-Policy-Report-Only "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; font-src 'self' data:; worker-src 'self' blob:; child-src 'self' blob:; connect-src 'self' https://utcmcikhvxnohbxchbrs.supabase.co wss://utcmcikhvxnohbxchbrs.supabase.co https://api.mapbox.com https://events.mapbox.com https://*.tiles.mapbox.com https://api.anthropic.com https://api.openai.com https://generativelanguage.googleapis.com https://data.itsmigu.com https://pub-eae6980c040441adbd1eaded2870d3d2.r2.dev; frame-src 'self' https:; media-src 'self' blob: https:; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'self'" always;
+        # ──────────────────────────────────────────────────────────────────────
     }
 
     # 靜態資源快取

--- a/scripts/deploy/pull-deploy-assets.sh
+++ b/scripts/deploy/pull-deploy-assets.sh
@@ -35,6 +35,12 @@ aws s3 sync "$S3/" "$DATA_DIR/geo/" --no-progress --exclude "*" \
   --include "water_*.geojson" --include "water_*.pmtiles" --include "fire_*.geojson" \
   --include "medical_*.geojson"
 
+# PT-1 PMTiles（geo 鏡像子前綴 deploy-assets/geo/）→ /data/geo/（前端請求 /geo/*.pmtiles）
+# 與上方扁平 geojson include-filter 並存；aws s3 sync 非破壞（無 --delete），兩者同進 /data/geo/ 不衝突。
+# national_highway / provincial_road / bus_stations_city / fire_hydrants / medical_{clinics,pharmacies,aed,ltc} + water_*
+echo "[pull] sync geo pmtiles → $DATA_DIR/geo/"
+aws s3 sync "$S3/geo/" "$DATA_DIR/geo/" --no-progress
+
 echo "[pull] sync h3 → $DATA_DIR/h3/"
 aws s3 sync "$S3/" "$DATA_DIR/h3/" --no-progress --exclude "*" --include "h3_*_res8.json"
 
@@ -43,7 +49,7 @@ aws s3 sync "$S3/" "$DATA_DIR/h3/" --no-progress --exclude "*" --include "h3_*_r
 #    必須用 --exclude "agriculture/*" 排除（否則農業 pmtiles 會被灌進 /data/fire/agriculture/）。
 #    未來新增其他「含 pmtiles 的子前綴」也要在此比照排除；搬成鏡像結構後本行可簡化（見 06 搬家計畫）。
 echo "[pull] sync fire pmtiles → $DATA_DIR/fire/"
-aws s3 sync "$S3/" "$DATA_DIR/fire/" --no-progress --exclude "*" --include "*.pmtiles" --exclude "agriculture/*" --exclude "medical/*" --exclude "flood/*" --exclude "forestry/*" --exclude "coverage/*" --exclude "base_map/*" --exclude "water_*.pmtiles"
+aws s3 sync "$S3/" "$DATA_DIR/fire/" --no-progress --exclude "*" --include "*.pmtiles" --exclude "agriculture/*" --exclude "medical/*" --exclude "flood/*" --exclude "forestry/*" --exclude "coverage/*" --exclude "base_map/*" --exclude "geo/*" --exclude "water_*.pmtiles"
 
 # 醫療：鏡像子前綴 deploy-assets/medical/ → /data/medical/（基礎點位 + 等時圈 PMTiles）
 echo "[pull] sync medical → $DATA_DIR/medical/"

--- a/scripts/deploy/upload-deploy-assets.sh
+++ b/scripts/deploy/upload-deploy-assets.sh
@@ -60,17 +60,19 @@ for f in public/geo/water_*.pmtiles; do
   aws s3 cp "$f" "s3://$BUCKET/$PREFIX/$name" --region ap-southeast-2
 done
 
-# PT-1 批次 PMTiles：geo / agriculture / forestry 三目錄通吃 *.pmtiles
-# 新增 PMTiles 不用改本腳本，跑 tippecanoe 後直接 upload 即可
-for d in public/geo public/agriculture public/forestry; do
-  for f in "$d"/*.pmtiles; do
-    [ -f "$f" ] || continue
-    name=$(basename "$f")
-    # 避開已被上方明確 glob 上傳的 water_*.pmtiles（aws s3 cp idempotent，重複也 OK）
-    echo "Uploading $name (pmtiles glob from $d)..."
-    aws s3 cp "$f" "s3://$BUCKET/$PREFIX/$name" --region ap-southeast-2
-  done
+# PT-1 批次 PMTiles（geo 子目錄）：上傳到 deploy-assets/geo/ 鏡像子前綴。
+# ⚠️ 為何不上扁平根（2026-07-04 修 13 層 404 教訓）：
+#   pull 端 /data/geo/ 用 include-filter 只挑既有扁平 geojson 檔名，扁平根的新 pmtiles
+#   挑不進 /data/geo/，反被 fire 的 *.pmtiles glob 誤抓進 /data/fire/ → 前端 /geo/*.pmtiles 404。
+#   改走 deploy-assets/geo/ 鏡像後，pull 端 `aws s3 sync $S3/geo/ → /data/geo/` 整夾同步，nginx /geo/ 直送。
+# 涵蓋 national_highway / provincial_road / bus_stations_city / fire_hydrants / medical_{clinics,pharmacies,aed,ltc} + water_*。
+for f in public/geo/*.pmtiles; do
+  [ -f "$f" ] || continue
+  name=$(basename "$f")
+  echo "Uploading geo/$name (pmtiles mirror)..."
+  aws s3 cp "$f" "s3://$BUCKET/$PREFIX/geo/$name" --region ap-southeast-2
 done
+# agriculture / forestry 的 PMTiles 改由下方 AGRI_FILES / FOREST_FILES 明確清單上傳到各自鏡像子前綴
 
 # 消防圖層：glob 動態上傳 public/geo/fire_*.geojson（同 water 慣例）
 # 新增 fire_xxx.geojson 不用改本腳本，export 完直接跑 upload 即可
@@ -131,6 +133,16 @@ AGRI_FILES=(
   "public/agriculture/produce_wholesale_companies.geojson"
   "public/agriculture/farm_roads.geojson"
   "public/agriculture/eco_network_zones.geojson"
+  # 🐷 畜牧 Livestock（靜態點層，去日期穩定檔名；farm 4 層前端共用此檔 + filter）
+  "public/agriculture/livestock_farms.geojson"
+  "public/agriculture/slaughterhouses.geojson"
+  "public/agriculture/feed_factories.geojson"
+  "public/agriculture/livestock_markets.geojson"
+  # PT-1 PMTiles（前端 sourceUrl 已切 .pmtiles；geojson 保留但未使用）
+  "public/agriculture/agri_retail_companies.pmtiles"
+  "public/agriculture/produce_wholesale_companies.pmtiles"
+  "public/agriculture/farm_roads.pmtiles"
+  "public/agriculture/eco_network_zones.pmtiles"
 )
 for f in "${AGRI_FILES[@]}"; do
   name=$(basename "$f")
@@ -166,6 +178,8 @@ FOREST_FILES=(
   "public/forestry/trail_coverage_per_compartment.geojson"
   # 全台步道整合（A 林業署 + B OSM 寬版 + C 雪霸/金門 NP + D 北市大縱走 + D 新北 GPX）
   "public/forestry/hiking_trails.geojson"
+  # PT-1 PMTiles（前端 sourceUrl 已切 .pmtiles；geojson 保留但未使用）
+  "public/forestry/hiking_trails.pmtiles"
 )
 for f in "${FOREST_FILES[@]}"; do
   name=$(basename "$f")


### PR DESCRIPTION
## Summary
- 修好線上 13 個 PMTiles 圖層（點開全空白 / 404）+ 補 BC-4 公開前置的安全 header

## Changes
- `upload-deploy-assets.sh`：geo 8 個 pmtiles 改上 `deploy-assets/geo/` 鏡像子前綴；agri 4 + forestry 1 進各自 `AGRI_FILES`/`FOREST_FILES`（＋順帶含先前未提交的畜牧 4 層 geojson 上傳行）
- `pull-deploy-assets.sh`：新增 `geo/` 鏡像 sync → `/data/geo/`；fire glob 加 `--exclude geo/*` 防誤抓
- `nginx.conf`：BC-4 安全 header（X-Frame-Options/nosniff/Referrer-Policy 立即 enforcing）+ CSP **Report-Only**（connect-src 白名單三家 LLM+Supabase+Mapbox+CDN）

## 根因
前端 sourceUrl 已切 `.pmtiles`，但檔案上到 S3 扁平根 → pull 端 `/data/geo/` 的 include-filter 挑不到、反被 fire 的 `*.pmtiles` glob 誤抓進 `/data/fire/` → 線上 `/geo/*.pmtiles` 全 404。與已正常的農業/林業層對照即證（那些走鏡像子前綴）。13 個 pmtiles 已先手動 `aws s3 cp` 同步到正確位置。

## Test
- [x] `bash -n` 兩腳本語法過 + glob 模擬涵蓋 13 檔
- [x] nginx.conf 包 http{} 實測 `nginx -t` syntax ok
- [x] S3 已驗證 13 檔在正確鏡像前綴
- [ ] merge → Zeabur 自動部署後，打線上驗 13 URL 轉 200 + CSP header present（我會做）

## Risk / Rollback
- 部署腳本改動非破壞（`aws s3 sync` 無 --delete）；CSP 走 Report-Only 不阻擋任何請求 → 零白畫面風險
- 回滾：revert 本 PR 即可；線上舊 .geojson 仍在（未刪）

## Related
- Backlog: PT-1（13 檔 PMTiles）、Fire F-1（消防栓）、BC-4（CSP/OAuth 公開前置）
- ⚠️ CSP 目前 Report-Only；browser 實測全功能無 violation 後改 header 名為 `Content-Security-Policy` 才 enforcing
- ⚠️ OAuth 正式網域切換為 dashboard 手動步驟（見 PR 討論）