### PR TITLE
feat(urban): 台北行道樹 2024/11 vs 現在三狀態 PMTiles 圖層

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,6 +90,8 @@ public/forestry/hiking_trails.pmtiles
 public/base_map/*.pmtiles
 # 路況省道幾何 PMTiles（road_congestion_highway 3.1MB，前端 feature-state 染色，走 S3 deploy-assets/road/）
 public/road/*.pmtiles
+# 都市開放空間 PMTiles（台北行道樹變化 3.1MB，走 S3 deploy-assets/urban/）
+public/urban/*.pmtiles
 # 警政司法民防 19 dataset（172MB，dev 用 symlink → taipei-gis-analytics/data/processed/police_justice/）
 # Production：走 S3 deploy-assets/police_justice/
 public/police_justice

--- a/docs/features/street_trees_taipei_diff/README.md
+++ b/docs/features/street_trees_taipei_diff/README.md
@@ -1,0 +1,55 @@
+# 行道樹變化 Street Tree Diff（台北）
+
+> **Slug**：`street_trees_taipei_diff`（與 `taipei-gis-analytics/docs/handoff/street_trees_taipei_diff.md` 一致）
+> **狀態**：dev（本地接線完成，未 push）
+> **Owner**：migu
+> **上線日期**：（pending）
+> **相關 PR**：（pending）
+
+## 一句話說明
+
+台北市行道樹 2024/11 基準 vs 現在的「三狀態變化」點圖層：存續（persisted）/ 消失（disappeared）/ 新增（appeared）。掛在 Layers 側欄「環境氣候 Environment」主題下新分組「都市開放空間 Urban Open Space」，公開（非 owner-gated），預設關閉。
+
+## 圖層 / 元件（🌳 都市開放空間分組，1 layer，預設關）
+
+| layer key | 名稱 | 類型 | 資料源 | 顏色 | 筆數 | zoom |
+|---|---|---|---|---|---|---|
+| `streetTreesTaipeiDiff` | 行道樹變化 | PMTiles circle | `public/urban/street_trees_taipei_diff.pmtiles`（sourceLayer `street_trees_taipei_diff`, z5–14） | `status` 三色：`#2e7d32` 綠（persisted）/ `#e53935` 紅（disappeared）/ `#9ccc65` 淺綠（appeared） | 99,527 點 | pmtiles 原生 z5–14 |
+
+> 單一 circle layer；`status` 用 `match` 分三色；`renumber_suspect=true`（真 boolean）用透明度降 0.35 倍避免誤讀為真消失/新增。狀態篩選 select（全部 / 只看消失 / 只看變動）走 opacity 篩選（filter 靜態，只 paint 隨 param 重算，仿 aquacultureWaterSatellite 信心層級慣例）。
+
+## 資料路由（前端 CDN 靜態，不打 Supabase）
+
+- **前端（用戶讀）→ CDN 靜態，走 `public/urban/`**：
+  - `streetTreesTaipeiDiff` → `street_trees_taipei_diff.pmtiles`（3.1MB，向量磚）
+- **無 Supabase、無 RPC**（同 fishery/agriculture 靜態面資料那一層）。
+- 部署走 **D 類（≥2MB PMTiles）**，新 group `urban/`：`.gitignore` 排除 + upload/pull/nginx 三處已接（見 handoff.md）。
+
+## 渲染參數
+
+- 單 circle layer：`circle-color` 依 `status` match 三色；`circle-opacity` 用 `case` 判 `renumber_suspect` 降透明 + status 篩選；`circle-radius` 隨 zoom `interpolate`（z5=1 → z14=4.5），避免低 zoom 糊成一片。
+- 控制項：狀態 select（all/disappeared/changed，編成 idx 進 paint）+ 透明度 slider（預設 0.7）。
+- 預設關閉（`false`，未列入 `useLayerVisibility` 的 `DEFAULT_ON` → 自動派生 false）。
+
+## 關鍵檔案
+
+- Overlay：`src/map/overlayRegistry.ts`（`streetTreesTaipeiDiff` OverlayConfig，circle）
+- Catalog：`src/components/sidebar/layerCatalog.ts`（`LAYER_COLORS` + THEMES「環境氣候」→「都市開放空間」子分組）
+- Icon：`src/components/IconRailSidebar.tsx`（`TreePine`）
+- 參數：`src/hooks/useTransportParams.ts`（opacity slider + status select）
+- Legend：`src/components/LegendPanel.tsx`（`StreetTreesTaipeiDiffLegend` + `LEGEND_REGISTRY`）
+- Popup：`src/hooks/useMapInteraction.ts` + `src/components/featureInfo/urbanPanels.tsx`（`StreetTreesTaipeiDiffPanel`）+ `registry.tsx`
+- Upstream registry：`src/data/upstreamRegistry.ts`
+- Types：`src/types/index.ts`（`LayerVisibility` / `ExpandableLayerKey` / `FeatureInfo` 三處加 key）
+
+## 資料契約摘要
+
+看 [handoff.md](./handoff.md)。上游 SSOT：`taipei-gis-analytics/docs/handoff/street_trees_taipei_diff.md`。
+
+## 相關 backlog
+
+看 [backlog.md](./backlog.md)。
+
+## 歷次改動
+
+看 [changelog.md](./changelog.md)。

--- a/docs/features/street_trees_taipei_diff/backlog.md
+++ b/docs/features/street_trees_taipei_diff/backlog.md
@@ -1,0 +1,20 @@
+# Backlog — 行道樹變化 Street Tree Diff
+
+> 本 feature 的待辦。與全站 `.claude/memory/BACKLOG.md` 對應項編號要一致。
+
+## 進行中
+
+- （無）
+
+## 待辦
+
+- [ ] **STD-1**：擴充到其他縣市（目前僅台北市）— 待上游產出對應 diff dataset。
+- [ ] **STD-2**：時間軸切換多個 Wayback 基準（目前單一 2024/11 快照）。
+
+## 已完成（近期）
+
+- [x] **STD-0**：前端接線 `streetTreesTaipeiDiff`（PMTiles circle，status 三色 + renumber 降透明 + status 篩選）— PR #（pending）
+
+## 已放棄 / 延後
+
+- （無）

--- a/docs/features/street_trees_taipei_diff/changelog.md
+++ b/docs/features/street_trees_taipei_diff/changelog.md
@@ -1,0 +1,21 @@
+# Changelog — 行道樹變化 Street Tree Diff
+
+> 逐 PR 變更紀錄。最新在上。
+
+格式：
+```
+## YYYY-MM-DD — PR #NN <squash commit hash>
+- <what changed>
+- <why (optional)>
+- <breaking? migration needed?>
+```
+
+---
+
+## 2026-07-12 — PR #（pending）`（pending）`
+
+- 新增 `streetTreesTaipeiDiff` 圖層（台北行道樹 2024/11 vs 現在 三狀態變化）
+- 資料源：上游 `street_trees_taipei_diff` PMTiles（99,527 點，sourceLayer `street_trees_taipei_diff`, z5–14，9 欄 keep_attrs）
+- 接線：types 三處 / overlayRegistry circle / layerCatalog（新分組「都市開放空間」）/ IconRailSidebar（TreePine）/ useTransportParams（opacity + status select）/ LegendPanel / useMapInteraction + urbanPanels + registry / upstreamRegistry
+- 部署：新 group `urban/`（D 類），.gitignore + upload/pull/nginx 三處已接
+- Breaking：無

--- a/docs/features/street_trees_taipei_diff/handoff.md
+++ b/docs/features/street_trees_taipei_diff/handoff.md
@@ -1,0 +1,69 @@
+# Handoff — 行道樹變化 Street Tree Diff（下游視角）
+
+> **上游 SSOT**：`../../../taipei-gis-analytics/docs/handoff/street_trees_taipei_diff.md`（詳細契約看那份）
+> 上游 catalog：`taipei-gis-analytics/docs/data-catalog/urban_open_space/street_trees_taipei_diff.md`（已存在，upstream 契約 verified）
+>
+> 本檔只放**前端接線的簡表 + 硬依賴欄位**。契約細節不重複寫，只反向引用。
+
+## 上游 handoff 摘要
+
+- 產物路徑（前端 CDN，走 `public/urban/`）：
+  - `street_trees_taipei_diff.pmtiles`（3.1MB，sourceLayer `street_trees_taipei_diff`, z5–14）
+- 更新頻率：靜態（一次性 diff 快照；2024/11 基準取自 Wayback vs 現在）
+- 座標系統：WGS84
+- 資料量：99,527 點
+- status 三值：`persisted`（存續）/ `disappeared`（2024 有、現在無）/ `appeared`（2024 無、現在有）
+
+（完整契約 → 上游 handoff / catalog doc）
+
+## 前端接線位置
+
+- Overlay：`src/map/overlayRegistry.ts`（`streetTreesTaipeiDiff` 單 circle layer）
+- Popup：`src/hooks/useMapInteraction.ts`（hit-test `street-trees-taipei-diff-circle`）+ `src/components/featureInfo/urbanPanels.tsx`（`StreetTreesTaipeiDiffPanel`）+ `registry.tsx`
+- 參數：`src/hooks/useTransportParams.ts`（opacity slider + status select，4 接觸點）
+- Legend：`src/components/LegendPanel.tsx`（`StreetTreesTaipeiDiffLegend`）+ `LEGEND_REGISTRY`
+- UI toggle：`src/components/sidebar/layerCatalog.ts`（`LAYER_COLORS` + THEMES「環境氣候」→「都市開放空間」子分組）+ `src/components/IconRailSidebar.tsx`（`TreePine` icon）
+- Types：`src/types/index.ts`（`LayerVisibility` / `ExpandableLayerKey` / `FeatureInfo["layerType"]` 三處）
+- Upstream registry：`src/data/upstreamRegistry.ts`
+
+## 硬依賴欄位（改一定爆）
+
+PMTiles keep_attrs 9 欄契約（sourceLayer `street_trees_taipei_diff`；改名 → source 掛不上，layer 全消）：
+
+- `TreeID`（string）— popup 顯示 / 唯一識別。
+- `TreeType`（string）— popup Title 樹種。
+- `Dist`（string）— popup 路名附註的行政區。
+- `Region`（string）— popup「路名」主值。
+- `Diameter`（number|null）— popup「胸徑」（cm）；null 時 Row 自動隱藏。
+- `TreeHeight`（number|null）— popup「樹高」（m）；null 時 Row 自動隱藏。
+- `SurveyDate`（string）— popup「調查日」。
+- `status`（string，三值 persisted/disappeared/appeared）— **paint 分色硬依賴**（`["match", ["get","status"], ...]`）+ popup 狀態標籤 + status 篩選。
+- `renumber_suspect`（**boolean**）— **paint 透明度硬依賴**（`["case", ["==", ["get","renumber_suspect"], true], ...]`）+ popup 提示列；型別為 boolean，改成 0/1 或字串會讓 case 表達式落 else 分支（疑似重編號點誤判為正常顯示）。
+
+> ⚠️ 上游若移除或改名上述任一欄位（尤其 sourceLayer / `status` 三值語意 / `renumber_suspect` 型別），下游 overlay + popup 直接爆 → **務必先開 upstream handoff**。
+
+## 上游改動 → 下游要跟改的觸發點
+
+| 上游改動 | 下游動作 |
+|---|---|
+| pmtiles keep_attrs 增刪欄位 | `urbanPanels.tsx` popup 對應 Row 跟改 |
+| pmtiles sourceLayer 改名 | `overlayRegistry.ts` 的 `pmtiles.sourceLayer` 跟改 |
+| status 新增第 4 值 | `overlayRegistry.ts` match 表 + `StreetTreesTaipeiDiffLegend` + `urbanPanels.tsx` `STATUS_TIER` 三處跟改 |
+| `renumber_suspect` 型別/語意改 | `overlayRegistry.ts` 的 case 表達式 + popup 提示文字跟改 |
+| 更新 diff 基準（換 Wayback 日期） | README + popup caveat 文字跟改 |
+
+## 部署（D 類 · 新 group `urban/`）
+
+PMTiles 3.1MB ≥ 2MB → 走 **D 類**，新增 group `urban/`，五處：
+- `.gitignore`：`public/urban/*.pmtiles`（已加）
+- `scripts/deploy/upload-deploy-assets.sh`：urban glob 段（`for f in public/urban/*.pmtiles`，已加）
+- `scripts/deploy/pull-deploy-assets.sh`：`mkdir -p $DATA_DIR/urban` + `aws s3 sync $S3/urban/ $DATA_DIR/urban/` + fire glob 補 `--exclude "urban/*"`（已加）
+- `nginx.conf`：`location /urban/ { root /data; try_files $uri @dist; ... }`（已加）
+- `docker-compose.yml`：比照 fishery/aquaculture 不動（deployContract 測試不驗它）
+
+## 已知不對稱 / 待決
+
+- **TreeID 消失≠砍除**：2024 基準取自 Wayback，可能含颱風後清運滯後；popup 一行 ⓘ 誠實標註。
+- **重編號干擾**：`renumber_suspect=true`（同路名同樹種 10m 內配對）可能非真消失/新增；地圖降透明 + popup 提示列。
+- **popup footer source 可能空**：若上游未帶 `source_org` / `source_tier`，`SourceFooter` 顯示「資料來源 (Tier ?)」（cosmetic）。
+- **狀態**：本地接線完成、tsc + 契約測試綠，**未 commit / 未 push**；PR / squash hash pending。

--- a/nginx.conf
+++ b/nginx.conf
@@ -59,6 +59,14 @@ server {
         add_header Cache-Control "public";
     }
 
+    # 都市開放空間 PMTiles（台北行道樹變化）在 /data/urban/（S3 大檔），git 小檔在 dist → fallback
+    location /urban/ {
+        root /data;
+        try_files $uri @dist;
+        expires 1d;
+        add_header Cache-Control "public";
+    }
+
     # 農業 GeoJSON + PMTiles 在 /data/agriculture/（純 S3，無 git 小檔，不需 fallback）
     location /agriculture/ {
         root /data;

--- a/scripts/deploy/pull-deploy-assets.sh
+++ b/scripts/deploy/pull-deploy-assets.sh
@@ -18,7 +18,7 @@ PREFIX="deploy-assets"
 DATA_DIR="/data"
 S3="s3://$BUCKET/$PREFIX"
 CACHE="$DATA_DIR/.cache"
-mkdir -p "$DATA_DIR" "$DATA_DIR/geo" "$DATA_DIR/h3" "$DATA_DIR/bus" "$DATA_DIR/fire" "$DATA_DIR/medical" "$DATA_DIR/agriculture" "$DATA_DIR/sports" "$DATA_DIR/flood" "$DATA_DIR/forestry" "$DATA_DIR/fishery" "$DATA_DIR/coverage" "$DATA_DIR/base_map" "$DATA_DIR/climate" "$DATA_DIR/static-rpc" "$DATA_DIR/water_resources" "$DATA_DIR/road" "$CACHE"
+mkdir -p "$DATA_DIR" "$DATA_DIR/geo" "$DATA_DIR/h3" "$DATA_DIR/bus" "$DATA_DIR/fire" "$DATA_DIR/medical" "$DATA_DIR/agriculture" "$DATA_DIR/sports" "$DATA_DIR/flood" "$DATA_DIR/forestry" "$DATA_DIR/fishery" "$DATA_DIR/coverage" "$DATA_DIR/base_map" "$DATA_DIR/climate" "$DATA_DIR/static-rpc" "$DATA_DIR/water_resources" "$DATA_DIR/urban" "$DATA_DIR/road" "$CACHE"
 
 echo "[pull] sync root json → $DATA_DIR/"
 aws s3 sync "$S3/" "$DATA_DIR/" --no-progress \
@@ -49,7 +49,7 @@ aws s3 sync "$S3/" "$DATA_DIR/h3/" --no-progress --exclude "*" --include "h3_*_r
 #    必須用 --exclude "agriculture/*" 排除（否則農業 pmtiles 會被灌進 /data/fire/agriculture/）。
 #    未來新增其他「含 pmtiles 的子前綴」也要在此比照排除；搬成鏡像結構後本行可簡化（見 06 搬家計畫）。
 echo "[pull] sync fire pmtiles → $DATA_DIR/fire/"
-aws s3 sync "$S3/" "$DATA_DIR/fire/" --no-progress --exclude "*" --include "*.pmtiles" --exclude "agriculture/*" --exclude "medical/*" --exclude "flood/*" --exclude "forestry/*" --exclude "fishery/*" --exclude "coverage/*" --exclude "base_map/*" --exclude "geo/*" --exclude "road/*" --exclude "water_*.pmtiles"
+aws s3 sync "$S3/" "$DATA_DIR/fire/" --no-progress --exclude "*" --include "*.pmtiles" --exclude "agriculture/*" --exclude "medical/*" --exclude "flood/*" --exclude "forestry/*" --exclude "fishery/*" --exclude "coverage/*" --exclude "base_map/*" --exclude "geo/*" --exclude "road/*" --exclude "urban/*" --exclude "water_*.pmtiles"
 
 # 醫療：鏡像子前綴 deploy-assets/medical/ → /data/medical/（基礎點位 + 等時圈 PMTiles）
 echo "[pull] sync medical → $DATA_DIR/medical/"
@@ -79,6 +79,10 @@ aws s3 sync "$S3/fishery/" "$DATA_DIR/fishery/" --no-progress
 # 水資源：鏡像子前綴 deploy-assets/water_resources/ → /data/water_resources/（湖泊/埤塘 PMTiles，整夾 sync，加新檔免改腳本）
 echo "[pull] sync water_resources → $DATA_DIR/water_resources/"
 aws s3 sync "$S3/water_resources/" "$DATA_DIR/water_resources/" --no-progress
+
+# 都市開放空間：鏡像子前綴 deploy-assets/urban/ → /data/urban/（台北行道樹變化 PMTiles，整夾 sync，加新檔免改腳本）
+echo "[pull] sync urban → $DATA_DIR/urban/"
+aws s3 sync "$S3/urban/" "$DATA_DIR/urban/" --no-progress
 
 # 房地產：鏡像子前綴 deploy-assets/coverage/ → /data/coverage/（real_estate_* 大檔；gas 小檔在 dist fallback）
 echo "[pull] sync coverage → $DATA_DIR/coverage/"

--- a/scripts/deploy/upload-deploy-assets.sh
+++ b/scripts/deploy/upload-deploy-assets.sh
@@ -228,6 +228,15 @@ for f in public/water_resources/*.pmtiles; do
   aws s3 cp "$f" "s3://$BUCKET/$PREFIX/water_resources/$name" --region ap-southeast-2
 done
 
+# 都市開放空間圖層：上傳到 deploy-assets/urban/ 子前綴（鏡像結構，pull 端整夾 sync）
+# 台北行道樹變化 PMTiles（3.1MB，99,527 點，純 S3，無 git 小檔；glob 動態上傳加新檔免改腳本）
+for f in public/urban/*.pmtiles; do
+  [ -f "$f" ] || continue
+  name=$(basename "$f")
+  echo "Uploading urban/$name..."
+  aws s3 cp "$f" "s3://$BUCKET/$PREFIX/urban/$name" --region ap-southeast-2
+done
+
 # Base map PMTiles：上傳到 deploy-assets/base_map/ 子前綴（鏡像結構，pull 端整夾 sync）。
 # 6 檔合計 ~406MB（行政邊界 3 + 等高線 2 + OSM 路網 1）。SSOT 在 taipei-gis-analytics。
 for f in public/base_map/*.pmtiles; do

--- a/src/components/IconRailSidebar.tsx
+++ b/src/components/IconRailSidebar.tsx
@@ -163,6 +163,7 @@ const LAYER_ICONS: Record<keyof LayerVisibility, LucideIcon> = {
   aquacultureCageNet: Fish,
   aquacultureWaterSatellite: Satellite,
   aquacultureIntegrated: Fish,
+  streetTreesTaipeiDiff: TreePine,
   // 🏟️ 運動場館 Sports
   sportsSchool: GraduationCap,
   sportsPublicOther: Activity,

--- a/src/components/LegendPanel.tsx
+++ b/src/components/LegendPanel.tsx
@@ -189,6 +189,7 @@ export const LEGEND_REGISTRY: LegendEntry[] = [
   { keys: ["livestockSlaughter", "livestockFeed", "livestockMarket"], render: () => <LivestockFacilityLegend /> },
   { keys: ["aquaculturePonds", "aquacultureZone", "aquacultureCageNet", "aquacultureWaterSatellite"], render: ({ visibility }) => <AquacultureLegend visibility={visibility} /> },
   { keys: ["aquacultureIntegrated"], render: () => <AquacultureIntegratedLegend /> },
+  { keys: ["streetTreesTaipeiDiff"], render: () => <StreetTreesTaipeiDiffLegend /> },
   { keys: ["sportsSchool", "sportsPublicOther", "sportsPrivate", "sportsPark", "sportsCenter"], render: () => <SportsVenueLegend /> },
   { keys: ["ecoNetworkZones"], render: () => <EcoNetworkZonesLegend /> },
   {
@@ -668,6 +669,39 @@ function AquacultureIntegratedLegend() {
             <span style={{ fontSize: FONT_SIZE.xs, color: t.textMuted }}>{it.label}</span>
           </div>
         ))}
+      </div>
+    </div>
+  );
+}
+
+function StreetTreesTaipeiDiffLegend() {
+  const t = useLegendTheme();
+  const rows = [
+    { color: "#2e7d32", label: "存續 persisted" },
+    { color: "#e53935", label: "消失 disappeared" },
+    { color: "#9ccc65", label: "新增 appeared" },
+  ];
+  return (
+    <div>
+      <div style={{ fontSize: FONT_SIZE.xs, color: t.textDim, letterSpacing: 1, marginBottom: 4 }}>
+        行道樹變化 STREET TREE DIFF
+      </div>
+      <div style={{ display: "flex", flexDirection: "column", gap: 2 }}>
+        {rows.map((it) => (
+          <div key={it.label} style={{ display: "flex", alignItems: "center", gap: 6 }}>
+            <div
+              style={{
+                width: 10, height: 10, borderRadius: RADIUS.full, background: it.color,
+                opacity: 0.9, border: "1px solid rgba(255,255,255,0.6)",
+                boxSizing: "border-box", flexShrink: 0,
+              }}
+            />
+            <span style={{ fontSize: FONT_SIZE.xs, color: t.textMuted }}>{it.label}</span>
+          </div>
+        ))}
+        <div style={{ fontSize: FONT_SIZE.xs, color: t.textDim, marginTop: 2, lineHeight: 1.4 }}>
+          半透明點 = 疑似重編號（非真消失/新增）
+        </div>
       </div>
     </div>
   );

--- a/src/components/featureInfo/registry.tsx
+++ b/src/components/featureInfo/registry.tsx
@@ -33,6 +33,7 @@ import {
   AquaculturePondsPanel, AquacultureZonePanel, AquacultureCageNetPanel,
   AquacultureWaterSatellitePanel, AquacultureIntegratedPanel,
 } from "./fisheryPanels";
+import { StreetTreesTaipeiDiffPanel } from "./urbanPanels";
 import { SportsVenuePanel } from "./sportsPanels";
 import { MedicalPOIPanel, MedicalIsochronePanel, EmergencyHospitalPanel } from "./medicalPanels";
 import { ParkingOnstreetPanel, ParkingOffstreetPanel } from "./parkingPanels";
@@ -234,6 +235,8 @@ export const PANEL_REGISTRY: Partial<Record<FeatureInfo["layerType"], FC<PanelPr
   aquacultureCageNet: AquacultureCageNetPanel,
   aquacultureWaterSatellite: AquacultureWaterSatellitePanel,
   aquacultureIntegrated: AquacultureIntegratedPanel,
+  // 🌳 都市開放空間
+  streetTreesTaipeiDiff: StreetTreesTaipeiDiffPanel,
   // 🏟️ 運動場館
   sportsVenue: SportsVenuePanel,
 };
@@ -311,6 +314,7 @@ export const HEADER_LABELS: Record<FeatureInfo["layerType"], string> = {
   aquacultureCageNet: "海上箱網",
   aquacultureWaterSatellite: "衛星偵測養殖水體",
   aquacultureIntegrated: "養殖漁業整合",
+  streetTreesTaipeiDiff: "行道樹變化",
   sportsVenue: "運動場館",
   medicalPOI: "醫療據點",
   medicalIsochrone: "醫療等時圈",

--- a/src/components/featureInfo/urbanPanels.tsx
+++ b/src/components/featureInfo/urbanPanels.tsx
@@ -1,0 +1,55 @@
+import { RADIUS, FONT_SIZE } from "../../styles/designTokens";
+import { Row, SourceFooter } from "./shared";
+import { useFeatureTheme } from "./featureTheme";
+
+// 本檔 Title 為極簡本地版（同 fisheryPanels 慣例）：shared.tsx 未 export Title，故不去改動它。
+function Title({ color, children }: { color: string; children: string }) {
+  const t = useFeatureTheme();
+  return (
+    <div style={{ display: "flex", alignItems: "center", gap: 6, marginBottom: 6 }}>
+      <div style={{ width: 10, height: 10, borderRadius: RADIUS.full, background: color, flexShrink: 0 }} />
+      <div style={{ fontSize: FONT_SIZE.lg, fontWeight: 700, color: t.textStrong, letterSpacing: 0.5 }}>{children}</div>
+    </div>
+  );
+}
+
+/** 數值 + 單位；非有限值回空字串（Row 對空值自動隱藏） */
+function numUnit(v: unknown, unit: string): string {
+  const n = Number(v);
+  return Number.isFinite(n) ? `${n.toLocaleString(undefined, { maximumFractionDigits: 1 })} ${unit}` : "";
+}
+
+/** status 三值 → 中文標籤 + 代表色（存續 綠 / 消失 紅 / 新增 淺綠） */
+const STATUS_TIER: Record<string, { label: string; color: string }> = {
+  persisted: { label: "存續（2024→現在）", color: "#2e7d32" },
+  disappeared: { label: "消失（2024 有、現在無）", color: "#e53935" },
+  appeared: { label: "新增（2024 無、現在有）", color: "#9ccc65" },
+};
+
+export function StreetTreesTaipeiDiffPanel({ props }: { props: Record<string, unknown> }) {
+  const status = typeof props.status === "string" ? props.status : "";
+  const tier = STATUS_TIER[status] ?? { label: status || "未知", color: "#9e9e9e" };
+  const renumberSuspect = props.renumber_suspect === true;
+  // 路名（附行政區）：Region 為主，Dist 括號附註
+  const region = String(props.Region ?? "");
+  const dist = String(props.Dist ?? "");
+  const roadValue = region && dist ? `${region}（${dist}）` : region || dist;
+  return (
+    <>
+      <Title color={tier.color}>{String(props.TreeType ?? "行道樹")}</Title>
+      <Row label="狀態" value={tier.label} color={tier.color} />
+      <Row label="路名" value={roadValue} />
+      <Row label="TreeID" value={String(props.TreeID ?? "")} />
+      <Row label="胸徑" value={numUnit(props.Diameter, "cm")} />
+      <Row label="樹高" value={numUnit(props.TreeHeight, "m")} />
+      <Row label="調查日" value={String(props.SurveyDate ?? "")} />
+      {renumberSuspect && (
+        <Row label="提示" value="⚠️ 疑似重編號（同路名同樹種 10m 內配對，可能非真消失/新增）" color="#fbbf24" />
+      )}
+      <div style={{ fontSize: FONT_SIZE.sm, color: "rgba(150,200,255,0.6)", lineHeight: 1.5, marginTop: 6 }}>
+        ⓘ TreeID 消失≠砍除；2024 基準取自 Wayback，含颱風後清運滯後
+      </div>
+      <SourceFooter props={props} />
+    </>
+  );
+}

--- a/src/components/sidebar/layerCatalog.ts
+++ b/src/components/sidebar/layerCatalog.ts
@@ -151,6 +151,7 @@ export const LAYER_COLORS: Record<keyof LayerVisibility, string> = {
   aquacultureCageNet: "#5c6bc0",
   aquacultureWaterSatellite: "#26c6da",
   aquacultureIntegrated: "#26c6da",
+  streetTreesTaipeiDiff: "#2e7d32",
   sportsSchool: "#5c6bc0",
   sportsPublicOther: "#26a69a",
   sportsPrivate: "#ef6c00",
@@ -524,6 +525,12 @@ export const THEMES: ThemeDef[] = [
           { key: "pollutionPenaltyGeneral", label: "一般裁處 General Penalty", labelMobile: "一般裁處 General", expandable: true },
           { key: "pollutionPenaltyMobile", label: "移動污染 Mobile Penalty", labelMobile: "移動污染 Mobile", expandable: true },
           { key: "pollutionSite", label: "污染場址 Site", labelMobile: "污染場址 Site (8,253)", expandable: true },
+        ],
+      },
+      {
+        title: "都市開放空間 Urban Open Space",
+        layers: [
+          { key: "streetTreesTaipeiDiff", label: "行道樹變化 Street Tree Diff", expandable: true },
         ],
       },
     ],

--- a/src/data/upstreamRegistry.ts
+++ b/src/data/upstreamRegistry.ts
@@ -530,6 +530,8 @@ export const UPSTREAM_REGISTRY: Record<keyof LayerVisibility, UpstreamRef> = {
     processing: '整合逐口魚塭（OSM）+ 衛星偵測補充 + 生產區為單一 PMTiles（20,212 面），依 source 三色染色',
     note: '派生分析：三來源養殖面聚合',
   },
+  // 🌳 都市開放空間 Urban Open Space（台北行道樹 2024/11 vs 現在 三狀態變化）
+  streetTreesTaipeiDiff: { status: 'verified', datasets: [{ datasetId: 'street_trees_taipei_diff', confidence: 'HIGH' }] },
   // 🏟️ 運動場館 Sports（全國 15,000 點，運動部 22849；catalog: sports/all_venues）
   sportsSchool: { status: 'verified', datasets: [{ datasetId: 'all_venues', confidence: 'HIGH' }] },
   sportsPublicOther: { status: 'verified', datasets: [{ datasetId: 'all_venues', confidence: 'HIGH' }] },

--- a/src/hooks/useMapInteraction.ts
+++ b/src/hooks/useMapInteraction.ts
@@ -290,6 +290,7 @@ export function useMapInteraction(
           { layers: ["aquaculture-cage-net-fill", "aquaculture-cage-net-line"], type: "aquacultureCageNet" },
           { layers: ["aquaculture-water-satellite-fill", "aquaculture-water-satellite-line"], type: "aquacultureWaterSatellite" },
           { layers: ["aquaculture-integrated-fill", "aquaculture-integrated-line"], type: "aquacultureIntegrated" },
+          { layers: ["street-trees-taipei-diff-circle"], type: "streetTreesTaipeiDiff" },
           { layers: ["sports-venues-school", "sports-venues-public-other", "sports-venues-private", "sports-venues-park", "sports-venues-center"], type: "sportsVenue" },
           { layers: ["sat-current-point"], type: "satellite" },
           { layers: ["medical-hospitals-circle"], type: "medicalPOI" },

--- a/src/hooks/useTransportParams.ts
+++ b/src/hooks/useTransportParams.ts
@@ -178,6 +178,9 @@ export function useTransportParams() {
   const [aquacultureWaterSatelliteOpacity, setAquacultureWaterSatelliteOpacity] = useState(0.5);
   const [aquacultureWaterSatelliteConfidence, setAquacultureWaterSatelliteConfidence] = useState<string>("all"); // all / reservoir / certain（累積式信心篩選）
   const [aquacultureIntegratedOpacity, setAquacultureIntegratedOpacity] = useState(0.6);
+  const [streetTreesTaipeiDiffOpacity, setStreetTreesTaipeiDiffOpacity] = useState(0.7);
+  const [streetTreesTaipeiDiffStatus, setStreetTreesTaipeiDiffStatus] = useState<string>("all"); // all / disappeared / changed
+  const [streetTreesTaipeiDiffRadius, setStreetTreesTaipeiDiffRadius] = useState(1.0); // 點位大小縮放倍率
   const [lakesPondsOsmOpacity, setLakesPondsOsmOpacity] = useState(0.5);
   const [crimeAreaMonthlyOpacity, setCrimeAreaMonthlyOpacity] = useState(0.55);
   const [theftTaoyuanOpacity, setTheftTaoyuanOpacity] = useState(0.8);
@@ -844,6 +847,10 @@ export function useTransportParams() {
     aquacultureWaterSatelliteOpacity, aquacultureIntegratedOpacity, lakesPondsOsmOpacity,
     // 信心層級 select（all/reservoir/certain）編成 idx（0/1/2）；paint 端 decode 做 opacity 篩選
     aquacultureWaterSatelliteConfidenceIdx: ["all", "reservoir", "certain"].indexOf(aquacultureWaterSatelliteConfidence),
+    streetTreesTaipeiDiffOpacity,
+    // status 篩選 select（all/disappeared/changed）編成 idx（0/1/2）；paint 端 decode 做 opacity 篩選
+    streetTreesTaipeiDiffStatusIdx: ["all", "disappeared", "changed"].indexOf(streetTreesTaipeiDiffStatus),
+    streetTreesTaipeiDiffRadius,
     crimeAreaMonthlyOpacity,
     theftTaoyuanOpacity, theftTaoyuanScale,
     trafficAccidentYearlyOpacity, trafficAccidentYearlyScale,
@@ -1180,6 +1187,7 @@ export function useTransportParams() {
     correctionalFacilityOpacity, correctionalFacilityScale, courtJurisdictionOpacity,
     aquaculturePondsOpacity, aquacultureZoneOpacity, aquacultureCageNetOpacity,
     aquacultureWaterSatelliteOpacity, aquacultureWaterSatelliteConfidence, aquacultureIntegratedOpacity, lakesPondsOsmOpacity,
+    streetTreesTaipeiDiffOpacity, streetTreesTaipeiDiffStatus, streetTreesTaipeiDiffRadius,
     crimeAreaMonthlyOpacity, theftTaoyuanOpacity, theftTaoyuanScale,
     trafficAccidentYearlyOpacity, trafficAccidentYearlyScale, accidentTaipeiOpacity, accidentTaipeiScale,
     a1AccidentRealtimeOpacity, a1AccidentRealtimeScale, investigationBureauOpacity, investigationBureauScale,
@@ -2230,6 +2238,11 @@ export function useTransportParams() {
       ];
       case "aquacultureIntegrated": return [
         { label: `填色透明度 ${aquacultureIntegratedOpacity.toFixed(2)}`, value: aquacultureIntegratedOpacity, min: 0, max: 0.85, step: 0.05, onChange: setAquacultureIntegratedOpacity },
+      ];
+      case "streetTreesTaipeiDiff": return [
+        { type: "select" as const, label: "狀態", value: streetTreesTaipeiDiffStatus, options: [{ label: "全部", value: "all" }, { label: "只看消失", value: "disappeared" }, { label: "只看變動", value: "changed" }], onChange: setStreetTreesTaipeiDiffStatus },
+        { label: `透明度 ${streetTreesTaipeiDiffOpacity.toFixed(2)}`, value: streetTreesTaipeiDiffOpacity, min: 0, max: 1, step: 0.05, onChange: setStreetTreesTaipeiDiffOpacity },
+        { label: `點位大小 ${streetTreesTaipeiDiffRadius.toFixed(2)}`, value: streetTreesTaipeiDiffRadius, min: 0.5, max: 3.0, step: 0.25, onChange: setStreetTreesTaipeiDiffRadius },
       ];
       case "crimeAreaMonthly": return [
         { label: `填色透明度 ${crimeAreaMonthlyOpacity.toFixed(2)}`, value: crimeAreaMonthlyOpacity, min: 0.1, max: 0.9, step: 0.05, onChange: setCrimeAreaMonthlyOpacity },

--- a/src/map/overlayRegistry.ts
+++ b/src/map/overlayRegistry.ts
@@ -2967,6 +2967,58 @@ export const OVERLAY_REGISTRY: OverlayConfig[] = [
     ],
   },
 
+  // ── 🌳 都市開放空間 Urban Open Space（靜態 overlay PMTiles 點，走 ./urban/）──
+  // 台北行道樹 2024/11 vs 現在 三狀態點圖層（status 分色 + renumber 疑似重編號降透明 + status 篩選）
+  {
+    id: "streetTreesTaipeiDiff",
+    sourceUrl: "./urban/street_trees_taipei_diff.pmtiles",
+    sourceId: "street-trees-taipei-diff",
+    pmtiles: { sourceLayer: "street_trees_taipei_diff", minzoom: 5, maxzoom: 14 },
+    rebuildOnParamChange: ["streetTreesTaipeiDiffOpacity", "streetTreesTaipeiDiffStatusIdx", "streetTreesTaipeiDiffRadius"],
+    layers: [
+      {
+        suffix: "circle", type: "circle",
+        paint: (_isDark, p) => {
+          const base = p?.streetTreesTaipeiDiffOpacity ?? 0.7;
+          const filt = p?.streetTreesTaipeiDiffStatusIdx ?? 0; // 0=全部 1=只看消失 2=只看變動
+          const radiusMult = p?.streetTreesTaipeiDiffRadius ?? 1;
+          const opFor = (st: string) => {
+            if (filt === 1 && st !== "disappeared") return 0;      // 只看消失
+            if (filt === 2 && st === "persisted") return 0;        // 只看變動（消失+新增）
+            return base;
+          };
+          const opExpr = (mult: number): unknown[] => [
+            "match", ["get", "status"],
+            "disappeared", opFor("disappeared") * mult,
+            "appeared", opFor("appeared") * mult,
+            opFor("persisted") * mult, // persisted / default
+          ];
+          return {
+            "circle-color": ["match", ["get", "status"],
+              "disappeared", "#e53935",
+              "appeared", "#9ccc65",
+              "#2e7d32"], // persisted
+            // renumber_suspect 疑似重編號（真 boolean）→ 透明度降 0.35 倍
+            "circle-opacity": ["case",
+              ["==", ["get", "renumber_suspect"], true], opExpr(0.35),
+              opExpr(1)],
+            // 隨 zoom 漸變的基準值 × 點位大小倍率，並設 1.5px 下限，避免低 zoom（拉遠）
+            // 配合縮小倍率時點位小到肉眼看不見（PMTiles 沒有 minzoom 限制，z5 起即可見）。
+            // 注意：MapLibre 規定 zoom 表達式只能在最外層 interpolate/step，
+            // 故倍率與下限在 JS 端算進各 stop（radiusMult 是重繪時的純數字）。
+            "circle-radius": ["interpolate", ["linear"], ["zoom"],
+              5, Math.max(1.5, 1 * radiusMult),
+              9, Math.max(1.5, 1.8 * radiusMult),
+              12, Math.max(1.5, 3 * radiusMult),
+              14, Math.max(1.5, 4.5 * radiusMult),
+            ],
+            "circle-stroke-width": 0,
+          };
+        },
+      },
+    ],
+  },
+
   // ── 🏟️ 運動場館 Sports（靜態 CDN geojson，走 ./sports/）──
   // 5 sublayer 共用 sports-venues source（sourceId 相同 → 只 fetch 一次），靠 config.filter 分 layer 隸屬類。
   // circle：category 27 類 match 分色 + area_sqm log 點大小（NULL fallback 固定半徑）+ open_status="不對外" 淡化。

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -111,6 +111,8 @@ export type ExpandableLayerKey =
   | "aquaculturePonds" | "aquacultureZone" | "aquacultureCageNet"
   | "aquacultureWaterSatellite"
   | "aquacultureIntegrated"
+  // 🌳 都市開放空間 Urban Open Space（靜態 overlay PMTiles 點）
+  | "streetTreesTaipeiDiff"
   // 運動場館 SPORTS（5 sublayer 共用 sports-venues source + layer filter）
   | "sportsSchool" | "sportsPublicOther" | "sportsPrivate" | "sportsPark" | "sportsCenter"
   | "youbikeFullness"
@@ -626,6 +628,7 @@ export interface FeatureInfo {
     | "aquaculturePonds" | "aquacultureZone" | "aquacultureCageNet"
     | "aquacultureWaterSatellite"
     | "aquacultureIntegrated"
+    | "streetTreesTaipeiDiff"
     | "sportsVenue"
     | "medicalPOI"
     | "medicalIsochrone"
@@ -797,6 +800,8 @@ export interface LayerVisibility {
   aquacultureCageNet: boolean;    // 海上箱網（42 面）
   aquacultureWaterSatellite: boolean; // 衛星偵測養殖水體（Sentinel-2 RF，5,095 面，信心 3 級染色：確定/蓄水池/不確定 藍→灰）
   aquacultureIntegrated: boolean; // 養殖漁業整合（PMTiles，20,212 面；source 三色：ponds 青/satellite 綠/production 橙）
+  // 🌳 都市開放空間 Urban Open Space（靜態 overlay PMTiles 點）
+  streetTreesTaipeiDiff: boolean; // 台北行道樹 2024/11 vs 現在 三狀態變化（PMTiles，99,527 點；status 分色 persisted/disappeared/appeared）
   // 🏟️ 運動場館 SPORTS（全國 15,000 點靜態 GeoJSON；5 sublayer 共用 sports-venues source + layer filter）
   sportsSchool: boolean;          // 學校場館（12,221）
   sportsPublicOther: boolean;     // 其他公共場館（1,135）


### PR DESCRIPTION
## 內容

台北行道樹「2024-11-21（康芮颱風後3週）vs 2026-07-12（現行）」三狀態點圖層 `streetTreesTaipeiDiff`：

- **99,527 點**：persisted 88,004（深綠 #2e7d32）/ disappeared 7,494（紅 #e53935）/ appeared 4,029（淺綠 #9ccc65）
- renumber_suspect（疑似重編號 447 點）降透明度顯示
- 狀態篩選下拉（全部/只看消失/只看變動）、點位大小滑桿（0.5–3x）、透明度滑桿
- PMTiles `-r1` 不抽稀：所有 zoom 全點保留（拉遠不消失），最小半徑 1.5px
- 掛「環境氣候 → 都市開放空間」分組；圖例 / popup / upstreamRegistry 全套接線
- D 類大檔五處到齊：.gitignore / upload / pull / nginx `location /urban/`；**PMTiles（13.2MB）已上 S3 `deploy-assets/urban/`**

## 上游

- 資料：taipei-gis-analytics `pipelines/urban_open_space/street_trees_taipei_diff/`（commit 33f323c）
- handoff：`taipei-gis-analytics/docs/handoff/street_trees_taipei_diff.md`
- 2024 快照來源：Wayback Machine（data.taipei 官方無版本歷史）

## 驗證

- `tsc -b` 0 error
- `pnpm test` 190/190 通過（含 deployContract / layerConsistency 契約測試）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SPeHoTVJ4BAWjK74HpG8sB