### PR TITLE
feat: UI 鎖/乾淨鎖分型 + powerPlants 補鎖

### DIFF
--- a/src/components/admin/AdminPanel.tsx
+++ b/src/components/admin/AdminPanel.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useState } from "react";
 import { X, ShieldCheck, Users, ScrollText, Lock, Database } from "lucide-react";
 import {
   listMembers, setMemberTier, listAudit, listGatedLayers, setLayerGate,
-  TIERS, type Tier, type AdminMember, type AuditRow, type GatedLayerRow,
+  TIERS, type Tier, type LockType, type AdminMember, type AuditRow, type GatedLayerRow,
 } from "../../lib/adminApi";
 import { loadLayerGates } from "../../lib/layerGates";
 import {
@@ -225,10 +225,10 @@ function LayersTab() {
   const { data, loading, error, reload } = useAsync(listGatedLayers, []);
   const [busy, setBusy] = useState<string | null>(null);
 
-  const apply = async (row: GatedLayerRow, tier: Tier, enabled: boolean) => {
+  const apply = async (row: GatedLayerRow, tier: Tier, enabled: boolean, lockType?: LockType) => {
     setBusy(row.layer_key);
     try {
-      await setLayerGate(row.layer_key, tier, enabled);
+      await setLayerGate(row.layer_key, tier, enabled, lockType);
       await loadLayerGates(); // 讓地圖鎖頭即時更新
       reload();
     } catch (err) {
@@ -248,12 +248,16 @@ function LayersTab() {
 
   return (
     <div>
+      <div style={{ fontSize: FONT_SIZE.sm, color: COLORS.textMuted, marginBottom: SPACING.md, lineHeight: 1.6 }}>
+        鎖型 <b>full（乾淨鎖）</b>= DB 真鎖機密（改此欄<b>不會</b>動 DB grant，需另跑 migration REVOKE/GRANT）；
+        <b>ui（UI 鎖）</b>= 資料公開、僅前端引導未登入者登入。改 lock_type 只影響前端鎖頭行為，不碰後端真鎖狀態。
+      </div>
       {[...byCat.entries()].map(([cat, list]) => (
         <div key={cat} style={{ marginBottom: SPACING.xl }}>
           <div style={{ fontSize: FONT_SIZE.md, fontWeight: 600, color: COLORS.textStrong, marginBottom: SPACING.sm }}>{cat}</div>
           <table style={{ width: "100%", borderCollapse: "collapse" }}>
             <thead>
-              <tr><th style={th}>圖層</th><th style={th}>required_tier</th><th style={th}>啟用</th><th style={th}>新鮮度</th></tr>
+              <tr><th style={th}>圖層</th><th style={th}>required_tier</th><th style={th}>鎖型</th><th style={th}>啟用</th><th style={th}>新鮮度</th></tr>
             </thead>
             <tbody>
               {list.map((r) => (
@@ -266,6 +270,13 @@ function LayersTab() {
                     <select value={r.required_tier} disabled={busy === r.layer_key} style={selectStyle}
                       onChange={(e) => void apply(r, e.target.value as Tier, r.enabled)}>
                       {TIERS.map((t) => <option key={t} value={t}>{t}</option>)}
+                    </select>
+                  </td>
+                  <td style={td}>
+                    <select value={r.lock_type} disabled={busy === r.layer_key} style={selectStyle}
+                      onChange={(e) => void apply(r, r.required_tier as Tier, r.enabled, e.target.value as LockType)}>
+                      <option value="full">full 乾淨鎖</option>
+                      <option value="ui">ui UI 鎖</option>
                     </select>
                   </td>
                   <td style={td}>

--- a/src/components/sidebar/layerCatalog.ts
+++ b/src/components/sidebar/layerCatalog.ts
@@ -1130,7 +1130,7 @@ export const GATED_LAYERS: ReadonlySet<keyof LayerVisibility> = new Set<keyof La
   // 僅做 UI 鎖（資料載入路徑不動）
   "aviationRestrictedGlow",
   // 已從 sidebar 下架但 API 敏感（無鎖頭 UI；仍 gate 掉 bulk/chat 等程式化開啟路徑）
-  "facOffshore", "osmPowerPlantsStatic",
+  "facOffshore", "osmPowerPlantsStatic", "powerPlants",
 ]);
 
 /** 對某使用者而言此 key 是否上鎖（gated 且非 owner）。 */

--- a/src/lib/adminApi.ts
+++ b/src/lib/adminApi.ts
@@ -29,6 +29,8 @@ export interface AuditRow {
   granted: boolean;
 }
 
+export type LockType = "ui" | "full";
+
 export interface GatedLayerRow {
   layer_key: string;
   category: string;
@@ -36,6 +38,7 @@ export interface GatedLayerRow {
   rpc_name: string | null;
   required_tier: string;
   enabled: boolean;
+  lock_type: LockType;
   sort_order: number | null;
   source_date: string | null;
   next_refresh: string | null;
@@ -69,11 +72,18 @@ export async function listGatedLayers(): Promise<GatedLayerRow[]> {
   return unwrap<GatedLayerRow[]>(data, error, "admin_list_gated_layers");
 }
 
-export async function setLayerGate(layerKey: string, requiredTier: Tier, enabled: boolean): Promise<void> {
+export async function setLayerGate(
+  layerKey: string,
+  requiredTier: Tier,
+  enabled: boolean,
+  lockType?: LockType,
+): Promise<void> {
+  // p_lock_type 省略（undefined）時後端 COALESCE 不改該欄（宣告性欄位，不動 DB grant）。
   const { error } = await supabase.rpc("admin_set_layer_gate", {
     p_layer_key: layerKey,
     p_required_tier: requiredTier,
     p_enabled: enabled,
+    ...(lockType ? { p_lock_type: lockType } : {}),
   });
   if (error) throw new Error(`admin_set_layer_gate: ${error.message}`);
 }

--- a/src/lib/layerGates.ts
+++ b/src/lib/layerGates.ts
@@ -23,6 +23,13 @@ export function tierRank(tier: string | null | undefined): number {
 export interface LayerGate {
   required_tier: string;
   enabled: boolean;
+  /**
+   * 鎖型（migration 278）：
+   * - 'full'：乾淨鎖（DB 已 REVOKE anon，機密資料）。未登入也 locked。
+   * - 'ui'  ：UI 鎖（DB 未 REVOKE、資料公開）。未登入 locked（引導登入）、
+   *           登入且 tier>=required 即開。
+   */
+  lock_type: "ui" | "full";
 }
 export type LayerGates = ReadonlyMap<string, LayerGate>;
 
@@ -47,8 +54,12 @@ export async function loadLayerGates(): Promise<void> {
     const { data, error } = await supabase.rpc("get_layer_gates");
     if (error) throw error;
     const next = new Map<string, LayerGate>();
-    for (const row of (data ?? []) as Array<{ layer_key: string; required_tier: string; enabled: boolean }>) {
-      next.set(row.layer_key, { required_tier: row.required_tier, enabled: row.enabled });
+    for (const row of (data ?? []) as Array<{ layer_key: string; required_tier: string; enabled: boolean; lock_type?: "ui" | "full" }>) {
+      next.set(row.layer_key, {
+        required_tier: row.required_tier,
+        enabled: row.enabled,
+        lock_type: row.lock_type === "ui" ? "ui" : "full", // 缺值 fallback 'full'（fail-safe）
+      });
     }
     gatesCache = next;
     emit();
@@ -74,8 +85,13 @@ export function useLayerGates(): LayerGates | null {
 /**
  * 某 key 對某 tier 是否上鎖（純函式）。
  * - gates 已載入 → 權威來源（get_layer_gates 只回 enabled 的鎖定層）：
- *   不在清單 = 公開；在清單 = 需 tierRank(tier) >= tierRank(required_tier) 才解鎖。
- * - gates=null（未載入 / 失敗）→ fail-safe 用靜態 GATED_LAYERS，需 owner 才解鎖。
+ *   不在清單 = 公開；在清單 = 依 lock_type 判定：
+ *     • full：tierRank(tier) < required → locked（未登入 tier=null → rank 0，也 locked）。
+ *     • ui  ：未登入（tier==null）→ locked（顯示鎖頭引導登入）；
+ *             已登入 → tierRank(tier) < required 才 locked（tier>=required 即開）。
+ *   （full 與 ui 唯一差異：ui 對「未登入」一律上鎖，即使 required=free；
+ *    真正資料保護在 DB grant，此處僅前端顯示行為。）
+ * - gates=null（未載入 / 失敗）→ fail-safe 用靜態 GATED_LAYERS，一律當 full 鎖需 owner。
  */
 export function isLayerLocked(
   key: keyof LayerVisibility,
@@ -86,6 +102,12 @@ export function isLayerLocked(
   if (gates) {
     const gate = gates.get(key);
     if (!gate) return false;
+    if (gate.lock_type === "ui") {
+      // UI 鎖：未登入一律上鎖（引導登入）；已登入依 tier 判定
+      if (tier == null) return true;
+      return userRank < tierRank(gate.required_tier);
+    }
+    // full（乾淨鎖，現狀不變）
     return userRank < tierRank(gate.required_tier);
   }
   return GATED_LAYERS.has(key) && userRank < tierRank("owner");


### PR DESCRIPTION
## Summary
- 前端支援兩種鎖型（UI 鎖引導註冊 / 乾淨鎖 DB 真鎖），後台可切；並把已下架的 powerPlants 圖層補進鎖定清單。搭配 gis-platform #30。

## Changes
- `layerGates.ts`: LayerGate 加 lock_type；isLayerLocked 依 lock_type 分支（ui：未登入鎖頭引導、登入即開；full：現狀依 tier）；fail-safe 不變
- `adminApi.ts` / `AdminPanel.tsx`: 圖層鎖定分頁加鎖型 select + 說明（切 lock_type 不動 DB grant）
- `layerCatalog.ts`: powerPlants 加進 GATED_LAYERS（用剛 REVOKE 的 all_power_plants_v，防程式化開啟打 401）

## Test
- [x] npx tsc -b 綠（隔離 worktree 純 lock_type 驗證）
- [x] pnpm test 190/190
- [x] 現有 34 圖層全 lock_type=full，行為零變化（回歸）

## Related
- DB: gis-platform #30（278 lock_type + 279 電廠洩漏修補）