### PR TITLE
feat(map): 開站預設鏡位台北 z12.5 + 行道樹點位大小預設 0.5

### DIFF
--- a/src/hooks/useTransportParams.ts
+++ b/src/hooks/useTransportParams.ts
@@ -180,7 +180,7 @@ export function useTransportParams() {
   const [aquacultureIntegratedOpacity, setAquacultureIntegratedOpacity] = useState(0.6);
   const [streetTreesTaipeiDiffOpacity, setStreetTreesTaipeiDiffOpacity] = useState(0.7);
   const [streetTreesTaipeiDiffStatus, setStreetTreesTaipeiDiffStatus] = useState<string>("all"); // all / disappeared / changed
-  const [streetTreesTaipeiDiffRadius, setStreetTreesTaipeiDiffRadius] = useState(1.0); // 點位大小縮放倍率
+  const [streetTreesTaipeiDiffRadius, setStreetTreesTaipeiDiffRadius] = useState(0.5); // 點位大小縮放倍率
   const [lakesPondsOsmOpacity, setLakesPondsOsmOpacity] = useState(0.5);
   const [crimeAreaMonthlyOpacity, setCrimeAreaMonthlyOpacity] = useState(0.55);
   const [theftTaoyuanOpacity, setTheftTaoyuanOpacity] = useState(0.8);

--- a/src/map/cameraPresets.ts
+++ b/src/map/cameraPresets.ts
@@ -284,7 +284,13 @@ export const ALL_PRESETS: CameraPreset[] = [
   },
 ];
 
-export const DEFAULT_CAMERA: CameraPreset = ALL_PRESETS[0]!;
+// 開站預設鏡位：台北市中心 z12.5（行道樹圖層預設開啟，進站直接落在主場景；
+// 「全台總覽」preset 本身不動，仍可從鏡位選單切換）
+export const DEFAULT_CAMERA: CameraPreset = {
+  ...ALL_PRESETS[0]!,
+  center: [121.5318, 25.0464],
+  zoom: 12.5,
+};
 
 export function getPresetById(id: string): CameraPreset | undefined {
   return ALL_PRESETS.find((p) => p.id === id);


### PR DESCRIPTION
- DEFAULT_CAMERA 改為台北市中心 (121.5318, 25.0464) z12.5，
  「全台總覽」preset 不動仍可切換
- streetTreesTaipeiDiffRadius 預設 1.0 → 0.5

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01SPeHoTVJ4BAWjK74HpG8sB
