### PR TITLE
fix: migrate direct-SQL references realtime.* -> live.

### DIFF
--- a/scripts/deploy/upload_fire_events.py
+++ b/scripts/deploy/upload_fire_events.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """
-Upload pre-processed fire events GeoJSON to Supabase realtime.fire_events.
+Upload pre-processed fire events GeoJSON to Supabase spatial.fire_events
+(via PostgREST REST API with `Content-Profile: spatial` header, not realtime schema).
 
 Source: taipei-gis-analytics/output/fire/fire_111_113_kepler.geojson
         (民國 111~113 年 ~48k 筆，已 geocoding)

--- a/scripts/preprocess/extract_climate_uv.py
+++ b/scripts/preprocess/extract_climate_uv.py
@@ -74,7 +74,7 @@ def latest_s3_uri(env: dict[str, str], dataset_id: str) -> Tuple[str, str]:
         cur.execute(
             """
             SELECT s3_uri, observed_at
-              FROM realtime.global_climate_grids
+              FROM live.global_climate_grids
              WHERE dataset_id = %s
                AND s3_uri IS NOT NULL
              ORDER BY observed_at DESC

--- a/scripts/preprocess/preprocess-youbike-h3.py
+++ b/scripts/preprocess/preprocess-youbike-h3.py
@@ -74,7 +74,7 @@ print("[2/4] Querying 15-min aggregated snapshots from Supabase...")
 with conn.cursor() as cur:
     cur.execute("""
         SELECT MIN(collected_at), MAX(collected_at), COUNT(*)
-        FROM realtime.youbike_snapshots
+        FROM live.youbike_snapshots
         WHERE city IN %s
     """, (CITIES,))
     min_time, max_time, total_rows = cur.fetchone()
@@ -91,7 +91,7 @@ with conn.cursor() as cur:
             AVG(y.available_rent) AS avg_rent,
             AVG(y.total) AS avg_total,
             COUNT(*) AS sample_count
-        FROM realtime.youbike_snapshots y
+        FROM live.youbike_snapshots y
         WHERE y.city IN %s
         GROUP BY y.station_uid, y.city, quarter_tw
         ORDER BY quarter_tw
@@ -167,7 +167,7 @@ for res in H3_RESOLUTIONS:
         "metadata": {
             "resolution": res,
             "cell_count": len(all_cells_set),
-            "source": "supabase:realtime.youbike_snapshots",
+            "source": "supabase:live.youbike_snapshots",
             "generated_at": datetime.now().isoformat(),
             "time_range": [time_keys[0], time_keys[-1]] if time_keys else [],
             "snapshot_count": len(snapshots),

--- a/scripts/preprocess/preprocess-youbike-h3.py
+++ b/scripts/preprocess/preprocess-youbike-h3.py
@@ -5,7 +5,7 @@ YouBike H3 滿車率預處理腳本 v3
 聚合到 H3 多解析度六角格，輸出帶實際時間戳的滿車率。
 
 資料來源：
-  - realtime.youbike_snapshots（時序資料，按日分區）
+  - live.youbike_snapshots（時序資料，按日分區）
   - reference.stations（站點座標，system='youbike'）
 
 輸出：


### PR DESCRIPTION
realtime schema 全量搬遷至 live（ADR-0010）配套：preprocess-youbike-h3 / extract_climate_uv 直連 SQL 改寫＋upload_fire_events docstring 修正（實際走 spatial 不受影響）。前端 src/ 全走 public RPC 不受影響。

⚠️ merge 時機：DB 套用 gis-platform migration 312 之後。

🤖 Generated with [Claude Code](https://claude.com/claude-code)