### PR TITLE
feat(sidebar): 行道樹圖層 streetTreesTaipeiDiff 預設開啟

### DIFF
--- a/src/hooks/useLayerVisibility.ts
+++ b/src/hooks/useLayerVisibility.ts
@@ -7,8 +7,10 @@ import { LAYER_COLORS } from "../components/sidebar/layerCatalog";
  * key 全集從 layerCatalog 的 LAYER_COLORS 派生（型別強制完整）—
  * 新增 layer 不用再改本檔，除非要預設開啟。
  */
-// 全部預設關閉：訪客一進站不打任何 RPC；PMTiles 圖層也依使用者 toggle 才顯示。
-const DEFAULT_ON: ReadonlySet<keyof LayerVisibility> = new Set<keyof LayerVisibility>([]);
+// 預設幾乎全關：訪客一進站不打任何 RPC；唯行道樹（靜態 PMTiles，經 Cloudflare 邊緣快取）預設開啟。
+const DEFAULT_ON: ReadonlySet<keyof LayerVisibility> = new Set<keyof LayerVisibility>([
+  "streetTreesTaipeiDiff",
+]);
 
 function buildDefaults(): LayerVisibility {
   const keys = Object.keys(LAYER_COLORS) as (keyof LayerVisibility)[];


### PR DESCRIPTION
- DEFAULT_ON 加入 streetTreesTaipeiDiff（靜態 PMTiles、經 Cloudflare 邊緣快取，
  進站即載不打 RPC）；其餘圖層維持預設關閉

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01SPeHoTVJ4BAWjK74HpG8sB
