### PR TITLE
feat(urban): 北市+新北土地使用分區 PMTiles 圖層（urban-zoning）

### DIFF
--- a/docs/features/urban-zoning/README.md
+++ b/docs/features/urban-zoning/README.md
@@ -8,7 +8,7 @@
 
 ## 一句話說明
 
-北市 + 新北官方都市計畫使用分區 polygon（住宅/商業/工業/農業/綠地/公設/交通/保護/其他 9 類統一分色），掛「都市分析」主題新 group「土地使用分區 Zoning」。
+北市 + 新北官方都市計畫使用分區 polygon（住宅/商業/工業/農業/綠地/公設/交通/保護/其他 9 類統一分色），掛「底圖 Base Map」主題新 group「土地使用分區 Zoning」（官方參考底圖，非分析產物；上游 topic-research 原始目標即底圖層）。
 
 ## 圖層 / 元件
 
@@ -22,7 +22,7 @@
 - 色票 SSOT：`src/data/urbanZoningTypes.ts`（9 類 zone_category）
 - Overlay：`src/map/overlayRegistry.ts`（fill + line 雙 spec，pmtiles sourceLayer 各自對應）
 - Popup：`src/components/featureInfo/urbanPanels.tsx`（兩 key 共用 UrbanZoningPanel）
-- Catalog：`src/components/sidebar/layerCatalog.ts`（都市分析 > 土地使用分區）
+- Catalog：`src/components/sidebar/layerCatalog.ts`（底圖 Base Map > 土地使用分區）
 
 ## 資料契約摘要
 

--- a/docs/features/urban-zoning/README.md
+++ b/docs/features/urban-zoning/README.md
@@ -1,0 +1,43 @@
+# 都市計畫土地使用分區（urban-zoning）
+
+> **Slug**：`urban-zoning`（與 taipei-gis-analytics handoff 一致）
+> **狀態**：dev
+> **Owner**：migu
+> **上線日期**：TBD
+> **相關 PR**：TBD
+
+## 一句話說明
+
+北市 + 新北官方都市計畫使用分區 polygon（住宅/商業/工業/農業/綠地/公設/交通/保護/其他 9 類統一分色），掛「都市分析」主題新 group「土地使用分區 Zoning」。
+
+## 圖層 / 元件
+
+| 名稱（layer key） | 類型 | 資料源 | 狀態 |
+|---|---|---|---|
+| urbanZoningTaipei | polygon (PMTiles z6-15) | `public/urban/urban_zoning_taipei.pmtiles`（15,518，S3 管理） | dev |
+| urbanZoningNewTaipei | polygon (PMTiles z6-15) | `public/urban/urban_zoning_newtaipei.pmtiles`（34,190，S3 管理） | dev |
+
+## 關鍵檔案
+
+- 色票 SSOT：`src/data/urbanZoningTypes.ts`（9 類 zone_category）
+- Overlay：`src/map/overlayRegistry.ts`（fill + line 雙 spec，pmtiles sourceLayer 各自對應）
+- Popup：`src/components/featureInfo/urbanPanels.tsx`（兩 key 共用 UrbanZoningPanel）
+- Catalog：`src/components/sidebar/layerCatalog.ts`（都市分析 > 土地使用分區）
+
+## 資料契約摘要
+
+看 [handoff.md](./handoff.md)。上游 SSOT：`taipei-gis-analytics/docs/handoff/urban-zoning.md`。
+
+重點：PMTiles 走 S3（gitignored，upload 腳本 urban glob 已涵蓋）；`zone_category` 9 值是分色/篩選硬依賴；新北官方站 TLS 憑證問題在上游 pipeline 層處理。
+
+## 相關 backlog
+
+看 [backlog.md](./backlog.md)。
+
+## 歷次改動
+
+看 [changelog.md](./changelog.md)。
+
+## 相關 ADR
+
+無（來源決策見上游 `docs/topic-research/urban_zoning_polygon/_status.md`）。

--- a/docs/features/urban-zoning/backlog.md
+++ b/docs/features/urban-zoning/backlog.md
@@ -1,19 +1,23 @@
-# Backlog — <feature-name>
+# Backlog — urban-zoning
 
-> 本 feature 的待辦。與全站 `.claude/memory/BACKLOG.md` 對應項編號要一致（例如 RE-1、RE-2）。
+> 本 feature 的待辦。與全站 `.claude/memory/BACKLOG.md` 對應項編號要一致（UZ 系列）。
 
 ## 進行中
 
-- [ ] **RE-X**：<描述> — <為什麼、下一步>
+（無）
 
 ## 待辦
 
-- [ ] **RE-Y**：<描述>
+- [ ] **UZ-1**：其他縣市逐城擴充 — 上游依 `docs/topic-research/urban_zoning_polygon/_status.md` 的來源矩陣逐城下載/清洗/PMTiles；下游每城同構複製 entry（色票/圖例/panel 共用零改動）
+- [ ] **UZ-2**：新北官方站 TLS 憑證信任問題 — 上游 pipeline 目前 `--insecure` + SHA-256 記錄，正式排程前處理（上游事項，此處追蹤）
+- [ ] **UZ-3**：NLSC LUIMAP WMS raster 全國視覺層 — 向量未覆蓋縣市的暫時疊圖選項（僅視覺、不可查詢，需標註來源與限制），見上游 status「路徑 A」
+- [ ] **UZ-4**：deploy 前跑 `upload-deploy-assets.sh` 上傳 2 個 pmtiles 到 S3（urban glob 已涵蓋，只需執行）
+- [ ] **UZ-5**：上游 02_normalize drop 北市 4 筆範圍框 meta-polygon（zone_name/zone_raw=`"nan"`，feature_id taipei_detail_0/1/2/2220）— 前端已 filter 防禦，上游清掉後 filter 留著無害
 
 ## 已完成（近期）
 
-- [x] **RE-Z**：<描述> — PR #NN, YYYY-MM-DD
+- [x] **UZ-0**：北市+新北 2 層接線 — commit `8a8de4b`，2026-07-17，PR 待開
 
 ## 已放棄 / 延後
 
-- **RE-W**：<描述> — 原因：...
+- OSS godspeedhuang 2020 全國預跑庫當上線資料 — 資料時點 stale（2020），僅留歷史比較用（上游決策）

--- a/docs/features/urban-zoning/backlog.md
+++ b/docs/features/urban-zoning/backlog.md
@@ -1,0 +1,19 @@
+# Backlog — <feature-name>
+
+> 本 feature 的待辦。與全站 `.claude/memory/BACKLOG.md` 對應項編號要一致（例如 RE-1、RE-2）。
+
+## 進行中
+
+- [ ] **RE-X**：<描述> — <為什麼、下一步>
+
+## 待辦
+
+- [ ] **RE-Y**：<描述>
+
+## 已完成（近期）
+
+- [x] **RE-Z**：<描述> — PR #NN, YYYY-MM-DD
+
+## 已放棄 / 延後
+
+- **RE-W**：<描述> — 原因：...

--- a/docs/features/urban-zoning/changelog.md
+++ b/docs/features/urban-zoning/changelog.md
@@ -1,19 +1,11 @@
-# Changelog — <feature-name>
+# Changelog — urban-zoning
 
 > 逐 PR 變更紀錄。最新在上。
 
-格式：
-```
-## YYYY-MM-DD — PR #NN <squash commit hash>
-- <what changed>
-- <why (optional)>
-- <breaking? migration needed?>
-```
-
 ---
 
-## YYYY-MM-DD — PR #NN `xxxxxxx`
+## 2026-07-17 — PR 待開（branch feat/urban-zoning）
 
-- 新增 xxx 圖層
-- 資料源：<摘要>
+- `8a8de4b` feat(urban)：北市（15,518）+ 新北（34,190）土地使用分區 PMTiles 圖層，zone_category 9 類統一分色、分類篩選 dropdown、共用圖例/panel；資產 gitignored 走 S3，零 deploy 變更
+- 上游：pipelines/urban_composite/urban_zoning（官方向量，OGDL）+ handoff `urban-zoning.md`
 - Breaking：無

--- a/docs/features/urban-zoning/changelog.md
+++ b/docs/features/urban-zoning/changelog.md
@@ -1,0 +1,19 @@
+# Changelog — <feature-name>
+
+> 逐 PR 變更紀錄。最新在上。
+
+格式：
+```
+## YYYY-MM-DD — PR #NN <squash commit hash>
+- <what changed>
+- <why (optional)>
+- <breaking? migration needed?>
+```
+
+---
+
+## YYYY-MM-DD — PR #NN `xxxxxxx`
+
+- 新增 xxx 圖層
+- 資料源：<摘要>
+- Breaking：無

--- a/docs/features/urban-zoning/handoff.md
+++ b/docs/features/urban-zoning/handoff.md
@@ -15,7 +15,7 @@
 
 - 色票 SSOT：`src/data/urbanZoningTypes.ts`
 - Overlay：`src/map/overlayRegistry.ts`（pmtiles fill + line，篩選 filter 函式，`rebuildOnParamChange: ["fill","line"]`）
-- UI toggle：`layerCatalog.ts`（都市分析 > 土地使用分區 Zoning）
+- UI toggle：`layerCatalog.ts`（底圖 Base Map > 土地使用分區 Zoning）
 - Popup：`urbanPanels.tsx` UrbanZoningPanel（兩 key 共用）
 
 ## 硬依賴欄位（改一定爆）

--- a/docs/features/urban-zoning/handoff.md
+++ b/docs/features/urban-zoning/handoff.md
@@ -1,0 +1,32 @@
+# Handoff — urban-zoning（下游視角）
+
+> **上游 SSOT**：`../../../taipei-gis-analytics/docs/handoff/urban-zoning.md`（詳細契約看那份）
+>
+> 本檔只放**前端接線的簡表 + 上游約定的差異點**。契約細節不重複寫，只反向引用。
+
+## 上游 handoff 摘要
+
+- 產物：`public/urban/urban_zoning_taipei.pmtiles`（3.4MB / 15,518）+ `urban_zoning_newtaipei.pmtiles`（8.3MB / 34,190），WGS84 MultiPolygon，z6–15，source-layer 名 = 檔名 stem
+- 更新頻率：irregular（都計變更後上游重跑 pipeline `--publish`），檔案整檔替換、前端無需改碼
+- 資產管理：**gitignored 走 S3**（`public/urban/*.pmtiles` 既有規則；upload/pull/nginx 已全數登記，本次零 deploy 變更）
+- 授權：OGDL-Taiwan-1.0（北市 data.taipei 2026-04-01 / 新北 opendata 2026-02-26）
+
+## 前端接線位置
+
+- 色票 SSOT：`src/data/urbanZoningTypes.ts`
+- Overlay：`src/map/overlayRegistry.ts`（pmtiles fill + line，篩選 filter 函式，`rebuildOnParamChange: ["fill","line"]`）
+- UI toggle：`layerCatalog.ts`（都市分析 > 土地使用分區 Zoning）
+- Popup：`urbanPanels.tsx` UrbanZoningPanel（兩 key 共用）
+
+## 硬依賴欄位（改一定爆）
+
+- `zone_category`（9 值統一分類）— match 分色 + 分類篩選 + 圖例
+- `zone_name` — popup 標題（`other` 類占 13-19%，全靠它讓用戶看到原始分區名）
+- `zone_short` / `zone_code` / `city` / `plan_level` — popup rows
+- source-layer 名 `urban_zoning_taipei` / `urban_zoning_newtaipei` — overlayRegistry pmtiles.sourceLayer
+
+## 上游改動 → 下游要跟改的觸發點
+
+- 新增縣市 → 新 pmtiles + 新 key（同構複製 entry），色票/圖例/panel 全部共用不用改
+- `zone_category` 增減值 → `urbanZoningTypes.ts` 色票表 + 圖例自動跟隨（讀表渲染）
+- 新北 TLS 憑證問題屬上游 fetch 層，下游無感

--- a/docs/features/urban-zoning/handoff.md
+++ b/docs/features/urban-zoning/handoff.md
@@ -21,7 +21,8 @@
 ## 硬依賴欄位（改一定爆）
 
 - `zone_category`（9 值統一分類）— match 分色 + 分類篩選 + 圖例
-- `zone_name` — popup 標題（`other` 類占 13-19%，全靠它讓用戶看到原始分區名）
+- `zone_name` / `zone_raw` — popup 標題 fallback 鏈（北市用 zone_name；**新北 zone_name/zone_short 全空，靠 zone_raw**）；`"nan"`/`"null"` 字面字串視為缺值
+- 北市 4 筆範圍框 meta-polygon（zone_raw=`"nan"`）已用 filter 濾除（渲染+點擊都排除），上游 UZ-5 清資料前不可移除此 filter
 - `zone_short` / `zone_code` / `city` / `plan_level` — popup rows
 - source-layer 名 `urban_zoning_taipei` / `urban_zoning_newtaipei` — overlayRegistry pmtiles.sourceLayer
 

--- a/src/components/IconRailSidebar.tsx
+++ b/src/components/IconRailSidebar.tsx
@@ -32,6 +32,8 @@ import {
   Biohazard,
   // 🎭 CULTURE icons（Building2 / CalendarDays 已 import 復用）
   Landmark, Theater, Library,
+  // 🗺️ 土地使用分區 icons
+  LandPlot, Map,
   type LucideIcon,
 } from "lucide-react";
 import type {
@@ -175,6 +177,8 @@ const LAYER_ICONS: Record<keyof LayerVisibility, LucideIcon> = {
   treePitsTaipei: Flower2,
   buildingsGba: Building2,
   urbanFormGrid: LayoutGrid,
+  urbanZoningTaipei: LandPlot,
+  urbanZoningNewTaipei: Map,
   // 🏟️ 運動場館 Sports
   sportsSchool: GraduationCap,
   sportsPublicOther: Activity,

--- a/src/components/LegendPanel.tsx
+++ b/src/components/LegendPanel.tsx
@@ -44,6 +44,7 @@ import {
 import {
   URBAN_FORM_GRID_MODES, URBAN_FORM_GRID_ATTRIBUTION_GBA, URBAN_FORM_GRID_ATTRIBUTION_META,
 } from "../data/urbanFormGridTypes";
+import { URBAN_ZONING_CATEGORIES } from "../data/urbanZoningTypes";
 import { MEDICAL_ISOCHRONE_BANDS, MEDICAL_ISOCHRONE_NOTE } from "../data/medicalIsochroneTypes";
 import {
   SOIL_FERTILITY_METRICS,
@@ -220,6 +221,7 @@ export const LEGEND_REGISTRY: LegendEntry[] = [
   { keys: ["treePitsTaipei"], render: () => <TreePitsTaipeiLegend /> },
   { keys: ["buildingsGba"], render: ({ overlayParams }) => <BuildingsGbaLegend modeIdx={overlayParams.buildingsGbaModeIdx ?? 0} /> },
   { keys: ["urbanFormGrid"], render: ({ overlayParams }) => <UrbanFormGridLegend modeIdx={overlayParams.urbanFormGridModeIdx ?? 5} /> },
+  { keys: ["urbanZoningTaipei", "urbanZoningNewTaipei"], render: () => <UrbanZoningLegend /> },
   { keys: ["canopyHeight"], render: () => <CanopyHeightLegend /> },
   { keys: ["sportsSchool", "sportsPublicOther", "sportsPrivate", "sportsPark", "sportsCenter"], render: () => <SportsVenueLegend /> },
   { keys: ["culturalFacilities"], render: () => <CulturalFacilitiesLegend /> },
@@ -958,6 +960,22 @@ function UrbanFormGridLegend({ modeIdx = 5 }: { modeIdx?: number }) {
       </div>
       <div style={{ fontSize: FONT_SIZE.xs, color: t.textDim, lineHeight: 1.4 }}>
         {URBAN_FORM_GRID_ATTRIBUTION_META}
+      </div>
+    </div>
+  );
+}
+
+// 土地使用分區圖例（北市 + 新北共用）：zone_category 9 類統一分色（色票 SSOT = urbanZoningTypes.ts）。
+function UrbanZoningLegend() {
+  const t = useLegendTheme();
+  return (
+    <div>
+      <div style={{ fontSize: FONT_SIZE.xs, color: t.textDim, letterSpacing: 1, marginBottom: 4 }}>
+        土地使用分區 ZONING
+      </div>
+      <div style={{ fontSize: FONT_SIZE.xs, color: t.textMuted, marginBottom: 3 }}>分類 CATEGORY</div>
+      <div style={{ display: "flex", flexDirection: "column", gap: 2 }}>
+        {URBAN_ZONING_CATEGORIES.map((c) => <UrbanDotRow key={c.value} color={c.color} label={c.label} />)}
       </div>
     </div>
   );

--- a/src/components/featureInfo/registry.tsx
+++ b/src/components/featureInfo/registry.tsx
@@ -37,6 +37,7 @@ import {
   StreetTreesTaipeiDiffPanel, ProtectedTreesNationalPanel,
   RiversideTreesTaipeiPanel, ParksTaipeiPanel, StreetTrees3epochPanel,
   StreetTreesNationalPanel, TreePitsTaipeiPanel, BuildingsGbaPanel, UrbanFormGridPanel,
+  UrbanZoningPanel,
 } from "./urbanPanels";
 import { SportsVenuePanel } from "./sportsPanels";
 import {
@@ -253,6 +254,8 @@ export const PANEL_REGISTRY: Partial<Record<FeatureInfo["layerType"], FC<PanelPr
   treePitsTaipei: TreePitsTaipeiPanel,
   buildingsGba: BuildingsGbaPanel,
   urbanFormGrid: UrbanFormGridPanel,
+  urbanZoningTaipei: UrbanZoningPanel,
+  urbanZoningNewTaipei: UrbanZoningPanel,
   // 🏟️ 運動場館
   sportsVenue: SportsVenuePanel,
   // 🎭 文化
@@ -345,6 +348,8 @@ export const HEADER_LABELS: Record<FeatureInfo["layerType"], string> = {
   treePitsTaipei: "人行道樹穴",
   buildingsGba: "建物",
   urbanFormGrid: "都市紋理",
+  urbanZoningTaipei: "土地使用分區",
+  urbanZoningNewTaipei: "土地使用分區",
   sportsVenue: "運動場館",
   culturalFacilities: "文化設施",
   culturalMuseums: "地方文化館",

--- a/src/components/featureInfo/urbanPanels.tsx
+++ b/src/components/featureInfo/urbanPanels.tsx
@@ -7,6 +7,7 @@ import {
 } from "../../data/urbanOpenSpaceTypes";
 import { buildingHeightBandColor } from "../../data/buildingsGbaTypes";
 import { GG_INDEX_BANDS, gridBandColor, URBAN_FORM_GRID_APPROX_NOTE } from "../../data/urbanFormGridTypes";
+import { urbanZoningCategoryLabel, urbanZoningCategoryColor } from "../../data/urbanZoningTypes";
 
 // 本檔 Title 為極簡本地版（同 fisheryPanels 慣例）：shared.tsx 未 export Title，故不去改動它。
 function Title({ color, children }: { color: string; children: string }) {
@@ -292,6 +293,29 @@ export function UrbanFormGridPanel({ props }: { props: Record<string, unknown> }
       <div style={{ fontSize: FONT_SIZE.sm, color: "rgba(150,200,255,0.6)", lineHeight: 1.5, marginTop: 6 }}>
         ⓘ {URBAN_FORM_GRID_APPROX_NOTE}
       </div>
+      <SourceFooter props={props} />
+    </>
+  );
+}
+
+// ── 都市計畫土地使用分區（北市 15,518 + 新北 34,190 面；北市 / 新北兩 layerType 共用本 panel）──
+
+/**
+ * 土地使用分區：Title=zone_name 原始分區全名（色點依 zone_category）；
+ * Row：分類（中文 label）/ 簡稱 / 代碼 / 城市 / 計畫層級。
+ * zone_category 9 類色票 SSOT = urbanZoningTypes.ts（與 overlayRegistry / Legend 同源）。
+ */
+export function UrbanZoningPanel({ props }: { props: Record<string, unknown> }) {
+  const category = String(props.zone_category ?? "");
+  const color = urbanZoningCategoryColor(category);
+  return (
+    <>
+      <Title color={color}>{String(props.zone_name ?? "土地使用分區")}</Title>
+      <Row label="分類" value={urbanZoningCategoryLabel(category)} color={color} />
+      <Row label="簡稱" value={String(props.zone_short ?? "")} />
+      <Row label="代碼" value={String(props.zone_code ?? "")} />
+      <Row label="城市" value={String(props.city ?? "")} />
+      <Row label="計畫層級" value={String(props.plan_level ?? "")} />
       <SourceFooter props={props} />
     </>
   );

--- a/src/components/featureInfo/urbanPanels.tsx
+++ b/src/components/featureInfo/urbanPanels.tsx
@@ -301,21 +301,30 @@ export function UrbanFormGridPanel({ props }: { props: Record<string, unknown> }
 // ── 都市計畫土地使用分區（北市 15,518 + 新北 34,190 面；北市 / 新北兩 layerType 共用本 panel）──
 
 /**
- * 土地使用分區：Title=zone_name 原始分區全名（色點依 zone_category）；
- * Row：分類（中文 label）/ 簡稱 / 代碼 / 城市 / 計畫層級。
+ * 土地使用分區：Title 走 fallback 鏈 zone_name → zone_raw → zone_short → 分類 label
+ * （北市 zone_name 齊全；新北 zone_name/zone_short 全空、原始分區名在 zone_raw——見上游 handoff §2）；
+ * "nan"/"null" 字面字串一律視為缺值（北市範圍框 meta-polygon 遺留，上游 UZ-5 待清）。
  * zone_category 9 類色票 SSOT = urbanZoningTypes.ts（與 overlayRegistry / Legend 同源）。
  */
+const zoneText = (v: unknown): string => {
+  const s = String(v ?? "").trim();
+  return s && s !== "nan" && s !== "null" ? s : "";
+};
+
 export function UrbanZoningPanel({ props }: { props: Record<string, unknown> }) {
   const category = String(props.zone_category ?? "");
   const color = urbanZoningCategoryColor(category);
+  const title =
+    zoneText(props.zone_name) || zoneText(props.zone_raw) || zoneText(props.zone_short) ||
+    urbanZoningCategoryLabel(category) || "土地使用分區";
   return (
     <>
-      <Title color={color}>{String(props.zone_name ?? "土地使用分區")}</Title>
+      <Title color={color}>{title}</Title>
       <Row label="分類" value={urbanZoningCategoryLabel(category)} color={color} />
-      <Row label="簡稱" value={String(props.zone_short ?? "")} />
-      <Row label="代碼" value={String(props.zone_code ?? "")} />
-      <Row label="城市" value={String(props.city ?? "")} />
-      <Row label="計畫層級" value={String(props.plan_level ?? "")} />
+      <Row label="簡稱" value={zoneText(props.zone_short)} />
+      <Row label="代碼" value={zoneText(props.zone_code)} />
+      <Row label="城市" value={zoneText(props.city)} />
+      <Row label="計畫層級" value={zoneText(props.plan_level)} />
       <SourceFooter props={props} />
     </>
   );

--- a/src/components/sidebar/layerCatalog.ts
+++ b/src/components/sidebar/layerCatalog.ts
@@ -160,6 +160,8 @@ export const LAYER_COLORS: Record<keyof LayerVisibility, string> = {
   treePitsTaipei: "#8d6e63",
   buildingsGba: "#78909c",
   urbanFormGrid: "#8d9c6b",
+  urbanZoningTaipei: "#f2c94c",
+  urbanZoningNewTaipei: "#eb5757",
   sportsSchool: "#5c6bc0",
   sportsPublicOther: "#26a69a",
   sportsPrivate: "#ef6c00",
@@ -527,6 +529,13 @@ export const THEMES: ThemeDef[] = [
         title: "都市紋理",
         layers: [
           { key: "urbanFormGrid", label: "都市紋理網格 Urban Form", expandable: true },
+        ],
+      },
+      {
+        title: "土地使用分區 Zoning",
+        layers: [
+          { key: "urbanZoningTaipei", label: "北市土地使用分區 Taipei Zoning", labelMobile: "北市土地使用分區", expandable: true },
+          { key: "urbanZoningNewTaipei", label: "新北土地使用分區 New Taipei Zoning", labelMobile: "新北土地使用分區", expandable: true },
         ],
       },
     ],

--- a/src/components/sidebar/layerCatalog.ts
+++ b/src/components/sidebar/layerCatalog.ts
@@ -406,6 +406,14 @@ export const THEMES: ThemeDef[] = [
         ],
       },
       {
+        // 官方參考底圖（非分析產物）——上游 topic-research 原始目標即「pulse 底圖層」
+        title: "土地使用分區 Zoning",
+        layers: [
+          { key: "urbanZoningTaipei", label: "北市土地使用分區 Taipei Zoning", labelMobile: "北市土地使用分區", expandable: true },
+          { key: "urbanZoningNewTaipei", label: "新北土地使用分區 New Taipei Zoning", labelMobile: "新北土地使用分區", expandable: true },
+        ],
+      },
+      {
         title: "道路底圖",
         layers: [
           { key: "osmRoadDrive", label: "OSM 道路 OSM Roads", expandable: true },
@@ -529,13 +537,6 @@ export const THEMES: ThemeDef[] = [
         title: "都市紋理",
         layers: [
           { key: "urbanFormGrid", label: "都市紋理網格 Urban Form", expandable: true },
-        ],
-      },
-      {
-        title: "土地使用分區 Zoning",
-        layers: [
-          { key: "urbanZoningTaipei", label: "北市土地使用分區 Taipei Zoning", labelMobile: "北市土地使用分區", expandable: true },
-          { key: "urbanZoningNewTaipei", label: "新北土地使用分區 New Taipei Zoning", labelMobile: "新北土地使用分區", expandable: true },
         ],
       },
     ],

--- a/src/data/upstreamRegistry.ts
+++ b/src/data/upstreamRegistry.ts
@@ -541,6 +541,9 @@ export const UPSTREAM_REGISTRY: Record<keyof LayerVisibility, UpstreamRef> = {
   treePitsTaipei: { status: 'catalog_missing', datasets: [], note: '台北人行道樹穴 56,720 面（public/urban/tree_pits_taipei.pmtiles），catalog 待建' },
   buildingsGba: { status: 'catalog_missing', datasets: [], note: '全台 3D 建物輪廓 152 萬棟（GBA/OSM 融合，public/urban/buildings_3d_taiwan.pmtiles），catalog 待建；上游 handoff 見 taipei-gis-analytics/docs/handoff/gba_canopy_frontend.md' },
   urbanFormGrid: { status: 'catalog_missing', datasets: [], note: '都市紋理網格 500m 145,119 格（GBA+Meta 樹冠合成，public/urban/urban_form_grid_500m.pmtiles），catalog 待建；上游 handoff 見 taipei-gis-analytics/docs/handoff/urban-form-grid.md' },
+  // 🗺️ 都市計畫土地使用分區（上游 handoff: taipei-gis-analytics/docs/handoff/urban-zoning.md；catalog: docs/data-catalog/urban_composite/）
+  urbanZoningTaipei: { status: 'verified', datasets: [{ datasetId: 'urban_zoning_taipei', confidence: 'HIGH' }], note: '臺北市都市計畫土地使用分區 15,518 面（data.taipei SHP，docs/data-catalog/urban_composite/urban_zoning_taipei.md）' },
+  urbanZoningNewTaipei: { status: 'verified', datasets: [{ datasetId: 'urban_zoning_newtaipei', confidence: 'HIGH' }], note: '新北市都市計畫土地使用分區 34,190 面（urban.planning.ntpc.gov.tw opendata，docs/data-catalog/urban_composite/urban_zoning_newtaipei.md）' },
   // 🏟️ 運動場館 Sports（全國 15,000 點，運動部 22849；catalog: sports/all_venues）
   sportsSchool: { status: 'verified', datasets: [{ datasetId: 'all_venues', confidence: 'HIGH' }] },
   sportsPublicOther: { status: 'verified', datasets: [{ datasetId: 'all_venues', confidence: 'HIGH' }] },

--- a/src/data/urbanZoningTypes.ts
+++ b/src/data/urbanZoningTypes.ts
@@ -1,0 +1,47 @@
+/**
+ * 都市計畫土地使用分區（北市 15,518 + 新北 34,190）2 層 PMTiles polygon 的
+ * 顏色與分類單一真實來源。
+ * 給 overlayRegistry 配色（fill-color / line-color 表達式）、LegendPanel 圖例、
+ * featureInfo popup Title 三處共用（同 buildingsGbaTypes.ts / urbanFormGridTypes.ts 慣例）。
+ *
+ * `zone_category`：9 值跨市統一分類（分色 / 篩選硬依賴，上游 handoff urban-zoning.md §2）。
+ * 錨定色沿用都計圖慣例（住宅黃 / 商業紅 / 工業紫 / 綠地綠），深色底圖上可辨。
+ *
+ * ⚠️ 表達式不得含 ["zoom"]：zoom 只能在最外層 interpolate/step（同 urbanFormGridTypes.ts 註）。
+ */
+
+// 缺值 / 非 9 類共用中性灰
+export const URBAN_ZONING_MISSING_COLOR = "#9e9e9e";
+
+// zone_category 9 類（value 對齊 PMTiles zone_category 欄位值；index 對齊 overlayRegistry 讀的
+// urbanZoning*CategoryIdx：0=全部，1..9 照本陣列順序）
+export const URBAN_ZONING_CATEGORIES: { value: string; label: string; color: string }[] = [
+  { value: "residential",     label: "住宅",     color: "#f2c94c" },
+  { value: "commercial",      label: "商業",     color: "#eb5757" },
+  { value: "industrial",      label: "工業",     color: "#9b6dd6" },
+  { value: "agricultural",    label: "農業",     color: "#b5cc6a" },
+  { value: "open_space",      label: "公園綠地", color: "#4caf72" },
+  { value: "public_facility", label: "公共設施", color: "#4d9de0" },
+  { value: "transport",       label: "交通",     color: "#9aa5b1" },
+  { value: "conservation",    label: "保護保育", color: "#2d8659" },
+  { value: "other",           label: "其他",     color: "#8a8a8a" },
+];
+
+/** zone_category → 9 色，其餘灰（fill-color / line-color 共用） */
+export function urbanZoningColorExpr(): unknown[] {
+  return [
+    "match", ["get", "zone_category"],
+    ...URBAN_ZONING_CATEGORIES.flatMap((c) => [c.value, c.color]),
+    URBAN_ZONING_MISSING_COLOR,
+  ];
+}
+
+/** zone_category → 中文 label（popup / 圖例共用，純 JS 不進 mapbox 表達式） */
+export function urbanZoningCategoryLabel(value: string): string {
+  return URBAN_ZONING_CATEGORIES.find((c) => c.value === value)?.label ?? value;
+}
+
+/** zone_category → 代表色（popup Title 上色，純 JS 版；缺值中性灰） */
+export function urbanZoningCategoryColor(value: string): string {
+  return URBAN_ZONING_CATEGORIES.find((c) => c.value === value)?.color ?? URBAN_ZONING_MISSING_COLOR;
+}

--- a/src/hooks/useMapInteraction.ts
+++ b/src/hooks/useMapInteraction.ts
@@ -299,6 +299,8 @@ export function useMapInteraction(
           { layers: ["tree-pits-taipei-fill", "tree-pits-taipei-line"], type: "treePitsTaipei" },
           { layers: ["buildings-gba-fill", "buildings-gba-extrusion"], type: "buildingsGba" },
           { layers: ["urban-form-grid-fill"], type: "urbanFormGrid" },
+          { layers: ["urban-zoning-taipei-fill"], type: "urbanZoningTaipei" },
+          { layers: ["urban-zoning-newtaipei-fill"], type: "urbanZoningNewTaipei" },
           { layers: ["sports-venues-school", "sports-venues-public-other", "sports-venues-private", "sports-venues-park", "sports-venues-center"], type: "sportsVenue" },
           { layers: ["culture-facilities-circle"], type: "culturalFacilities" },
           { layers: ["culture-museums-circle"], type: "culturalMuseums" },

--- a/src/hooks/useTransportParams.ts
+++ b/src/hooks/useTransportParams.ts
@@ -20,6 +20,7 @@ import {
 } from "../data/urbanOpenSpaceTypes";
 import { BUILDINGS_GBA_MODES } from "../data/buildingsGbaTypes";
 import { URBAN_FORM_GRID_MODES } from "../data/urbanFormGridTypes";
+import { URBAN_ZONING_CATEGORIES } from "../data/urbanZoningTypes";
 import { CULTURAL_FACILITY_TYPES, CULTURAL_MUSEUM_TYPES } from "../data/cultureTypes";
 
 export interface SliderConfig {
@@ -233,6 +234,11 @@ export function useTransportParams() {
   // 都市紋理網格（0-5：棟數/平均高度/總量體/建蔽率/樹冠覆蓋/灰綠指數；預設 5=灰綠指數）
   const [urbanFormGridModeIdx, setUrbanFormGridModeIdx] = useState(5);
   const [urbanFormGridOpacity, setUrbanFormGridOpacity] = useState(0.55);
+  // 🗺️ 都市計畫土地使用分區（北市 + 新北）：category select（all / 9 類）+ 透明度
+  const [urbanZoningTaipeiOpacity, setUrbanZoningTaipeiOpacity] = useState(0.5);
+  const [urbanZoningTaipeiCategory, setUrbanZoningTaipeiCategory] = useState<string>("all"); // all / 9 類 zone_category
+  const [urbanZoningNewTaipeiOpacity, setUrbanZoningNewTaipeiOpacity] = useState(0.5);
+  const [urbanZoningNewTaipeiCategory, setUrbanZoningNewTaipeiCategory] = useState<string>("all"); // all / 9 類 zone_category
   const [lakesPondsOsmOpacity, setLakesPondsOsmOpacity] = useState(0.5);
   const [crimeAreaMonthlyOpacity, setCrimeAreaMonthlyOpacity] = useState(0.55);
   const [theftTaoyuanOpacity, setTheftTaoyuanOpacity] = useState(0.8);
@@ -935,6 +941,11 @@ export function useTransportParams() {
     treePitsTaipeiTypeIdx: ["all", ...TREE_PIT_TYPES.map((t) => t.name)].indexOf(treePitsTaipeiType),
     buildingsGbaModeIdx, buildingsGbaMinHeight, buildingsGbaOpacity,
     urbanFormGridModeIdx, urbanFormGridOpacity,
+    // 🗺️ 土地使用分區：category select 編成 Idx 餵 filter（overlayParams 只收數字，0=全部 1..9 單類）
+    urbanZoningTaipeiOpacity,
+    urbanZoningTaipeiCategoryIdx: ["all", ...URBAN_ZONING_CATEGORIES.map((c) => c.value)].indexOf(urbanZoningTaipeiCategory),
+    urbanZoningNewTaipeiOpacity,
+    urbanZoningNewTaipeiCategoryIdx: ["all", ...URBAN_ZONING_CATEGORIES.map((c) => c.value)].indexOf(urbanZoningNewTaipeiCategory),
     crimeAreaMonthlyOpacity,
     theftTaoyuanOpacity, theftTaoyuanScale,
     trafficAccidentYearlyOpacity, trafficAccidentYearlyScale,
@@ -1286,6 +1297,8 @@ export function useTransportParams() {
     treePitsTaipeiOpacity, treePitsTaipeiType,
     buildingsGbaModeIdx, buildingsGbaMinHeight, buildingsGbaOpacity,
     urbanFormGridModeIdx, urbanFormGridOpacity,
+    urbanZoningTaipeiOpacity, urbanZoningTaipeiCategory,
+    urbanZoningNewTaipeiOpacity, urbanZoningNewTaipeiCategory,
     crimeAreaMonthlyOpacity, theftTaoyuanOpacity, theftTaoyuanScale,
     trafficAccidentYearlyOpacity, trafficAccidentYearlyScale, accidentTaipeiOpacity, accidentTaipeiScale,
     a1AccidentRealtimeOpacity, a1AccidentRealtimeScale, investigationBureauOpacity, investigationBureauScale,
@@ -2408,6 +2421,14 @@ export function useTransportParams() {
       case "urbanFormGrid": return [
         { type: "select" as const, label: "顯示模式", value: String(urbanFormGridModeIdx), options: [...URBAN_FORM_GRID_MODES], onChange: (v: string) => setUrbanFormGridModeIdx(parseInt(v, 10)) },
         { label: `填色透明度 ${urbanFormGridOpacity.toFixed(2)}`, value: urbanFormGridOpacity, min: 0, max: 1, step: 0.05, onChange: setUrbanFormGridOpacity },
+      ];
+      case "urbanZoningTaipei": return [
+        { type: "select" as const, label: "分區", value: urbanZoningTaipeiCategory, options: [{ label: "全部", value: "all" }, ...URBAN_ZONING_CATEGORIES.map((c) => ({ label: c.label, value: c.value }))], onChange: setUrbanZoningTaipeiCategory },
+        { label: `填色透明度 ${urbanZoningTaipeiOpacity.toFixed(2)}`, value: urbanZoningTaipeiOpacity, min: 0, max: 1, step: 0.05, onChange: setUrbanZoningTaipeiOpacity },
+      ];
+      case "urbanZoningNewTaipei": return [
+        { type: "select" as const, label: "分區", value: urbanZoningNewTaipeiCategory, options: [{ label: "全部", value: "all" }, ...URBAN_ZONING_CATEGORIES.map((c) => ({ label: c.label, value: c.value }))], onChange: setUrbanZoningNewTaipeiCategory },
+        { label: `填色透明度 ${urbanZoningNewTaipeiOpacity.toFixed(2)}`, value: urbanZoningNewTaipeiOpacity, min: 0, max: 1, step: 0.05, onChange: setUrbanZoningNewTaipeiOpacity },
       ];
       case "crimeAreaMonthly": return [
         { label: `填色透明度 ${crimeAreaMonthlyOpacity.toFixed(2)}`, value: crimeAreaMonthlyOpacity, min: 0.1, max: 0.9, step: 0.05, onChange: setCrimeAreaMonthlyOpacity },

--- a/src/map/overlayRegistry.ts
+++ b/src/map/overlayRegistry.ts
@@ -38,6 +38,7 @@ import {
 } from "../data/urbanOpenSpaceTypes";
 import { buildingHeightColorExpr, buildingSrcColorExpr } from "../data/buildingsGbaTypes";
 import { urbanFormGridColorExpr, urbanFormGridOpacityExpr } from "../data/urbanFormGridTypes";
+import { urbanZoningColorExpr, URBAN_ZONING_CATEGORIES } from "../data/urbanZoningTypes";
 import {
   culturalFacilityColorExpr, CULTURAL_FACILITY_TYPES,
   culturalMuseumColorExpr, CULTURAL_MUSEUM_TYPES,
@@ -3375,6 +3376,85 @@ export const OVERLAY_REGISTRY: OverlayConfig[] = [
             "fill-opacity": urbanFormGridOpacityExpr(modeIdx, base),
           };
         },
+      },
+    ],
+  },
+  // 都市計畫土地使用分區（vector PMTiles，北市 15,518 + 新北 34,190，z6-15；WGS84 MultiPolygon，
+  // tippecanoe -y 10 欄全保留，上游 handoff urban-zoning.md）：zone_category 9 類跨市統一分色
+  // （SSOT 見 urbanZoningTypes.ts），fill + 細邊界 line 兩 sublayer。分類篩選走 per-layer filter
+  // 函式（同 buildingsGba；idx 0=全部 1..9 單類 → 未選中的分區被濾除而非淡化），故
+  // rebuildOnParamChange 收 ["fill","line"] 兩 suffix（收參數名會靜默失效，見
+  // .claude/pitfalls/2026-07-16-rebuildonparamchange-suffix-not-param.md）。line-opacity 跟主 opacity
+  // 連動 ×0.6；line-width z10 0.3px → z15 1px 內插（zoom 只在最外層 interpolate）。
+  {
+    id: "urbanZoningTaipei",
+    sourceUrl: "./urban/urban_zoning_taipei.pmtiles",
+    sourceId: "urban-zoning-taipei",
+    pmtiles: { sourceLayer: "urban_zoning_taipei", minzoom: 6, maxzoom: 15 },
+    rebuildOnParamChange: ["fill", "line"],
+    layers: [
+      {
+        suffix: "fill",
+        type: "fill",
+        filter: (p) => {
+          const idx = p?.urbanZoningTaipeiCategoryIdx ?? 0; // 0=全部 1..9=單一分類
+          const cat = idx > 0 ? URBAN_ZONING_CATEGORIES[idx - 1]?.value : undefined;
+          return cat ? ["==", ["get", "zone_category"], cat] : ["has", "zone_category"];
+        },
+        paint: (_isDark, p) => ({
+          "fill-color": urbanZoningColorExpr(),
+          "fill-opacity": p?.urbanZoningTaipeiOpacity ?? 0.5,
+        }),
+      },
+      {
+        suffix: "line",
+        type: "line",
+        filter: (p) => {
+          const idx = p?.urbanZoningTaipeiCategoryIdx ?? 0;
+          const cat = idx > 0 ? URBAN_ZONING_CATEGORIES[idx - 1]?.value : undefined;
+          return cat ? ["==", ["get", "zone_category"], cat] : ["has", "zone_category"];
+        },
+        paint: (_isDark, p) => ({
+          "line-color": urbanZoningColorExpr(),
+          "line-width": ["interpolate", ["linear"], ["zoom"], 10, 0.3, 15, 1],
+          "line-opacity": (p?.urbanZoningTaipeiOpacity ?? 0.5) * 0.6,
+        }),
+      },
+    ],
+  },
+  {
+    id: "urbanZoningNewTaipei",
+    sourceUrl: "./urban/urban_zoning_newtaipei.pmtiles",
+    sourceId: "urban-zoning-newtaipei",
+    pmtiles: { sourceLayer: "urban_zoning_newtaipei", minzoom: 6, maxzoom: 15 },
+    rebuildOnParamChange: ["fill", "line"],
+    layers: [
+      {
+        suffix: "fill",
+        type: "fill",
+        filter: (p) => {
+          const idx = p?.urbanZoningNewTaipeiCategoryIdx ?? 0; // 0=全部 1..9=單一分類
+          const cat = idx > 0 ? URBAN_ZONING_CATEGORIES[idx - 1]?.value : undefined;
+          return cat ? ["==", ["get", "zone_category"], cat] : ["has", "zone_category"];
+        },
+        paint: (_isDark, p) => ({
+          "fill-color": urbanZoningColorExpr(),
+          "fill-opacity": p?.urbanZoningNewTaipeiOpacity ?? 0.5,
+        }),
+      },
+      {
+        suffix: "line",
+        type: "line",
+        filter: (p) => {
+          const idx = p?.urbanZoningNewTaipeiCategoryIdx ?? 0;
+          const cat = idx > 0 ? URBAN_ZONING_CATEGORIES[idx - 1]?.value : undefined;
+          return cat ? ["==", ["get", "zone_category"], cat] : ["has", "zone_category"];
+        },
+        paint: (_isDark, p) => ({
+          "line-color": urbanZoningColorExpr(),
+          "line-width": ["interpolate", ["linear"], ["zoom"], 10, 0.3, 15, 1],
+          "line-opacity": (p?.urbanZoningNewTaipeiOpacity ?? 0.5) * 0.6,
+        }),
       },
     ],
   },

--- a/src/map/overlayRegistry.ts
+++ b/src/map/overlayRegistry.ts
@@ -3399,7 +3399,9 @@ export const OVERLAY_REGISTRY: OverlayConfig[] = [
         filter: (p) => {
           const idx = p?.urbanZoningTaipeiCategoryIdx ?? 0; // 0=全部 1..9=單一分類
           const cat = idx > 0 ? URBAN_ZONING_CATEGORIES[idx - 1]?.value : undefined;
-          return cat ? ["==", ["get", "zone_category"], cat] : ["has", "zone_category"];
+          // zone_raw="nan" 的 4 筆是規劃範圍框（meta-polygon 非分區面），不渲染不點擊；上游 drop 前的防禦（UZ-5）
+          const notMeta = ["!=", ["get", "zone_raw"], "nan"];
+          return ["all", notMeta, cat ? ["==", ["get", "zone_category"], cat] : ["has", "zone_category"]];
         },
         paint: (_isDark, p) => ({
           "fill-color": urbanZoningColorExpr(),
@@ -3412,7 +3414,8 @@ export const OVERLAY_REGISTRY: OverlayConfig[] = [
         filter: (p) => {
           const idx = p?.urbanZoningTaipeiCategoryIdx ?? 0;
           const cat = idx > 0 ? URBAN_ZONING_CATEGORIES[idx - 1]?.value : undefined;
-          return cat ? ["==", ["get", "zone_category"], cat] : ["has", "zone_category"];
+          const notMeta = ["!=", ["get", "zone_raw"], "nan"];
+          return ["all", notMeta, cat ? ["==", ["get", "zone_category"], cat] : ["has", "zone_category"]];
         },
         paint: (_isDark, p) => ({
           "line-color": urbanZoningColorExpr(),

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -118,6 +118,8 @@ export type ExpandableLayerKey =
   | "streetTreesNational" | "treePitsTaipei"
   | "buildingsGba"
   | "urbanFormGrid"
+  // 🗺️ 都市計畫土地使用分區（PMTiles polygon，zone_category 9 類分色 + 分類篩選）
+  | "urbanZoningTaipei" | "urbanZoningNewTaipei"
   // 運動場館 SPORTS（5 sublayer 共用 sports-venues source + layer filter）
   | "sportsSchool" | "sportsPublicOther" | "sportsPrivate" | "sportsPark" | "sportsCenter"
   // 🎭 文化 Culture（靜態 overlay GeoJSON 點）
@@ -650,6 +652,7 @@ export interface FeatureInfo {
     | "streetTreesNational" | "treePitsTaipei"
     | "buildingsGba"
     | "urbanFormGrid"
+    | "urbanZoningTaipei" | "urbanZoningNewTaipei"
     | "sportsVenue"
     | "culturalFacilities" | "culturalMuseums" | "artsEvents" | "performingVenues"
     | "librarySeats"
@@ -833,6 +836,9 @@ export interface LayerVisibility {
   treePitsTaipei: boolean;        // 台北人行道樹穴（PMTiles，56,720 面；pit_type 樹穴/花圃二色 fill + 類型篩選）
   buildingsGba: boolean;          // 全台 3D 建物輪廓（PMTiles，152 萬棟；height 6 級/來源二色/3D 立體三模式 + 高度門檻篩選，CC BY-NC 4.0）
   urbanFormGrid: boolean;         // 都市紋理網格（PMTiles，500m 格，145,119 格；棟數/平均高度/總量體/建蔽率/樹冠覆蓋/灰綠指數 六模式染色，CC BY-NC 4.0）
+  // 🗺️ 都市計畫土地使用分區（靜態 PMTiles polygon；zone_category 9 類統一分色 + 分類篩選；OGDL-Taiwan-1.0）
+  urbanZoningTaipei: boolean;     // 臺北市都市計畫土地使用分區（15,518 面，z6-15）
+  urbanZoningNewTaipei: boolean;  // 新北市都市計畫土地使用分區（34,190 面，z6-15）
   // 🏟️ 運動場館 SPORTS（全國 15,000 點靜態 GeoJSON；5 sublayer 共用 sports-venues source + layer filter）
   sportsSchool: boolean;          // 學校場館（12,221）
   sportsPublicOther: boolean;     // 其他公共場館（1,135）


### PR DESCRIPTION
## Summary
- 官方都市計畫土地使用分區 2 圖層（北市 15,518 / 新北 34,190 面，PMTiles z6-15），zone_category 9 類統一分色，掛「底圖 Base Map > 土地使用分區 Zoning」

## Changes
- `8a8de4b` 2 層接線：色票 SSOT `urbanZoningTypes.ts`（住宅黃/商業紅/工業紫等都計慣例色）、fill+line 雙 spec、分類篩選 10 選項 dropdown、共用圖例與 `UrbanZoningPanel`；`rebuildOnParamChange: ["fill","line"]`（照 07-16 pitfall）；資產 gitignored 走 S3、零 deploy 變更
- `6ad58ff` 資料品質防禦：濾除北市 4 筆「規劃範圍」meta-polygon（`zone_raw="nan"`，渲染+點擊都排除）；popup 標題 fallback 鏈 zone_name→zone_raw→zone_short→分類 label（新北 zone_name 全空、真名在 zone_raw）
- `bca05c5` 搬群：都市分析 → 底圖 Base Map（官方參考底圖非分析產物）

## Test
- [x] npx tsc -b 通過（0 錯）
- [x] pnpm test 通過（190/190）
- [x] Browser 驗收兩輪：功能面全 PASS（source/渲染/透明度/篩選 filter 實值/圖例/popup/雙開/z6-z15）；修正復驗 2/2（viewport 10,728 面零 nan、新北 popup 顯示「住宅區」）

## Risk / Rollback
- 兩層預設 off；PMTiles 不進 git，deploy 前需跑 upload-deploy-assets.sh（UZ-4）
- 回滾：revert squash commit（資產檔不受 git 影響）

## Related
- Feature: docs/features/urban-zoning/
- Upstream handoff: taipei-gis-analytics/docs/handoff/urban-zoning.md
- Upstream research: taipei-gis-analytics/docs/topic-research/urban_zoning_polygon/_status.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)