### PR TITLE
docs(tree-layers): canopy v2 + canopyGiants 收尾（changelog + TL-4 done + STATUS）

### DIFF
--- a/.claude/memory/STATUS.md
+++ b/.claude/memory/STATUS.md
@@ -72,7 +72,7 @@ Fable 5 總指揮（規格核對→循序 worker 分批→gate 驗收），worke
 - 驗收：tsc 0 錯 / 190 tests 全綠 / agent-browser 逐層 7/7 PASS（All Off 後單層開、popup/圖例/controls/篩選全驗、台中點位實證、canopy raster 206）
 - **編排心得**：PMTiles/geojson 層無 loader/hook（全走 overlayRegistry），共用檔為主 → subagent 平行寫檔必衝突，改「循序 worker（每批唯一寫檔者）+ 主 agent 批間 gate 驗收」
 - 待辦：TL-1 S3 deploy-assets 上傳 7 資料檔（>2MB 不進 git）、TL-2 上游 data-catalog 補條目、上游 handoff `tree-layers.md` 已寫未 commit（在 analytics repo，避免污染其 aquaculture branch，待用戶拍板）
-- 非阻擋觀察：城市篩選 opacity 歸零法理論上隱形點仍可點擊（沿用既有慣例）；canopy tile 256px 但 mapbox-pmtiles 寫死 512 顯示略軟（TL-4）
+- 非阻擋觀察：城市篩選 opacity 歸零法理論上隱形點仍可點擊（沿用既有慣例）。canopy 256px 略軟（TL-4）→ PR #83 改 512px 高度編碼磚已解
 
 ## 本 session 完成（2026-07-10）— Batch 3 停車（hybrid v1，接 Batch 2 後）
 

--- a/docs/features/tree-layers/backlog.md
+++ b/docs/features/tree-layers/backlog.md
@@ -11,7 +11,7 @@
 - [ ] **TL-1**：S3 deploy-assets 上傳 5 個新檔（protected/riverside/parks geojson + national/tree_pits/3epoch/canopy pmtiles）— 部署前必做，>2MB 檔不進 git
 - [ ] **TL-2**：上游 taipei-gis-analytics 補 data-catalog 條目（7 個 dataset 目前 upstreamRegistry 標 `catalog_missing`）
 - [ ] **TL-3**：樹穴 × 行道樹 spatial overlay「空樹穴偵測」（規格書建議的進階分析，本次未做）
-- [ ] **TL-4**：canopy 512px tile 重出評估（mapbox-pmtiles tileSize 寫死 512，現以 256 tile 顯示略軟；瀏覽驗收若覺模糊再做）
+- [x] **TL-4**：canopy 512px tile 重出 — PR #83 已改高度編碼 RGBA 512px（z13≈20m），mapbox-pmtiles 512 假設變正確、順帶解糊
 - [ ] **TL-5**：全國行道樹上游瘦身（剔 lat/lon 冗餘欄可減磚重；需重出 PMTiles）
 
 ## 已完成（近期）

--- a/docs/features/tree-layers/changelog.md
+++ b/docs/features/tree-layers/changelog.md
@@ -4,6 +4,15 @@
 
 ---
 
+## 2026-07-24 — PR #83 `caef2ec`
+
+- **canopyHeight v2（解糊）**：上游 pipeline 由預烤 Greens PNG 改單通道高度編碼 RGBA（R=G=B=公尺, A=nodata mask, 512px, z13≈20m）；前端改 mapbox `raster-color` 動態上色（`raster-color-mix` 取 R×6.375、0–40m 綠色階）+ `raster-resampling: nearest`。舊 38m/z12/256px → ~20m/512px，放大不再被 over-zoom + mapbox-pmtiles 512 假設額外抹軟。→ 解決 **TL-4**。
+- **canopyGiants（新圖層）**：🌲 樹冠巨木 GeoJSON 7,823 點，依離道路距離 `dist_access_m` 分級染色（circle）；五處接線 + 分析文件 `docs/features/tree-layers/canopy-accessibility/`。
+- 上游 catalog：analytics `docs/data-catalog/forestry/canopy_height_meta.md` 補齊（原標「待補」）。
+- ⚠️ 部署（G012）：canopyHeight 80MB pmtiles 走 gitignore（`canopy_height_*.pmtiles`）+ S3/Volume，未上則 prod 404；canopyGiants geojson 在 git，prod 直接可用。
+
+---
+
 ## 2026-07-15 — PR #70 `34b8fd5`
 
 - 一次新增 7 個樹木圖層：protectedTreesNational / riversideTreesTaipei / parksTaipei（GeoJSON 點層）、streetTreesTaipei3epoch / streetTreesNational（PMTiles 點層）、treePitsTaipei（PMTiles 面層）、canopyHeight（raster PMTiles）


### PR DESCRIPTION
PR #83（canopy 高度編碼 + canopyGiants）的文件/記憶收尾：
- tree-layers changelog 補 #83 條目
- backlog TL-4（canopy 256px 略軟）打勾 — 已由 512px 高度編碼磚解決
- STATUS TL-4 非阻擋觀察標記已解
- 上游 analytics catalog canopy_height_meta.md 已補齊（本 repo 外，local）

2 顆 atomic commit（docs + memory），rebase merge 保留。

🤖 Generated with [Claude Code](https://claude.com/claude-code)