### PR TITLE
feat(security): owner-gated 敏感圖層鎖定 + 分層治理後台

### DIFF
--- a/docs/features/owner-gated-layers/README.md
+++ b/docs/features/owner-gated-layers/README.md
@@ -1,0 +1,136 @@
+# owner-gated-layers（私人圖層鎖定）
+
+> **Slug**：`owner-gated-layers`
+> **狀態**：dev
+> **Owner**：migu
+> **上線日期**：YYYY-MM-DD
+> **相關 PR**：#XX
+> **依賴 migration**：275（RPC 加 owner 檢查 + REVOKE anon）+ 276（Phase 2：分層 tier + 治理表 + admin RPC + 公開 `get_layer_gates`）；profiles.tier 讀取靠 migration 270 的 `profiles_select_own` RLS
+
+## 一句話說明
+
+把一批敏感私有資料圖層鎖起來：只有登入且 `profiles.tier='owner'` 的帳號能開啟；
+其他訪客照常看到圖層名稱但顯示鎖頭、無法 toggle、資料也不會下載。
+
+## 機制摘要
+
+三層防護：
+
+1. **前端 SSOT 旗標**：`src/components/sidebar/layerCatalog.ts` 的 `GATED_LAYERS`（Set）為單一真實來源，
+   LayerDef 另加 `gated?: boolean` 型別欄位。桌機 `IconRailSidebar` 與手機 `LayerSidebar` 兩邊
+   都依 `GATED_LAYERS.has(key) && !isOwner` 顯示鎖頭（inline SVG，非 emoji）+ 降透明度 + title 提示。
+2. **前端 toggle gate**：`App.tsx` 的 `handleGatedIntercept` 攔截所有「開啟」意圖
+   （`handleToggleVisibility` / `handleLayerClick` / 手機 inline onLayerClick / `handleBulkSetVisibility`）——
+   非 owner 點鎖層：未登入→導 Google 登入（`signInWithGoogle`）；已登入非 owner→顯示「私人圖層，僅擁有者可檢視」提示。
+   因所有 loader 都「visible 才 fetch」，toggle 擋住 → 資料永不下載（避免 403 洗版）。
+3. **後端 owner 檢查（migration 275）**：對應 RPC 加 owner 檢查 + REVOKE anon（另一 agent 負責）。
+
+owner 判定：`src/lib/auth.ts` 的 `useMemberGate()` 登入後 `select tier from profiles where id = auth.uid()`；
+tier 載入為非同步，載入完成前 `isOwner=false`（先顯示鎖），完成後才解鎖。
+
+## 鎖定的 layer keys
+
+有鎖頭 UI（在 sidebar）：
+
+| 群組 | keys |
+|---|---|
+| 畜牧 Livestock | livestockFarmPig / Chicken / Cattle / Duck / Goose / Sheep / Other、livestockSlaughter |
+| 石化 · 油氣 | lpgSubpackaging、lpgRetailers、lngTerminal、pipelineGas、pipelineOilGas、industrialRefinery、industrialStorageTank、industrialPowerPlant、coalTerminal、fossilFuelInfra |
+| 電力 · 電網 | osmSubstationsEhv、osmSubstations、osmPowerLines、osmPowerTowers、substationEhvGlow、powerLinesGlow |
+| 電力 · 廠 | facPrimary、facPlanned、facHistorical、facSecondary、facOsmSupplement、powerGenerationUnit、powerPlantGlow |
+| 僅 UI 鎖（資料路徑不動） | aviationRestrictedGlow |
+
+無鎖頭 UI（已從 sidebar 下架，但 API 敏感 → loader 改直連 + 列入 GATED_LAYERS 防程式化開啟）：
+
+- facOffshore（get_ssot_facilities_offshore_zones）
+- osmPowerPlantsStatic（get_osm_power_plants_static）
+
+**明確排除（保持公開，不鎖）**：`waterCanals`（灌排渠道）、`powerPoles`（電桿 2.96M）、
+加油站 5 層（gasStationCpc/Fpcc/Taisugar/Other/Canonical）與加油站覆蓋分析。
+
+## 資料路徑變更
+
+| 圖層群 | 原路徑 | 新路徑 |
+|---|---|---|
+| 畜牧飼養場 / 屠宰場 | 靜態 `./agriculture/*.geojson` | owner-only RPC `get_livestock_farms` / `get_livestock_slaughterhouses`（dynamicData + setData） |
+| 石化 9 層 | staticRpc CDN `get_fossil_fuel_layers` | 直連 `supabase.rpc("get_fossil_fuel_layers")` |
+| 加油站 5 層（公開） | staticRpc `get_fossil_fuel_layers`（共用） | 拆出走公開 `staticRpc("get_gas_station_layers")` |
+| 電網 4 + 電廠 5 + fossil infra + offshore + osm static | staticRpc CDN | 直連 `supabase.rpc(...)` |
+
+## 關鍵檔案
+
+- Auth：`src/lib/auth.ts`（`useMemberGate`）
+- Catalog SSOT：`src/components/sidebar/layerCatalog.ts`（`GATED_LAYERS`、`isLayerLockedFor`）
+- Sidebar：`src/components/IconRailSidebar.tsx`、`src/components/LayerSidebar.tsx`（鎖頭 UI）
+- Toggle gate：`src/App.tsx`（`handleGatedIntercept` + 提示 toast）
+- Loaders：`src/data/fossilFuelLoader.ts`（拆兩路）、`src/data/energyLoader.ts`、`src/data/livestockLoader.ts`（新）
+- Hooks：`src/hooks/useFossilFuelLayers.ts`、`src/hooks/useLivestockLayers.ts`（新）
+- Overlay：`src/map/overlayRegistry.ts`（畜牧 8 config 加 `dynamicData: true`）
+- Deploy：`scripts/deploy/upload-deploy-assets.sh`、`scripts/deploy/pull-deploy-assets.sh`、`scripts/export/export-static-rpc-snapshots.sh`
+
+## livestock RPC 契約（前端依賴的 properties）
+
+- `get_livestock_farms` → GeoJSON FeatureCollection（Point）：`證號 / 場名 / 縣市 / 主畜種 / 總隻數 / 種類明細 / 段 / 地號 / 定位來源 / 精度`
+  - paint/filter 實際依賴：`主畜種`（分 7 畜種）、`總隻數`（size/color ramp）、`種類明細`（品項高亮）、`精度`（低精度淡化）
+- `get_livestock_slaughterhouses` → GeoJSON FeatureCollection（Point）：`場名 / 種類 / 來源 / 地址 / geocode_type`
+  - paint 實際依賴：`種類`（首字分家畜/家禽）
+
+## 風險
+
+- ⚠️ **`get_fossil_fuel_layers` 一 RPC 餵兩類**：公開加油站 + 私有石化。migration 若對它 blanket REVOKE anon 會連加油站也斷。
+  已依 coordinator 契約拆出公開 `get_gas_station_layers`，前端加油站改走它；`get_fossil_fuel_layers` 可安全鎖。
+- tier 讀取失敗（RLS/網路）→ isOwner 保持 false（fail-safe 上鎖，不會誤放行）。
+
+## Phase 2 — 分層治理系統（migration 276 + 站內後台）
+
+把 Phase 1 的「單人 owner 硬鎖」升級成可治理的分層存取 + owner-only 後台。
+
+### 分層 tier 模型（有序 4 級）
+
+| tier | rank | 意義 |
+|---|---|---|
+| `free` | 0 | 一般訪客 / 未升級會員 |
+| `member` | 1 | 登入會員（保留給未來一般付費層） |
+| `insider` | 2 | 受信任、可看敏感圖層的授權帳號 |
+| `owner` | 3 | 全權 + 後台唯一管理者 |
+
+授權判斷一律 `tier_rank(使用者tier) >= tier_rank(圖層required_tier)`。`insider` 只是「能看鎖定圖層」，**不能進後台**（後台仍限 `is_owner()`）。
+
+### 動態 gating 機制（取代寫死的 GATED_LAYERS Set）
+
+- 公開 RPC `get_layer_gates()`（anon 可呼叫，只回 `layer_key / required_tier / enabled`，**不含任何地理資料**）為圖層鎖定的權威來源。
+- 前端 `src/lib/layerGates.ts`：
+  - `loadLayerGates()` — App 啟動拉一次，存 module-level cache；admin 改動後 refetch。
+  - `useLayerGates()` — `useSyncExternalStore` 訂閱，載入 / refetch 後自動 re-render。
+  - `isLayerLocked(key, tier, gates)` — 純函式解析；`tierRank()` 做 4 級對應。
+  - `isAccessDenied(err)` — 辨識 403 / code 42501，供 loader 靜默處理。
+- **fail-safe（絕不因 RPC 失敗而解鎖）**：`get_layer_gates()` 失敗 / 尚未回來時 `gatesCache=null`，一律 fallback 回靜態 `GATED_LAYERS` Set（保持鎖定，需 owner 才解鎖）；載入成功後動態清單為權威（owner 若把某層設 `enabled=false` 或降到 `insider`，地圖鎖頭即時跟隨）。
+- `App.tsx` 從動態清單 + 當前使用者 tier 算出 `lockedKeys: Set`，取代兩個 sidebar 原本 inline 的 `!isOwner && GATED_LAYERS.has(key)`（sidebar prop 由 `isOwner` 改為 `lockedKeys`）；`handleGatedIntercept` / `handleBulkSetVisibility` 亦改讀 `lockedKeys`。
+- `useMemberGate()` 擴充回傳 `tier`（字串），供分層判斷；`isOwner` 保留為 `tier==='owner'` 捷徑。
+
+### 站內治理後台（owner-only）
+
+- 入口：`UserAvatar` 下拉新增「🛡 資料治理」項，**僅 `isOwner` 才渲染**（非 owner 完全看不到）。
+- `src/components/admin/AdminPanel.tsx` — 站內 modal（跟隨 design token，無新路由 / 無新套件），四分頁：
+  1. **會員管理** — `admin_list_members`，每列 tier `<select>`（4 選項）→ `admin_set_member_tier`；自己那列禁改（呼應 DB 端防呆），改動後 refetch。
+  2. **稽核記錄** — `admin_list_audit`（預設 limit 200），granted=false 紅底；「只看被拒」toggle 切 `p_only_denied`。**匿名限制**（頂部灰字說明）：anon 打鎖定 RPC 在 API gateway / ACL 層就被擋、函式未執行 → **不進 audit_log**；本表只涵蓋「已登入且函式有跑到」的存取（owner 正常使用 + 登入者越權嘗試），真正的匿名掃描記錄需看 Supabase 平台 logs。
+  3. **圖層鎖定** — `admin_list_gated_layers` 依 category 分組，每列 required_tier `<select>` + enabled checkbox → `admin_set_layer_gate`，改動後 `loadLayerGates()` refetch 讓地圖鎖頭即時更新；`is_stale` 紅點。
+  4. **資料新鮮度** — 唯讀顯示各 dataset 的 source_date / next_refresh / refresh_cadence / row_count / is_stale（過期紅標）；編輯（`admin_upsert_freshness`）留待未來。
+- `src/lib/adminApi.ts` — admin RPC 型別化薄封裝。
+
+### 錯誤處理（§6.4）
+
+鎖定 RPC 對非授權者回 403 / code 42501。gated loader 的 hook catch 以 `isAccessDenied()` 辨識並靜默（不噴 console、不重試）；正常路徑仍由前端 gate 擋在 fetch 之前（Phase 1 行為不變）。專案所有 gated loader 一律 `console.warn` + 無 retry（Supabase resilientFetch 只 retry 5xx/429，不 retry 403）。
+
+### Phase 2 關鍵檔案
+
+- `src/lib/layerGates.ts`（新）、`src/lib/adminApi.ts`（新）、`src/components/admin/AdminPanel.tsx`（新）
+- `src/lib/auth.ts`（`useMemberGate` 加回傳 `tier`）
+- `src/components/auth/UserAvatar.tsx`（加 owner-only 後台入口）
+- `src/App.tsx`（`lockedKeys` 動態計算 + 接線 + 掛 AdminPanel）
+- `src/components/IconRailSidebar.tsx` / `LayerSidebar.tsx`（prop `isOwner` → `lockedKeys`）
+- `src/hooks/useLivestockLayers.ts` / `useFossilFuelLayers.ts`（access-denied 靜默）
+
+## 相關 backlog / changelog / ADR
+
+看 [backlog.md](./backlog.md)、[changelog.md](./changelog.md)。上游 handoff：taipei-gis-analytics/docs/handoff/owner-gated-layers.md（migration 275 由 DB agent 維護）。

--- a/docs/features/owner-gated-layers/backlog.md
+++ b/docs/features/owner-gated-layers/backlog.md
@@ -1,0 +1,19 @@
+# Backlog — <feature-name>
+
+> 本 feature 的待辦。與全站 `.claude/memory/BACKLOG.md` 對應項編號要一致（例如 RE-1、RE-2）。
+
+## 進行中
+
+- [ ] **RE-X**：<描述> — <為什麼、下一步>
+
+## 待辦
+
+- [ ] **RE-Y**：<描述>
+
+## 已完成（近期）
+
+- [x] **RE-Z**：<描述> — PR #NN, YYYY-MM-DD
+
+## 已放棄 / 延後
+
+- **RE-W**：<描述> — 原因：...

--- a/docs/features/owner-gated-layers/changelog.md
+++ b/docs/features/owner-gated-layers/changelog.md
@@ -1,0 +1,19 @@
+# Changelog — <feature-name>
+
+> 逐 PR 變更紀錄。最新在上。
+
+格式：
+```
+## YYYY-MM-DD — PR #NN <squash commit hash>
+- <what changed>
+- <why (optional)>
+- <breaking? migration needed?>
+```
+
+---
+
+## YYYY-MM-DD — PR #NN `xxxxxxx`
+
+- 新增 xxx 圖層
+- 資料源：<摘要>
+- Breaking：無

--- a/docs/features/owner-gated-layers/handoff.md
+++ b/docs/features/owner-gated-layers/handoff.md
@@ -1,0 +1,38 @@
+# Handoff — <feature-name>（下游視角）
+
+> **上游 SSOT**：`../../../taipei-gis-analytics/docs/handoff/<slug>.md`（詳細契約看那份）
+>
+> 本檔只放**前端接線的簡表 + 上游約定的差異點**。契約細節不重複寫，只反向引用。
+
+## 上游 handoff 摘要
+
+- 產物路徑：<S3 path / RPC 名稱>
+- 更新頻率：<>
+- 座標系統：WGS84
+- 資料量：<>
+
+（完整契約 → 上游 handoff）
+
+## 前端接線位置
+
+- Loader：`src/data/xxxLoader.ts`
+- Hook：`src/hooks/useXxxLayer.ts`
+- Overlay：`src/map/overlayRegistry.ts` 或 `src/map/xxxCustomLayer.ts`
+- UI toggle：`src/components/sidebar/layerCatalog.ts`（LAYER_COLORS + SECTIONS）
+
+## 硬依賴欄位（改一定爆）
+
+從上游 handoff 挑出「前端硬依賴」的欄位，列在這：
+- `field_a` — 用於 <哪個功能>
+- `field_b` — 用於 <哪個功能>
+
+## 上游改動 → 下游要跟改的觸發點
+
+| 上游改動 | 下游動作 |
+|---|---|
+| 加新 city | `LAYER_COLORS` 檢查 domain |
+| 改 refresh 頻率 | timeStore 節流可能要調 |
+
+## 已知不對稱
+
+（上下游對這個 feature 認知不一致的地方）

--- a/scripts/deploy/pull-deploy-assets.sh
+++ b/scripts/deploy/pull-deploy-assets.sh
@@ -56,8 +56,12 @@ echo "[pull] sync medical → $DATA_DIR/medical/"
 aws s3 sync "$S3/medical/" "$DATA_DIR/medical/" --no-progress
 
 # 農業：鏡像子前綴 deploy-assets/agriculture/ → /data/agriculture/（整夾 sync，加新檔免改腳本）
+# ⚠️ owner-gated：livestock_farms.geojson / slaughterhouses.geojson 改走 owner-only RPC → 排除 +
+#    rm -f 清掉既有 volume 殘留舊檔（防繼續供應）。見 docs/features/owner-gated-layers。
 echo "[pull] sync agriculture → $DATA_DIR/agriculture/"
-aws s3 sync "$S3/agriculture/" "$DATA_DIR/agriculture/" --no-progress
+aws s3 sync "$S3/agriculture/" "$DATA_DIR/agriculture/" --no-progress \
+  --exclude "livestock_farms.geojson" --exclude "slaughterhouses.geojson"
+rm -f "$DATA_DIR/agriculture/livestock_farms.geojson" "$DATA_DIR/agriculture/slaughterhouses.geojson"
 
 # 🏟️ 運動場館：鏡像子前綴 deploy-assets/sports/ → /data/sports/（整夾 sync，加新檔免改腳本）
 echo "[pull] sync sports → $DATA_DIR/sports/"
@@ -82,8 +86,29 @@ echo "[pull] sync climate → $DATA_DIR/climate/"
 aws s3 sync "$S3/climate/" "$DATA_DIR/climate/" --no-progress
 
 # 靜態化 RPC 快照：鏡像子前綴 deploy-assets/static-rpc/ → /data/static-rpc/（整夾 sync，加新檔免改腳本）
+# ⚠️ owner-gated：12 支快照改走 owner-only 直連 RPC → 排除 + rm -f 清既有 volume 殘留舊檔。
+#    get_gas_station_layers 仍公開，照常 sync。見 docs/features/owner-gated-layers。
 echo "[pull] sync static-rpc → $DATA_DIR/static-rpc/"
-aws s3 sync "$S3/static-rpc/" "$DATA_DIR/static-rpc/" --no-progress
+aws s3 sync "$S3/static-rpc/" "$DATA_DIR/static-rpc/" --no-progress \
+  --exclude "get_fossil_fuel_layers.json" \
+  --exclude "get_fossil_fuel_infrastructure.json" \
+  --exclude "get_osm_substations.json" \
+  --exclude "get_osm_power_lines.json" \
+  --exclude "get_osm_power_towers.json" \
+  --exclude "get_ssot_facilities_primary_operating.json" \
+  --exclude "get_ssot_facilities_planned.json" \
+  --exclude "get_ssot_facilities_historical.json" \
+  --exclude "get_ssot_facilities_secondary_small.json" \
+  --exclude "get_ssot_facilities_osm_supplement.json" \
+  --exclude "get_osm_power_plants_static.json" \
+  --exclude "get_ssot_facilities_offshore_zones.json"
+for gated in \
+  get_fossil_fuel_layers get_fossil_fuel_infrastructure get_osm_substations \
+  get_osm_power_lines get_osm_power_towers get_ssot_facilities_primary_operating \
+  get_ssot_facilities_planned get_ssot_facilities_historical get_ssot_facilities_secondary_small \
+  get_ssot_facilities_osm_supplement get_osm_power_plants_static get_ssot_facilities_offshore_zones; do
+  rm -f "$DATA_DIR/static-rpc/$gated.json"
+done
 
 # 淹水感測 isochrone：鏡像子前綴 deploy-assets/flood/ → /data/flood/
 echo "[pull] sync flood → $DATA_DIR/flood/"

--- a/scripts/deploy/upload-deploy-assets.sh
+++ b/scripts/deploy/upload-deploy-assets.sh
@@ -133,9 +133,9 @@ AGRI_FILES=(
   "public/agriculture/produce_wholesale_companies.geojson"
   "public/agriculture/farm_roads.geojson"
   "public/agriculture/eco_network_zones.geojson"
-  # 🐷 畜牧 Livestock（靜態點層，去日期穩定檔名；farm 4 層前端共用此檔 + filter）
-  "public/agriculture/livestock_farms.geojson"
-  "public/agriculture/slaughterhouses.geojson"
+  # 🐷 畜牧 Livestock（靜態點層，去日期穩定檔名）
+  # ⚠️ owner-gated：livestock_farms.geojson / slaughterhouses.geojson 已改走 owner-only RPC，
+  #    刻意不上傳（斷 prod 供應）；本地 public/ 檔案保留不刪。見 docs/features/owner-gated-layers。
   "public/agriculture/feed_factories.geojson"
   "public/agriculture/livestock_markets.geojson"
   # PT-1 PMTiles（前端 sourceUrl 已切 .pmtiles；geojson 保留但未使用）
@@ -230,9 +230,30 @@ done
 
 # 靜態化 RPC 快照：上傳到 deploy-assets/static-rpc/ 子前綴（鏡像結構，pull 端整夾 sync）
 # 見 docs/features/static-to-cdn。新增靜態層跑 export 後直接 upload，免改本腳本。
+# ⚠️ owner-gated：以下 12 支快照刻意不上傳（改走 owner-only 直連 RPC，斷 prod CDN 供應）。
+#    見 docs/features/owner-gated-layers。get_gas_station_layers 仍為公開，照常上傳。
+STATIC_RPC_GATED_EXCLUDE=(
+  "get_fossil_fuel_layers.json"
+  "get_fossil_fuel_infrastructure.json"
+  "get_osm_substations.json"
+  "get_osm_power_lines.json"
+  "get_osm_power_towers.json"
+  "get_ssot_facilities_primary_operating.json"
+  "get_ssot_facilities_planned.json"
+  "get_ssot_facilities_historical.json"
+  "get_ssot_facilities_secondary_small.json"
+  "get_ssot_facilities_osm_supplement.json"
+  "get_osm_power_plants_static.json"
+  "get_ssot_facilities_offshore_zones.json"
+)
 for f in public/static-rpc/*.json; do
   [ -f "$f" ] || continue
   name=$(basename "$f")
+  skip=""
+  for ex in "${STATIC_RPC_GATED_EXCLUDE[@]}"; do
+    [ "$name" = "$ex" ] && { skip=1; break; }
+  done
+  [ -n "$skip" ] && { echo "Skipping owner-gated static-rpc/$name (不上傳)"; continue; }
   echo "Uploading static-rpc/$name..."
   aws s3 cp "$f" "s3://$BUCKET/$PREFIX/static-rpc/$name" --region ap-southeast-2
 done

--- a/scripts/export/export-static-rpc-snapshots.sh
+++ b/scripts/export/export-static-rpc-snapshots.sh
@@ -29,27 +29,24 @@ PSQL_SET="SET statement_timeout='120s'; SET idle_in_transaction_session_timeout=
 #   kind = table  → RETURNS TABLE，用 jsonb_agg 包成陣列
 #   kind = jsonb  → RETURNS jsonb，本身已是陣列，直接 SELECT
 # 新增靜態層時：在此 append 一行即可（batch 1 之後陸續補）。
+# ⚠️ owner-gated（docs/features/owner-gated-layers）：以下 12 支已從匯出清單移除，
+#    改走 owner-only 直連 RPC（不再產 CDN 快照，避免重跑又把私有資料放回公開 CDN）：
+#      get_osm_substations / get_osm_power_lines / get_osm_power_towers /
+#      get_osm_power_plants_static / get_fossil_fuel_infrastructure / get_fossil_fuel_layers /
+#      get_ssot_facilities_{primary_operating,planned,historical,secondary_small,osm_supplement,offshore_zones}
+#    get_gas_station_layers（公開）取代 get_fossil_fuel_layers，讓加油站層續有快照。
+#    ⚠️ get_gas_station_layers 需 migration 套用後才存在，實際 export 前確認 RPC 已建。
 RPCS=(
-  # ── Pilot：電網 3 層（BC-8）──
-  "get_osm_substations:table"
-  "get_osm_power_lines:table"
-  "get_osm_power_towers:jsonb"
+  # ── 加油站（公開，取代 get_fossil_fuel_layers）──
+  "get_gas_station_layers:table"
   # ── Batch 1：param-less 能源靜態（全 RETURNS TABLE，DB 探型別確認）──
   "get_osm_wind_turbines:table"
   "get_osm_solar_farms:table"
-  "get_osm_power_plants_static:table"
   "get_renewable_permits_taipei:table"
   "get_offshore_wind_zones:table"
   "get_geothermal_wells:table"
   "get_island_power_grid:table"
-  "get_fossil_fuel_infrastructure:table"
-  "get_fossil_fuel_layers:table"
   "get_ev_charging_stations:table"
-  "get_ssot_facilities_secondary_small:table"
-  "get_ssot_facilities_planned:table"
-  "get_ssot_facilities_offshore_zones:table"
-  "get_ssot_facilities_historical:table"
-  "get_ssot_facilities_osm_supplement:table"
   # ── Batch 1b：param-less 廢棄物 sidebar 數量（no-cache，每次 toggle 都打 DB）──
   "get_waste_facility_counts:table"
   "get_waste_disposal_point_counts:table"
@@ -60,8 +57,6 @@ RPCS=(
   "get_waste_facilities:table"
   "get_waste_disposal_points:table"
   "get_waste_cleaning_squads:table"
-  # ── 收尾：主要電廠座標（靜態）；loader 仍另打 realtime 出力 RPC 做 has_realtime join ──
-  "get_ssot_facilities_primary_operating:table"
 )
 
 CURRENT_PSQL_PID=""

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -130,6 +130,11 @@ import { StyleSelector, getStyleUrl } from "./components/StyleSelector";
 import { MobileBottomSheet } from "./components/MobileBottomSheet";
 import { InfoModal } from "./components/InfoModal";
 import { UserAvatar } from "./components/auth/UserAvatar";
+import { AdminPanel } from "./components/admin/AdminPanel";
+import { useMemberGate, signInWithGoogle } from "./lib/auth";
+import { GATED_LAYERS } from "./components/sidebar/layerCatalog";
+import { useLayerGates, loadLayerGates, isLayerLocked } from "./lib/layerGates";
+import { useLivestockLayers } from "./hooks/useLivestockLayers";
 import { FeatureInfoPanel } from "./components/FeatureInfoPanel";
 import { HEADER_LABELS } from "./components/featureInfo/registry";
 import { ChatPanel } from "./components/chat/ChatPanel";
@@ -154,6 +159,37 @@ function styleReady(map: MapboxMap | null): map is MapboxMap {
 export default function App() {
   // layer visibility 必須早於動態資料 hook 宣告：供 boot lazy gating（圖層關 → 不抓資料）
   const { layerVisibility, layerVisibilityRef, setLayerVisibility, toggleVisibility } = useLayerVisibility();
+
+  // owner-only 私人圖層閘門（見 docs/features/owner-gated-layers）：
+  // tier 載入完成前 isOwner=false（顯示鎖）。非 owner 點鎖層 → 未登入導 Google 登入 / 已登入顯示提示。
+  const { user: memberUser, tier: memberTier, isOwner } = useMemberGate();
+  const memberUserRef = useRef(memberUser);
+  memberUserRef.current = memberUser;
+  const [gatedNotice, setGatedNotice] = useState(false);
+  const [adminOpen, setAdminOpen] = useState(false);
+  useEffect(() => {
+    if (!gatedNotice) return;
+    const t = setTimeout(() => setGatedNotice(false), 2600);
+    return () => clearTimeout(t);
+  }, [gatedNotice]);
+
+  // 動態 gating（Phase 2）：啟動拉一次公開 get_layer_gates()（fail-safe：失敗維持靜態 GATED_LAYERS）。
+  useEffect(() => { void loadLayerGates(); }, []);
+  const layerGates = useLayerGates();
+  // 對「目前使用者」上鎖的 keys（tier + 動態清單解析）。owner → 空集合。
+  const lockedKeys = useMemo(() => {
+    const s = new Set<keyof LayerVisibility>();
+    const candidates = new Set<keyof LayerVisibility>([
+      ...GATED_LAYERS,
+      ...((layerGates ? [...layerGates.keys()] : []) as (keyof LayerVisibility)[]),
+    ]);
+    for (const key of candidates) {
+      if (isLayerLocked(key, memberTier, layerGates)) s.add(key);
+    }
+    return s;
+  }, [memberTier, layerGates]);
+  const lockedKeysRef = useRef(lockedKeys);
+  lockedKeysRef.current = lockedKeys;
 
   const {
     flights: allFlights,
@@ -849,8 +885,10 @@ export default function App() {
     showFacSecondary: layerVisibility.facSecondary,
     showFacOsmSupplement: layerVisibility.facOsmSupplement,
   });
-  // 化石燃料 14 layer（Phase B — public.get_fossil_fuel_layers()）
+  // 化石燃料：加油站（公開 get_gas_station_layers）+ 石化（owner-gated get_fossil_fuel_layers）
   useFossilFuelLayers({ mapRef, visibility: layerVisibility });
+  // 畜牧 owner-only 動態層（get_livestock_farms / get_livestock_slaughterhouses）
+  useLivestockLayers({ mapRef, visibility: layerVisibility });
   // A1 即時死亡事故（rpc_a1_by_bbox，每 12h 更新）
   useA1AccidentRealtimeLayer(mapRef, layerVisibility.a1AccidentRealtime);
   // 雲林 POC 覆蓋分析 5 layer 改 PMTiles — 由 overlayRegistry pmtiles 設定自動處理
@@ -1452,7 +1490,21 @@ export default function App() {
     wasteTrucks: wasteCount,
   }), [displayedFlights.length, ships.length, trainCount, busCount, busIntercityCount, wasteCount]);
 
+  // owner-only 圖層：非 owner 的開啟意圖一律攔截（回 true = 呼叫端直接 return no-op）。
+  // 未登入 → 導 Google 登入；已登入非 owner → 顯示「私人圖層」提示。
+  const handleGatedIntercept = useCallback((layer: keyof LayerVisibility): boolean => {
+    // lockedKeys 已內含 tier 判定（owner / 授權 tier → 不在集合）
+    if (!lockedKeysRef.current.has(layer)) return false;
+    if (!memberUserRef.current) {
+      void signInWithGoogle().catch((err) => console.error("[owner-gate] signIn failed", err));
+    } else {
+      setGatedNotice(true);
+    }
+    return true;
+  }, []);
+
   const handleLayerClick = useCallback((layer: keyof LayerVisibility) => {
+    if (handleGatedIntercept(layer)) return;
     const isVisible = layerVisibilityRef.current[layer];
     if (!isVisible) {
       setLayerVisibility((prev) => ({ ...prev, [layer]: true }));
@@ -1466,15 +1518,17 @@ export default function App() {
     // 點 layer 時自動關掉即時情報 / 衛星情報 panel（與點 location 一致）
     setIntelOpen(false);
     satelliteConsoleStore.setOpen(false);
-  }, [layerVisibilityRef, setLayerVisibility]);
+  }, [layerVisibilityRef, setLayerVisibility, handleGatedIntercept]);
 
   const handleToggleVisibility = useCallback((layer: keyof LayerVisibility) => {
+    // 已開啟的圖層允許關閉；只攔截「開啟」意圖（gated 且非 owner 恆為關閉態，故等同全攔）
+    if (!layerVisibilityRef.current[layer] && handleGatedIntercept(layer)) return;
     const wasVisible = layerVisibilityRef.current[layer];
     toggleVisibility(layer);
     sessionTracker.logWithSnapshot("layer_toggle", { layer, on: !wasVisible }, layerVisibilityRef.current);
     setIntelOpen(false);
     satelliteConsoleStore.setOpen(false);
-  }, [toggleVisibility, layerVisibilityRef]);
+  }, [toggleVisibility, layerVisibilityRef, handleGatedIntercept]);
 
   const handleDisplayModeChange = useCallback((mode: DisplayMode) => {
     setDisplayMode(mode);
@@ -1503,14 +1557,18 @@ export default function App() {
 
   const handleBulkSetVisibility = useCallback(
     (keys: (keyof LayerVisibility)[], value: boolean) => {
+      // 開啟時（value=true）過濾掉對此使用者上鎖的 key（Theme 全開 / chat bridge 亦走此路徑）
+      const effectiveKeys = value
+        ? keys.filter((k) => !lockedKeysRef.current.has(k))
+        : keys;
       setLayerVisibility((prev) => {
         const next = { ...prev };
-        for (const k of keys) next[k] = value;
+        for (const k of effectiveKeys) next[k] = value;
         return next;
       });
       sessionTracker.logWithSnapshot(
         "layer_toggle",
-        { bulk: true, keys, on: value },
+        { bulk: true, keys: effectiveKeys, on: value },
         layerVisibilityRef.current,
       );
     },
@@ -1586,6 +1644,32 @@ export default function App() {
   return (
     <div style={{ position: "relative", width: "100vw", height: "100vh" }}>
       {showLoadingScreen && <LoadingScreen steps={loadingSteps} />}
+      {/* owner-only 私人圖層：已登入非 owner 點鎖層時的提示（未登入則直接導 Google 登入，不走這裡） */}
+      {gatedNotice && (
+        <div
+          style={{
+            position: "fixed",
+            bottom: 28,
+            left: "50%",
+            transform: "translateX(-50%)",
+            zIndex: 3000,
+            padding: "9px 16px",
+            background: "rgba(0,0,0,0.82)",
+            backdropFilter: "blur(8px)",
+            WebkitBackdropFilter: "blur(8px)",
+            border: "1px solid rgba(255,255,255,0.14)",
+            borderRadius: 10,
+            color: "#E5E7EB",
+            fontSize: 13,
+            fontFamily: "Inter, system-ui, sans-serif",
+            whiteSpace: "nowrap",
+            pointerEvents: "none",
+            boxShadow: "0 6px 24px rgba(0,0,0,0.35)",
+          }}
+        >
+          私人圖層，僅擁有者可檢視
+        </div>
+      )}
       {/* Day-loading overlay — 半透明遮罩 */}
       {(shipsDayLoading || flightsDayLoading || railScheduleLoading) && (
         <div style={{
@@ -1799,6 +1883,7 @@ export default function App() {
           <div style={{ position: "absolute", top: 0, left: 0, bottom: 0, zIndex: 11, pointerEvents: "none" }}>
             <IconRailSidebar
               visibility={layerVisibility}
+              lockedKeys={lockedKeys}
               expandedLayer={expandedLayer}
               viewMode={viewMode}
               displayMode={displayMode}
@@ -2080,7 +2165,7 @@ export default function App() {
             >
               Info
             </button>
-            <UserAvatar />
+            <UserAvatar isOwner={isOwner} onOpenAdmin={() => setAdminOpen(true)} />
           </div>
 
           {/* 操作提示 */}
@@ -2253,7 +2338,7 @@ export default function App() {
               {renderMode === "3d" ? "3D" : "2D"}
             </button>
 
-            <UserAvatar />
+            <UserAvatar isOwner={isOwner} onOpenAdmin={() => setAdminOpen(true)} />
           </div>
 
           {/* Timeline */}
@@ -2320,6 +2405,7 @@ export default function App() {
                   <div style={{ marginTop: 12 }}>
                     <LayerSidebar
                       visibility={layerVisibility}
+                      lockedKeys={lockedKeys}
                       expandedLayer={expandedLayer}
                       viewMode={viewMode}
                       displayMode={displayMode}
@@ -2335,6 +2421,7 @@ export default function App() {
                       }}
                       onLayerClick={(layer) => {
                         const isVisible = layerVisibility[layer];
+                        if (!isVisible && handleGatedIntercept(layer)) return;
                         if (!isVisible) {
                           setLayerVisibility((prev) => ({ ...prev, [layer]: true }));
                           setExpandedLayer(layer as ExpandableLayerKey);
@@ -2711,6 +2798,7 @@ export default function App() {
 
       {/* ── Info Modal ── */}
       <InfoModal open={showInfo} onClose={() => setShowInfo(false)} isMobile={isMobile} />
+      {isOwner && <AdminPanel open={adminOpen} onClose={() => setAdminOpen(false)} selfId={memberUser?.id ?? null} />}
 
       {/* ── BYOK 對話浮層（桌機右側 / 手機底部上拉，自帶 mobile 版型）── */}
       <ChatPanel

--- a/src/components/IconRailSidebar.tsx
+++ b/src/components/IconRailSidebar.tsx
@@ -321,6 +321,8 @@ for (const [icao, info] of Object.entries(AIRPORT_INFO)) {
 
 interface IconRailSidebarProps {
   visibility: LayerVisibility;
+  /** 對目前使用者上鎖的圖層 keys（動態 gating，見 lib/layerGates）：命中 → 顯示鎖頭 + 禁 toggle */
+  lockedKeys?: ReadonlySet<keyof LayerVisibility>;
   expandedLayer: ExpandableLayerKey | null;
   viewMode: ViewMode;
   displayMode: DisplayMode;
@@ -368,7 +370,7 @@ const RAIL_WIDTH = 56;
 const PANEL_WIDTH = 288;
 
 export function IconRailSidebar({
-  visibility, expandedLayer, viewMode, displayMode,
+  visibility, lockedKeys, expandedLayer, viewMode, displayMode,
   counts, onLayerClick, onToggleVisibility,
   onViewModeChange, onDisplayModeChange, onHideTransport, onAllOff,
   onBulkSetVisibility,
@@ -592,6 +594,7 @@ export function IconRailSidebar({
             {activePanel === "layers" && (
               <LayersPanel
                 visibility={visibility}
+                lockedKeys={lockedKeys}
                 expandedLayer={expandedLayer}
                 viewMode={viewMode}
                 displayMode={displayMode}
@@ -745,6 +748,7 @@ function ToggleSwitch({ on, onChange }: { on: boolean; onChange: () => void }) {
 
 interface LayersPanelProps {
   visibility: LayerVisibility;
+  lockedKeys?: ReadonlySet<keyof LayerVisibility>;
   expandedLayer: ExpandableLayerKey | null;
   viewMode: ViewMode;
   displayMode: DisplayMode;
@@ -768,6 +772,8 @@ interface LayerRowProps {
   label: string;
   expandable: boolean;
   active: boolean;
+  /** owner-only 私人圖層且當前 viewer 非 owner → 顯示鎖頭、禁 toggle */
+  locked: boolean;
   color: string;
   count: number | undefined;
   isExpanded: boolean;
@@ -777,16 +783,19 @@ interface LayerRowProps {
 }
 
 const LayerRow = memo(function LayerRow({
-  layerKey, label, expandable, active, color, count, isExpanded, Icon,
+  layerKey, label, expandable, active, locked, color, count, isExpanded, Icon,
   onLayerClick, onToggleVisibility,
 }: LayerRowProps) {
+  // locked：點整列一律走 onToggleVisibility → App 端 gate（未登入導登入 / 已登入顯示提示）
   const handleClick = () =>
-    expandable ? onLayerClick(layerKey) : onToggleVisibility(layerKey);
+    locked ? onToggleVisibility(layerKey)
+      : expandable ? onLayerClick(layerKey) : onToggleVisibility(layerKey);
   const handleToggle = () => onToggleVisibility(layerKey);
 
   return (
     <div
       onClick={handleClick}
+      title={locked ? "私人圖層，僅擁有者可檢視" : undefined}
       style={{
         display: "flex",
         alignItems: "center",
@@ -795,6 +804,7 @@ const LayerRow = memo(function LayerRow({
         cursor: "pointer",
         borderLeft: active ? `2px solid ${color}` : "2px solid transparent",
         paddingLeft: 10,
+        opacity: locked ? 0.5 : 1,
         transition: "background 0.1s",
       }}
       onMouseEnter={(e) => {
@@ -816,7 +826,7 @@ const LayerRow = memo(function LayerRow({
       >
         {label}
       </span>
-      {count != null && count > 0 && (
+      {count != null && count > 0 && !locked && (
         <span
           style={{
             fontFamily: FONT_DATA,
@@ -828,12 +838,14 @@ const LayerRow = memo(function LayerRow({
           {count.toLocaleString()}
         </span>
       )}
-      {expandable && (
+      {expandable && !locked && (
         <span style={{ color: DIM, flexShrink: 0, display: "flex" }}>
           {isExpanded ? <ChevronDown size={12} /> : <ChevronRight size={12} />}
         </span>
       )}
-      <ToggleSwitch on={active} onChange={handleToggle} />
+      {locked
+        ? <Lock size={13} color={DIM} style={{ flexShrink: 0 }} />
+        : <ToggleSwitch on={active} onChange={handleToggle} />}
     </div>
   );
 });
@@ -922,7 +934,7 @@ function SubGroupLabel({ children }: { children: string }) {
 }
 
 function LayersPanel({
-  visibility, expandedLayer, viewMode: _viewMode, displayMode,
+  visibility, lockedKeys, expandedLayer, viewMode: _viewMode, displayMode,
   getCount, onLayerClick, onToggleVisibility,
   onViewModeChange: _onViewModeChange, onDisplayModeChange, onHideTransport,
   onAllOff, onBulkSetVisibility, getControls, onClose,
@@ -1014,6 +1026,7 @@ function LayersPanel({
                           label={label}
                           expandable={!!expandable}
                           active={active}
+                          locked={!!lockedKeys?.has(key)}
                           color={LAYER_COLORS[key]}
                           count={getCount(key)}
                           isExpanded={isExpanded}

--- a/src/components/LayerSidebar.tsx
+++ b/src/components/LayerSidebar.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { Lock } from "lucide-react";
 import type { LayerVisibility, ExpandableLayerKey, ViewMode, DisplayMode } from "../types";
 import type { ParamControl } from "../hooks/useTransportParams";
 // 圖層目錄常數單一真實來源（與 IconRailSidebar 共用，消除漂移）
@@ -9,6 +10,8 @@ import { SURFACE, FONT_DATA, RADIUS, FONT_SIZE } from "../styles/designTokens";
 
 interface LayerSidebarProps {
   visibility: LayerVisibility;
+  /** 對目前使用者上鎖的圖層 keys（動態 gating，見 lib/layerGates）：命中 → 顯示鎖頭 + 禁 toggle */
+  lockedKeys?: ReadonlySet<keyof LayerVisibility>;
   expandedLayer: ExpandableLayerKey | null;
   viewMode: ViewMode;
   displayMode: DisplayMode;
@@ -29,6 +32,7 @@ interface LayerSidebarProps {
 
 export function LayerSidebar({
   visibility,
+  lockedKeys,
   expandedLayer,
   viewMode,
   displayMode,
@@ -65,7 +69,7 @@ export function LayerSidebar({
   if (isMobile) {
     return (
       <SidebarContent
-        visibility={visibility} expandedLayer={expandedLayer} viewMode={viewMode}
+        visibility={visibility} lockedKeys={lockedKeys} expandedLayer={expandedLayer} viewMode={viewMode}
         displayMode={displayMode} isDarkTheme={isDarkTheme} isMobile={isMobile}
         textColor={textColor} dimColor={dimColor} baseFontSize={baseFontSize}
         getCount={getCount} onLayerClick={onLayerClick} onToggleVisibility={onToggleVisibility}
@@ -149,7 +153,7 @@ export function LayerSidebar({
         &#x25C0;
       </button>
       <SidebarContent
-        visibility={visibility} expandedLayer={expandedLayer} viewMode={viewMode}
+        visibility={visibility} lockedKeys={lockedKeys} expandedLayer={expandedLayer} viewMode={viewMode}
         displayMode={displayMode} isDarkTheme={isDarkTheme} isMobile={isMobile}
         textColor={textColor} dimColor={dimColor} baseFontSize={baseFontSize}
         getCount={getCount} onLayerClick={onLayerClick} onToggleVisibility={onToggleVisibility}
@@ -163,12 +167,13 @@ export function LayerSidebar({
 // ── Sidebar Content (extracted for reuse) ──
 
 function SidebarContent({
-  visibility, expandedLayer, viewMode, displayMode, isDarkTheme, isMobile,
+  visibility, lockedKeys, expandedLayer, viewMode, displayMode, isDarkTheme, isMobile,
   textColor, dimColor, baseFontSize,
   getCount, onLayerClick, onToggleVisibility,
   onViewModeChange, onDisplayModeChange, onHideTransport, onBulkSetVisibility, getControls,
 }: {
   visibility: LayerVisibility;
+  lockedKeys?: ReadonlySet<keyof LayerVisibility>;
   expandedLayer: ExpandableLayerKey | null;
   viewMode: ViewMode;
   displayMode: DisplayMode;
@@ -327,39 +332,52 @@ function SidebarContent({
             const count = getCount(key);
             const isExpanded = expandedLayer === key;
             const isTransport = key in TRANSPORT_LABELS;
+            // 動態 gating：對此使用者上鎖 → 顯示鎖頭、點擊走 App 端 gate（onToggleVisibility）
+            const locked = !!lockedKeys?.has(key);
 
             return (
               <div key={key}>
                 <div
+                  title={locked ? "私人圖層，僅擁有者可檢視" : undefined}
                   style={{
                     display: "flex",
                     alignItems: "center",
                     gap: 6,
                     padding: "4px 12px",
                     cursor: "pointer",
+                    opacity: locked ? 0.5 : 1,
                     background: isExpanded
                       ? (isDarkTheme ? `${color}15` : `${color}10`)
                       : "transparent",
                     transition: "background 0.15s",
                   }}
                 >
-                  <button
-                    onClick={(e) => { e.stopPropagation(); onToggleVisibility(key); }}
-                    style={{
-                      width: 14,
-                      height: 14,
-                      borderRadius: RADIUS.full,
-                      background: active ? color : "transparent",
-                      border: `1.5px solid ${active ? color : (isDarkTheme ? "rgba(255,255,255,0.25)" : "rgba(0,0,0,0.2)")}`,
-                      cursor: "pointer",
-                      flexShrink: 0,
-                      padding: 0,
-                      transition: "all 0.15s",
-                    }}
-                  />
+                  {locked ? (
+                    <span
+                      onClick={(e) => { e.stopPropagation(); onToggleVisibility(key); }}
+                      style={{ display: "flex", flexShrink: 0, color: dimColor, cursor: "pointer" }}
+                    >
+                      <Lock size={13} />
+                    </span>
+                  ) : (
+                    <button
+                      onClick={(e) => { e.stopPropagation(); onToggleVisibility(key); }}
+                      style={{
+                        width: 14,
+                        height: 14,
+                        borderRadius: RADIUS.full,
+                        background: active ? color : "transparent",
+                        border: `1.5px solid ${active ? color : (isDarkTheme ? "rgba(255,255,255,0.25)" : "rgba(0,0,0,0.2)")}`,
+                        cursor: "pointer",
+                        flexShrink: 0,
+                        padding: 0,
+                        transition: "all 0.15s",
+                      }}
+                    />
+                  )}
 
                   <div
-                    onClick={() => expandable ? onLayerClick(key) : onToggleVisibility(key)}
+                    onClick={() => locked ? onToggleVisibility(key) : (expandable ? onLayerClick(key) : onToggleVisibility(key))}
                     style={{
                       flex: 1,
                       fontSize: baseFontSize,
@@ -369,14 +387,14 @@ function SidebarContent({
                     }}
                   >
                     {displayLabel}
-                    {count != null && count > 0 && (
+                    {count != null && count > 0 && !locked && (
                       <span style={{ marginLeft: 4, opacity: 0.5, fontSize: baseFontSize - 1 }}>
                         {count}
                       </span>
                     )}
                   </div>
 
-                  {expandable && (
+                  {expandable && !locked && (
                     <span
                       onClick={() => onLayerClick(key)}
                       style={{

--- a/src/components/admin/AdminPanel.tsx
+++ b/src/components/admin/AdminPanel.tsx
@@ -1,0 +1,333 @@
+import { useCallback, useEffect, useState } from "react";
+import { X, ShieldCheck, Users, ScrollText, Lock, Database } from "lucide-react";
+import {
+  listMembers, setMemberTier, listAudit, listGatedLayers, setLayerGate,
+  TIERS, type Tier, type AdminMember, type AuditRow, type GatedLayerRow,
+} from "../../lib/adminApi";
+import { loadLayerGates } from "../../lib/layerGates";
+import {
+  SURFACE, BORDER, RADIUS, FONT_SIZE, SPACING, COLORS, FONT_CJK, ELEVATION,
+} from "../../styles/designTokens";
+
+/**
+ * 站內 owner-only 治理後台（Phase 2，spec §6）。
+ * 四分頁：會員管理 / 稽核記錄 / 圖層鎖定 / 資料新鮮度。
+ * 入口在 UserAvatar 下拉，僅 isOwner 渲染 → 這裡不再重複守門。
+ */
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  /** 目前登入者 uid：自己那列 tier 禁止修改（呼應 DB 端防呆）。 */
+  selfId: string | null;
+}
+
+type TabKey = "members" | "audit" | "layers" | "freshness";
+const TABS: { key: TabKey; label: string; Icon: typeof Users }[] = [
+  { key: "members", label: "會員管理", Icon: Users },
+  { key: "audit", label: "稽核記錄", Icon: ScrollText },
+  { key: "layers", label: "圖層鎖定", Icon: Lock },
+  { key: "freshness", label: "資料新鮮度", Icon: Database },
+];
+
+const RED = "#ef4444";
+
+export function AdminPanel({ open, onClose, selfId }: Props) {
+  const [tab, setTab] = useState<TabKey>("members");
+  if (!open) return null;
+
+  return (
+    <div
+      onClick={onClose}
+      style={{
+        position: "fixed", inset: 0, background: "rgba(0,0,0,0.6)", zIndex: 10001,
+        display: "flex", alignItems: "center", justifyContent: "center",
+      }}
+    >
+      <div
+        onClick={(e) => e.stopPropagation()}
+        style={{
+          background: SURFACE.solid, color: COLORS.textDefault, borderRadius: RADIUS.xl,
+          border: `1px solid ${BORDER.panel}`, boxShadow: ELEVATION.lg,
+          width: "min(920px, 94vw)", maxHeight: "88vh", display: "flex", flexDirection: "column",
+          fontFamily: FONT_CJK, overflow: "hidden",
+        }}
+      >
+        {/* Header */}
+        <div style={{
+          display: "flex", alignItems: "center", justifyContent: "space-between",
+          padding: `${SPACING.lg}px ${SPACING.xl}px`, borderBottom: `1px solid ${BORDER.soft}`,
+        }}>
+          <div style={{ display: "flex", alignItems: "center", gap: SPACING.sm, fontSize: FONT_SIZE.xl, fontWeight: 600, color: COLORS.textStrong }}>
+            <ShieldCheck size={18} /> 資料治理後台
+          </div>
+          <button onClick={onClose} aria-label="關閉"
+            style={{ background: "transparent", border: "none", color: COLORS.textMuted, cursor: "pointer" }}>
+            <X size={20} />
+          </button>
+        </div>
+
+        {/* Tabs */}
+        <div style={{ display: "flex", gap: SPACING.xs, padding: `${SPACING.md}px ${SPACING.xl}px 0`, borderBottom: `1px solid ${BORDER.soft}` }}>
+          {TABS.map(({ key, label, Icon }) => (
+            <button key={key} onClick={() => setTab(key)}
+              style={{
+                display: "inline-flex", alignItems: "center", gap: SPACING.xs,
+                padding: `${SPACING.sm}px ${SPACING.md}px`, background: "transparent", cursor: "pointer",
+                border: "none", borderBottom: `2px solid ${tab === key ? COLORS.accent : "transparent"}`,
+                color: tab === key ? COLORS.textStrong : COLORS.textMuted,
+                fontSize: FONT_SIZE.md, fontFamily: FONT_CJK, fontWeight: tab === key ? 600 : 400,
+              }}>
+              <Icon size={13} /> {label}
+            </button>
+          ))}
+        </div>
+
+        {/* Body */}
+        <div style={{ padding: SPACING.xl, overflow: "auto", flex: 1 }}>
+          {tab === "members" && <MembersTab selfId={selfId} />}
+          {tab === "audit" && <AuditTab />}
+          {tab === "layers" && <LayersTab />}
+          {tab === "freshness" && <FreshnessTab />}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ── 共用小工具 ──
+
+function useAsync<T>(fn: () => Promise<T>, deps: unknown[]): { data: T | null; loading: boolean; error: string | null; reload: () => void } {
+  const [data, setData] = useState<T | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [epoch, setEpoch] = useState(0);
+  const reload = useCallback(() => setEpoch((e) => e + 1), []);
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    fn()
+      .then((d) => { if (!cancelled) { setData(d); setLoading(false); } })
+      .catch((err) => { if (!cancelled) { setError(err instanceof Error ? err.message : String(err)); setLoading(false); } });
+    return () => { cancelled = true; };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [...deps, epoch]);
+  return { data, loading, error, reload };
+}
+
+function Status({ loading, error }: { loading: boolean; error: string | null }) {
+  if (loading) return <div style={{ color: COLORS.textMuted, fontSize: FONT_SIZE.md, padding: SPACING.lg }}>載入中…</div>;
+  if (error) return <div style={{ color: RED, fontSize: FONT_SIZE.md, padding: SPACING.lg }}>載入失敗：{error}</div>;
+  return null;
+}
+
+const th: React.CSSProperties = { textAlign: "left", padding: `${SPACING.xs}px ${SPACING.md}px`, color: COLORS.textMuted, fontSize: FONT_SIZE.sm, fontWeight: 600, borderBottom: `1px solid ${BORDER.panel}`, whiteSpace: "nowrap" };
+const td: React.CSSProperties = { padding: `${SPACING.sm}px ${SPACING.md}px`, fontSize: FONT_SIZE.md, borderBottom: `1px solid ${BORDER.soft}`, verticalAlign: "middle" };
+const selectStyle: React.CSSProperties = { background: SURFACE.strong, color: COLORS.textDefault, border: `1px solid ${BORDER.mid}`, borderRadius: RADIUS.md, padding: `${SPACING.xxs}px ${SPACING.sm}px`, fontSize: FONT_SIZE.sm, fontFamily: FONT_CJK };
+const fmt = (s: string | null) => (s ? s.replace("T", " ").slice(0, 16) : "—");
+
+// ── Tab 1：會員管理 ──
+
+function MembersTab({ selfId }: { selfId: string | null }) {
+  const { data, loading, error, reload } = useAsync(listMembers, []);
+  const [busy, setBusy] = useState<string | null>(null);
+
+  const onChange = async (m: AdminMember, tier: Tier) => {
+    setBusy(m.id);
+    try {
+      await setMemberTier(m.id, tier);
+      reload();
+    } catch (err) {
+      alert(`修改失敗：${err instanceof Error ? err.message : String(err)}`);
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  if (loading || error) return <Status loading={loading} error={error} />;
+  const members = data ?? [];
+  return (
+    <table style={{ width: "100%", borderCollapse: "collapse" }}>
+      <thead>
+        <tr>
+          <th style={th}>Email</th><th style={th}>名稱</th><th style={th}>分級 Tier</th>
+          <th style={th}>註冊</th><th style={th}>最後登入</th>
+        </tr>
+      </thead>
+      <tbody>
+        {members.map((m) => {
+          const isSelf = m.id === selfId;
+          return (
+            <tr key={m.id}>
+              <td style={td}>{m.email ?? "—"}{isSelf && <span style={{ color: COLORS.accent, marginLeft: 6, fontSize: FONT_SIZE.sm }}>（你）</span>}</td>
+              <td style={td}>{m.display_name ?? "—"}</td>
+              <td style={td}>
+                <select value={m.tier} disabled={isSelf || busy === m.id} style={{ ...selectStyle, opacity: isSelf ? 0.5 : 1 }}
+                  onChange={(e) => void onChange(m, e.target.value as Tier)}>
+                  {TIERS.map((t) => <option key={t} value={t}>{t}</option>)}
+                </select>
+              </td>
+              <td style={{ ...td, color: COLORS.textMuted }}>{fmt(m.created_at)}</td>
+              <td style={{ ...td, color: COLORS.textMuted }}>{fmt(m.last_sign_in_at)}</td>
+            </tr>
+          );
+        })}
+      </tbody>
+    </table>
+  );
+}
+
+// ── Tab 2：稽核記錄 ──
+
+function AuditTab() {
+  const [onlyDenied, setOnlyDenied] = useState(false);
+  const { data, loading, error } = useAsync<AuditRow[]>(() => listAudit(200, onlyDenied), [onlyDenied]);
+
+  return (
+    <div>
+      <div style={{ fontSize: FONT_SIZE.sm, color: COLORS.textMuted, marginBottom: SPACING.md, lineHeight: 1.6 }}>
+        匿名掃描於 API gateway 攔截（函式未執行），不列入此表；完整記錄見 Supabase 平台 logs。
+        本表為已登入且函式有跑到的存取（owner 正常使用 + 登入者越權嘗試）。
+      </div>
+      <label style={{ display: "inline-flex", alignItems: "center", gap: SPACING.xs, fontSize: FONT_SIZE.md, marginBottom: SPACING.md, cursor: "pointer" }}>
+        <input type="checkbox" checked={onlyDenied} onChange={(e) => setOnlyDenied(e.target.checked)} /> 只看被拒
+      </label>
+      {(loading || error) ? <Status loading={loading} error={error} /> : (
+        <table style={{ width: "100%", borderCollapse: "collapse" }}>
+          <thead>
+            <tr>
+              <th style={th}>時間</th><th style={th}>Email</th><th style={th}>Tier</th>
+              <th style={th}>RPC</th><th style={th}>需求</th><th style={th}>結果</th>
+            </tr>
+          </thead>
+          <tbody>
+            {(data ?? []).map((r) => (
+              <tr key={r.id} style={{ background: r.granted ? undefined : `${RED}14` }}>
+                <td style={{ ...td, color: COLORS.textMuted, whiteSpace: "nowrap" }}>{fmt(r.occurred_at)}</td>
+                <td style={td}>{r.email ?? "—"}</td>
+                <td style={td}>{r.user_tier ?? "—"}</td>
+                <td style={{ ...td, fontFamily: "monospace", fontSize: FONT_SIZE.sm }}>{r.rpc_name}</td>
+                <td style={td}>{r.required_tier ?? "—"}</td>
+                <td style={{ ...td, color: r.granted ? "#22c55e" : RED, fontWeight: 600 }}>{r.granted ? "允許" : "拒絕"}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </div>
+  );
+}
+
+// ── Tab 3：圖層鎖定 ──
+
+function LayersTab() {
+  const { data, loading, error, reload } = useAsync(listGatedLayers, []);
+  const [busy, setBusy] = useState<string | null>(null);
+
+  const apply = async (row: GatedLayerRow, tier: Tier, enabled: boolean) => {
+    setBusy(row.layer_key);
+    try {
+      await setLayerGate(row.layer_key, tier, enabled);
+      await loadLayerGates(); // 讓地圖鎖頭即時更新
+      reload();
+    } catch (err) {
+      alert(`修改失敗：${err instanceof Error ? err.message : String(err)}`);
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  if (loading || error) return <Status loading={loading} error={error} />;
+  const rows = data ?? [];
+  const byCat = new Map<string, GatedLayerRow[]>();
+  for (const r of rows) {
+    if (!byCat.has(r.category)) byCat.set(r.category, []);
+    byCat.get(r.category)!.push(r);
+  }
+
+  return (
+    <div>
+      {[...byCat.entries()].map(([cat, list]) => (
+        <div key={cat} style={{ marginBottom: SPACING.xl }}>
+          <div style={{ fontSize: FONT_SIZE.md, fontWeight: 600, color: COLORS.textStrong, marginBottom: SPACING.sm }}>{cat}</div>
+          <table style={{ width: "100%", borderCollapse: "collapse" }}>
+            <thead>
+              <tr><th style={th}>圖層</th><th style={th}>required_tier</th><th style={th}>啟用</th><th style={th}>新鮮度</th></tr>
+            </thead>
+            <tbody>
+              {list.map((r) => (
+                <tr key={r.layer_key}>
+                  <td style={td}>
+                    {r.label}
+                    <span style={{ color: COLORS.textFaint, fontSize: FONT_SIZE.sm, marginLeft: 6, fontFamily: "monospace" }}>{r.layer_key}</span>
+                  </td>
+                  <td style={td}>
+                    <select value={r.required_tier} disabled={busy === r.layer_key} style={selectStyle}
+                      onChange={(e) => void apply(r, e.target.value as Tier, r.enabled)}>
+                      {TIERS.map((t) => <option key={t} value={t}>{t}</option>)}
+                    </select>
+                  </td>
+                  <td style={td}>
+                    <input type="checkbox" checked={r.enabled} disabled={busy === r.layer_key}
+                      onChange={(e) => void apply(r, r.required_tier as Tier, e.target.checked)} />
+                  </td>
+                  <td style={td}>
+                    {r.is_stale
+                      ? <span style={{ color: RED, display: "inline-flex", alignItems: "center", gap: 4 }}><Dot color={RED} />過期</span>
+                      : r.source_date ? <span style={{ color: COLORS.textMuted }}>{r.source_date}</span> : <span style={{ color: COLORS.textFaint }}>—</span>}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+// ── Tab 4：資料新鮮度（唯讀）──
+
+function FreshnessTab() {
+  const { data, loading, error } = useAsync(listGatedLayers, []);
+  if (loading || error) return <Status loading={loading} error={error} />;
+  // 以 dataset（category）為單位去重，避免同 category 多 layer 重複列
+  const seen = new Set<string>();
+  const rows = (data ?? []).filter((r) => {
+    const k = r.category;
+    if (seen.has(k)) return false;
+    seen.add(k);
+    return true;
+  });
+  return (
+    <table style={{ width: "100%", borderCollapse: "collapse" }}>
+      <thead>
+        <tr>
+          <th style={th}>資料集</th><th style={th}>基準日</th><th style={th}>下次更新</th>
+          <th style={th}>頻率</th><th style={th}>筆數</th><th style={th}>狀態</th>
+        </tr>
+      </thead>
+      <tbody>
+        {rows.map((r) => (
+          <tr key={r.category}>
+            <td style={td}>{r.category}</td>
+            <td style={{ ...td, color: COLORS.textMuted }}>{r.source_date ?? "—"}</td>
+            <td style={{ ...td, color: r.is_stale ? RED : COLORS.textMuted }}>{r.next_refresh ?? "—"}</td>
+            <td style={{ ...td, color: COLORS.textMuted }}>{r.refresh_cadence ?? "—"}</td>
+            <td style={{ ...td, color: COLORS.textMuted }}>{r.row_count?.toLocaleString() ?? "—"}</td>
+            <td style={td}>
+              {r.is_stale
+                ? <span style={{ color: RED, display: "inline-flex", alignItems: "center", gap: 4 }}><Dot color={RED} />過期</span>
+                : <span style={{ color: "#22c55e" }}>最新</span>}
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}
+
+function Dot({ color }: { color: string }) {
+  return <span style={{ width: 8, height: 8, borderRadius: RADIUS.full, background: color, display: "inline-block" }} />;
+}

--- a/src/components/auth/UserAvatar.tsx
+++ b/src/components/auth/UserAvatar.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from "react";
-import { LogIn, LogOut, User as UserIcon } from "lucide-react";
+import { LogIn, LogOut, ShieldCheck, User as UserIcon } from "lucide-react";
 import { signInWithGoogle, signOut, useUser } from "../../lib/auth";
 import {
   COLORS,
@@ -19,7 +19,11 @@ import {
  * 未登入 → 「使用 Google 登入」按鈕；登入 → avatar + 名稱 + 下拉（登出）。
  * 純元件、獨立掛載，App.tsx 接線待 byok-chat PR 併回 master 後再做。
  */
-export function UserAvatar() {
+/**
+ * @param isOwner      是否為 owner（決定是否顯示「資料治理」入口）。
+ * @param onOpenAdmin  點「資料治理」時開啟站內後台（僅 owner）。
+ */
+export function UserAvatar({ isOwner, onOpenAdmin }: { isOwner?: boolean; onOpenAdmin?: () => void } = {}) {
   const { user, loading } = useUser();
   const [open, setOpen] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
@@ -127,6 +131,35 @@ export function UserAvatar() {
           >
             {user.email ?? displayName}
           </div>
+          {isOwner && onOpenAdmin && (
+            <button
+              type="button"
+              onClick={() => {
+                setOpen(false);
+                onOpenAdmin();
+              }}
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: SPACING.sm,
+                width: "100%",
+                padding: `${SPACING.md}px ${SPACING.lg}px`,
+                background: "transparent",
+                color: COLORS.textDefault,
+                border: "none",
+                borderBottom: `1px solid ${BORDER.soft}`,
+                fontSize: FONT_SIZE.md,
+                fontFamily: FONT_CJK,
+                textAlign: "left",
+                cursor: "pointer",
+              }}
+              onMouseEnter={(e) => (e.currentTarget.style.background = WHITE_ALPHA[8])}
+              onMouseLeave={(e) => (e.currentTarget.style.background = "transparent")}
+            >
+              <ShieldCheck size={14} />
+              資料治理
+            </button>
+          )}
           <button
             type="button"
             onClick={() => {

--- a/src/components/sidebar/layerCatalog.ts
+++ b/src/components/sidebar/layerCatalog.ts
@@ -309,6 +309,11 @@ export interface LayerDef {
   /** 手機 LayerSidebar 顯示文字（多為較長全稱）；未填則沿用 label */
   labelMobile?: string;
   expandable?: boolean;
+  /**
+   * owner-only 私人圖層：非 owner 帳號顯示鎖頭、禁 toggle。
+   * runtime SSOT 為下方 GATED_LAYERS（兩個 sidebar + App toggle gate 共用）。
+   */
+  gated?: boolean;
 }
 
 export interface SubGroupDef {
@@ -1087,3 +1092,32 @@ export const LAYER_LABELS: Partial<Record<keyof LayerVisibility, string>> = (() 
   }
   return out;
 })();
+
+// ── owner-only 私人圖層 SSOT（見 docs/features/owner-gated-layers）──
+// 只有登入且 profiles.tier='owner' 的帳號能開啟。非 owner：sidebar 顯示鎖頭 + toggle no-op。
+// DB 端由 migration 275 同步：對應 RPC 加 owner 檢查 + REVOKE anon。
+// ⚠️ 明確排除（保持公開）：waterCanals（灌排渠道）、powerPoles（電桿 2.96M）。
+export const GATED_LAYERS: ReadonlySet<keyof LayerVisibility> = new Set<keyof LayerVisibility>([
+  // 畜牧 Livestock（改走 owner-only RPC；不含 livestockFeed / livestockMarket）
+  "livestockFarmPig", "livestockFarmChicken", "livestockFarmCattle", "livestockFarmDuck",
+  "livestockFarmGoose", "livestockFarmSheep", "livestockFarmOther", "livestockSlaughter",
+  // 石化 · 油氣
+  "lpgSubpackaging", "lpgRetailers", "lngTerminal", "pipelineGas", "pipelineOilGas",
+  "industrialRefinery", "industrialStorageTank", "industrialPowerPlant", "coalTerminal",
+  "fossilFuelInfra",
+  // 電力 · 電網
+  "osmSubstationsEhv", "osmSubstations", "osmPowerLines", "osmPowerTowers",
+  "substationEhvGlow", "powerLinesGlow",
+  // 電力 · 廠
+  "facPrimary", "facPlanned", "facHistorical", "facSecondary", "facOsmSupplement",
+  "powerGenerationUnit", "powerPlantGlow",
+  // 僅做 UI 鎖（資料載入路徑不動）
+  "aviationRestrictedGlow",
+  // 已從 sidebar 下架但 API 敏感（無鎖頭 UI；仍 gate 掉 bulk/chat 等程式化開啟路徑）
+  "facOffshore", "osmPowerPlantsStatic",
+]);
+
+/** 對某使用者而言此 key 是否上鎖（gated 且非 owner）。 */
+export function isLayerLockedFor(key: keyof LayerVisibility, isOwner: boolean): boolean {
+  return !isOwner && GATED_LAYERS.has(key);
+}

--- a/src/data/energyLoader.ts
+++ b/src/data/energyLoader.ts
@@ -232,7 +232,7 @@ const _l1Cached = cachedOnce(async () => {
   const [primaryRes, rtRes] = await Promise.all([
     withLoading(
       "energy:facPrimary", "主要電廠 209",
-      staticRpc("get_ssot_facilities_primary_operating"),
+      supabase.rpc("get_ssot_facilities_primary_operating"),  // owner-gated：直連 RPC
     ),
     supabase.rpc("get_ssot_realtime_facility_output"),
   ]);
@@ -250,7 +250,7 @@ export const fetchFacPrimary = (): Promise<FacilityPoint[]> => _l1Cached();
 const _l2Cached = cachedOnce(async () => {
   const { data, error } = await withLoading(
     "energy:facOffshore", "離岸風電場址 8",
-    staticRpc("get_ssot_facilities_offshore_zones"),
+    supabase.rpc("get_ssot_facilities_offshore_zones"),  // owner-gated：直連 RPC（敏感電廠資料）
   );
   if (error) throw new Error(`get_ssot_facilities_offshore_zones: ${error.message}`);
   return (data ?? []) as FacilityZone[];
@@ -261,7 +261,7 @@ export const fetchFacOffshore = (): Promise<FacilityZone[]> => _l2Cached();
 const _l3Cached = cachedOnce(async () => {
   const { data, error } = await withLoading(
     "energy:facPlanned", "規劃電廠 35",
-    staticRpc("get_ssot_facilities_planned"),
+    supabase.rpc("get_ssot_facilities_planned"),  // owner-gated：直連 RPC
   );
   if (error) throw new Error(`get_ssot_facilities_planned: ${error.message}`);
   return (data ?? []) as FacilityPoint[];
@@ -272,7 +272,7 @@ export const fetchFacPlanned = (): Promise<FacilityPoint[]> => _l3Cached();
 const _l4Cached = cachedOnce(async () => {
   const { data, error } = await withLoading(
     "energy:facHistorical", "歷史電廠 15",
-    staticRpc("get_ssot_facilities_historical"),
+    supabase.rpc("get_ssot_facilities_historical"),  // owner-gated：直連 RPC
   );
   if (error) throw new Error(`get_ssot_facilities_historical: ${error.message}`);
   return (data ?? []) as FacilityPoint[];
@@ -283,7 +283,7 @@ export const fetchFacHistorical = (): Promise<FacilityPoint[]> => _l4Cached();
 const _l5Cached = cachedOnce(async () => {
   const { data, error } = await withLoading(
     "energy:facSecondary", "次要電廠 341",
-    staticRpc("get_ssot_facilities_secondary_small"),
+    supabase.rpc("get_ssot_facilities_secondary_small"),  // owner-gated：直連 RPC
   );
   if (error) throw new Error(`get_ssot_facilities_secondary_small: ${error.message}`);
   return (data ?? []) as FacilityPoint[];
@@ -294,7 +294,7 @@ export const fetchFacSecondary = (): Promise<FacilityPoint[]> => _l5Cached();
 const _l6Cached = cachedOnce(async () => {
   const { data, error } = await withLoading(
     "energy:facOsmSupplement", "OSM 補充 1,215",
-    staticRpc("get_ssot_facilities_osm_supplement"),
+    supabase.rpc("get_ssot_facilities_osm_supplement"),  // owner-gated：直連 RPC
   );
   if (error) throw new Error(`get_ssot_facilities_osm_supplement: ${error.message}`);
   return (data ?? []) as FacilityPoint[];
@@ -461,7 +461,7 @@ async function fetchOsmSubstationsUncached(): Promise<OsmSubstation[]> {
   const { data, error } = await withLoading(
     "energy:substations",
     "變電所 785",
-    staticRpc("get_osm_substations"),
+    supabase.rpc("get_osm_substations"),  // owner-gated：直連 RPC
   );
   if (error) throw new Error(`get_osm_substations: ${error.message}`);
   return (data ?? []) as OsmSubstation[];
@@ -499,7 +499,7 @@ async function fetchOsmPowerLinesUncached(): Promise<OsmPowerLine[]> {
   const { data, error } = await withLoading(
     "energy:powerLines",
     "高壓輸電線 2,305",
-    staticRpc("get_osm_power_lines"),
+    supabase.rpc("get_osm_power_lines"),  // owner-gated：直連 RPC
   );
   if (error) throw new Error(`get_osm_power_lines: ${error.message}`);
   return (data ?? []) as OsmPowerLine[];
@@ -512,7 +512,7 @@ async function fetchOsmPowerTowersUncached(): Promise<OsmPowerTower[]> {
   const { data, error } = await withLoading(
     "energy:powerTowers",
     "高壓鐵塔 26,589",
-    staticRpc("get_osm_power_towers"),
+    supabase.rpc("get_osm_power_towers"),  // owner-gated：直連 RPC
   );
   if (error) throw new Error(`get_osm_power_towers: ${error.message}`);
   return (data ?? []) as unknown as OsmPowerTower[];
@@ -629,7 +629,7 @@ async function fetchOsmPowerPlantsStaticUncached(): Promise<OsmPowerPlantStatic[
   const { data, error } = await withLoading(
     "energy:powerPlantsStatic",
     "OSM 電廠 513",
-    staticRpc("get_osm_power_plants_static"),
+    supabase.rpc("get_osm_power_plants_static"),  // owner-gated：直連 RPC（敏感電廠資料）
   );
   if (error) throw new Error(`get_osm_power_plants_static: ${error.message}`);
   return (data ?? []) as OsmPowerPlantStatic[];
@@ -740,7 +740,7 @@ async function fetchFossilFuelInfraUncached(): Promise<FossilFuelFacility[]> {
   const { data, error } = await withLoading(
     "energy:fossilFuel",
     "化石燃料設施 9",
-    staticRpc("get_fossil_fuel_infrastructure"),
+    supabase.rpc("get_fossil_fuel_infrastructure"),  // owner-gated：直連 RPC
   );
   if (error) throw new Error(`get_fossil_fuel_infrastructure: ${error.message}`);
   return (data ?? []) as FossilFuelFacility[];

--- a/src/data/fossilFuelLoader.ts
+++ b/src/data/fossilFuelLoader.ts
@@ -1,3 +1,4 @@
+import { supabase } from "../lib/supabase";
 import { staticRpc } from "./staticRpc";
 import { withLoading } from "../lib/loadingRegistry";
 
@@ -33,6 +34,17 @@ export const FOSSIL_LAYER_MAP = {
 } as const;
 
 export type FossilLayerKey = (typeof FOSSIL_LAYER_MAP)[keyof typeof FOSSIL_LAYER_MAP];
+
+// owner-gated 資料路徑拆分（coordinator 契約）：
+// - 加油站 5 層 → 公開 RPC get_gas_station_layers（走 staticRpc 保留 CDN 快照+fallback，不 gated）
+// - 石化 9 層  → 直連 supabase.rpc get_fossil_fuel_layers（owner-gated；新版仍含加油站 key，忽略即可）
+export const GAS_STATION_FE_KEYS: readonly FossilLayerKey[] = [
+  "gasStationCpc", "gasStationFpcc", "gasStationTaisugar", "gasStationOther", "gasStationCanonical",
+];
+export const FOSSIL_LOCKED_FE_KEYS: readonly FossilLayerKey[] = [
+  "lpgSubpackaging", "lpgRetailers", "lngTerminal", "pipelineGas", "pipelineOilGas",
+  "industrialRefinery", "industrialStorageTank", "industrialPowerPlant", "coalTerminal",
+];
 
 interface RawRow {
   layer: string;
@@ -137,28 +149,13 @@ function rowToFeature(r: RawRow): GeoJSON.Feature | null {
   return { type: "Feature", geometry: geom, properties };
 }
 
-/** 載入化石燃料 13 layer。一次 RPC + client-side group by layer。 */
-export async function fetchFossilFuelLayers(): Promise<FossilFuelLayers> {
-  const t0 = performance.now();
-  const { data, error } = await withLoading(
-    "fossilFuel:all",
-    "化石燃料 13 圖層",
-    staticRpc("get_fossil_fuel_layers"),
-  );
-  if (error) throw new Error(`get_fossil_fuel_layers: ${error.message}`);
-
+/** rows → FossilFuelLayers（group by layer；industrialRefinery 白名單過濾 + industrial halo centroid）。 */
+function parseRows(rows: RawRow[]): FossilFuelLayers {
   const out = emptyAll();
-  const rows = (data ?? []) as RawRow[];
-  let industrialRefineryRaw = 0;
-  let industrialRefineryKept = 0;
   for (const r of rows) {
     const feKey = (FOSSIL_LAYER_MAP as Record<string, FossilLayerKey | undefined>)[r.layer];
     if (!feKey) continue;
-    if (feKey === "industrialRefinery") {
-      industrialRefineryRaw += 1;
-      if (!isTrueRefineryChemicalPlant(r)) continue;
-      industrialRefineryKept += 1;
-    }
+    if (feKey === "industrialRefinery" && !isTrueRefineryChemicalPlant(r)) continue;
     const f = rowToFeature(r);
     if (!f) continue;
     out[feKey].features.push(f);
@@ -174,11 +171,40 @@ export async function fetchFossilFuelLayers(): Promise<FossilFuelLayers> {
       }
     }
   }
+  return out;
+}
 
-  const counts = Object.entries(out).map(([k, v]) => `${k}=${v.features.length}`).join(" ");
-  console.log(
-    `[FossilFuel] loaded ${rows.length} rows in ${(performance.now() - t0).toFixed(0)}ms · ${counts}` +
-    ` · industrialRefinery filtered ${industrialRefineryRaw}→${industrialRefineryKept} polygons`,
+/**
+ * 加油站 5 層（公開）：走 public.get_gas_station_layers()，staticRpc 保留 CDN 快照 + fallback。
+ * 回傳的 FossilFuelLayers 只有加油站 key 有值（其餘空 FC）。
+ */
+export async function fetchGasStationLayers(): Promise<FossilFuelLayers> {
+  const t0 = performance.now();
+  const { data, error } = await withLoading(
+    "fossilFuel:gasStations",
+    "加油站 5 圖層",
+    staticRpc("get_gas_station_layers"),
   );
+  if (error) throw new Error(`get_gas_station_layers: ${error.message}`);
+  const out = parseRows((data ?? []) as RawRow[]);
+  console.log(`[FossilFuel] gas stations loaded in ${(performance.now() - t0).toFixed(0)}ms`);
+  return out;
+}
+
+/**
+ * 石化 9 層（owner-gated）：直連 supabase.rpc get_fossil_fuel_layers（脫離公開 CDN 快照）。
+ * 新版 RPC 仍含加油站 key，但本路徑只餵石化 source（hook 端負責），忽略加油站部分。
+ * 非 owner 前端 toggle 已擋 → 不會走到這裡。
+ */
+export async function fetchFossilFuelLockedLayers(): Promise<FossilFuelLayers> {
+  const t0 = performance.now();
+  const { data, error } = await withLoading(
+    "fossilFuel:locked",
+    "石化能源 9 圖層",
+    supabase.rpc("get_fossil_fuel_layers"),
+  );
+  if (error) throw new Error(`get_fossil_fuel_layers: ${error.message}`);
+  const out = parseRows((data ?? []) as RawRow[]);
+  console.log(`[FossilFuel] locked layers loaded in ${(performance.now() - t0).toFixed(0)}ms`);
   return out;
 }

--- a/src/data/livestockLoader.ts
+++ b/src/data/livestockLoader.ts
@@ -1,0 +1,37 @@
+import { supabase } from "../lib/supabase";
+import { withLoading } from "../lib/loadingRegistry";
+
+/**
+ * 畜牧 owner-only 動態載入器（見 docs/features/owner-gated-layers）。
+ *
+ * 原本走靜態 `./agriculture/livestock_farms.geojson` / `slaughterhouses.geojson`（公開 CDN），
+ * 改為 owner-only Supabase RPC：
+ *   - public.get_livestock_farms()           → GeoJSON FeatureCollection（jsonb）
+ *   - public.get_livestock_slaughterhouses() → GeoJSON FeatureCollection（jsonb）
+ * properties 與原靜態檔完全相同（farms：證號/場名/縣市/主畜種/總隻數/種類明細/段/地號/定位來源/精度；
+ * slaughter：場名/種類/來源/地址/geocode_type），故 overlayRegistry paint/filter、popup、legend 全不變。
+ *
+ * migration 275 對這兩支 RPC 加 owner 檢查 + REVOKE anon；非 owner 前端 toggle 已擋（不會呼叫本檔）。
+ */
+
+const EMPTY_FC = (): GeoJSON.FeatureCollection => ({ type: "FeatureCollection", features: [] });
+
+export async function fetchLivestockFarms(): Promise<GeoJSON.FeatureCollection> {
+  const { data, error } = await withLoading(
+    "livestock:farms",
+    "畜禽飼養場",
+    supabase.rpc("get_livestock_farms"),
+  );
+  if (error) throw new Error(`get_livestock_farms: ${error.message}`);
+  return (data ?? EMPTY_FC()) as unknown as GeoJSON.FeatureCollection;
+}
+
+export async function fetchLivestockSlaughterhouses(): Promise<GeoJSON.FeatureCollection> {
+  const { data, error } = await withLoading(
+    "livestock:slaughter",
+    "屠宰場",
+    supabase.rpc("get_livestock_slaughterhouses"),
+  );
+  if (error) throw new Error(`get_livestock_slaughterhouses: ${error.message}`);
+  return (data ?? EMPTY_FC()) as unknown as GeoJSON.FeatureCollection;
+}

--- a/src/hooks/useFossilFuelLayers.ts
+++ b/src/hooks/useFossilFuelLayers.ts
@@ -2,20 +2,22 @@ import { useCallback, useEffect, useRef } from "react";
 import type { Map as MapboxMap, GeoJSONSource } from "mapbox-gl";
 import type { LayerVisibility } from "../types";
 import {
-  fetchFossilFuelLayers,
-  FOSSIL_LAYER_MAP,
+  fetchGasStationLayers,
+  fetchFossilFuelLockedLayers,
+  GAS_STATION_FE_KEYS,
+  FOSSIL_LOCKED_FE_KEYS,
   type FossilFuelLayers,
   type FossilLayerKey,
 } from "../data/fossilFuelLoader";
+import { isAccessDenied } from "../lib/layerGates";
 
 /**
- * 化石燃料 13 圖層的資料供應 hook。
+ * 化石燃料圖層資料供應 hook（拆兩條路徑，coordinator owner-gated 契約）：
+ * - 加油站 5 層（公開）：get_gas_station_layers（staticRpc CDN 快照）
+ * - 石化 9 層（owner-gated）：get_fossil_fuel_layers（直連 supabase.rpc）
  *
- * 設計：
- * - 一次 RPC 拉全部（後端 86ms / ~7,730 rows），不分段拉
- * - 任一 visibility true 才觸發 fetch
- * - Fetched FC 用 module-level 變數 cache 30 min（重新 toggle on 不重打）
- * - 樣式（circle / line / fill）在 overlayRegistry 內定義，本 hook 只 setData
+ * 各自「任一 visible 才 fetch」+ module-level 30 min cache；樣式在 overlayRegistry，本 hook 只 setData。
+ * 非 owner：石化 9 key 的 toggle 被 App 端 gate no-op → 不觸發 locked fetch。
  */
 
 /** sourceId 命名（與 overlayRegistry 對齊） */
@@ -39,28 +41,32 @@ const SRC_ID: Record<FossilLayerKey, string> = {
 const EMPTY_FC: GeoJSON.FeatureCollection = { type: "FeatureCollection", features: [] };
 const CACHE_TTL_MS = 30 * 60_000;
 
-let cachedData: FossilFuelLayers | null = null;
-let cachedAt = 0;
-let inflight: Promise<FossilFuelLayers> | null = null;
-
-function loadCached(): Promise<FossilFuelLayers> {
+// ── 加油站 cache（公開）──
+let gasCache: FossilFuelLayers | null = null;
+let gasCachedAt = 0;
+let gasInflight: Promise<FossilFuelLayers> | null = null;
+function loadGas(): Promise<FossilFuelLayers> {
   const now = Date.now();
-  if (cachedData && now - cachedAt < CACHE_TTL_MS) {
-    return Promise.resolve(cachedData);
-  }
-  if (inflight) return inflight;
-  inflight = fetchFossilFuelLayers()
-    .then((d) => {
-      cachedData = d;
-      cachedAt = Date.now();
-      inflight = null;
-      return d;
-    })
-    .catch((err) => {
-      inflight = null;
-      throw err;
-    });
-  return inflight;
+  if (gasCache && now - gasCachedAt < CACHE_TTL_MS) return Promise.resolve(gasCache);
+  if (gasInflight) return gasInflight;
+  gasInflight = fetchGasStationLayers()
+    .then((d) => { gasCache = d; gasCachedAt = Date.now(); gasInflight = null; return d; })
+    .catch((err) => { gasInflight = null; throw err; });
+  return gasInflight;
+}
+
+// ── 石化 cache（owner-gated）──
+let lockedCache: FossilFuelLayers | null = null;
+let lockedCachedAt = 0;
+let lockedInflight: Promise<FossilFuelLayers> | null = null;
+function loadLocked(): Promise<FossilFuelLayers> {
+  const now = Date.now();
+  if (lockedCache && now - lockedCachedAt < CACHE_TTL_MS) return Promise.resolve(lockedCache);
+  if (lockedInflight) return lockedInflight;
+  lockedInflight = fetchFossilFuelLockedLayers()
+    .then((d) => { lockedCache = d; lockedCachedAt = Date.now(); lockedInflight = null; return d; })
+    .catch((err) => { lockedInflight = null; throw err; });
+  return lockedInflight;
 }
 
 export interface UseFossilFuelLayersOpts {
@@ -69,48 +75,54 @@ export interface UseFossilFuelLayersOpts {
 }
 
 export function useFossilFuelLayers({ mapRef, visibility }: UseFossilFuelLayersOpts) {
-  const dataRef = useRef<FossilFuelLayers | null>(null);
-  const keys = Object.values(FOSSIL_LAYER_MAP) as FossilLayerKey[];
+  const gasDataRef = useRef<FossilFuelLayers | null>(null);
+  const lockedDataRef = useRef<FossilFuelLayers | null>(null);
 
-  // 把目前 data 餵進對應 source（visible 的）
-  const feedAll = useCallback(() => {
+  const feed = useCallback((keys: readonly FossilLayerKey[], data: FossilFuelLayers | null) => {
     const map = mapRef.current;
     if (!map) return;
-    const d = dataRef.current;
     for (const k of keys) {
       const src = map.getSource(SRC_ID[k]) as GeoJSONSource | undefined;
       if (!src) continue;
-      src.setData(d ? d[k] : EMPTY_FC);
+      src.setData(data ? data[k] : EMPTY_FC);
     }
-  }, [mapRef, keys]);
+  }, [mapRef]);
 
-  // 任一 visible 才 fetch
-  const anyVisible = keys.some((k) => visibility[k]);
+  const feedAll = useCallback(() => {
+    feed(GAS_STATION_FE_KEYS, gasDataRef.current);
+    feed(FOSSIL_LOCKED_FE_KEYS, lockedDataRef.current);
+  }, [feed]);
 
+  const anyGasVisible = GAS_STATION_FE_KEYS.some((k) => visibility[k]);
+  const anyLockedVisible = FOSSIL_LOCKED_FE_KEYS.some((k) => visibility[k]);
+
+  // 加油站：任一 visible 才拉（公開）
   useEffect(() => {
-    if (!anyVisible) return;
+    if (!anyGasVisible) return;
     let cancelled = false;
-    loadCached()
-      .then((d) => {
-        if (cancelled) return;
-        dataRef.current = d;
-        feedAll();
-      })
-      .catch((err) => console.warn("[FossilFuel] load failed:", err));
-    return () => {
-      cancelled = true;
-    };
-  }, [anyVisible, feedAll]);
+    loadGas()
+      .then((d) => { if (cancelled) return; gasDataRef.current = d; feed(GAS_STATION_FE_KEYS, d); })
+      .catch((err) => console.warn("[FossilFuel] gas load failed:", err));
+    return () => { cancelled = true; };
+  }, [anyGasVisible, feed]);
+
+  // 石化：任一 visible 才拉（owner-gated）
+  useEffect(() => {
+    if (!anyLockedVisible) return;
+    let cancelled = false;
+    loadLocked()
+      .then((d) => { if (cancelled) return; lockedDataRef.current = d; feed(FOSSIL_LOCKED_FE_KEYS, d); })
+      .catch((err) => { if (!isAccessDenied(err)) console.warn("[FossilFuel] locked load failed:", err); });
+    return () => { cancelled = true; };
+  }, [anyLockedVisible, feed]);
 
   // map style.load 後重新餵
   useEffect(() => {
     const map = mapRef.current;
-    if (!map || !anyVisible) return;
+    if (!map || (!anyGasVisible && !anyLockedVisible)) return;
     const onStyleLoad = () => feedAll();
     map.on("style.load", onStyleLoad);
     feedAll();
-    return () => {
-      map.off("style.load", onStyleLoad);
-    };
-  }, [mapRef, anyVisible, feedAll]);
+    return () => { map.off("style.load", onStyleLoad); };
+  }, [mapRef, anyGasVisible, anyLockedVisible, feedAll]);
 }

--- a/src/hooks/useLivestockLayers.ts
+++ b/src/hooks/useLivestockLayers.ts
@@ -1,0 +1,131 @@
+import { useCallback, useEffect, useRef } from "react";
+import type { Map as MapboxMap, GeoJSONSource } from "mapbox-gl";
+import type { LayerVisibility } from "../types";
+import { fetchLivestockFarms, fetchLivestockSlaughterhouses } from "../data/livestockLoader";
+import { isAccessDenied } from "../lib/layerGates";
+
+/**
+ * 畜牧 owner-only 動態圖層資料供應 hook（見 docs/features/owner-gated-layers）。
+ *
+ * overlayRegistry 已把 7 個飼養場 layer（共用 sourceId "livestock-farms"）+ 屠宰場
+ * （"livestock-slaughter"）改為 dynamicData（空 FC 起手）；本 hook 只負責 fetch + setData。
+ * 樣式 / filter / popup / legend 全在 overlayRegistry / featureInfo 既有路徑，維持不變。
+ *
+ * 設計比照 useFossilFuelLayers：
+ * - 任一飼養場 layer visible 才拉 farms；livestockSlaughter visible 才拉屠宰場
+ * - module-level cache 30 min（重新 toggle on 不重打）
+ * - map style.load 後重新餵（切底圖 source 會被重建為空 FC）
+ * - 非 owner：這些 key 的 toggle 被 App 端 gate no-op → visibility 恆 false → 不觸發 fetch
+ */
+
+const SRC_FARMS = "livestock-farms";
+const SRC_SLAUGHTER = "livestock-slaughter";
+const EMPTY_FC: GeoJSON.FeatureCollection = { type: "FeatureCollection", features: [] };
+const CACHE_TTL_MS = 30 * 60_000;
+
+const FARM_KEYS: (keyof LayerVisibility)[] = [
+  "livestockFarmPig", "livestockFarmChicken", "livestockFarmCattle", "livestockFarmDuck",
+  "livestockFarmGoose", "livestockFarmSheep", "livestockFarmOther",
+];
+
+// ── module-level cache（fossilFuel 同款）──
+let farmsCache: GeoJSON.FeatureCollection | null = null;
+let farmsCachedAt = 0;
+let farmsInflight: Promise<GeoJSON.FeatureCollection> | null = null;
+let slaughterCache: GeoJSON.FeatureCollection | null = null;
+let slaughterCachedAt = 0;
+let slaughterInflight: Promise<GeoJSON.FeatureCollection> | null = null;
+
+function loadCached(
+  getCache: () => GeoJSON.FeatureCollection | null,
+  getAt: () => number,
+  getInflight: () => Promise<GeoJSON.FeatureCollection> | null,
+  setCache: (d: GeoJSON.FeatureCollection) => void,
+  setInflight: (p: Promise<GeoJSON.FeatureCollection> | null) => void,
+  fetcher: () => Promise<GeoJSON.FeatureCollection>,
+): Promise<GeoJSON.FeatureCollection> {
+  const now = Date.now();
+  const cached = getCache();
+  if (cached && now - getAt() < CACHE_TTL_MS) return Promise.resolve(cached);
+  const inflight = getInflight();
+  if (inflight) return inflight;
+  const p = fetcher()
+    .then((d) => {
+      setCache(d);
+      setInflight(null);
+      return d;
+    })
+    .catch((err) => {
+      setInflight(null);
+      throw err;
+    });
+  setInflight(p);
+  return p;
+}
+
+const loadFarms = () =>
+  loadCached(
+    () => farmsCache, () => farmsCachedAt, () => farmsInflight,
+    (d) => { farmsCache = d; farmsCachedAt = Date.now(); },
+    (p) => { farmsInflight = p; },
+    fetchLivestockFarms,
+  );
+const loadSlaughter = () =>
+  loadCached(
+    () => slaughterCache, () => slaughterCachedAt, () => slaughterInflight,
+    (d) => { slaughterCache = d; slaughterCachedAt = Date.now(); },
+    (p) => { slaughterInflight = p; },
+    fetchLivestockSlaughterhouses,
+  );
+
+export interface UseLivestockLayersOpts {
+  mapRef: React.RefObject<MapboxMap | null>;
+  visibility: LayerVisibility;
+}
+
+export function useLivestockLayers({ mapRef, visibility }: UseLivestockLayersOpts) {
+  const farmsDataRef = useRef<GeoJSON.FeatureCollection | null>(null);
+  const slaughterDataRef = useRef<GeoJSON.FeatureCollection | null>(null);
+
+  const anyFarmVisible = FARM_KEYS.some((k) => visibility[k]);
+  const slaughterVisible = visibility.livestockSlaughter;
+
+  const feedAll = useCallback(() => {
+    const map = mapRef.current;
+    if (!map) return;
+    const farmsSrc = map.getSource(SRC_FARMS) as GeoJSONSource | undefined;
+    if (farmsSrc) farmsSrc.setData(farmsDataRef.current ?? EMPTY_FC);
+    const slaughterSrc = map.getSource(SRC_SLAUGHTER) as GeoJSONSource | undefined;
+    if (slaughterSrc) slaughterSrc.setData(slaughterDataRef.current ?? EMPTY_FC);
+  }, [mapRef]);
+
+  // farms：任一飼養場 layer visible 才拉
+  useEffect(() => {
+    if (!anyFarmVisible) return;
+    let cancelled = false;
+    loadFarms()
+      .then((d) => { if (cancelled) return; farmsDataRef.current = d; feedAll(); })
+      .catch((err) => { if (!isAccessDenied(err)) console.warn("[Livestock] farms load failed:", err); });
+    return () => { cancelled = true; };
+  }, [anyFarmVisible, feedAll]);
+
+  // slaughterhouses：livestockSlaughter visible 才拉
+  useEffect(() => {
+    if (!slaughterVisible) return;
+    let cancelled = false;
+    loadSlaughter()
+      .then((d) => { if (cancelled) return; slaughterDataRef.current = d; feedAll(); })
+      .catch((err) => { if (!isAccessDenied(err)) console.warn("[Livestock] slaughter load failed:", err); });
+    return () => { cancelled = true; };
+  }, [slaughterVisible, feedAll]);
+
+  // map style.load 後重新餵（切底圖 source 被重建為空 FC）
+  useEffect(() => {
+    const map = mapRef.current;
+    if (!map || (!anyFarmVisible && !slaughterVisible)) return;
+    const onStyleLoad = () => feedAll();
+    map.on("style.load", onStyleLoad);
+    feedAll();
+    return () => { map.off("style.load", onStyleLoad); };
+  }, [mapRef, anyFarmVisible, slaughterVisible, feedAll]);
+}

--- a/src/lib/adminApi.ts
+++ b/src/lib/adminApi.ts
@@ -1,0 +1,79 @@
+import { supabase } from "./supabase";
+
+/**
+ * Owner-only 治理後台 RPC 薄封裝（Phase 2，migration 276）。
+ * 全部 SECURITY DEFINER + owner 守門；非 owner 呼叫回 403 / 42501。
+ * 前端入口已 owner-only（AdminPanel 僅 isOwner 渲染），這裡不再重複守門。
+ */
+
+export type Tier = "free" | "member" | "insider" | "owner";
+export const TIERS: Tier[] = ["free", "member", "insider", "owner"];
+
+export interface AdminMember {
+  id: string;
+  email: string | null;
+  display_name: string | null;
+  tier: string;
+  created_at: string;
+  last_sign_in_at: string | null;
+}
+
+export interface AuditRow {
+  id: number;
+  occurred_at: string;
+  user_id: string | null;
+  email: string | null;
+  rpc_name: string;
+  user_tier: string | null;
+  required_tier: string | null;
+  granted: boolean;
+}
+
+export interface GatedLayerRow {
+  layer_key: string;
+  category: string;
+  label: string;
+  rpc_name: string | null;
+  required_tier: string;
+  enabled: boolean;
+  sort_order: number | null;
+  source_date: string | null;
+  next_refresh: string | null;
+  is_stale: boolean | null;
+  refresh_cadence: string | null;
+  row_count: number | null;
+}
+
+function unwrap<T>(data: unknown, error: { message: string } | null, ctx: string): T {
+  if (error) throw new Error(`${ctx}: ${error.message}`);
+  return (data ?? []) as T;
+}
+
+export async function listMembers(): Promise<AdminMember[]> {
+  const { data, error } = await supabase.rpc("admin_list_members");
+  return unwrap<AdminMember[]>(data, error, "admin_list_members");
+}
+
+export async function setMemberTier(target: string, tier: Tier): Promise<void> {
+  const { error } = await supabase.rpc("admin_set_member_tier", { p_target: target, p_tier: tier });
+  if (error) throw new Error(`admin_set_member_tier: ${error.message}`);
+}
+
+export async function listAudit(limit = 200, onlyDenied = false): Promise<AuditRow[]> {
+  const { data, error } = await supabase.rpc("admin_list_audit", { p_limit: limit, p_only_denied: onlyDenied });
+  return unwrap<AuditRow[]>(data, error, "admin_list_audit");
+}
+
+export async function listGatedLayers(): Promise<GatedLayerRow[]> {
+  const { data, error } = await supabase.rpc("admin_list_gated_layers");
+  return unwrap<GatedLayerRow[]>(data, error, "admin_list_gated_layers");
+}
+
+export async function setLayerGate(layerKey: string, requiredTier: Tier, enabled: boolean): Promise<void> {
+  const { error } = await supabase.rpc("admin_set_layer_gate", {
+    p_layer_key: layerKey,
+    p_required_tier: requiredTier,
+    p_enabled: enabled,
+  });
+  if (error) throw new Error(`admin_set_layer_gate: ${error.message}`);
+}

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -55,3 +55,47 @@ export function useUser(): { user: User | null; loading: boolean } {
 
   return { user, loading };
 }
+
+/**
+ * 會員分級閘門（owner-gated 私人圖層用）。
+ * 登入後 select profiles.tier where id = auth.uid()（migration 270 的 RLS 允許讀自己 row）。
+ * - tier 載入為非同步：載入完成前 isOwner=false（顯示鎖），完成後才可能解鎖。
+ * - 未登入：user=null / tier=null / isOwner=false。
+ * - tier 用於 Phase 2 分層 gating（free/member/insider/owner，見 lib/layerGates）；
+ *   isOwner 為 tier==='owner' 的捷徑（後台入口 + 舊鎖頭邏輯共用）。
+ */
+export function useMemberGate(): { user: User | null; tier: string | null; isOwner: boolean; loading: boolean } {
+  const { user, loading: userLoading } = useUser();
+  const [tier, setTier] = useState<string | null>(null);
+  const [tierLoading, setTierLoading] = useState(false);
+
+  useEffect(() => {
+    if (!user) {
+      setTier(null);
+      setTierLoading(false);
+      return;
+    }
+    let mounted = true;
+    setTierLoading(true);
+    void supabase
+      .from("profiles")
+      .select("tier")
+      .eq("id", user.id)
+      .maybeSingle()
+      .then(({ data }) => {
+        if (!mounted) return;
+        setTier((data?.tier as string | undefined) ?? null);
+        setTierLoading(false);
+      });
+    return () => {
+      mounted = false;
+    };
+  }, [user]);
+
+  return {
+    user,
+    tier,
+    isOwner: tier === "owner",
+    loading: userLoading || tierLoading,
+  };
+}

--- a/src/lib/layerGates.ts
+++ b/src/lib/layerGates.ts
@@ -1,0 +1,99 @@
+import { useSyncExternalStore } from "react";
+import { supabase } from "./supabase";
+import { GATED_LAYERS } from "../components/sidebar/layerCatalog";
+import type { LayerVisibility } from "../types";
+
+/**
+ * 動態圖層鎖定（Phase 2 治理系統，見 docs/features/owner-gated-layers）。
+ *
+ * 公開 RPC `get_layer_gates()`（anon 可呼叫，只回 keys 不含地理資料）提供
+ * 「哪些 layer 被鎖 + 需要什麼 tier」的權威清單，取代 Phase 1 寫死的 GATED_LAYERS Set。
+ *
+ * fail-safe：RPC 失敗 / 尚未回來時 gatesCache=null → 一律 fallback 回靜態 GATED_LAYERS
+ * （保持鎖定，絕不因 RPC 失敗而解鎖）。
+ */
+
+// ── tier 有序 4 級（free 0 < member 1 < insider 2 < owner 3）──
+const TIER_RANK: Record<string, number> = { free: 0, member: 1, insider: 2, owner: 3 };
+
+export function tierRank(tier: string | null | undefined): number {
+  return TIER_RANK[tier ?? "free"] ?? 0;
+}
+
+export interface LayerGate {
+  required_tier: string;
+  enabled: boolean;
+}
+export type LayerGates = ReadonlyMap<string, LayerGate>;
+
+// ── module-level cache（null = 尚未成功載入 → 用靜態 fallback）──
+let gatesCache: LayerGates | null = null;
+let inflight = false;
+const listeners = new Set<() => void>();
+
+function emit(): void {
+  for (const l of listeners) l();
+}
+
+/**
+ * 拉一次 get_layer_gates() 存進 module cache。
+ * 併發保護：同時只有一個 in-flight；可重複呼叫（admin panel 改動後 refetch）。
+ * 失敗時不動既有 cache（維持既有鎖定，fail-safe）。
+ */
+export async function loadLayerGates(): Promise<void> {
+  if (inflight) return;
+  inflight = true;
+  try {
+    const { data, error } = await supabase.rpc("get_layer_gates");
+    if (error) throw error;
+    const next = new Map<string, LayerGate>();
+    for (const row of (data ?? []) as Array<{ layer_key: string; required_tier: string; enabled: boolean }>) {
+      next.set(row.layer_key, { required_tier: row.required_tier, enabled: row.enabled });
+    }
+    gatesCache = next;
+    emit();
+  } catch (err) {
+    if (import.meta.env.DEV) console.warn("[layerGates] load failed → fallback to static GATED_LAYERS", err);
+  } finally {
+    inflight = false;
+  }
+}
+
+/** React 訂閱：gates 載入 / refetch 後自動 re-render。null = 尚未載入（fallback 態）。 */
+export function useLayerGates(): LayerGates | null {
+  return useSyncExternalStore(
+    (cb) => {
+      listeners.add(cb);
+      return () => listeners.delete(cb);
+    },
+    () => gatesCache,
+    () => gatesCache,
+  );
+}
+
+/**
+ * 某 key 對某 tier 是否上鎖（純函式）。
+ * - gates 已載入 → 權威來源（get_layer_gates 只回 enabled 的鎖定層）：
+ *   不在清單 = 公開；在清單 = 需 tierRank(tier) >= tierRank(required_tier) 才解鎖。
+ * - gates=null（未載入 / 失敗）→ fail-safe 用靜態 GATED_LAYERS，需 owner 才解鎖。
+ */
+export function isLayerLocked(
+  key: keyof LayerVisibility,
+  tier: string | null | undefined,
+  gates: LayerGates | null,
+): boolean {
+  const userRank = tierRank(tier);
+  if (gates) {
+    const gate = gates.get(key);
+    if (!gate) return false;
+    return userRank < tierRank(gate.required_tier);
+  }
+  return GATED_LAYERS.has(key) && userRank < tierRank("owner");
+}
+
+/** 後端鎖定 RPC 對非授權者回 403 / code 42501 —— 視為「無權限」靜默處理（不噴 error / 不重試）。 */
+export function isAccessDenied(err: unknown): boolean {
+  const code = (err as { code?: string } | null)?.code;
+  const msg = err instanceof Error ? err.message : String(err ?? "");
+  return code === "42501" || /42501|access denied|permission denied/i.test(msg);
+}

--- a/src/map/overlayRegistry.ts
+++ b/src/map/overlayRegistry.ts
@@ -79,6 +79,9 @@ function livestockFarmOverlay(
     id,
     sourceUrl: FARM_SOURCE,
     sourceId: "livestock-farms",
+    // owner-only 動態：改由 useLivestockLayers 從 owner-only RPC setData（見 docs/features/owner-gated-layers）；
+    // sourceUrl 保留作 loader 端 fallback（本層已改走 RPC，實務不再 fetch 該檔）。
+    dynamicData: true,
     filter,
     layers: [
       {
@@ -2711,6 +2714,8 @@ export const OVERLAY_REGISTRY: OverlayConfig[] = [
     id: "livestockSlaughter",
     sourceUrl: "./agriculture/slaughterhouses.geojson",
     sourceId: "livestock-slaughter",
+    // owner-only 動態：改由 useLivestockLayers 從 owner-only RPC setData
+    dynamicData: true,
     layers: [
       {
         suffix: "circle",


### PR DESCRIPTION
## Summary
- 把敏感圖層（畜牧/石化油氣/電網/電廠）鎖成「只有 owner 帳號可看」，並加一套站內 owner-only 治理後台。搭配 gis-platform migration 275/276/277（已上線 DB）。

## Changes
**鎖定 / gating**
- `layerGates.ts` 動態 gating + `GATED_LAYERS` fail-safe；單色 Lock 鎖頭 UI（桌機 IconRailSidebar + 手機 LayerSidebar）
- 非 owner 擋 toggle / bulk / chat-bridge 各入口
- `fossilFuelLoader` 拆兩路：加油站走公開 `get_gas_station_layers`、石化走 owner-only `get_fossil_fuel_layers`
- `energyLoader` 11 支 RPC 改直連 owner-only；畜牧改 owner-only RPC 動態載入（`livestockLoader` + `useLivestockLayers`）

**治理後台**（`components/admin/`，頭像選單入口，僅 owner 渲染）
- 會員/tier 管理、存取稽核、圖層鎖定清單、資料新鮮度四分頁（`adminApi.ts`）
- `useMemberGate()` 擴充回傳 tier

**斷源**
- deploy 腳本：12 檔 static-rpc 快照排除 + livestock geojson 移除 + `rm -f` 防殘留（S3 檔案不刪、只斷 prod 供應）

## Test
- [x] `npx tsc -b` 綠（隔離 worktree 純 owner 驗證）
- [x] `pnpm test` 190/190
- [x] anon 直打鎖定 RPC/表 → 401；owner 模擬 → 回資料；service_role → 403
- [ ] Browser 驗收（owner 登入看圖層 + 後台）— 需登入帳號，留給 reviewer

## Risk / Rollback
- 部署順序：DB migration 已先上；此前端要 **後** 部署。部署後記得 Cloudflare purge 快取
- 回滾：revert 本 PR 前端可恢復（DB 端仍鎖，圖層會對所有人 403，需一併回滾 gis-platform migration）

## Related
- DB: gis-platform PR #28（migration 275/276/277）
- Feature: docs/features/owner-gated-layers/