### PR TITLE
feat(buildings): 建物輪廓「夜景燈光」顯示模式 + 高樓 bloom

### DIFF
--- a/docs/features/buildings-night-lights/README.md
+++ b/docs/features/buildings-night-lights/README.md
@@ -1,0 +1,48 @@
+# 建物夜景燈光 Buildings Night Lights
+
+> **Slug**：`buildings-night-lights`
+> **狀態**：dev（未 push）
+> **Owner**：migu
+> **啟動日期**：2026-07-22
+> **分支**：`feat/buildings-night-lights`
+
+## 一句話說明
+
+在既有「建物輪廓 Buildings」(`buildingsGba`) 圖層新增**第 4 個顯示模式「夜景燈光」**：深色底圖上以建物高度驅動暖橘／白發光，橘白交錯模擬台灣城市夜空；高樓額外疊一層 Three.js additive bloom 光暈補「爆白」質感。參考「發電廠 Bloom 測試 ✨」的技法。
+
+## 圖層 / 元件
+
+| 名稱 | 類型 | 資料源 | 狀態 |
+|---|---|---|---|
+| `buildingsGba` mode 3「夜景燈光」 | Mapbox fill | `buildings_3d_taiwan.pmtiles`（既有，152 萬棟） | ✅ |
+| `buildings-night-bloom-3d` 高樓 bloom 疊層 | Three.js CustomLayer（`GlowPointsScene`） | 同上 source，render 時 querySourceFeatures 取視野內高樓 | ✅ |
+
+## 運作重點
+
+- **夜景 fill**（純 Mapbox）：`buildingNightLightColorExpr()` 兩組 6 段色階（暖橘家族 / 白光家族）依 `height` 由暗轉亮；`round(height*10) % 3 == 0` 做確定性 pseudo-random 分流 → 約 1/3 白光交錯。全量 152 萬棟、零效能風險。
+- **高樓 bloom**（Three.js additive）：夜景模式開啟時，每次 moveend 從 `buildings-gba` source 撈視野內建物 → 篩 `height ≥ 門檻`（slider 40–200m，預設 100m）→ 去重 → 取最高前 **4096 棟**（對齊 `GlowPointsScene` 上限）→ 暖白光暈、核心爆純白、zoom 自適應。低 zoom = 地標群聚發亮、高 zoom = 逐棟 beacon。
+
+## 關鍵檔案
+
+- 配色 SSOT：`src/data/buildingsGbaTypes.ts`（`buildingNightLightColorExpr` / `BUILDING_NIGHT_LEGEND` / `BUILDINGS_GBA_MODES`）
+- Fill paint：`src/map/overlayRegistry.ts`（`buildingsGba` entry，modeIdx===3 分支）
+- Bloom CustomLayer：`src/map/buildingsNightBloomCustomLayer.ts`
+- Bloom Hook：`src/hooks/useBuildingsNightBloomLayer.ts`
+- 光暈 primitive（復用）：`src/three/GlowPointsScene.ts`
+- 圖例：`src/components/LegendPanel.tsx`（`BuildingsGbaLegend` modeIdx===3）
+- 參數 slider：`src/hooks/useTransportParams.ts`（`buildingsGbaBloomMinHeight`）
+- 接線：`src/App.tsx`（`useBuildingsNightBloomLayer`）
+
+## 資料契約
+
+**無新契約** — 純視覺模式，復用既有 `buildings_3d_taiwan.pmtiles` 的 `height` 欄位，故不需 upstream handoff / ADR。
+
+## 已知限制 / 坑
+
+- 建物 PMTiles **minzoom 8**，「整島一畫面」（z6-7）無資料；效果落在 **z8+（城市／區域級）**。
+- 一份 gl context 只能有一個「同時 render」的 Three.js 光暈 Scene（見 `docs/features/bloom-experiments/README.md` 雙 Scene pitfall）→ **勿與「發電廠/變電所 Bloom 測試」同時開啟**；不同時可見則安全（render 不可見時提前 return）。
+- 樓層無真實欄位，沿用 `height/3` 精神直接吃 `height`。
+
+## 歷次改動
+
+看 [changelog.md](./changelog.md)。

--- a/docs/features/buildings-night-lights/changelog.md
+++ b/docs/features/buildings-night-lights/changelog.md
@@ -1,0 +1,14 @@
+# Changelog — 建物夜景燈光 Buildings Night Lights
+
+> 逐 PR 變更紀錄。最新在上。
+
+---
+
+## 2026-07-22 — 初版（本地 commit，未 push）
+
+- `buildingsGba` 新增 mode 3「夜景燈光」：純 Mapbox fill，暖橘/白雙色階依 `height` 由暗轉亮 + `%3` pseudo-random 交錯（約 1/3 白光）。
+- 新增高樓 bloom 疊層 `buildings-night-bloom-3d`：夜景模式時對視野內 `height ≥ 門檻`（slider 預設 100m）取最高前 4096 棟疊 Three.js additive 光暈，復用 `GlowPointsScene`。
+- 新 slider `buildingsGbaBloomMinHeight`（40–200m）。
+- 圖例補 mode 3 分支 + 「搭深色底圖」提示。
+- Breaking：無（無資料契約變更）。
+- 待補：PR # + squash hash（merge 後回填）。

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -84,6 +84,7 @@ import { usePowerRegionBarsLayer } from "./hooks/usePowerRegionBarsLayer";
 import { usePowerGenerationBeamLayer } from "./hooks/usePowerGenerationBeamLayer";
 import { usePowerPlantGlowLayer } from "./hooks/usePowerPlantGlowLayer";
 import { useSubstationEhvGlowLayer } from "./hooks/useSubstationEhvGlowLayer";
+import { useBuildingsNightBloomLayer } from "./hooks/useBuildingsNightBloomLayer";
 import { usePowerLinesGlowTestLayer } from "./hooks/usePowerLinesGlowTestLayer";
 import { useAviationRestrictedGlowLayer } from "./hooks/useAviationRestrictedGlowLayer";
 import { useLightningLayer, useNuclearLayer } from "./hooks/useHazardLayer";
@@ -981,6 +982,13 @@ export default function App() {
     layerVisibility.powerPlantGlow,
     transportParams.overlayParams.powerPlantGlowOpacity ?? 0.9,
     transportParams.overlayParams.powerPlantGlowSize ?? 1,
+  );
+  // 夜景燈光 mode 3 的高樓 bloom 疊層（層開 且 顯示模式=夜景燈光 時才 render）
+  useBuildingsNightBloomLayer(
+    mapRef,
+    layerVisibility.buildingsGba && (transportParams.overlayParams.buildingsGbaModeIdx ?? 0) === 3,
+    transportParams.overlayParams.buildingsGbaOpacity ?? 0.75,
+    transportParams.overlayParams.buildingsGbaBloomMinHeight ?? 100,
   );
   useSubstationEhvGlowLayer(
     mapRef,

--- a/src/components/LegendPanel.tsx
+++ b/src/components/LegendPanel.tsx
@@ -40,7 +40,7 @@ import {
   LIBRARY_SEATS_COLORS,
 } from "../data/cultureTypes";
 import {
-  BUILDING_HEIGHT_BANDS, BUILDING_SRC_LABELS, BUILDINGS_GBA_ATTRIBUTION,
+  BUILDING_HEIGHT_BANDS, BUILDING_SRC_LABELS, BUILDINGS_GBA_ATTRIBUTION, BUILDING_NIGHT_LEGEND,
 } from "../data/buildingsGbaTypes";
 import {
   URBAN_FORM_GRID_MODES, URBAN_FORM_GRID_ATTRIBUTION_GBA, URBAN_FORM_GRID_ATTRIBUTION_META,
@@ -1044,8 +1044,10 @@ function TreePitsTaipeiLegend() {
 // GBA 建物輪廓圖例：依顯示模式（0=高度分級 1=資料來源 2=3D 立體沿用高度色階）切換內容 + 必掛署名。
 function BuildingsGbaLegend({ modeIdx = 0 }: { modeIdx?: number }) {
   const t = useLegendTheme();
-  const subhead = modeIdx === 1 ? "資料來源 SOURCE" : "高度 HEIGHT";
-  const rows = modeIdx === 1
+  const subhead = modeIdx === 3 ? "夜景燈光 NIGHT LIGHTS" : modeIdx === 1 ? "資料來源 SOURCE" : "高度 HEIGHT";
+  const rows = modeIdx === 3
+    ? BUILDING_NIGHT_LEGEND
+    : modeIdx === 1
     ? BUILDING_SRC_LABELS.map((s) => ({ color: s.color, label: s.label }))
     : BUILDING_HEIGHT_BANDS.map((b) => ({ color: b.color, label: b.label }));
   return (
@@ -1057,6 +1059,11 @@ function BuildingsGbaLegend({ modeIdx = 0 }: { modeIdx?: number }) {
       <div style={{ display: "flex", flexDirection: "column", gap: 2 }}>
         {rows.map((it) => <UrbanDotRow key={it.label} color={it.color} label={it.label} />)}
       </div>
+      {modeIdx === 3 && (
+        <div style={{ fontSize: FONT_SIZE.xs, color: t.textDim, marginTop: 4, lineHeight: 1.4 }}>
+          樓層越高光越亮 · 橘白交錯 · 建議搭深色底圖
+        </div>
+      )}
       <div style={{ fontSize: FONT_SIZE.xs, color: t.textDim, marginTop: 4, lineHeight: 1.4 }}>
         {BUILDINGS_GBA_ATTRIBUTION}
       </div>

--- a/src/data/buildingsGbaTypes.ts
+++ b/src/data/buildingsGbaTypes.ts
@@ -64,11 +64,55 @@ export function buildingSrcColorExpr(): unknown[] {
   return ["match", ["get", "src"], "osm", BUILDING_SRC_COLORS.osm, BUILDING_SRC_COLORS.other];
 }
 
+// 夜景燈光模式：深色底圖上模擬城市夜空。height 越高 → 越亮越白（低樓層暗暖橘、高樓層爆白），
+// 以 height 小數位做確定性 pseudo-random 分流，約 1/3 建物走白光家族、其餘走暖橘家族 → 橘白交錯（偏白）。
+// Mapbox fill 無 additive blending，靠深底 + 明亮暖白色階近似 bloom 觀感（非真光暈）。
+// 兩組 6 段色階皆隨 height 由暗轉亮，對齊「樓層越高光越亮」語意。
+const NIGHT_WARM_RAMP: [number, string][] = [
+  [0, "#2a1505"],
+  [8, "#7a3d12"],
+  [18, "#c46220"],
+  [35, "#ff9838"],
+  [70, "#ffd59a"],
+  [140, "#fff4e2"],
+];
+const NIGHT_WHITE_RAMP: [number, string][] = [
+  [0, "#43392a"],
+  [8, "#807763"],
+  [18, "#c6bea8"],
+  [35, "#ece7d8"],
+  [70, "#fbf9f2"],
+  [140, "#ffffff"],
+];
+
+function nightRampExpr(h: unknown[], ramp: [number, string][]): unknown[] {
+  const e: unknown[] = ["interpolate", ["linear"], h];
+  for (const [stop, color] of ramp) e.push(stop, color);
+  return e;
+}
+
+/** 夜景燈光 fill-color：橘/白雙家族依 height 由暗轉亮，pseudo-random 交錯（⚠️ 不含 ["zoom"]） */
+export function buildingNightLightColorExpr(): unknown[] {
+  const h: unknown[] = ["to-number", ["get", "height"], 0];
+  // round(height*10) mod 3 == 0 → 白光家族（約 1/3，偏白），其餘暖橘；height 小數位讓相鄰建物散開
+  const bucket: unknown[] = ["%", ["round", ["*", h, 10]], 3];
+  return ["case", ["==", bucket, 0], nightRampExpr(h, NIGHT_WHITE_RAMP), nightRampExpr(h, NIGHT_WARM_RAMP)];
+}
+
+/** 夜景燈光圖例色帶（低→高，代表暖橘→暖白爆光；白光家族僅點綴不另列） */
+export const BUILDING_NIGHT_LEGEND: { color: string; label: string }[] = [
+  { color: "#7a3d12", label: "低樓層 · 暖橘微光" },
+  { color: "#ff9838", label: "中樓層 · 橘光" },
+  { color: "#fff4e2", label: "高樓層 · 暖白" },
+  { color: "#ffffff", label: "超高層 · 白熱交錯" },
+];
+
 /** 顯示模式 select 選項；index 對齊 overlayRegistry 讀的 buildingsGbaModeIdx */
 export const BUILDINGS_GBA_MODES = [
   { label: "高度分級", value: "0" },
   { label: "資料來源", value: "1" },
   { label: "3D 立體", value: "2" },
+  { label: "夜景燈光", value: "3" },
 ] as const;
 
 // 圖例必掛署名（CC BY-NC 4.0，禁商用）

--- a/src/hooks/useBuildingsNightBloomLayer.ts
+++ b/src/hooks/useBuildingsNightBloomLayer.ts
@@ -1,0 +1,55 @@
+import { useEffect, useRef } from "react";
+import type { Map as MapboxMap } from "mapbox-gl";
+import {
+  createBuildingsNightBloomLayer,
+  BUILDINGS_NIGHT_BLOOM_LAYER_ID,
+} from "../map/buildingsNightBloomCustomLayer";
+
+/**
+ * 夜景燈光 mode 3 的高樓 bloom 疊層。資料來源復用 buildingsGba 的 pmtile source
+ * （source id "buildings-gba" / source-layer "buildings"），不另外 fetch —— render 時
+ * 直接 querySourceFeatures 取視野內高樓。visible 由呼叫端組（layer 開 且 modeIdx===3）。
+ *
+ * ⚠️ Style toggle race：走 try/catch + idle retry（同 usePowerPlantGlowLayer 慣例）。
+ */
+export function useBuildingsNightBloomLayer(
+  mapRef: React.RefObject<MapboxMap | null>,
+  visible: boolean,
+  opacity: number,
+  minHeight: number,
+) {
+  const visibleRef = useRef(visible);
+  visibleRef.current = visible;
+  const opacityRef = useRef(opacity);
+  opacityRef.current = opacity;
+  const minHeightRef = useRef(minHeight);
+  minHeightRef.current = minHeight;
+
+  useEffect(() => {
+    const map = mapRef.current;
+    if (!map) return;
+
+    const tryMount = () => {
+      if (map.getLayer(BUILDINGS_NIGHT_BLOOM_LAYER_ID)) return;
+      try {
+        const layer = createBuildingsNightBloomLayer({
+          getIsVisible: () => visibleRef.current,
+          getOpacity: () => opacityRef.current,
+          getMinHeight: () => minHeightRef.current,
+          sourceId: "buildings-gba",
+          sourceLayer: "buildings",
+        });
+        map.addLayer(layer);
+      } catch (e) {
+        console.log("[BuildingsNightBloom] addLayer 失敗 → idle 後重試", e);
+        map.once("idle", tryMount);
+      }
+    };
+
+    tryMount();
+    map.on("style.load", tryMount);
+    return () => {
+      map.off("style.load", tryMount);
+    };
+  }, [mapRef, visible]);
+}

--- a/src/hooks/useTransportParams.ts
+++ b/src/hooks/useTransportParams.ts
@@ -237,10 +237,12 @@ export function useTransportParams() {
   // 台北人行道樹穴（pit_type 樹穴/花圃二色 fill + 類型篩選）
   const [treePitsTaipeiOpacity, setTreePitsTaipeiOpacity] = useState(0.55);
   const [treePitsTaipeiType, setTreePitsTaipeiType] = useState<string>("all"); // all / 樹穴 / 花圃
-  // GBA 全台建物輪廓（0=高度分級 1=資料來源 2=3D 立體；高度門檻篩選 + 透明度）
+  // GBA 全台建物輪廓（0=高度分級 1=資料來源 2=3D 立體 3=夜景燈光；高度門檻篩選 + 透明度）
   const [buildingsGbaModeIdx, setBuildingsGbaModeIdx] = useState(0);
   const [buildingsGbaMinHeight, setBuildingsGbaMinHeight] = useState(0);
   const [buildingsGbaOpacity, setBuildingsGbaOpacity] = useState(0.75);
+  // 夜景燈光 mode 3 專用：≥N m 高樓額外給 Three.js additive bloom 光暈（視野內取最高前 4096 棟）
+  const [buildingsGbaBloomMinHeight, setBuildingsGbaBloomMinHeight] = useState(100);
   // 都市紋理網格（0-5：棟數/平均高度/總量體/建蔽率/樹冠覆蓋/灰綠指數；預設 5=灰綠指數）
   const [urbanFormGridModeIdx, setUrbanFormGridModeIdx] = useState(5);
   const [urbanFormGridOpacity, setUrbanFormGridOpacity] = useState(0.55);
@@ -977,7 +979,7 @@ export function useTransportParams() {
     streetTreesNationalCityIdx: ["all", ...STREET_TREE_NATIONAL_CITIES.map((c) => c.value)].indexOf(streetTreesNationalCity),
     treePitsTaipeiOpacity,
     treePitsTaipeiTypeIdx: ["all", ...TREE_PIT_TYPES.map((t) => t.name)].indexOf(treePitsTaipeiType),
-    buildingsGbaModeIdx, buildingsGbaMinHeight, buildingsGbaOpacity,
+    buildingsGbaModeIdx, buildingsGbaMinHeight, buildingsGbaOpacity, buildingsGbaBloomMinHeight,
     urbanFormGridModeIdx, urbanFormGridOpacity,
     // 🗺️ 土地使用分區：category select 編成 Idx 餵 filter（overlayParams 只收數字，0=全部 1..9 單類）
     urbanZoningTaipeiOpacity,
@@ -1345,7 +1347,7 @@ export function useTransportParams() {
     streetTreesTaipei3epochOpacity, streetTreesTaipei3epochRadius, streetTreesTaipei3epochColorMode, streetTreesTaipei3epochTrajFilter,
     streetTreesNationalOpacity, streetTreesNationalRadius, streetTreesNationalColorMode, streetTreesNationalCity,
     treePitsTaipeiOpacity, treePitsTaipeiType,
-    buildingsGbaModeIdx, buildingsGbaMinHeight, buildingsGbaOpacity,
+    buildingsGbaModeIdx, buildingsGbaMinHeight, buildingsGbaOpacity, buildingsGbaBloomMinHeight,
     urbanFormGridModeIdx, urbanFormGridOpacity,
     urbanZoningTaipeiOpacity, urbanZoningTaipeiCategory,
     urbanZoningNewTaipeiOpacity, urbanZoningNewTaipeiCategory,
@@ -2515,6 +2517,9 @@ export function useTransportParams() {
         { type: "select" as const, label: "顯示模式", value: String(buildingsGbaModeIdx), options: [...BUILDINGS_GBA_MODES], onChange: (v: string) => setBuildingsGbaModeIdx(parseInt(v, 10)) },
         { label: `高度門檻 ≥ ${buildingsGbaMinHeight} m`, value: buildingsGbaMinHeight, min: 0, max: 100, step: 5, onChange: setBuildingsGbaMinHeight },
         { label: `透明度 ${buildingsGbaOpacity.toFixed(2)}`, value: buildingsGbaOpacity, min: 0, max: 1, step: 0.05, onChange: setBuildingsGbaOpacity },
+        ...(buildingsGbaModeIdx === 3
+          ? [{ label: `Bloom 高樓門檻 ≥ ${buildingsGbaBloomMinHeight} m`, value: buildingsGbaBloomMinHeight, min: 40, max: 200, step: 10, onChange: setBuildingsGbaBloomMinHeight }]
+          : []),
       ];
       case "urbanFormGrid": return [
         { type: "select" as const, label: "顯示模式", value: String(urbanFormGridModeIdx), options: [...URBAN_FORM_GRID_MODES], onChange: (v: string) => setUrbanFormGridModeIdx(parseInt(v, 10)) },

--- a/src/map/buildingsNightBloomCustomLayer.ts
+++ b/src/map/buildingsNightBloomCustomLayer.ts
@@ -1,0 +1,139 @@
+import type { CustomLayerInterface, Map as MapboxMap, MapSourceDataEvent } from "mapbox-gl";
+import { GlowPointsScene, type GlowPoint } from "../three/GlowPointsScene";
+
+/**
+ * 夜景燈光 mode 3 專用的高樓 bloom 疊層 — 在 Mapbox fill「一片橘光」上，
+ * 給 ≥N m 的高樓額外一層 Three.js additive 光暈（真爆白，補 Mapbox fill 沒有的 bloom 觀感）。
+ *
+ * 資料來源直接復用 buildingsGba 的 pmtile source（同一份，不另外載）：
+ * 每次 moveend 從 map.querySourceFeatures 撈視野內建物 → 篩 height ≥ 門檻 → 算中心點 →
+ * 去重 → 取最高前 4096 棟（對齊 GlowPointsScene 上限）餵光暈。因此低 zoom（全城）為城市地標
+ * 群聚發亮、高 zoom（街廓）為逐棟高樓 beacon，都自動貼合視野。
+ *
+ * ⚠️ 一份 gl context 只掛一個「同時 render」的 GlowPointsScene（見 bloom-experiments README
+ * 雙 Scene 打架 pitfall）：本層與發電廠/變電所 Bloom 測試層互斥 —— 只要不同時「可見」即安全
+ * （render 在不可見時提前 return，不會污染 GL state）。
+ */
+
+export const BUILDINGS_NIGHT_BLOOM_LAYER_ID = "buildings-night-bloom-3d";
+
+const MAX_BLOOM = 4096; // 對齊 GlowPointsScene.MAX_POINT_COUNT
+const BLOOM_COLOR = "#fff2d8"; // 暖白；核心經 coreBoost 推到純白
+const HEIGHT_MAX = 300; // sizeNorm 正規化上界（m），約台北 101 之下的高樓級距
+
+export interface BuildingsNightBloomLayerOptions {
+  getIsVisible: () => boolean;
+  getOpacity: () => number;
+  getMinHeight: () => number;
+  sourceId: string;
+  sourceLayer: string;
+}
+
+function ringCentroid(coords: number[][]): [number, number] {
+  let x = 0;
+  let y = 0;
+  let n = 0;
+  for (const c of coords) {
+    if (!c || c.length < 2) continue;
+    x += c[0]!;
+    y += c[1]!;
+    n++;
+  }
+  return n ? [x / n, y / n] : [NaN, NaN];
+}
+
+function featureCentroid(geom: GeoJSON.Geometry | null | undefined): [number, number] | null {
+  if (!geom) return null;
+  if (geom.type === "Polygon") {
+    const ring = geom.coordinates[0];
+    return ring && ring.length >= 3 ? ringCentroid(ring as number[][]) : null;
+  }
+  if (geom.type === "MultiPolygon") {
+    const ring = geom.coordinates[0]?.[0];
+    return ring && ring.length >= 3 ? ringCentroid(ring as number[][]) : null;
+  }
+  return null;
+}
+
+export function createBuildingsNightBloomLayer(
+  opts: BuildingsNightBloomLayerOptions,
+): CustomLayerInterface {
+  const scene = new GlowPointsScene({ minSizePx: 8, maxSizePx: 90, coreBoost: 1.0 });
+  let map: MapboxMap | null = null;
+  let dirty = true;
+
+  const markDirty = () => {
+    dirty = true;
+  };
+  const onSourceData = (e: MapSourceDataEvent) => {
+    if (e.sourceId === opts.sourceId && e.isSourceLoaded) dirty = true;
+  };
+
+  function rebuild() {
+    if (!map) return;
+    const minH = opts.getMinHeight();
+    const denom = Math.max(1, HEIGHT_MAX - minH);
+    let feats: GeoJSON.Feature[];
+    try {
+      feats = map.querySourceFeatures(opts.sourceId, {
+        sourceLayer: opts.sourceLayer,
+      }) as unknown as GeoJSON.Feature[];
+    } catch {
+      return;
+    }
+
+    const seen = new Set<string>();
+    const rows: { lon: number; lat: number; h: number }[] = [];
+    for (const f of feats) {
+      const h = Number((f.properties as { height?: number } | null)?.height);
+      if (!Number.isFinite(h) || h < minH) continue;
+      const c = featureCentroid(f.geometry);
+      if (!c || !Number.isFinite(c[0]) || !Number.isFinite(c[1])) continue;
+      const key = `${c[0].toFixed(5)},${c[1].toFixed(5)}`;
+      if (seen.has(key)) continue; // 去重（querySourceFeatures 跨 tile 會重複回傳）
+      seen.add(key);
+      rows.push({ lon: c[0], lat: c[1], h });
+    }
+    rows.sort((a, b) => b.h - a.h); // 最高的優先
+    const points: GlowPoint[] = rows.slice(0, MAX_BLOOM).map((r) => ({
+      lon: r.lon,
+      lat: r.lat,
+      colorHex: BLOOM_COLOR,
+      sizeNorm: Math.min(1, Math.max(0, (r.h - minH) / denom)),
+    }));
+    scene.setData(points);
+  }
+
+  return {
+    id: BUILDINGS_NIGHT_BLOOM_LAYER_ID,
+    type: "custom" as const,
+    renderingMode: "3d" as const,
+
+    onAdd(mapInstance, gl) {
+      map = mapInstance;
+      scene.init(gl);
+      map.on("moveend", markDirty);
+      map.on("sourcedata", onSourceData);
+    },
+
+    render(_gl, matrix) {
+      const visible = opts.getIsVisible();
+      scene.setVisible(visible);
+      if (!visible) return;
+      if (dirty) {
+        rebuild();
+        dirty = false;
+      }
+      scene.setOpacity(opts.getOpacity());
+      if (map) scene.setZoom(map.getZoom());
+      const moving = scene.render(matrix);
+      if (moving) map?.triggerRepaint();
+    },
+
+    onRemove() {
+      map?.off("moveend", markDirty);
+      map?.off("sourcedata", onSourceData);
+      scene.dispose();
+    },
+  };
+}

--- a/src/map/overlayRegistry.ts
+++ b/src/map/overlayRegistry.ts
@@ -36,7 +36,7 @@ import {
   streetTreeNationalSpeciesColorExpr, streetTreeNationalCityColorExpr, STREET_TREE_NATIONAL_CITIES,
   treePitTypeColorExpr, TREE_PIT_TYPES,
 } from "../data/urbanOpenSpaceTypes";
-import { buildingHeightColorExpr, buildingSrcColorExpr } from "../data/buildingsGbaTypes";
+import { buildingHeightColorExpr, buildingSrcColorExpr, buildingNightLightColorExpr } from "../data/buildingsGbaTypes";
 import { urbanFormGridColorExpr, urbanFormGridOpacityExpr } from "../data/urbanFormGridTypes";
 import { urbanZoningColorExpr, URBAN_ZONING_CATEGORIES } from "../data/urbanZoningTypes";
 import {
@@ -3814,8 +3814,9 @@ export const OVERLAY_REGISTRY: OverlayConfig[] = [
   // z8-12 為 tippecanoe tiny-polygon 合併近似（只當建成區紋理，不可逐棟分析，extrusion
   // 因此 minzoom 鎖 13）；height 100% 有值 float，
   // src=osm 為 OSM 志願者繪製、其餘為 GBA AI 推估；CC BY-NC 4.0，署名見 LegendPanel）：
-  // 三種顯示模式 modeIdx 0=高度 6 級分級（fill）1=資料來源二色（fill）2=3D 立體（fill-extrusion，
-  // 沿用高度色階）。suffix fill/extrusion 兩層永遠都在，靠 paint 把非當前模式那層的 opacity
+  // 四種顯示模式 modeIdx 0=高度 6 級分級（fill）1=資料來源二色（fill）2=3D 立體（fill-extrusion，
+  // 沿用高度色階）3=夜景燈光（fill，深底暖橘/白發光，height 越高越亮，橘白交錯，建議搭深色底圖）。
+  // suffix fill/extrusion 兩層永遠都在，靠 paint 把非當前模式那層的 opacity
   // 壓成 0（純 JS 常數，非 data-driven，fill-extrusion-opacity 合法）── 不用 layout.visibility
   // 切換，因為 rebuildOnParamChange 的 wasHidden 還原邏輯是整組 suffix 共用同一顆布林值，
   // 若靠 visibility 做「模式互斥顯示」會被誤判成使用者關閉整層而遭覆寫（見 overlayManager.ts）。
@@ -3834,10 +3835,13 @@ export const OVERLAY_REGISTRY: OverlayConfig[] = [
         type: "fill",
         filter: (p) => [">=", ["get", "height"], p?.buildingsGbaMinHeight ?? 0],
         paint: (_isDark, p) => {
-          const modeIdx = p?.buildingsGbaModeIdx ?? 0; // 0=高度 1=來源 2=3D
+          const modeIdx = p?.buildingsGbaModeIdx ?? 0; // 0=高度 1=來源 2=3D 3=夜景燈光
           const op = p?.buildingsGbaOpacity ?? 0.75;
           return {
-            "fill-color": modeIdx === 1 ? buildingSrcColorExpr() : buildingHeightColorExpr(),
+            "fill-color":
+              modeIdx === 3 ? buildingNightLightColorExpr()
+              : modeIdx === 1 ? buildingSrcColorExpr()
+              : buildingHeightColorExpr(),
             // 3D 模式：z<13 extrusion 不存在（minzoom 鎖 13），fill 用 zoom step 當平面後備；
             // z13+ 壓 0 交棒給 extrusion（zoom 表達式合法，非 data-driven）
             "fill-opacity": modeIdx === 2 ? ["step", ["zoom"], op, 13, 0] : op,


### PR DESCRIPTION
## Summary
- 建物輪廓 (`buildingsGba`) 新增第 4 個顯示模式「夜景燈光」：深色底圖上以 `height` 驅動暖橘/白發光模擬台灣城市夜空；高樓額外疊一層 Three.js additive bloom 光暈補「爆白」質感。參考「發電廠 Bloom 測試 ✨」技法。

## Changes
- `buildingsGbaTypes.ts`：`buildingNightLightColorExpr()`（橘/白雙 6 段色階依 height 由暗轉亮 + `round(height*10)%3` pseudo-random 交錯，約 1/3 白光）+ 圖例色帶 + mode 選項
- `overlayRegistry.ts`：fill-color `modeIdx===3` 分支
- `buildingsNightBloomCustomLayer.ts`（新）+ `useBuildingsNightBloomLayer.ts`（新）：高樓 bloom 疊層 — 夜景模式時 `querySourceFeatures` 取視野內 `height≥門檻` 高樓、去重、取最高前 4096 棟 → 復用 `GlowPointsScene`（zoom 自適應）
- `useTransportParams.ts`：Bloom 高樓門檻 slider（40–200m，預設 100）
- `LegendPanel.tsx`：mode 3 圖例
- `App.tsx`：接線
- `docs/features/buildings-night-lights/`（README + changelog）

## Test
- [x] `npx tsc -b` 通過
- [x] `pnpm test` 通過（197）
- [x] Browser 驗收：夜景 fill z12/z14（橘白光海）+ bloom 資料管線（信義區 ≥100m 取出 12 棟真摩天樓）

## Risk / Rollback
- 純視覺新模式 + 復用既有 pmtile source，**無資料契約變更、無效能風險**
- Rollback：revert 該 squash commit
- ⚠️ 勿與「發電廠/變電所 Bloom 測試」同時開（一 gl context 單一 Three Scene，見 bloom-experiments pitfall）

## Related
- Feature: `docs/features/buildings-night-lights/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)