### PR TITLE
fix(timeline): 初始 timeStore.setTime 移出 render body 進掛載 effect

### DIFF
--- a/src/hooks/useTimeline.ts
+++ b/src/hooks/useTimeline.ts
@@ -102,15 +102,21 @@ export function useTimeline({
     timeStore.setWindowDateKeys(keys);
   }, [selectedDate, rangeDays]);
 
-  // 首次渲染寫入 timeStore 初始值（從「現在 - 1 小時」開始；過去日期從午夜開始）
+  // 首次掛載寫入 timeStore 初始值（從「現在 - 1 小時」開始；過去日期從午夜開始）。
+  // ⚠️ 必走 effect 不可放 render body：本 hook 下方以 useSyncExternalStore 訂閱 timeStore
+  // （currentTime），若在 App render 期間直接 timeStore.setTime() 會同步通知該訂閱者，觸發
+  // React「Cannot update a component (App) while rendering a different component (App)」警告。
   const initRef = useRef(false);
-  if (!initRef.current) {
+  useEffect(() => {
+    if (initRef.current) return;
+    initRef.current = true;
     const startUnix = Date.now() / 1000 - 3600;
     const initial =
       startUnix >= windowStart && startUnix <= windowEnd ? startUnix : windowStart;
     timeStore.setTime(initial);
-    initRef.current = true;
-  }
+    // 僅初始化一次，刻意使用首次掛載的視窗界限
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const [playing, setPlaying] = useState(false);
   const [speed, setSpeed] = useState(60);


### PR DESCRIPTION
## Summary
- 修 React 警告「Cannot update a component (`App`) while rendering a different component (`App`)」。

## Changes
- `useTimeline.ts`：一次性 `timeStore.setTime()` 初始化從 render body 搬進掛載 `useEffect`
- 根因：render 期間寫入一個被同 hook 以 `useSyncExternalStore` 訂閱的 `timeStore`，會同步通知訂閱者 → 違反 render 純度
- `timeStore` 預設值本就是 `Date.now()`，故首次繪製時間軸位置無感差異

## Test
- [x] `npx tsc -b` 通過
- [x] `pnpm test` 通過（197）
- [x] Browser：clean reload 後 **0 setState 警告 / 0 hook-order 錯誤 / 0 crash**，時間軸正確初始化（now−1h）

## Risk / Rollback
- 極低；只改一次性初始化的執行時機
- 全專案稽核（8 store 全 write 呼叫點 + 535 個 setState 呼叫點）確認**此為唯一 render-phase store 寫入**，其餘 layer/hook 皆乾淨
- Rollback：revert 該 squash commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)