### PR TITLE
feat(urban): 行道樹圖層四種染色模式（狀態/樹種/胸徑/樹高）

### DIFF
--- a/docs/features/street_trees_taipei_diff/README.md
+++ b/docs/features/street_trees_taipei_diff/README.md
@@ -27,8 +27,13 @@
 
 ## 渲染參數
 
-- 單 circle layer：`circle-color` 依 `status` match 三色；`circle-opacity` 用 `case` 判 `renumber_suspect` 降透明 + status 篩選；`circle-radius` 隨 zoom `interpolate`（z5=1 → z14=4.5），避免低 zoom 糊成一片。
-- 控制項：狀態 select（all/disappeared/changed，編成 idx 進 paint）+ 透明度 slider（預設 0.7）。
+- 單 circle layer：`circle-color` 依「染色模式」四選一（見下）；`circle-opacity` 用 `case` 判 `renumber_suspect` 降透明 + status 篩選（四種染色模式下都繼續有效）；`circle-radius` 隨 zoom `interpolate`（z5=1 → z14=4.5），避免低 zoom 糊成一片。
+- **染色模式**（`streetTreesTaipeiDiffColorModeIdx`，`src/data/streetTreeColors.ts` 為色票 SSOT）：
+  - `status`（預設）：三狀態色 綠存續 / 紅消失 / 淺綠新增
+  - `species`：前 10 大樹種各一色（榕樹/茄苳/樟樹/楓香/臺灣欒樹/白千層/黑板樹/小葉欖仁/大花紫薇/水黃皮）+ 其他灰，`match` TreeType
+  - `diameter`：胸徑 5 級 `step`（break 10/20/30/40 cm，全量分位取整），亮暖色帶淺→深＝細→粗，缺值/≤0 灰
+  - `height`：樹高 5 級 `step`（break 6/8/10/13 m），同暖色帶
+- 控制項：染色模式 select（status/species/diameter/height，編成 idx 進 paint）+ 狀態 select（all/disappeared/changed）+ 透明度 slider（預設 0.7）+ 點位大小 slider。
 - 預設關閉（`false`，未列入 `useLayerVisibility` 的 `DEFAULT_ON` → 自動派生 false）。
 
 ## 關鍵檔案

--- a/docs/features/street_trees_taipei_diff/changelog.md
+++ b/docs/features/street_trees_taipei_diff/changelog.md
@@ -12,6 +12,15 @@
 
 ---
 
+## 2026-07-13 — PR #（pending）`（pending）`
+
+- 新增「染色模式」select（依狀態 / 依樹種 / 依胸徑 / 依樹高），預設維持依狀態三色
+- 新增色票 SSOT `src/data/streetTreeColors.ts`（前 10 大樹種 categorical 亮色 + 胸徑/樹高 sequential 暖色帶 + 表達式 builder），overlayRegistry 與 LegendPanel 共用
+- 前 10 大樹種與分級 break 由全量 geojson（99,527 點）統計：Diameter 分位 → 10/20/30/40 cm；TreeHeight 分位 → 6/8/10/13 m；缺值/≤0 給灰
+- 接線：useTransportParams（colorMode state + colorModeIdx 進 params + deps + select）/ overlayRegistry（circle-color switch 分支 + rebuildOnParamChange）/ LegendPanel（圖例依 colorMode 切換）
+- status 篩選（opacity）與 renumber 降透明在四種模式下都繼續有效；circle-color 不引入 zoom（沿用 circle-radius 的雷防線）
+- Breaking：無
+
 ## 2026-07-12 — PR #（pending）`（pending）`
 
 - 新增 `streetTreesTaipeiDiff` 圖層（台北行道樹 2024/11 vs 現在 三狀態變化）

--- a/src/components/LegendPanel.tsx
+++ b/src/components/LegendPanel.tsx
@@ -22,6 +22,10 @@ import {
 } from "../data/fireTypes";
 import { FARM_SPECIES, OTHER_SPECIES_LEGEND, SLAUGHTER_CATS, FEED_COLOR, MARKET_COLOR } from "../data/livestockTypes";
 import { SPORTS_CATEGORIES } from "../data/sportsTypes";
+import {
+  STREET_TREE_SPECIES, STREET_TREE_OTHER_COLOR,
+  STREET_TREE_DIAMETER_BANDS, STREET_TREE_HEIGHT_BANDS,
+} from "../data/streetTreeColors";
 import { MEDICAL_ISOCHRONE_BANDS, MEDICAL_ISOCHRONE_NOTE } from "../data/medicalIsochroneTypes";
 import {
   SOIL_FERTILITY_METRICS,
@@ -189,7 +193,7 @@ export const LEGEND_REGISTRY: LegendEntry[] = [
   { keys: ["livestockSlaughter", "livestockFeed", "livestockMarket"], render: () => <LivestockFacilityLegend /> },
   { keys: ["aquaculturePonds", "aquacultureZone", "aquacultureCageNet", "aquacultureWaterSatellite"], render: ({ visibility }) => <AquacultureLegend visibility={visibility} /> },
   { keys: ["aquacultureIntegrated"], render: () => <AquacultureIntegratedLegend /> },
-  { keys: ["streetTreesTaipeiDiff"], render: () => <StreetTreesTaipeiDiffLegend /> },
+  { keys: ["streetTreesTaipeiDiff"], render: ({ overlayParams }) => <StreetTreesTaipeiDiffLegend colorModeIdx={overlayParams.streetTreesTaipeiDiffColorModeIdx ?? 0} /> },
   { keys: ["sportsSchool", "sportsPublicOther", "sportsPrivate", "sportsPark", "sportsCenter"], render: () => <SportsVenueLegend /> },
   { keys: ["ecoNetworkZones"], render: () => <EcoNetworkZonesLegend /> },
   {
@@ -674,31 +678,55 @@ function AquacultureIntegratedLegend() {
   );
 }
 
-function StreetTreesTaipeiDiffLegend() {
+// 行道樹變化圖例：依染色模式（0=狀態 1=樹種 2=胸徑 3=樹高）切換顯示內容。
+// 色票資料 = src/data/streetTreeColors.ts（與 overlayRegistry 配色同一 SSOT）。
+function StreetTreesTaipeiDiffLegend({ colorModeIdx = 0 }: { colorModeIdx?: number }) {
   const t = useLegendTheme();
-  const rows = [
-    { color: "#2e7d32", label: "存續 persisted" },
-    { color: "#e53935", label: "消失 disappeared" },
-    { color: "#9ccc65", label: "新增 appeared" },
-  ];
+
+  // 一列圓點色塊 + 標籤
+  const dotRow = (color: string, label: string) => (
+    <div key={label} style={{ display: "flex", alignItems: "center", gap: 6 }}>
+      <div
+        style={{
+          width: 10, height: 10, borderRadius: RADIUS.full, background: color,
+          opacity: 0.9, border: "1px solid rgba(255,255,255,0.6)",
+          boxSizing: "border-box", flexShrink: 0,
+        }}
+      />
+      <span style={{ fontSize: FONT_SIZE.xs, color: t.textMuted }}>{label}</span>
+    </div>
+  );
+
+  let subhead = "狀態 STATUS";
+  let rows: { color: string; label: string }[];
+  if (colorModeIdx === 1) {
+    subhead = "樹種 SPECIES（前 10 大）";
+    rows = [
+      ...STREET_TREE_SPECIES.map((s) => ({ color: s.color, label: s.name })),
+      { color: STREET_TREE_OTHER_COLOR, label: "其他 Other" },
+    ];
+  } else if (colorModeIdx === 2) {
+    subhead = "胸徑 DIAMETER (cm)";
+    rows = STREET_TREE_DIAMETER_BANDS.map((b) => ({ color: b.color, label: b.label }));
+  } else if (colorModeIdx === 3) {
+    subhead = "樹高 HEIGHT (m)";
+    rows = STREET_TREE_HEIGHT_BANDS.map((b) => ({ color: b.color, label: b.label }));
+  } else {
+    rows = [
+      { color: "#2e7d32", label: "存續 persisted" },
+      { color: "#e53935", label: "消失 disappeared" },
+      { color: "#9ccc65", label: "新增 appeared" },
+    ];
+  }
+
   return (
     <div>
       <div style={{ fontSize: FONT_SIZE.xs, color: t.textDim, letterSpacing: 1, marginBottom: 4 }}>
         行道樹變化 STREET TREE DIFF
       </div>
+      <div style={{ fontSize: FONT_SIZE.xs, color: t.textMuted, marginBottom: 3 }}>{subhead}</div>
       <div style={{ display: "flex", flexDirection: "column", gap: 2 }}>
-        {rows.map((it) => (
-          <div key={it.label} style={{ display: "flex", alignItems: "center", gap: 6 }}>
-            <div
-              style={{
-                width: 10, height: 10, borderRadius: RADIUS.full, background: it.color,
-                opacity: 0.9, border: "1px solid rgba(255,255,255,0.6)",
-                boxSizing: "border-box", flexShrink: 0,
-              }}
-            />
-            <span style={{ fontSize: FONT_SIZE.xs, color: t.textMuted }}>{it.label}</span>
-          </div>
-        ))}
+        {rows.map((it) => dotRow(it.color, it.label))}
         <div style={{ fontSize: FONT_SIZE.xs, color: t.textDim, marginTop: 2, lineHeight: 1.4 }}>
           半透明點 = 疑似重編號（非真消失/新增）
         </div>

--- a/src/data/streetTreeColors.ts
+++ b/src/data/streetTreeColors.ts
@@ -1,0 +1,97 @@
+/**
+ * 行道樹變化圖層「染色模式」的顏色 / 分級單一真實來源。
+ * 給 overlayRegistry 配色（circle-color 表達式）與 LegendPanel 圖例兩處共用。
+ *
+ * 四種染色模式：
+ * - status   ：維持現行三狀態色（存續/消失/新增），色票留在 overlayRegistry / Legend 既有處，本檔不管
+ * - species  ：資料量前 10 大樹種各一色 + 其他灰（colorblind-friendly 亮色 categorical）
+ * - diameter ：Diameter(cm) 分位數 5 級 sequential 亮暖色（淺→深＝細→粗）；缺值/<=0 給灰
+ * - height   ：TreeHeight(m) 分位數 5 級，沿用同一暖色帶（同 diameter 做法）
+ *
+ * 前 10 大樹種與分級 break 由全量 geojson（99,527 點）統計決定，見 docs changelog：
+ *   Diameter 分位 p20/p40/p60/p80 ≈ 10/20/28/38 → 取整 10/20/30/40
+ *   Height   分位 p20/p40/p60/p80 ≈ 5.8/8/10/12.5 → 取整 6/8/10/13
+ */
+
+// 缺值 / <=0（Diameter / TreeHeight）與非前 10 大樹種共用的中性灰
+export const STREET_TREE_MISSING_COLOR = "#8c929b";
+export const STREET_TREE_OTHER_COLOR = "#8c929b";
+
+// 前 10 大樹種（count desc）→ 亮色 categorical palette
+// （深色底圖可辨、彼此好區分；Tableau10 調亮版 / Okabe-Ito 混搭）
+export const STREET_TREE_SPECIES: { name: string; color: string }[] = [
+  { name: "榕樹",     color: "#4c9be0" }, // blue
+  { name: "茄苳",     color: "#f28e2b" }, // orange
+  { name: "樟樹",     color: "#59b359" }, // green
+  { name: "楓香",     color: "#f2d64b" }, // yellow
+  { name: "臺灣欒樹", color: "#b07ad9" }, // purple
+  { name: "白千層",   color: "#2fc2d4" }, // cyan
+  { name: "黑板樹",   color: "#e15759" }, // red
+  { name: "小葉欖仁", color: "#f58ebc" }, // pink
+  { name: "大花紫薇", color: "#9ed45a" }, // lime
+  { name: "水黃皮",   color: "#c69c6d" }, // tan
+];
+
+// sequential 亮暖色帶（淺黃→橘→紅）；由淺到深＝由小到大。
+// 選暖色帶而非 YlGn，因為深色底圖上「深綠」端對比不足，暖色帶末端（紅）仍夠亮。
+const SEQ_RAMP: [string, string, string, string, string] = ["#fff2a8", "#fecc5c", "#fd9843", "#f4611f", "#d7191c"];
+
+export interface StreetTreeBand {
+  /** 該級上界（不含）；最後一級為 null（無上界） */
+  max: number | null;
+  color: string;
+  label: string;
+}
+
+// 胸徑 cm 5 級（break 10/20/30/40）
+export const STREET_TREE_DIAMETER_BANDS: StreetTreeBand[] = [
+  { max: 10,   color: SEQ_RAMP[0], label: "< 10 cm" },
+  { max: 20,   color: SEQ_RAMP[1], label: "10–20 cm" },
+  { max: 30,   color: SEQ_RAMP[2], label: "20–30 cm" },
+  { max: 40,   color: SEQ_RAMP[3], label: "30–40 cm" },
+  { max: null, color: SEQ_RAMP[4], label: "≥ 40 cm" },
+];
+
+// 樹高 m 5 級（break 6/8/10/13）
+export const STREET_TREE_HEIGHT_BANDS: StreetTreeBand[] = [
+  { max: 6,    color: SEQ_RAMP[0], label: "< 6 m" },
+  { max: 8,    color: SEQ_RAMP[1], label: "6–8 m" },
+  { max: 10,   color: SEQ_RAMP[2], label: "8–10 m" },
+  { max: 13,   color: SEQ_RAMP[3], label: "10–13 m" },
+  { max: null, color: SEQ_RAMP[4], label: "≥ 13 m" },
+];
+
+// 染色模式 select 選項；index 對齊 overlayRegistry 讀的 streetTreesTaipeiDiffColorModeIdx
+export const STREET_TREE_COLOR_MODES = ["status", "species", "diameter", "height"] as const;
+export type StreetTreeColorMode = (typeof STREET_TREE_COLOR_MODES)[number];
+
+// ── MapLibre circle-color 表達式 builder ──
+// ⚠️ 這些表達式不得含 ["zoom"]：MapLibre 規定 zoom 只能在最外層 interpolate/step，
+//    circle-color 走 match/step（無 zoom）才不會踩到 circle-radius 曾踩過的雷。
+
+/** 樹種：match TreeType → 前 10 色，其餘灰 */
+export function streetTreeSpeciesColorExpr(): unknown[] {
+  return [
+    "match", ["get", "TreeType"],
+    ...STREET_TREE_SPECIES.flatMap((s) => [s.name, s.color]),
+    STREET_TREE_OTHER_COLOR,
+  ];
+}
+
+/** 分級 step：缺值/<=0 → 灰；否則依 band break 上色 */
+function bandStepColorExpr(field: string, bands: StreetTreeBand[]): unknown[] {
+  const val: unknown[] = ["to-number", ["get", field], 0]; // null → 0 → 判為缺值
+  const step: unknown[] = ["step", val, bands[0]!.color];
+  for (let i = 1; i < bands.length; i++) {
+    step.push(bands[i - 1]!.max as number, bands[i]!.color);
+  }
+  return ["case", ["<=", val, 0], STREET_TREE_MISSING_COLOR, step];
+}
+
+export function streetTreeDiameterColorExpr(): unknown[] {
+  return bandStepColorExpr("Diameter", STREET_TREE_DIAMETER_BANDS);
+}
+
+export function streetTreeHeightColorExpr(): unknown[] {
+  return bandStepColorExpr("TreeHeight", STREET_TREE_HEIGHT_BANDS);
+}

--- a/src/hooks/useTransportParams.ts
+++ b/src/hooks/useTransportParams.ts
@@ -181,6 +181,7 @@ export function useTransportParams() {
   const [streetTreesTaipeiDiffOpacity, setStreetTreesTaipeiDiffOpacity] = useState(0.7);
   const [streetTreesTaipeiDiffStatus, setStreetTreesTaipeiDiffStatus] = useState<string>("all"); // all / disappeared / changed
   const [streetTreesTaipeiDiffRadius, setStreetTreesTaipeiDiffRadius] = useState(0.5); // 點位大小縮放倍率
+  const [streetTreesTaipeiDiffColorMode, setStreetTreesTaipeiDiffColorMode] = useState<string>("status"); // status / species / diameter / height
   const [lakesPondsOsmOpacity, setLakesPondsOsmOpacity] = useState(0.5);
   const [crimeAreaMonthlyOpacity, setCrimeAreaMonthlyOpacity] = useState(0.55);
   const [theftTaoyuanOpacity, setTheftTaoyuanOpacity] = useState(0.8);
@@ -851,6 +852,8 @@ export function useTransportParams() {
     // status 篩選 select（all/disappeared/changed）編成 idx（0/1/2）；paint 端 decode 做 opacity 篩選
     streetTreesTaipeiDiffStatusIdx: ["all", "disappeared", "changed"].indexOf(streetTreesTaipeiDiffStatus),
     streetTreesTaipeiDiffRadius,
+    // 染色模式 select（status/species/diameter/height）編成 idx（0-3）；paint 端 switch 分支
+    streetTreesTaipeiDiffColorModeIdx: ["status", "species", "diameter", "height"].indexOf(streetTreesTaipeiDiffColorMode),
     crimeAreaMonthlyOpacity,
     theftTaoyuanOpacity, theftTaoyuanScale,
     trafficAccidentYearlyOpacity, trafficAccidentYearlyScale,
@@ -1187,7 +1190,7 @@ export function useTransportParams() {
     correctionalFacilityOpacity, correctionalFacilityScale, courtJurisdictionOpacity,
     aquaculturePondsOpacity, aquacultureZoneOpacity, aquacultureCageNetOpacity,
     aquacultureWaterSatelliteOpacity, aquacultureWaterSatelliteConfidence, aquacultureIntegratedOpacity, lakesPondsOsmOpacity,
-    streetTreesTaipeiDiffOpacity, streetTreesTaipeiDiffStatus, streetTreesTaipeiDiffRadius,
+    streetTreesTaipeiDiffOpacity, streetTreesTaipeiDiffStatus, streetTreesTaipeiDiffRadius, streetTreesTaipeiDiffColorMode,
     crimeAreaMonthlyOpacity, theftTaoyuanOpacity, theftTaoyuanScale,
     trafficAccidentYearlyOpacity, trafficAccidentYearlyScale, accidentTaipeiOpacity, accidentTaipeiScale,
     a1AccidentRealtimeOpacity, a1AccidentRealtimeScale, investigationBureauOpacity, investigationBureauScale,
@@ -2240,6 +2243,7 @@ export function useTransportParams() {
         { label: `填色透明度 ${aquacultureIntegratedOpacity.toFixed(2)}`, value: aquacultureIntegratedOpacity, min: 0, max: 0.85, step: 0.05, onChange: setAquacultureIntegratedOpacity },
       ];
       case "streetTreesTaipeiDiff": return [
+        { type: "select" as const, label: "染色模式", value: streetTreesTaipeiDiffColorMode, options: [{ label: "依狀態", value: "status" }, { label: "依樹種", value: "species" }, { label: "依胸徑", value: "diameter" }, { label: "依樹高", value: "height" }], onChange: setStreetTreesTaipeiDiffColorMode },
         { type: "select" as const, label: "狀態", value: streetTreesTaipeiDiffStatus, options: [{ label: "全部", value: "all" }, { label: "只看消失", value: "disappeared" }, { label: "只看變動", value: "changed" }], onChange: setStreetTreesTaipeiDiffStatus },
         { label: `透明度 ${streetTreesTaipeiDiffOpacity.toFixed(2)}`, value: streetTreesTaipeiDiffOpacity, min: 0, max: 1, step: 0.05, onChange: setStreetTreesTaipeiDiffOpacity },
         { label: `點位大小 ${streetTreesTaipeiDiffRadius.toFixed(2)}`, value: streetTreesTaipeiDiffRadius, min: 0.5, max: 3.0, step: 0.25, onChange: setStreetTreesTaipeiDiffRadius },

--- a/src/map/overlayRegistry.ts
+++ b/src/map/overlayRegistry.ts
@@ -23,6 +23,9 @@ import {
 import {
   availabilityColorExpr, neutralCapacityColorExpr, sourceCategoryRingExpr,
 } from "../data/parkingLoader";
+import {
+  streetTreeSpeciesColorExpr, streetTreeDiameterColorExpr, streetTreeHeightColorExpr,
+} from "../data/streetTreeColors";
 
 const BASE_RADIUS = 5;
 
@@ -2974,7 +2977,7 @@ export const OVERLAY_REGISTRY: OverlayConfig[] = [
     sourceUrl: "./urban/street_trees_taipei_diff.pmtiles",
     sourceId: "street-trees-taipei-diff",
     pmtiles: { sourceLayer: "street_trees_taipei_diff", minzoom: 5, maxzoom: 14 },
-    rebuildOnParamChange: ["streetTreesTaipeiDiffOpacity", "streetTreesTaipeiDiffStatusIdx", "streetTreesTaipeiDiffRadius"],
+    rebuildOnParamChange: ["streetTreesTaipeiDiffOpacity", "streetTreesTaipeiDiffStatusIdx", "streetTreesTaipeiDiffRadius", "streetTreesTaipeiDiffColorModeIdx"],
     layers: [
       {
         suffix: "circle", type: "circle",
@@ -2982,6 +2985,7 @@ export const OVERLAY_REGISTRY: OverlayConfig[] = [
           const base = p?.streetTreesTaipeiDiffOpacity ?? 0.7;
           const filt = p?.streetTreesTaipeiDiffStatusIdx ?? 0; // 0=全部 1=只看消失 2=只看變動
           const radiusMult = p?.streetTreesTaipeiDiffRadius ?? 1;
+          const colorMode = p?.streetTreesTaipeiDiffColorModeIdx ?? 0; // 0=status 1=species 2=diameter 3=height
           const opFor = (st: string) => {
             if (filt === 1 && st !== "disappeared") return 0;      // 只看消失
             if (filt === 2 && st === "persisted") return 0;        // 只看變動（消失+新增）
@@ -2993,11 +2997,21 @@ export const OVERLAY_REGISTRY: OverlayConfig[] = [
             "appeared", opFor("appeared") * mult,
             opFor("persisted") * mult, // persisted / default
           ];
+          // 染色模式分支（JS 端 switch，重繪時 colorMode 是純數字，不引入 zoom）。
+          // status 篩選（opacity）與 renumber 降透明在四種模式下都繼續有效（共用下方 opExpr）。
+          const statusColor: unknown[] = ["match", ["get", "status"],
+            "disappeared", "#e53935",
+            "appeared", "#9ccc65",
+            "#2e7d32"]; // persisted
+          let circleColor: unknown[];
+          switch (colorMode) {
+            case 1: circleColor = streetTreeSpeciesColorExpr(); break;
+            case 2: circleColor = streetTreeDiameterColorExpr(); break;
+            case 3: circleColor = streetTreeHeightColorExpr(); break;
+            default: circleColor = statusColor;
+          }
           return {
-            "circle-color": ["match", ["get", "status"],
-              "disappeared", "#e53935",
-              "appeared", "#9ccc65",
-              "#2e7d32"], // persisted
+            "circle-color": circleColor,
             // renumber_suspect 疑似重編號（真 boolean）→ 透明度降 0.35 倍
             "circle-opacity": ["case",
               ["==", ["get", "renumber_suspect"], true], opExpr(0.35),


### PR DESCRIPTION
- 新增 streetTreeColors.ts 色票 SSOT：Top10 樹種 categorical 10 色 + 其他灰；
  胸徑 10/20/30/40cm、樹高 6/8/10/13m 五級暖色帶（break 取自實際分位數）
- 染色模式下拉（預設依狀態）；圖例隨模式切換；狀態篩選與 renumber 降透明四模式皆保留
- tsc 0 error、190/190 tests

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01SPeHoTVJ4BAWjK74HpG8sB
