### PR TITLE
docs(buildings-night-lights): changelog 回填 PR #78 squash hash

### DIFF
--- a/docs/features/buildings-night-lights/changelog.md
+++ b/docs/features/buildings-night-lights/changelog.md
@@ -4,11 +4,10 @@
 
 ---
 
-## 2026-07-22 — 初版（本地 commit，未 push）
+## 2026-07-22 — PR #78 `ffff9ca`（初版）
 
 - `buildingsGba` 新增 mode 3「夜景燈光」：純 Mapbox fill，暖橘/白雙色階依 `height` 由暗轉亮 + `%3` pseudo-random 交錯（約 1/3 白光）。
 - 新增高樓 bloom 疊層 `buildings-night-bloom-3d`：夜景模式時對視野內 `height ≥ 門檻`（slider 預設 100m）取最高前 4096 棟疊 Three.js additive 光暈，復用 `GlowPointsScene`。
 - 新 slider `buildingsGbaBloomMinHeight`（40–200m）。
 - 圖例補 mode 3 分支 + 「搭深色底圖」提示。
 - Breaking：無（無資料契約變更）。
-- 待補：PR # + squash hash（merge 後回填）。


### PR DESCRIPTION
## Summary
- 回填 `docs/features/buildings-night-lights/changelog.md` 的 PR # + squash hash（PR #78 / `ffff9ca`），完成工作流 Step 7。

## Changes
- changelog 標題 `初版（本地 commit，未 push）` → `PR #78 \`ffff9ca\`（初版）`，移除「待補」佔位行。

## Test
- 純文件，無程式變更。

## Risk / Rollback
- 無風險；doc-only。

🤖 Generated with [Claude Code](https://claude.com/claude-code)