### PR TITLE
fix(deploy): FOREST_FILES canopy 檔名對齊 PR #83（rgb 高度編碼版）

### DIFF
--- a/scripts/deploy/upload-deploy-assets.sh
+++ b/scripts/deploy/upload-deploy-assets.sh
@@ -189,8 +189,8 @@ FOREST_FILES=(
   "public/forestry/hiking_trails.geojson"
   # PT-1 PMTiles（前端 sourceUrl 已切 .pmtiles；geojson 保留但未使用）
   "public/forestry/hiking_trails.pmtiles"
-  # 全台樹冠高度 raster PMTiles（93MB，Meta/WRI 2020 10m，tree-layers PR #70）
-  "public/forestry/canopy_height_taiwan.pmtiles"
+  # 全台樹冠高度 raster PMTiles（80MB，高度編碼 RGBA z13/512px，PR #83；舊預烤版 canopy_height_taiwan.pmtiles 已退役）
+  "public/forestry/canopy_height_rgb_taiwan.pmtiles"
 )
 for f in "${FOREST_FILES[@]}"; do
   name=$(basename "$f")


### PR DESCRIPTION
`upload-deploy-assets.sh` FOREST_FILES 舊 `canopy_height_taiwan.pmtiles`（PR #70 預烤版，已退役）→ `canopy_height_rgb_taiwan.pmtiles`（PR #83 高度編碼版）。本次 4 個新檔（canopy rgb + tourism D 類）已外科手動上傳 S3；此修正確保未來跑全腳本傳對檔。

🤖 Generated with [Claude Code](https://claude.com/claude-code)