### PR TITLE
feat: 環境污染圖層群組（設施/裁處/場址）

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ public/geo/active_faults.geojson
 # upload / pull 腳本都以 glob 動態處理，不需要逐檔維護名單
 public/geo/water_*.geojson
 public/geo/water_*.pmtiles
+public/geo/pollution_*.pmtiles
 
 # 大型公車路線 JSON（由 S3 deploy-assets 管理；小檔案仍進 git）
 public/bus/taipei_bus_routes.json

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -70,6 +70,7 @@ import { useFossilFuelLayers } from "./hooks/useFossilFuelLayers";
 import { useA1AccidentRealtimeLayer } from "./hooks/useA1AccidentRealtimeLayer";
 import { useOsmPowerLinesGlowLayer } from "./hooks/useOsmPowerLinesGlowLayer";
 import { usePowerPolesLayer } from "./hooks/usePowerPolesLayer";
+import { usePollutionLayers } from "./hooks/usePollutionLayers";
 import { useAviationAirspaceLayer } from "./hooks/useAviationAirspaceLayer";
 import { useDroneZonesLayer } from "./hooks/useDroneRestrictedZonesLayer";
 import { useSubstationDiamondIcon } from "./hooks/useSubstationDiamondIcon";
@@ -884,6 +885,25 @@ export default function App() {
     layerVisibility.droneRestrictedZone,
     transportParams.overlayParams.droneNfzOpacity ?? 0.45,
     transportParams.overlayParams.droneRestrictedOpacity ?? 0.45,
+  );
+  // 環境污染三層 filter（介質 / 嚴重度 / 年份時間軸 / 列管中）— paint 走 overlayManager
+  usePollutionLayers(
+    mapRef,
+    {
+      pollutionFacility: layerVisibility.pollutionFacility,
+      pollutionPenaltyCritical: layerVisibility.pollutionPenaltyCritical,
+      pollutionPenaltyGeneral: layerVisibility.pollutionPenaltyGeneral,
+      pollutionPenaltyMobile: layerVisibility.pollutionPenaltyMobile,
+      pollutionSite: layerVisibility.pollutionSite,
+    },
+    {
+      facilityMedia: transportParams.pollutionFacilityMedia,
+      facilityMinSev: transportParams.pollutionFacilityMinSev,
+      penaltyMediumIdx: transportParams.pollutionPenaltyMediumIdx,
+      penaltyYear: transportParams.pollutionPenaltyYear,
+      penaltyMode: transportParams.pollutionPenaltyMode,
+      siteActiveOnly: transportParams.pollutionSiteActiveOnly,
+    },
   );
   usePowerRegionBarsLayer(
     mapRef,

--- a/src/components/IconRailSidebar.tsx
+++ b/src/components/IconRailSidebar.tsx
@@ -27,6 +27,8 @@ import {
   // POLICE / JUSTICE / CIVIL DEFENSE icons（新增；既有 Shield/Search/MapPinned/PlaneTakeoff/Anchor/AlertTriangle/AlertCircle 已 import 復用）
   ShieldAlert, Gavel, Scale, Lock, Hexagon, Crosshair,
   Ban,
+  // 環境污染 icons
+  Biohazard,
   type LucideIcon,
 } from "lucide-react";
 import type {
@@ -308,6 +310,12 @@ const LAYER_ICONS: Record<keyof LayerVisibility, LucideIcon> = {
   policeIsoSubstation: Hexagon,
   policeIsoPrecinct: Hexagon,
   policeIsoCityDept: Hexagon,
+  // 環境污染
+  pollutionFacility: Factory,
+  pollutionPenaltyCritical: AlertTriangle,
+  pollutionPenaltyGeneral: AlertCircle,
+  pollutionPenaltyMobile: Car,
+  pollutionSite: Biohazard,
 };
 
 // ── IATA Map for Locations Panel ──

--- a/src/components/LegendPanel.tsx
+++ b/src/components/LegendPanel.tsx
@@ -42,6 +42,11 @@ import {
   NUCLEAR_LEVEL_COLORS,
   type NuclearDoseLevel,
 } from "../data/nuclearLoader";
+import {
+  SEVERITY_BANDS, POLLUTION_MEDIUM_COLORS, POLLUTION_MEDIUM_LABELS,
+  PENALTY_MEDIA, PENALTY_SEVERITY_COLORS, PENALTY_SEVERITY_LABELS,
+  type PollutionMedium, type PollutionPenaltySeverity,
+} from "../data/pollutionTypes";
 
 /**
  * 右下角圖例面板 — 只顯示目前開啟的圖層對應圖例
@@ -207,6 +212,12 @@ export const LEGEND_REGISTRY: LegendEntry[] = [
     ],
     render: ({ visibility }) => <PoliceJusticeLegend visibility={visibility} />,
   },
+  // 環境污染 3 層
+  { keys: ["pollutionFacility", "pollutionSite"], render: ({ visibility }) => <PollutionSeverityLegend visibility={visibility} /> },
+  {
+    keys: ["pollutionPenaltyCritical", "pollutionPenaltyGeneral", "pollutionPenaltyMobile"],
+    render: ({ visibility }) => <PollutionPenaltyLegend visibility={visibility} />,
+  },
 ];
 
 export function LegendPanel({ visibility, overlayParams }: LegendPanelProps) {
@@ -263,6 +274,56 @@ export function LegendPanel({ visibility, overlayParams }: LegendPanelProps) {
           ))}
         </div>
       )}
+    </div>
+  );
+}
+
+// ── 環境污染：嚴重度（設施 + 場址共用）──
+function PollutionSeverityLegend({ visibility }: { visibility: LayerVisibility }) {
+  const bands = visibility.pollutionSite && !visibility.pollutionFacility
+    ? SEVERITY_BANDS.filter((b) => b.sev === 4)
+    : SEVERITY_BANDS;
+  return (
+    <div>
+      <div style={{ fontSize: FONT_SIZE.xs, color: COLORS.textDim, letterSpacing: 1, marginBottom: 4 }}>
+        污染嚴重度 SEVERITY
+      </div>
+      <FireCatRows cats={bands.map((b) => ({ color: b.color, label: b.label }))} />
+      <div style={{ fontSize: FONT_SIZE.xs, color: COLORS.textDim, marginTop: 4, lineHeight: 1.3 }}>
+        列管 ≠ 污染｜設施色 = 最高嚴重度
+      </div>
+    </div>
+  );
+}
+
+// ── 環境污染：裁處事件介質 ──
+function PollutionPenaltyLegend({ visibility }: { visibility: LayerVisibility }) {
+  const severityKeys: PollutionPenaltySeverity[] = [
+    ...(visibility.pollutionPenaltyCritical ? ["critical" as const] : []),
+    ...(visibility.pollutionPenaltyGeneral ? (["high", "normal"] as const) : []),
+    ...(visibility.pollutionPenaltyMobile ? ["mobile" as const] : []),
+  ];
+  const severityCats = severityKeys.map((k) => ({
+    color: PENALTY_SEVERITY_COLORS[k],
+    label: PENALTY_SEVERITY_LABELS[k],
+  }));
+  const mediumCats = PENALTY_MEDIA.map((m: PollutionMedium) => ({
+    color: POLLUTION_MEDIUM_COLORS[m],
+    label: POLLUTION_MEDIUM_LABELS[m],
+  }));
+  return (
+    <div>
+      <div style={{ fontSize: FONT_SIZE.xs, color: COLORS.textDim, letterSpacing: 1, marginBottom: 4 }}>
+        裁處分層 PENALTY
+      </div>
+      <FireCatRows cats={severityCats} />
+      <div style={{ fontSize: FONT_SIZE.xs, color: COLORS.textDim, letterSpacing: 1, marginTop: 8, marginBottom: 4 }}>
+        介質 MEDIUM
+      </div>
+      <FireCatRows cats={mediumCats} />
+      <div style={{ fontSize: FONT_SIZE.xs, color: COLORS.textDim, marginTop: 4, lineHeight: 1.3 }}>
+        重大點大小 ∝ 罰鍰｜白框 = 連續 / 停工等｜可年份播放
+      </div>
     </div>
   );
 }

--- a/src/components/featureInfo/pollutionPanels.tsx
+++ b/src/components/featureInfo/pollutionPanels.tsx
@@ -1,0 +1,118 @@
+// 環境污染 popup panels（設施 / 裁處事件 / 場址）。
+// 語意紅線：EMS_S_01 列管 ≠ 污染源 → 標題與敘述皆用「污染潛勢設施」。
+import type { PanelProps } from "./registry";
+import { Row, Badge } from "./shared";
+import {
+  FACILITY_MEDIA, POLLUTION_MEDIUM_LABELS, POLLUTION_MEDIUM_COLORS,
+  SEVERITY_BANDS, PENALTY_SEVERITY_LABELS, PENALTY_SEVERITY_COLORS,
+  type PollutionMedium, type PollutionPenaltySeverity,
+} from "../../data/pollutionTypes";
+
+function sevLabel(sev: number): string {
+  const b = SEVERITY_BANDS.find((x) => x.sev === sev);
+  return b ? b.label : `S${sev}`;
+}
+
+const PRECISION_LABELS: Record<string, string> = {
+  facility_join: "設施座標（ems_no join）",
+  address_exact: "地址精確定位",
+  address_osm: "地址（OSM）",
+  parcel: "地號補點",
+  approx: "約略位置（內插）",
+  unknown: "未知",
+};
+
+export function PollutionFacilityPanel({ props }: PanelProps) {
+  const maxSev = Number(props.max_sev ?? 0);
+  return (
+    <div>
+      <Row label="名稱" value={String(props.name ?? "")} />
+      <Row label="縣市" value={String(props.county ?? "")} />
+      <Row label="行業" value={String(props.industry_macro ?? "")} />
+      <Row label="最高嚴重度" value={sevLabel(maxSev)} color={SEVERITY_BANDS.find((b) => b.sev === maxSev)?.color} />
+      <div style={{ display: "flex", flexWrap: "wrap", gap: 4, marginTop: 6 }}>
+        {FACILITY_MEDIA.map((m: PollutionMedium) => {
+          const raw = props[`sev_${m}`];
+          if (raw == null) return null;
+          const sev = Number(raw);
+          return (
+            <Badge key={m} label={`${POLLUTION_MEDIUM_LABELS[m]} S${sev}`} on={sev > 0} color={POLLUTION_MEDIUM_COLORS[m]} />
+          );
+        })}
+      </div>
+      <div style={{ marginTop: 8, fontSize: 11, color: "#94a3b8", lineHeight: 1.4 }}>
+        「環保列管對象」× 裁處紀錄推得之污染潛勢；列管 ≠ 污染。
+      </div>
+    </div>
+  );
+}
+
+export function PollutionPenaltyPanel({ props }: PanelProps) {
+  const medium = String(props.event_medium ?? "other") as PollutionMedium;
+  const severity = String(props.severity_event ?? "normal") as PollutionPenaltySeverity;
+  const money = Number(props.penalty_money ?? 0);
+  const illegalMoney = Number(props.illegal_money ?? 0);
+  const reason = String(props.severity_reason ?? "")
+    .split(",")
+    .filter(Boolean)
+    .map((r) => ({
+      money_100k: "罰鍰 >= 10 萬",
+      important: "重大案件",
+      continuous: "連續處罰",
+      stop_order: "停工 / 停業 / 勒令 / 廢止",
+      illegal_money: "不法利得",
+      money_30k_100k: "罰鍰 3-10 萬",
+      mobile: "移動污染",
+    }[r] ?? r))
+    .join("、");
+  return (
+    <div>
+      <Row label="受罰對象" value={String(props.fac_name ?? "")} />
+      <Row label="縣市" value={String(props.county ?? "")} />
+      <Row label="介質" value={POLLUTION_MEDIUM_LABELS[medium] ?? medium} color={POLLUTION_MEDIUM_COLORS[medium]} />
+      <Row label="分層" value={PENALTY_SEVERITY_LABELS[severity] ?? severity} color={PENALTY_SEVERITY_COLORS[severity]} />
+      {reason && <Row label="分層原因" value={reason} />}
+      <Row label="裁處類型" value={String(props.transgress_type ?? "")} />
+      <Row label="違反法規" value={String(props.transgress_law ?? "")} />
+      <Row label="違反事實" value={String(props.violation_fact ?? "")} />
+      <Row label="裁處日期" value={String(props.penalty_date ?? "")} />
+      <Row label="罰鍰" value={money > 0 ? `NT$ ${money.toLocaleString()}` : "—"} />
+      {illegalMoney > 0 && <Row label="不法利得" value={`NT$ ${illegalMoney.toLocaleString()}`} />}
+      {Number(props.is_continuous ?? 0) === 1 && (
+        <div style={{ marginTop: 6 }}>
+          <Badge label="連續處罰" on color="#dc2626" />
+        </div>
+      )}
+      {Number(props.is_stop_order ?? 0) === 1 && (
+        <div style={{ marginTop: 6 }}>
+          <Badge label="停工/勒令等" on color="#ef4444" />
+        </div>
+      )}
+      <Row label="改善狀態" value={String(props.is_improve ?? "")} />
+      <div style={{ marginTop: 8, fontSize: 11, color: "#94a3b8", lineHeight: 1.4 }}>
+        定位方式：{PRECISION_LABELS[String(props.geocode_precision ?? "unknown")] ?? String(props.geocode_precision ?? "")}
+      </div>
+    </div>
+  );
+}
+
+export function PollutionSitePanel({ props }: PanelProps) {
+  const active = Number(props.is_active ?? 0) === 1;
+  return (
+    <div>
+      <Row label="場址名稱" value={String(props.site_name ?? "")} />
+      <Row label="縣市" value={String(props.county ?? "")} />
+      <Row label="行政區" value={String(props.township ?? "")} />
+      <Row label="類型" value={String(props.site_type ?? "")} />
+      <Row label="控制類別" value={String(props.controltype ?? "")} />
+      <Row label="公告日期" value={String(props.anno_date ?? "")} />
+      <Row label="污染物" value={String(props.pollutant_short ?? "")} />
+      <div style={{ marginTop: 6 }}>
+        <Badge label={active ? "仍列管中" : "已解除列管"} on={active} color="#dc2626" />
+      </div>
+      <div style={{ marginTop: 8, fontSize: 11, color: "#94a3b8", lineHeight: 1.4 }}>
+        EMS_S_07 確認污染場址（嚴重度 S4）。
+      </div>
+    </div>
+  );
+}

--- a/src/components/featureInfo/registry.tsx
+++ b/src/components/featureInfo/registry.tsx
@@ -58,6 +58,7 @@ import {
   PoliceIsoSubstationPanel, PoliceIsoPrecinctPanel, PoliceIsoCityDeptPanel,
 } from "./policeJusticePanels";
 import { ChatHighlightPanel } from "./shared";
+import { PollutionFacilityPanel, PollutionPenaltyPanel, PollutionSitePanel } from "./pollutionPanels";
 
 export interface PanelProps {
   props: Record<string, unknown>;
@@ -202,6 +203,10 @@ export const PANEL_REGISTRY: Partial<Record<FeatureInfo["layerType"], FC<PanelPr
   policeIsoSubstation: PoliceIsoSubstationPanel,
   policeIsoPrecinct: PoliceIsoPrecinctPanel,
   policeIsoCityDept: PoliceIsoCityDeptPanel,
+  // 環境污染
+  pollutionFacility: PollutionFacilityPanel,
+  pollutionPenalty: PollutionPenaltyPanel,
+  pollutionSite: PollutionSitePanel,
   // AI 助手標記點
   chatHighlight: ChatHighlightPanel,
   // 🐷 畜牧
@@ -360,6 +365,10 @@ export const HEADER_LABELS: Record<FeatureInfo["layerType"], string> = {
   policeIsoSubstation: "派出所等時圈",
   policeIsoPrecinct: "分局等時圈",
   policeIsoCityDept: "縣市警局等時圈",
+  // 環境污染
+  pollutionFacility: "污染潛勢設施",
+  pollutionPenalty: "污染裁處事件",
+  pollutionSite: "污染場址",
   // AI 助手標記點
   chatHighlight: "地圖標記",
 };

--- a/src/components/sidebar/layerCatalog.ts
+++ b/src/components/sidebar/layerCatalog.ts
@@ -15,7 +15,7 @@
 //   缺 key 會 tsc 報錯 → 新增 layer 必補色。
 // - THEMES：新 SSOT；新增 layer 把 key 放進對應 theme.groups[].layers。
 // - 命名格式：`中文 English`（例：「水資源 Water」「國道 Highway」）。
-// - 預設全關（DEFAULT_ON = empty Set），開站乾淨。
+// - 預設開關由 useLayerVisibility 控制；動態 RPC 原則上預設關閉。
 //
 // 排序原則：
 // 1. BASE 頂置（不算主題、純底圖）
@@ -288,6 +288,12 @@ export const LAYER_COLORS: Record<keyof LayerVisibility, string> = {
   policeIsoSubstation: "#1e40af",
   policeIsoPrecinct: "#3b82f6",
   policeIsoCityDept: "#60a5fa",
+  // 環境污染 POLLUTION
+  pollutionFacility: "#f97316",
+  pollutionPenaltyCritical: "#ef4444",
+  pollutionPenaltyGeneral: "#94a3b8",
+  pollutionPenaltyMobile: "#22c55e",
+  pollutionSite: "#111827",
 };
 
 // ── Transport Labels ──
@@ -482,6 +488,16 @@ export const THEMES: ThemeDef[] = [
           { key: "aqiImagery", label: "空氣品質色階 AQI Raster", expandable: true },
           { key: "aqiStations", label: "空氣品質測站 AQI Station", expandable: true },
           { key: "aqiMicroSensors", label: "LASS 微型感測 Micro Sensor", expandable: true },
+        ],
+      },
+      {
+        title: "環境污染",
+        layers: [
+          { key: "pollutionFacility", label: "污染潛勢設施 Facility", labelMobile: "污染潛勢設施 Facility (152k)", expandable: true },
+          { key: "pollutionPenaltyCritical", label: "重大裁處 Critical Penalty", labelMobile: "重大裁處 Critical", expandable: true },
+          { key: "pollutionPenaltyGeneral", label: "一般裁處 General Penalty", labelMobile: "一般裁處 General", expandable: true },
+          { key: "pollutionPenaltyMobile", label: "移動污染 Mobile Penalty", labelMobile: "移動污染 Mobile", expandable: true },
+          { key: "pollutionSite", label: "污染場址 Site", labelMobile: "污染場址 Site (8,253)", expandable: true },
         ],
       },
     ],

--- a/src/data/pollutionTypes.ts
+++ b/src/data/pollutionTypes.ts
@@ -1,0 +1,115 @@
+// 環境污染主題共用常數（介質 / 嚴重度 / 年份）。
+// overlayRegistry / LegendPanel / featureInfo panels / useTransportParams 共用單一真實來源。
+//
+// 語意紅線（P0）：EMS_S_01 列管對象 ≠ 污染源。前端一律用：
+//   - 污染潛勢設施（regulated facility × 介質 × 嚴重度）
+//   - 污染裁處事件（P_46 開罰事件，分重大 / 一般 / 移動污染，可歷史時間軸播放）
+//   - 污染場址（EMS_S_07 確認污染場址 = S4）
+
+/** 介質 key（設施 5 介質；事件另有 noise / other） */
+export type PollutionMedium = "air" | "water" | "waste" | "toxic" | "soil" | "noise" | "other";
+export type PollutionPenaltySeverity = "critical" | "high" | "normal" | "mobile";
+
+/** 介質色（對應法規領域，與研究文件 schema-and-layers.md §1a 對齊） */
+export const POLLUTION_MEDIUM_COLORS: Record<PollutionMedium, string> = {
+  air: "#9ca3af",    // 灰 — 空氣污染防制法
+  water: "#3b82f6",  // 藍 — 水污染防治法
+  waste: "#a16207",  // 棕 — 廢棄物清理法
+  toxic: "#a855f7",  // 紫 — 毒性及關注化學物質管理法
+  soil: "#ca8a04",   // 土黃 — 土壤及地下水污染整治法
+  noise: "#f97316",  // 橘 — 噪音管制法（事件層專有）
+  other: "#64748b",  // 灰藍 — 其他自治條例
+};
+
+export const POLLUTION_MEDIUM_LABELS: Record<PollutionMedium, string> = {
+  air: "空污 Air",
+  water: "水污 Water",
+  waste: "廢棄物 Waste",
+  toxic: "毒化物 Toxic",
+  soil: "土污 Soil",
+  noise: "噪音 Noise",
+  other: "其他 Other",
+};
+
+/** 設施 filter checkbox 用的 5 介質（不含 noise/other，那是事件層的裁處法規類別） */
+export const FACILITY_MEDIA: PollutionMedium[] = ["air", "water", "waste", "toxic", "soil"];
+
+/** 裁處事件 medium select 選項（idx 0 = 全部；soil 來自土壤及地下水污染整治法裁處） */
+export const PENALTY_MEDIA: PollutionMedium[] = ["air", "water", "waste", "toxic", "soil", "noise", "other"];
+
+/** 嚴重度階梯（S0 潛勢 → S4 確認污染場址） */
+export interface SeverityBand {
+  sev: number;
+  color: string;
+  label: string;
+}
+
+export const SEVERITY_BANDS: SeverityBand[] = [
+  { sev: 0, color: "#fde68a", label: "S0 潛勢（登記未罰）" },
+  { sev: 1, color: "#fbbf24", label: "S1 曾違規（罰 ≥1）" },
+  { sev: 2, color: "#f97316", label: "S2 慣犯（罰 ≥3）" },
+  { sev: 3, color: "#dc2626", label: "S3 重大（連續 / 累計 ≥100 萬）" },
+  { sev: 4, color: "#111827", label: "S4 確認污染場址" },
+];
+
+/** Mapbox step expression：max_sev → 色（用於 facilities + sites 的 severity styling） */
+export const SEVERITY_COLOR_EXPR: unknown[] = [
+  "step", ["coalesce", ["to-number", ["get", "max_sev"]], 0],
+  SEVERITY_BANDS[0]!.color,
+  1, SEVERITY_BANDS[1]!.color,
+  2, SEVERITY_BANDS[2]!.color,
+  3, SEVERITY_BANDS[3]!.color,
+  4, SEVERITY_BANDS[4]!.color,
+];
+
+/** 裁處事件 event_medium → 色 */
+export const PENALTY_MEDIUM_COLOR_EXPR: unknown[] = [
+  "match", ["get", "event_medium"],
+  "air", POLLUTION_MEDIUM_COLORS.air,
+  "water", POLLUTION_MEDIUM_COLORS.water,
+  "waste", POLLUTION_MEDIUM_COLORS.waste,
+  "toxic", POLLUTION_MEDIUM_COLORS.toxic,
+  "soil", POLLUTION_MEDIUM_COLORS.soil,
+  "noise", POLLUTION_MEDIUM_COLORS.noise,
+  POLLUTION_MEDIUM_COLORS.other,
+];
+
+export const PENALTY_SEVERITY_LABELS: Record<PollutionPenaltySeverity, string> = {
+  critical: "重大裁處",
+  high: "高額一般裁處",
+  normal: "一般裁處",
+  mobile: "移動污染",
+};
+
+export const PENALTY_SEVERITY_COLORS: Record<PollutionPenaltySeverity, string> = {
+  critical: "#ef4444",
+  high: "#f59e0b",
+  normal: "#94a3b8",
+  mobile: "#22c55e",
+};
+
+export const PENALTY_CRITICAL_FILTER: unknown[] = ["==", ["get", "severity_event"], "critical"];
+export const PENALTY_GENERAL_FILTER: unknown[] = [
+  "any",
+  ["==", ["get", "severity_event"], "high"],
+  ["==", ["get", "severity_event"], "normal"],
+];
+export const PENALTY_MOBILE_FILTER: unknown[] = ["==", ["get", "severity_event"], "mobile"];
+
+/** 裁處事件年份範圍（來源 P_46 penalty_year 2010–2026） */
+export const PENALTY_YEAR_MIN = 2010;
+export const PENALTY_YEAR_MAX = 2026;
+
+export function pollutionYearOptions(): { label: string; value: string }[] {
+  const opts = [{ label: "全部年份 All", value: "0" }];
+  for (let y = PENALTY_YEAR_MIN; y <= PENALTY_YEAR_MAX; y++) {
+    opts.push({ label: String(y), value: String(y) });
+  }
+  return opts;
+}
+
+/** 播放模式：0 = 累積至該年、1 = 僅該年 */
+export const PENALTY_MODE_OPTIONS: { label: string; value: string }[] = [
+  { label: "累積 ≤ 該年", value: "0" },
+  { label: "僅該年", value: "1" },
+];

--- a/src/data/upstreamRegistry.ts
+++ b/src/data/upstreamRegistry.ts
@@ -1015,6 +1015,32 @@ export const UPSTREAM_REGISTRY: Record<keyof LayerVisibility, UpstreamRef> = {
   osmPowerPlantsStatic: { status: 'pulse_only', datasets: [], note: 'not in active THEMES (stale/unused color)' },
   islandPowerGrid: { status: 'pulse_only', datasets: [], note: 'not in active THEMES (stale/unused color)' },
   facOffshore: { status: 'pulse_only', datasets: [], note: 'not in active THEMES (stale/unused color)' },
+  // 環境污染（來源 taipei-gis-analytics environment/pollution_source；PMTiles）
+  pollutionFacility: {
+    status: 'verified',
+    datasets: [{ datasetId: 'pollution_source', confidence: 'HIGH' }],
+    processing: 'EMS_S_01 列管對象 × EMS_P_46 裁處 → 介質×嚴重度 PMTiles（列管≠污染）',
+  },
+  pollutionPenaltyCritical: {
+    status: 'verified',
+    datasets: [{ datasetId: 'pollution_source', confidence: 'HIGH' }],
+    processing: 'EMS_P_46 裁處事件 geocoded → severity_event=critical 重大裁處 PMTiles filter',
+  },
+  pollutionPenaltyGeneral: {
+    status: 'verified',
+    datasets: [{ datasetId: 'pollution_source', confidence: 'HIGH' }],
+    processing: 'EMS_P_46 裁處事件 geocoded → severity_event=high/normal 一般裁處 PMTiles filter',
+  },
+  pollutionPenaltyMobile: {
+    status: 'verified',
+    datasets: [{ datasetId: 'pollution_source', confidence: 'HIGH' }],
+    processing: 'EMS_P_46 裁處事件 geocoded → severity_event=mobile 移動污染 PMTiles filter',
+  },
+  pollutionSite: {
+    status: 'verified',
+    datasets: [{ datasetId: 'pollution_source', confidence: 'HIGH' }],
+    processing: 'EMS_S_07 確認污染場址（S4）PMTiles',
+  },
 };
 
 // ── Convenience helpers ──

--- a/src/hooks/useLayerVisibility.ts
+++ b/src/hooks/useLayerVisibility.ts
@@ -7,8 +7,7 @@ import { LAYER_COLORS } from "../components/sidebar/layerCatalog";
  * key 全集從 layerCatalog 的 LAYER_COLORS 派生（型別強制完整）—
  * 新增 layer 不用再改本檔，除非要預設開啟。
  */
-// 全部預設關閉：訪客一進站不打任何 RPC，手動開啟圖層才開始抓取/輪詢
-// （降低 Supabase 連線池壓力；poller 已依 enabled gating，關閉自動停止）
+// 全部預設關閉：訪客一進站不打任何 RPC；PMTiles 圖層也依使用者 toggle 才顯示。
 const DEFAULT_ON: ReadonlySet<keyof LayerVisibility> = new Set<keyof LayerVisibility>([]);
 
 function buildDefaults(): LayerVisibility {

--- a/src/hooks/useMapInteraction.ts
+++ b/src/hooks/useMapInteraction.ts
@@ -352,6 +352,17 @@ export function useMapInteraction(
           { layers: ["immigration-office-circle"], type: "immigrationOffice" },
           { layers: ["coast-guard-station-circle"], type: "coastGuardStation" },
           { layers: ["civil-defense-shelter-circle"], type: "civilDefenseShelter" },
+          // 環境污染（點層優先於大面積；三層皆 PMTiles circle）
+          { layers: ["pollution-site-circle"], type: "pollutionSite" },
+          {
+            layers: [
+              "pollution-penalty-critical-circle",
+              "pollution-penalty-general-circle",
+              "pollution-penalty-mobile-circle",
+            ],
+            type: "pollutionPenalty",
+          },
+          { layers: ["pollution-facility-circle"], type: "pollutionFacility" },
           { layers: ["aviation-control-fill", "aviation-control-line"], type: "aviationControl" },
           { layers: ["aviation-restricted-fill", "aviation-restricted-line"], type: "aviationRestricted" },
           { layers: ["drone-nfz-fill", "drone-nfz-line"], type: "droneNoFlyZone" },

--- a/src/hooks/usePollutionLayers.ts
+++ b/src/hooks/usePollutionLayers.ts
@@ -1,0 +1,137 @@
+import { useEffect } from "react";
+import type { Map as MapboxMap, FilterSpecification } from "mapbox-gl";
+import {
+  FACILITY_MEDIA,
+  PENALTY_MEDIA,
+  PENALTY_CRITICAL_FILTER,
+  PENALTY_GENERAL_FILTER,
+  PENALTY_MOBILE_FILTER,
+  type PollutionMedium,
+} from "../data/pollutionTypes";
+
+/**
+ * 環境污染三層的 filter 套用（介質 / 嚴重度 / 年份 / 模式 / 列管中）。
+ *
+ * paint（opacity / scale / 色）走 overlayRegistry + overlayManager 的 params 路徑；
+ * 這裡只負責「哪些 feature 要顯示」的 setFilter，比對 realEstate / 覆蓋分析 的分工。
+ *
+ * 設計要點：
+ * - 三層都是 PMTiles，Mapbox 會 lazy load tile；setFilter 是純表現層過濾，零重抓。
+ * - style.load 後 layer 會重建 → 監聽重新套用（比照 useRealEstateTimeline）。
+ * - 圖層關閉時不需套 filter（overlayManager 已設 visibility none）。
+ */
+
+const FACILITY_LAYER = "pollution-facility-circle";
+const PENALTY_CRITICAL_LAYER = "pollution-penalty-critical-circle";
+const PENALTY_GENERAL_LAYER = "pollution-penalty-general-circle";
+const PENALTY_MOBILE_LAYER = "pollution-penalty-mobile-circle";
+const SITE_LAYER = "pollution-site-circle";
+
+export interface PollutionFilterState {
+  facilityMedia: Record<PollutionMedium, boolean>;
+  facilityMinSev: number;
+  penaltyMediumIdx: number; // 0 = 全部；1.. = PENALTY_MEDIA[idx-1]
+  penaltyYear: number;      // 0 = 全部年份
+  penaltyMode: number;      // 0 = 累積 ≤ 該年、1 = 僅該年
+  siteActiveOnly: boolean;
+}
+
+function facilityFilter(media: Record<PollutionMedium, boolean>, minSev: number): unknown[] | null {
+  const clauses: unknown[] = [];
+  // 介質：勾選的介質中「至少登記一項」（sev_<m> 有值即代表登記該介質）
+  const selected = FACILITY_MEDIA.filter((m) => media[m]);
+  if (selected.length === 0) {
+    // 全不選 → 不顯示任何點
+    return ["==", ["literal", 1], ["literal", 0]];
+  }
+  if (selected.length < FACILITY_MEDIA.length) {
+    const any: unknown[] = ["any", ...selected.map((m) => ["has", `sev_${m}`])];
+    clauses.push(any);
+  }
+  if (minSev > 0) {
+    clauses.push([">=", ["coalesce", ["to-number", ["get", "max_sev"]], 0], minSev]);
+  }
+  if (clauses.length === 0) return null;
+  return ["all", ...clauses];
+}
+
+function penaltyFilter(mediumIdx: number, year: number, mode: number): unknown[] | null {
+  const clauses: unknown[] = [];
+  if (mediumIdx > 0) {
+    const m = PENALTY_MEDIA[mediumIdx - 1];
+    if (m) clauses.push(["==", ["get", "event_medium"], m]);
+  }
+  if (year > 0) {
+    const yExpr = ["coalesce", ["to-number", ["get", "penalty_year"]], 0];
+    // 模式 0 = 累積至該年（<=）；模式 1 = 僅該年（==）
+    clauses.push(mode === 1 ? ["==", yExpr, year] : ["<=", yExpr, year]);
+  }
+  if (clauses.length === 0) return null;
+  return ["all", ...clauses];
+}
+
+function combineFilters(base: unknown[], dynamic: unknown[] | null): unknown[] {
+  return dynamic ? ["all", base, dynamic] : base;
+}
+
+function siteFilter(activeOnly: boolean): unknown[] | null {
+  if (!activeOnly) return null;
+  return ["==", ["coalesce", ["to-number", ["get", "is_active"]], 0], 1];
+}
+
+export function usePollutionLayers(
+  mapRef: React.RefObject<MapboxMap | null>,
+  visibility: {
+    pollutionFacility: boolean;
+    pollutionPenaltyCritical: boolean;
+    pollutionPenaltyGeneral: boolean;
+    pollutionPenaltyMobile: boolean;
+    pollutionSite: boolean;
+  },
+  state: PollutionFilterState,
+) {
+  const {
+    facilityMedia, facilityMinSev,
+    penaltyMediumIdx, penaltyYear, penaltyMode,
+    siteActiveOnly,
+  } = state;
+
+  useEffect(() => {
+    const map = mapRef.current;
+    if (!map) return;
+
+    const apply = () => {
+      if (map.getLayer(FACILITY_LAYER)) {
+        map.setFilter(FACILITY_LAYER, facilityFilter(facilityMedia, facilityMinSev) as unknown as FilterSpecification);
+      }
+      const penaltyDynamicFilter = penaltyFilter(penaltyMediumIdx, penaltyYear, penaltyMode);
+      if (map.getLayer(PENALTY_CRITICAL_LAYER)) {
+        map.setFilter(PENALTY_CRITICAL_LAYER, combineFilters(PENALTY_CRITICAL_FILTER, penaltyDynamicFilter) as unknown as FilterSpecification);
+      }
+      if (map.getLayer(PENALTY_GENERAL_LAYER)) {
+        map.setFilter(PENALTY_GENERAL_LAYER, combineFilters(PENALTY_GENERAL_FILTER, penaltyDynamicFilter) as unknown as FilterSpecification);
+      }
+      if (map.getLayer(PENALTY_MOBILE_LAYER)) {
+        map.setFilter(PENALTY_MOBILE_LAYER, combineFilters(PENALTY_MOBILE_FILTER, penaltyDynamicFilter) as unknown as FilterSpecification);
+      }
+      if (map.getLayer(SITE_LAYER)) {
+        map.setFilter(SITE_LAYER, siteFilter(siteActiveOnly) as unknown as FilterSpecification);
+      }
+    };
+
+    apply();
+    map.on("style.load", apply);
+    return () => { map.off("style.load", apply); };
+  }, [
+    mapRef,
+    // 圖層開關變動 → layer 會被建立/顯示，需重套 filter
+    visibility.pollutionFacility,
+    visibility.pollutionPenaltyCritical,
+    visibility.pollutionPenaltyGeneral,
+    visibility.pollutionPenaltyMobile,
+    visibility.pollutionSite,
+    facilityMedia, facilityMinSev,
+    penaltyMediumIdx, penaltyYear, penaltyMode,
+    siteActiveOnly,
+  ]);
+}

--- a/src/hooks/useTransportParams.ts
+++ b/src/hooks/useTransportParams.ts
@@ -1,4 +1,4 @@
-import { useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import type { ExpandableLayerKey, BusCity, BusColorMode, BusGroup } from "../types";
 import { BUS_GROUP_CITIES, BUS_GROUP_LABELS, WASTE_GROUP_CITIES } from "../types";
 import { CROP_SUITABILITY_CROPS } from "../data/cropSuitabilityCrops";
@@ -8,6 +8,11 @@ import {
   SOIL_FERTILITY_METRIC_OPTIONS,
   type SoilFertilityMetric,
 } from "../data/agriSoilFertilityMetrics";
+import {
+  FACILITY_MEDIA, PENALTY_MEDIA, POLLUTION_MEDIUM_LABELS, SEVERITY_BANDS,
+  pollutionYearOptions, PENALTY_MODE_OPTIONS, PENALTY_YEAR_MIN, PENALTY_YEAR_MAX,
+  type PollutionMedium,
+} from "../data/pollutionTypes";
 
 export interface SliderConfig {
   type?: "slider";
@@ -188,6 +193,47 @@ export function useTransportParams() {
   const [policeIsoCityDeptOpacity, setPoliceIsoCityDeptOpacity] = useState(0.45);
   const [policeIsoCityDeptMode, setPoliceIsoCityDeptMode] = useState<"walk" | "drive">("drive");
   const [policeIsoCityDeptMinutes, setPoliceIsoCityDeptMinutes] = useState<"30" | "60">("30");
+  // ── 環境污染 POLLUTION ──
+  // 設施：opacity + scale + 5 介質 filter（勾選 → 只顯示登記該介質的設施）+ 最低嚴重度門檻
+  const [pollutionFacilityOpacity, setPollutionFacilityOpacity] = useState(0.8);
+  const [pollutionFacilityScale, setPollutionFacilityScale] = useState(1);
+  const [pollutionFacilityMedia, setPollutionFacilityMedia] = useState<Record<PollutionMedium, boolean>>({
+    air: true, water: true, waste: true, toxic: true, soil: true, noise: false, other: false,
+  });
+  const [pollutionFacilityMinSev, setPollutionFacilityMinSev] = useState(0);
+  // 裁處事件：opacity + scale + medium select + 年份 + 模式（累積/單年）+ 播放
+  const [pollutionPenaltyOpacity, setPollutionPenaltyOpacity] = useState(0.75);
+  const [pollutionPenaltyScale, setPollutionPenaltyScale] = useState(1);
+  const [pollutionPenaltyMediumIdx, setPollutionPenaltyMediumIdx] = useState(0); // 0 = 全部
+  // 預設「只有今年」：今年（clamp 到資料年份範圍）+ 僅該年模式。
+  const [pollutionPenaltyYear, setPollutionPenaltyYear] = useState(
+    Math.min(PENALTY_YEAR_MAX, Math.max(PENALTY_YEAR_MIN, new Date().getFullYear())),
+  );
+  const [pollutionPenaltyMode, setPollutionPenaltyMode] = useState(1);           // 0 = 累積、1 = 僅該年（預設僅今年）
+  const [pollutionPenaltyPlaying, setPollutionPenaltyPlaying] = useState(false);
+  // 場址：opacity + scale + 只看列管中
+  const [pollutionSiteOpacity, setPollutionSiteOpacity] = useState(0.9);
+  const [pollutionSiteScale, setPollutionSiteScale] = useState(1);
+  const [pollutionSiteActiveOnly, setPollutionSiteActiveOnly] = useState(true);
+
+  const setPollutionFacilityMedium = (m: PollutionMedium, v: boolean) =>
+    setPollutionFacilityMedia((p) => ({ ...p, [m]: v }));
+
+  // 裁處事件歷史播放引擎：從起始年逐年推進到 2026 後停（比照火災事件的自動播放）。
+  useEffect(() => {
+    if (!pollutionPenaltyPlaying) return;
+    const id = setInterval(() => {
+      setPollutionPenaltyYear((y) => {
+        const cur = y === 0 ? PENALTY_YEAR_MIN : y;
+        if (cur >= PENALTY_YEAR_MAX) {
+          setPollutionPenaltyPlaying(false);
+          return PENALTY_YEAR_MAX;
+        }
+        return cur + 1;
+      });
+    }, 1100);
+    return () => clearInterval(id);
+  }, [pollutionPenaltyPlaying]);
   // 救援等時圈（覆蓋聯集填色透明度 + 縣市篩選，"all" = 全台）
   const [fireIsochroneOpacity, setFireIsochroneOpacity] = useState(0.5);
   const [fireIsochroneCounty, setFireIsochroneCounty] = useState("all");
@@ -785,6 +831,10 @@ export function useTransportParams() {
     policeIsoCityDeptOpacity,
     policeIsoCityDeptMode_drive: policeIsoCityDeptMode === "drive" ? 1 : 0,
     policeIsoCityDeptMinutes_num: Number(policeIsoCityDeptMinutes),
+    // 環境污染（paint 用；filter 值另由 return 物件傳給 usePollutionLayers）
+    pollutionFacilityOpacity, pollutionFacilityScale,
+    pollutionPenaltyOpacity, pollutionPenaltyScale,
+    pollutionSiteOpacity, pollutionSiteScale,
     stationScale,
     airportOpacity,
     airportGlow,
@@ -1096,7 +1146,10 @@ export function useTransportParams() {
     coastGuardStationOpacity, coastGuardStationScale, civilDefenseShelterOpacity, civilDefenseShelterScale,
     policeIsoSubstationOpacity, policeIsoSubstationMode, policeIsoSubstationMinutes,
     policeIsoPrecinctOpacity, policeIsoPrecinctMode, policeIsoPrecinctMinutes,
-    policeIsoCityDeptOpacity, policeIsoCityDeptMode, policeIsoCityDeptMinutes]);
+    policeIsoCityDeptOpacity, policeIsoCityDeptMode, policeIsoCityDeptMinutes,
+    pollutionFacilityOpacity, pollutionFacilityScale,
+    pollutionPenaltyOpacity, pollutionPenaltyScale,
+    pollutionSiteOpacity, pollutionSiteScale]);
 
   const getControls = (layer: ExpandableLayerKey): ParamControl[] => {
     switch (layer) {
@@ -2166,6 +2219,36 @@ export function useTransportParams() {
         ], onChange: (v: string) => setPoliceIsoCityDeptMinutes(v as "30" | "60") },
         { label: `透明度 ${policeIsoCityDeptOpacity.toFixed(2)}`, value: policeIsoCityDeptOpacity, min: 0.1, max: 0.9, step: 0.05, onChange: setPoliceIsoCityDeptOpacity },
       ];
+      // ── 環境污染 POLLUTION ──
+      case "pollutionFacility": return [
+        { label: `透明度 ${pollutionFacilityOpacity.toFixed(2)}`, value: pollutionFacilityOpacity, min: 0.1, max: 1, step: 0.05, onChange: setPollutionFacilityOpacity },
+        { label: `大小 ${pollutionFacilityScale.toFixed(2)}`, value: pollutionFacilityScale, min: 0.3, max: 3, step: 0.1, onChange: setPollutionFacilityScale },
+        { type: "select" as const, label: "最低嚴重度", value: String(pollutionFacilityMinSev), options: SEVERITY_BANDS.slice(0, 4).map((b) => ({ label: `S${b.sev}+`, value: String(b.sev) })), onChange: (v: string) => setPollutionFacilityMinSev(Number(v)) },
+        ...FACILITY_MEDIA.map((m) => ({
+          type: "toggle" as const,
+          label: POLLUTION_MEDIUM_LABELS[m],
+          value: pollutionFacilityMedia[m],
+          onChange: (v: boolean) => setPollutionFacilityMedium(m, v),
+        })),
+      ];
+      case "pollutionPenaltyCritical":
+      case "pollutionPenaltyGeneral":
+      case "pollutionPenaltyMobile": {
+        const medOpts = [{ label: "全部介質", value: "0" }, ...PENALTY_MEDIA.map((m, i) => ({ label: POLLUTION_MEDIUM_LABELS[m], value: String(i + 1) }))];
+        return [
+          { label: `透明度 ${pollutionPenaltyOpacity.toFixed(2)}`, value: pollutionPenaltyOpacity, min: 0.1, max: 1, step: 0.05, onChange: setPollutionPenaltyOpacity },
+          { label: `大小 ${pollutionPenaltyScale.toFixed(2)}`, value: pollutionPenaltyScale, min: 0.3, max: 3, step: 0.1, onChange: setPollutionPenaltyScale },
+          { type: "select" as const, label: "介質", value: String(pollutionPenaltyMediumIdx), options: medOpts, onChange: (v: string) => setPollutionPenaltyMediumIdx(Number(v)) },
+          { type: "select" as const, label: "年份", value: String(pollutionPenaltyYear), options: pollutionYearOptions(), onChange: (v: string) => { setPollutionPenaltyYear(Number(v)); setPollutionPenaltyPlaying(false); } },
+          { type: "select" as const, label: "模式", value: String(pollutionPenaltyMode), options: PENALTY_MODE_OPTIONS, onChange: (v: string) => setPollutionPenaltyMode(Number(v)) },
+          { type: "toggle" as const, label: pollutionPenaltyPlaying ? "⏸ 停止播放" : "▶ 歷史播放", value: pollutionPenaltyPlaying, onChange: (v: boolean) => { if (v && (pollutionPenaltyYear === 0 || pollutionPenaltyYear >= PENALTY_YEAR_MAX)) setPollutionPenaltyYear(PENALTY_YEAR_MIN); setPollutionPenaltyPlaying(v); } },
+        ];
+      }
+      case "pollutionSite": return [
+        { label: `透明度 ${pollutionSiteOpacity.toFixed(2)}`, value: pollutionSiteOpacity, min: 0.1, max: 1, step: 0.05, onChange: setPollutionSiteOpacity },
+        { label: `大小 ${pollutionSiteScale.toFixed(2)}`, value: pollutionSiteScale, min: 0.3, max: 3, step: 0.1, onChange: setPollutionSiteScale },
+        { type: "toggle" as const, label: "只看列管中 Active", value: pollutionSiteActiveOnly, onChange: setPollutionSiteActiveOnly },
+      ];
       default: return [];
     }
   };
@@ -2249,5 +2332,12 @@ export function useTransportParams() {
     hillshadeOpacity,
     slopeOpacity,
     aspectOpacity,
+    // 環境污染 filter 狀態（餵 usePollutionLayers 的 setFilter）
+    pollutionFacilityMedia,
+    pollutionFacilityMinSev,
+    pollutionPenaltyMediumIdx,
+    pollutionPenaltyYear,
+    pollutionPenaltyMode,
+    pollutionSiteActiveOnly,
   };
 }

--- a/src/map/overlayRegistry.ts
+++ b/src/map/overlayRegistry.ts
@@ -3,6 +3,14 @@ import { ECO_NETWORK_ZONE_MATCH } from "../data/ecoNetworkZoneTypes";
 import { FOREST_RESERVE_TYPE_MATCH } from "../data/forestReserveTypes";
 import { NEWS_CATEGORY_COLOR_EXPR } from "../data/newsEventTypes";
 import {
+  SEVERITY_COLOR_EXPR,
+  PENALTY_MEDIUM_COLOR_EXPR,
+  PENALTY_SEVERITY_COLORS,
+  PENALTY_CRITICAL_FILTER,
+  PENALTY_GENERAL_FILTER,
+  PENALTY_MOBILE_FILTER,
+} from "../data/pollutionTypes";
+import {
   FARM_COLOR, FARM_COLOR_RAMP, FARM_SIZE_DOMAIN, FARM_RADIUS_PX, FARM_HIGHLIGHT_OPTIONS,
   OTHER_SPECIES_SIZE_DOMAIN, OTHER_SIZE_DOMAIN_DEFAULT,
   OTHER_SPECIES_COLOR_RAMP, OTHER_COLOR_RAMP_DEFAULT,
@@ -5994,6 +6002,196 @@ export const OVERLAY_REGISTRY: OverlayConfig[] = [
             "#64748b",
           ] as unknown as string,
           "circle-opacity": op,
+        };
+      },
+    }],
+  },
+
+  // ══════════════════════════════════════════════════════════════════
+  //  環境污染 POLLUTION（PMTiles，來自 taipei-gis-analytics environment/pollution_source）
+  //  ⚠️ 語意紅線：EMS_S_01 列管 ≠ 污染源。標籤用「污染潛勢設施」。
+  //  filter（介質 / 年份 / 模式）走專屬 hook 的 setFilter；此處不設 rebuildOnParamChange
+  //  以免 rebuild 洗掉 setFilter（比照 gasCoverage / realEstate）。opacity/大小走 paint diff。
+  // ══════════════════════════════════════════════════════════════════
+
+  // 污染潛勢設施（介質 × 嚴重度）— 一點一次渲染，色 = max_sev
+  {
+    id: "pollutionFacility",
+    sourceUrl: "./geo/pollution_facilities.pmtiles",
+    sourceId: "pollution-facility",
+    pmtiles: { sourceLayer: "pollution_facilities", minzoom: 0, maxzoom: 14 },
+    layers: [{
+      suffix: "circle",
+      type: "circle",
+      minzoom: 0,
+      paint: (_isDark, p) => {
+        const s = p?.pollutionFacilityScale ?? 1;
+        const op = p?.pollutionFacilityOpacity ?? 0.8;
+        return {
+          "circle-color": SEVERITY_COLOR_EXPR as unknown as string,
+          "circle-radius": [
+            "interpolate", ["linear"], ["zoom"],
+            0, ["*", s, ["+", 0.7, ["*", 0.35, ["coalesce", ["to-number", ["get", "max_sev"]], 0]]]],
+            5, ["*", s, ["+", 1.2, ["*", 0.7, ["coalesce", ["to-number", ["get", "max_sev"]], 0]]]],
+            11, ["*", s, ["+", 2.5, ["*", 1.3, ["coalesce", ["to-number", ["get", "max_sev"]], 0]]]],
+            14, ["*", s, ["+", 4, ["*", 2, ["coalesce", ["to-number", ["get", "max_sev"]], 0]]]],
+          ] as unknown as number,
+          "circle-opacity": op,
+          "circle-stroke-width": ["case", [">=", ["coalesce", ["to-number", ["get", "max_sev"]], 0], 3], 0.8, 0] as unknown as number,
+          "circle-stroke-color": "#ffffff",
+          "circle-blur": 0.15,
+        };
+      },
+    }],
+  },
+
+  // 污染裁處事件（重大亮點）— 色 = event_medium；大小 = penalty_money；filter 由 severity_event 切出
+  {
+    id: "pollutionPenaltyCritical",
+    sourceUrl: "./geo/pollution_penalties.pmtiles",
+    sourceId: "pollution-penalty",
+    pmtiles: { sourceLayer: "pollution_penalties", minzoom: 5, maxzoom: 14 },
+    layers: [{
+      suffix: "critical-circle",
+      type: "circle",
+      minzoom: 5,
+      filter: PENALTY_CRITICAL_FILTER,
+      paint: (_isDark, p) => {
+        const s = p?.pollutionPenaltyScale ?? 1;
+        const op = p?.pollutionPenaltyOpacity ?? 0.75;
+        return {
+          "circle-color": PENALTY_MEDIUM_COLOR_EXPR as unknown as string,
+          // 大小 ∝ 罰鍰：以 log10(penalty_money) 為主軸，**全 zoom（含拉到全台 z5）都反映金額**。
+          // moneyR = 依 log10 罰鍰映射基礎半徑（1萬→~2px．．．4億→~11px），再乘 zoom 微幅放大 + 使用者 scale。
+          //   moneyLog: 4(1萬)→3(3萬)→…→8.65(4.4億)；clamp 於 [3,9] 對應 [2,11]px。
+          "circle-radius": (() => {
+            const moneyR: unknown[] = [
+              "interpolate", ["linear"],
+              ["log10", ["max", 10, ["coalesce", ["to-number", ["get", "penalty_money"]], 10]]],
+              3, 2,   // ≤1千
+              4, 3,   // 1萬
+              5, 4.5, // 10萬
+              6, 6.5, // 100萬
+              7, 8.5, // 1千萬
+              9, 11,  // ≥1億
+            ];
+            // Mapbox 規則：["zoom"] 必須是 paint property 的 top-level step/interpolate input；
+            // 因此不要把 zoom interpolate 包進 ["*", ...]，否則整層 addLayer 會失敗。
+            return [
+              "interpolate", ["linear"], ["zoom"],
+              5, ["*", s, 0.85, moneyR],
+              10, ["*", s, 1.1, moneyR],
+              14, ["*", s, 1.6, moneyR],
+            ] as unknown as number;
+          })(),
+          "circle-opacity": op,
+          "circle-stroke-width": [
+            "case",
+            ["any",
+              ["==", ["coalesce", ["to-number", ["get", "is_continuous"]], 0], 1],
+              ["==", ["coalesce", ["to-number", ["get", "is_stop_order"]], 0], 1],
+            ],
+            1.2,
+            0.7,
+          ] as unknown as number,
+          "circle-stroke-color": "#fee2e2",
+          "circle-blur": 0.08,
+        };
+      },
+    }],
+  },
+
+  // 污染裁處事件（一般背景）— high + normal，淡色小點，與重大層分 toggle
+  {
+    id: "pollutionPenaltyGeneral",
+    sourceUrl: "./geo/pollution_penalties.pmtiles",
+    sourceId: "pollution-penalty",
+    pmtiles: { sourceLayer: "pollution_penalties", minzoom: 5, maxzoom: 14 },
+    layers: [{
+      suffix: "general-circle",
+      type: "circle",
+      minzoom: 5,
+      filter: PENALTY_GENERAL_FILTER,
+      paint: (_isDark, p) => {
+        const s = p?.pollutionPenaltyScale ?? 1;
+        const op = p?.pollutionPenaltyOpacity ?? 0.75;
+        return {
+          "circle-color": PENALTY_MEDIUM_COLOR_EXPR as unknown as string,
+          "circle-radius": [
+            "interpolate", ["linear"], ["zoom"],
+            5, ["*", s, ["case", ["==", ["get", "severity_event"], "high"], 1.8, 0.9]],
+            10, ["*", s, ["case", ["==", ["get", "severity_event"], "high"], 2.6, 1.4]],
+            14, ["*", s, ["case", ["==", ["get", "severity_event"], "high"], 4.0, 2.2]],
+          ] as unknown as number,
+          "circle-opacity": [
+            "case",
+            ["==", ["get", "severity_event"], "high"], op * 0.45,
+            op * 0.28,
+          ] as unknown as number,
+          "circle-stroke-width": 0,
+          "circle-blur": 0.25,
+        };
+      },
+    }],
+  },
+
+  // 污染裁處事件（移動污染）— 車輛排煙 / 空品維護區等，預設關閉
+  {
+    id: "pollutionPenaltyMobile",
+    sourceUrl: "./geo/pollution_penalties.pmtiles",
+    sourceId: "pollution-penalty",
+    pmtiles: { sourceLayer: "pollution_penalties", minzoom: 5, maxzoom: 14 },
+    layers: [{
+      suffix: "mobile-circle",
+      type: "circle",
+      minzoom: 5,
+      filter: PENALTY_MOBILE_FILTER,
+      paint: (_isDark, p) => {
+        const s = p?.pollutionPenaltyScale ?? 1;
+        const op = p?.pollutionPenaltyOpacity ?? 0.75;
+        return {
+          "circle-color": PENALTY_SEVERITY_COLORS.mobile,
+          "circle-radius": [
+            "interpolate", ["linear"], ["zoom"],
+            5, ["*", s, 0.9],
+            10, ["*", s, 1.5],
+            14, ["*", s, 2.6],
+          ] as unknown as number,
+          "circle-opacity": op * 0.55,
+          "circle-stroke-width": 0,
+          "circle-blur": 0.18,
+        };
+      },
+    }],
+  },
+
+  // 污染場址（S4 確認污染）— 深色方形觀感（circle + stroke），可選只看列管中
+  {
+    id: "pollutionSite",
+    sourceUrl: "./geo/pollution_sites.pmtiles",
+    sourceId: "pollution-site",
+    pmtiles: { sourceLayer: "pollution_sites", minzoom: 0, maxzoom: 14 },
+    layers: [{
+      suffix: "circle",
+      type: "circle",
+      minzoom: 0,
+      paint: (_isDark, p) => {
+        const s = p?.pollutionSiteScale ?? 1;
+        const op = p?.pollutionSiteOpacity ?? 0.9;
+        return {
+          // 仍列管（is_active=1）用亮紅描邊突顯，已解除用灰
+          "circle-color": ["case", ["==", ["coalesce", ["to-number", ["get", "is_active"]], 0], 1], "#dc2626", "#6b7280"] as unknown as string,
+          "circle-radius": [
+            "interpolate", ["linear"], ["zoom"],
+            0, ["*", s, 1.2],
+            5, ["*", s, 2],
+            11, ["*", s, 4],
+            14, ["*", s, 7],
+          ] as unknown as number,
+          "circle-opacity": op,
+          "circle-stroke-width": 1.2,
+          "circle-stroke-color": ["case", ["==", ["coalesce", ["to-number", ["get", "is_active"]], 0], 1], "#fecaca", "#9ca3af"] as unknown as string,
+          "circle-blur": 0.1,
         };
       },
     }],

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -293,7 +293,11 @@ export type ExpandableLayerKey =
   // 航空安全 — 無人機禁/限航區（共用 PMTiles + filter 拆兩 toggle）
   | "droneNoFlyZone" | "droneRestrictedZone"
   // 警察覆蓋分析 isochrone × 3 層級
-  | "policeIsoSubstation" | "policeIsoPrecinct" | "policeIsoCityDept";
+  | "policeIsoSubstation" | "policeIsoPrecinct" | "policeIsoCityDept"
+  // 環境污染
+  | "pollutionFacility"
+  | "pollutionPenaltyCritical" | "pollutionPenaltyGeneral" | "pollutionPenaltyMobile"
+  | "pollutionSite";
 
 /** 渲染模式：3D（Three.js 含高度）或 2D（Mapbox 原生平面） */
 export type RenderMode = "3d" | "2d";
@@ -652,6 +656,8 @@ export interface FeatureInfo {
     | "a1AccidentRealtime"
     | "investigationBureau" | "antiCorruptionOffice" | "immigrationOffice" | "coastGuardStation"
     | "civilDefenseShelter"
+    // 環境污染（PMTiles：設施 × 介質 × 嚴重度 / 裁處事件時間軸 / 污染場址）
+    | "pollutionFacility" | "pollutionPenalty" | "pollutionSite"
     // 航空器空域（eAIP，含 floor/ceiling，分管制 vs 禁限航 兩 layerType）
     | "aviationControl" | "aviationRestricted"
     // 無人機禁/限航區（PMTiles polygon，filter 拆兩 layerType）
@@ -945,6 +951,12 @@ export interface LayerVisibility {
   policeIsoSubstation: boolean;       // 派出所 isochrone（步行/開車 × 5/10 min）
   policeIsoPrecinct: boolean;         // 分局 isochrone（步行/開車 × 15/30 min）
   policeIsoCityDept: boolean;         // 縣市警局 isochrone（步行/開車 × 30/60 min）
+  // 環境污染 POLLUTION（PMTiles，來自 taipei-gis-analytics environment/pollution_source）
+  pollutionFacility: boolean;   // 污染潛勢設施（EMS_S_01 × 5 介質 × 嚴重度；152,246）
+  pollutionPenaltyCritical: boolean; // 重大裁處事件（severity_event=critical；預設亮點）
+  pollutionPenaltyGeneral: boolean;  // 一般裁處事件（severity_event=high/normal；預設背景）
+  pollutionPenaltyMobile: boolean;   // 移動污染裁處（severity_event=mobile；預設關閉）
+  pollutionSite: boolean;       // 污染場址（EMS_S_07；8,253；S4 確認污染）
 }
 
 // ── 空氣品質 ──


### PR DESCRIPTION
## Summary
- 新增環境污染圖層群組：污染潛勢設施、裁處事件（重大/一般/移動）、污染場址。資料源 taipei-gis-analytics environment/pollution_source。

## Changes
- 5 個圖層 key（pollutionFacility / pollutionPenaltyCritical / General / Mobile / pollutionSite）
- types / layerCatalog（LAYER_COLORS + SECTIONS）/ App 接線 / overlayRegistry / legend / popup(pollutionPanels) / interaction / opacity 參數
- `.gitignore` 加 `public/geo/pollution_*.pmtiles`（大檔走 S3）

## Test
- [x] `npx tsc -b` 綠（隔離 worktree 純 pollution 驗證）
- [x] `pnpm test` 190/190
- [ ] Browser 驗收 — 留給 reviewer

## Risk / Rollback
- ⚠️ **PMTiles 未進 git**（penalties 219M / facilities 53M 超 GitHub 限制）→ 需 upload 到 S3 + `upload-deploy-assets.sh` 接線，否則線上圖層 404
- 本 PR 由混合工作區拆分而來，pollution 實作細節請自行複核

## Related
- 與 owner-gated PR #60 同工作區拆分