### PR TITLE
fix(monitor): sparkline 尺寸失控 + body row flex 擠壓 + 機場卡軸域修正

### DIFF
--- a/src/components/TimeseriesSparkline.tsx
+++ b/src/components/TimeseriesSparkline.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useLayoutEffect, useMemo, useRef, useState } from "react";
 import { COLORS, FONT_SIZE } from "../styles/designTokens";
 
 /**
@@ -29,9 +29,14 @@ export interface TimeseriesSparklineProps {
   height?: number;
   /** 是否顯示資料區域填色 */
   fillArea?: boolean;
+  /**
+   * 缺口斷線（opt-in）：相鄰點時距 > gapSec 秒 → 折線分段、不跨接，
+   * 避免把「缺快照」讀成真實低谷。不傳 = 原行為（一路連線）。
+   */
+  gapSec?: number;
 }
 
-const W = 256;          // 固定寬，配 popup 280 寬扣 padding
+const DEFAULT_W = 256;  // fallback 寬（量到容器實際寬度前使用），原配 popup 280 寬扣 padding
 const PAD_L = 30;       // 左邊讓出空間給 Y 軸數字
 const PAD_R = 8;
 const PAD_T = 6;
@@ -56,7 +61,22 @@ function niceTicks(min: number, max: number, count = 3): number[] {
   return ticks;
 }
 
-function fmtTick(v: number): string {
+/**
+ * Y 軸刻度格式：依刻度步距決定精度（step ≥ 1 → 整數；千級 → k 縮寫），
+ * 修掉人數類量出現「0.00」的違和小數。
+ */
+function fmtTick(v: number, step: number): string {
+  if (Math.abs(v) >= 1000 && step >= 1000) {
+    const kv = v / 1000;
+    return `${Number.isInteger(kv) ? kv : +kv.toFixed(1)}k`;
+  }
+  if (step >= 1) return Math.round(v).toString();
+  if (step >= 0.1) return v.toFixed(1);
+  return v.toFixed(2);
+}
+
+/** 警戒線標籤格式（依值本身量級，不受刻度步距 round 影響，1.5 不會變 2） */
+function fmtValue(v: number): string {
   if (Math.abs(v) >= 100) return v.toFixed(0);
   if (Math.abs(v) >= 10) return v.toFixed(1);
   return v.toFixed(2);
@@ -71,7 +91,27 @@ export function TimeseriesSparkline({
   warningColor = "#ef4444",
   height = 120,
   fillArea = true,
+  gapSec,
 }: TimeseriesSparklineProps) {
+  const wrapRef = useRef<HTMLDivElement>(null);
+  const [w, setW] = useState(DEFAULT_W);
+
+  useLayoutEffect(() => {
+    const el = wrapRef.current;
+    if (!el) return;
+    const measure = (width: number) => {
+      if (width === 0) return; // 元素隱藏時維持原值
+      setW(Math.round(width));
+    };
+    measure(el.clientWidth);
+    const ro = new ResizeObserver((entries) => {
+      const entry = entries[0];
+      if (entry) measure(entry.contentRect.width);
+    });
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, []);
+
   const view = useMemo(() => {
     if (data.length === 0) return null;
     const tMin = data[0]!.t;
@@ -86,33 +126,60 @@ export function TimeseriesSparkline({
     }
     // 給 vMax 留 10% 空間，避免最高點貼頂
     const pad = (vMax - vMin) * 0.1 || Math.max(Math.abs(vMax), 1) * 0.1;
-    const yLo = vMin - pad * 0.2;
+    // 資料全非負（人數/雨量/水深…）→ y 下界 clamp 到 0，不長出負值刻度
+    const yLo = vMin >= 0 ? Math.max(0, vMin - pad * 0.2) : vMin - pad * 0.2;
     const yHi = vMax + pad;
     const ticks = niceTicks(yLo, yHi, 3);
+    const tickStep = ticks.length >= 2 ? ticks[1]! - ticks[0]! : Math.abs(yHi - yLo) || 1;
     const xScale = (t: number) =>
-      tMax === tMin ? PAD_L : PAD_L + ((t - tMin) / (tMax - tMin)) * (W - PAD_L - PAD_R);
+      tMax === tMin ? PAD_L : PAD_L + ((t - tMin) / (tMax - tMin)) * (w - PAD_L - PAD_R);
     const yScale = (v: number) =>
       yHi === yLo ? PAD_T : PAD_T + (1 - (v - yLo) / (yHi - yLo)) * (height - PAD_T - PAD_B);
 
-    const pts = data.map((d) => `${xScale(d.t).toFixed(1)},${yScale(d.v).toFixed(1)}`).join(" ");
-    const areaPath =
-      `M${xScale(data[0]!.t).toFixed(1)},${(height - PAD_B).toFixed(1)} ` +
-      `L${pts.split(" ").join(" L")} ` +
-      `L${xScale(data[data.length - 1]!.t).toFixed(1)},${(height - PAD_B).toFixed(1)} Z`;
+    // 缺口分段：相鄰點時距 > gapSec → 斷線（不跨接），避免缺快照被讀成低谷
+    const segments: SparklinePoint[][] = [];
+    let cur: SparklinePoint[] = [];
+    for (const d of data) {
+      if (cur.length > 0 && gapSec != null && d.t - cur[cur.length - 1]!.t > gapSec) {
+        segments.push(cur);
+        cur = [];
+      }
+      cur.push(d);
+    }
+    segments.push(cur);
 
-    // X 軸時間 tick（最多 4 個：起、1/3、2/3、終）
+    const baseY = (height - PAD_B).toFixed(1);
+    const segViews = segments.map((seg) => {
+      const pts = seg.map((d) => `${xScale(d.t).toFixed(1)},${yScale(d.v).toFixed(1)}`).join(" ");
+      const areaPath =
+        `M${xScale(seg[0]!.t).toFixed(1)},${baseY} ` +
+        `L${pts.split(" ").join(" L")} ` +
+        `L${xScale(seg[seg.length - 1]!.t).toFixed(1)},${baseY} Z`;
+      return { pts, areaPath, single: seg.length === 1, first: seg[0]! };
+    });
+
+    // X 軸時間 tick：取整點（local）、步距依範圍選 1/2/4/8h，最多 ~4 個
+    const rangeH = (tMax - tMin) / 3600;
+    const stepH = rangeH <= 4 ? 1 : rangeH <= 9 ? 2 : rangeH <= 18 ? 4 : 8;
     const timeTicks: { x: number; label: string }[] = [];
-    const tickCount = Math.min(4, data.length);
-    for (let i = 0; i < tickCount; i++) {
-      const t = tMin + ((tMax - tMin) * i) / (tickCount - 1);
+    for (let t = Math.ceil(tMin / 3600) * 3600; t <= tMax; t += 3600) {
       const d = new Date(t * 1000);
-      const hh = d.getHours().toString().padStart(2, "0");
-      const mm = d.getMinutes().toString().padStart(2, "0");
-      timeTicks.push({ x: xScale(t), label: `${hh}:${mm}` });
+      if (d.getHours() % stepH !== 0 || d.getMinutes() !== 0) continue;
+      timeTicks.push({ x: xScale(t), label: `${d.getHours().toString().padStart(2, "0")}:00` });
+    }
+    if (timeTicks.length === 0) {
+      // 超短範圍（< 1 整點）fallback：首尾 hh:mm
+      for (const t of tMax > tMin ? [tMin, tMax] : [tMin]) {
+        const d = new Date(t * 1000);
+        timeTicks.push({
+          x: xScale(t),
+          label: `${d.getHours().toString().padStart(2, "0")}:${d.getMinutes().toString().padStart(2, "0")}`,
+        });
+      }
     }
 
-    return { tMin, tMax, yLo, yHi, ticks, xScale, yScale, pts, areaPath, timeTicks };
-  }, [data, warningValue, height]);
+    return { tMin, tMax, yLo, yHi, ticks, tickStep, xScale, yScale, segViews, timeTicks };
+  }, [data, warningValue, height, w, gapSec]);
 
   if (data.length === 0 || !view) {
     return (
@@ -130,115 +197,133 @@ export function TimeseriesSparkline({
   }
 
   return (
-    <svg
-      width="100%"
-      viewBox={`0 0 ${W} ${height}`}
-      preserveAspectRatio="none"
-      style={{ display: "block", marginTop: 4 }}
-    >
-      {/* Y 軸 grid + tick label */}
-      {view.ticks.map((tv) => {
-        const y = view.yScale(tv);
-        return (
-          <g key={`y-${tv}`}>
+    <div ref={wrapRef} style={{ width: "100%" }}>
+      <svg
+        width="100%"
+        height={height}
+        viewBox={`0 0 ${w} ${height}`}
+        style={{ display: "block", marginTop: 4 }}
+      >
+        {/* Y 軸 grid + tick label */}
+        {view.ticks.map((tv) => {
+          const y = view.yScale(tv);
+          return (
+            <g key={`y-${tv}`}>
+              <line
+                x1={PAD_L}
+                x2={w - PAD_R}
+                y1={y}
+                y2={y}
+                stroke="rgba(255,255,255,0.08)"
+                strokeWidth={0.5}
+              />
+              <text
+                x={PAD_L - 4}
+                y={y + 3}
+                fontSize={8}
+                textAnchor="end"
+                fill="rgba(255,255,255,0.5)"
+                fontFamily="monospace"
+              >
+                {fmtTick(tv, view.tickStep)}
+              </text>
+            </g>
+          );
+        })}
+
+        {/* 警戒線 */}
+        {warningValue != null && (
+          <g>
             <line
               x1={PAD_L}
-              x2={W - PAD_R}
-              y1={y}
-              y2={y}
-              stroke="rgba(255,255,255,0.08)"
-              strokeWidth={0.5}
+              x2={w - PAD_R}
+              y1={view.yScale(warningValue)}
+              y2={view.yScale(warningValue)}
+              stroke={warningColor}
+              strokeWidth={0.8}
+              strokeDasharray="3 2"
             />
             <text
-              x={PAD_L - 4}
-              y={y + 3}
+              x={w - PAD_R - 2}
+              y={view.yScale(warningValue) - 2}
               fontSize={8}
               textAnchor="end"
-              fill="rgba(255,255,255,0.5)"
+              fill={warningColor}
               fontFamily="monospace"
             >
-              {fmtTick(tv)}
+              {warningLabel} {fmtValue(warningValue)}
             </text>
           </g>
-        );
-      })}
+        )}
 
-      {/* 警戒線 */}
-      {warningValue != null && (
-        <g>
-          <line
-            x1={PAD_L}
-            x2={W - PAD_R}
-            y1={view.yScale(warningValue)}
-            y2={view.yScale(warningValue)}
-            stroke={warningColor}
-            strokeWidth={0.8}
-            strokeDasharray="3 2"
-          />
+        {/* 區域填色（依缺口分段） */}
+        {fillArea &&
+          view.segViews.map((sv, i) =>
+            sv.single ? null : (
+              <path key={`a-${i}`} d={sv.areaPath} fill={lineColor} fillOpacity={0.15} />
+            ),
+          )}
+
+        {/* 主線（依缺口分段；單點段畫小圓點） */}
+        {view.segViews.map((sv, i) =>
+          sv.single ? (
+            <circle
+              key={`s-${i}`}
+              cx={view.xScale(sv.first.t)}
+              cy={view.yScale(sv.first.v)}
+              r={1.6}
+              fill={lineColor}
+            />
+          ) : (
+            <polyline
+              key={`s-${i}`}
+              points={sv.pts}
+              fill="none"
+              stroke={lineColor}
+              strokeWidth={1.4}
+              strokeLinejoin="round"
+              strokeLinecap="round"
+            />
+          ),
+        )}
+
+        {/* 最末點 marker */}
+        <circle
+          cx={view.xScale(data[data.length - 1]!.t)}
+          cy={view.yScale(data[data.length - 1]!.v)}
+          r={2.2}
+          fill={lineColor}
+        />
+
+        {/* X 軸時間 tick（貼邊者換錨點避免裁切） */}
+        {view.timeTicks.map((tk, i) => (
           <text
-            x={W - PAD_R - 2}
-            y={view.yScale(warningValue) - 2}
+            key={`x-${i}`}
+            x={tk.x}
+            y={height - 2}
             fontSize={8}
-            textAnchor="end"
-            fill={warningColor}
+            textAnchor={tk.x < PAD_L + 12 ? "start" : tk.x > w - PAD_R - 12 ? "end" : "middle"}
+            fill="rgba(255,255,255,0.5)"
             fontFamily="monospace"
           >
-            {warningLabel} {fmtTick(warningValue)}
+            {tk.label}
           </text>
-        </g>
-      )}
+        ))}
 
-      {/* 區域填色 */}
-      {fillArea && (
-        <path d={view.areaPath} fill={lineColor} fillOpacity={0.15} />
-      )}
-
-      {/* 主線 */}
-      <polyline
-        points={view.pts}
-        fill="none"
-        stroke={lineColor}
-        strokeWidth={1.4}
-        strokeLinejoin="round"
-        strokeLinecap="round"
-      />
-
-      {/* 最末點 marker */}
-      <circle
-        cx={view.xScale(data[data.length - 1]!.t)}
-        cy={view.yScale(data[data.length - 1]!.v)}
-        r={2.2}
-        fill={lineColor}
-      />
-
-      {/* X 軸時間 tick */}
-      {view.timeTicks.map((tk, i) => (
-        <text
-          key={`x-${i}`}
-          x={tk.x}
-          y={height - 2}
-          fontSize={8}
-          textAnchor={i === 0 ? "start" : i === view.timeTicks.length - 1 ? "end" : "middle"}
-          fill="rgba(255,255,255,0.5)"
-          fontFamily="monospace"
-        >
-          {tk.label}
-        </text>
-      ))}
-
-      {/* 單位（右上角） */}
-      {unit && (
-        <text
-          x={W - PAD_R}
-          y={PAD_T + 8}
-          fontSize={8}
-          textAnchor="end"
-          fill="rgba(255,255,255,0.4)"
-          fontFamily="monospace"
-        >
-          {unit}
-        </text>
-      )}
-    </svg>
+        {/* 單位（右上角） */}
+        {unit && (
+          <text
+            x={w - PAD_R}
+            y={PAD_T + 8}
+            fontSize={8}
+            textAnchor="end"
+            fill="rgba(255,255,255,0.4)"
+            fontFamily="monospace"
+          >
+            {unit}
+          </text>
+        )}
+      </svg>
+    </div>
   );
 }

--- a/src/components/intel/monitor/AirportPaxCard.tsx
+++ b/src/components/intel/monitor/AirportPaxCard.tsx
@@ -28,8 +28,15 @@ export function AirportPaxCard({ open }: Props) {
       fetchAirportHourlyPax(activeCode, 24)
         .then((rows) => {
           if (cancelled) return;
-          setInSeries(rows.map((r) => ({ t: Date.parse(r.hour_bucket) / 1000, v: Number(r.pax_in) || 0 })));
-          setOutSeries(rows.map((r) => ({ t: Date.parse(r.hour_bucket) / 1000, v: Number(r.pax_out) || 0 })));
+          // v=0 視為缺格剔除：APIS 快照常見「該小時只收到單一方向細格」，
+          // 另一方向被 RPC SUM(CASE…ELSE 0) 聚合成假 0（TPE 白天 in=0 即此類）。
+          // 剔除後由 sparkline 的 gapSec 呈現斷線；24h 加總不受影響（0 貢獻 0）。
+          const toSeries = (pick: (r: (typeof rows)[number]) => number) =>
+            rows
+              .map((r) => ({ t: Date.parse(r.hour_bucket) / 1000, v: pick(r) || 0 }))
+              .filter((p) => p.v > 0);
+          setInSeries(toSeries((r) => Number(r.pax_in)));
+          setOutSeries(toSeries((r) => Number(r.pax_out)));
         })
         .catch((e) => console.warn("[AirportPaxCard]", e))
         .finally(() => { if (!cancelled) setLoading(false); });
@@ -90,8 +97,9 @@ export function AirportPaxCard({ open }: Props) {
           </div>
         ) : (
           <>
-            <TimeseriesSparkline data={inSeries} unit="人" lineColor="#10b981" height={70} />
-            <TimeseriesSparkline data={outSeries} unit="人" lineColor="#fb7185" height={70} />
+            {/* gapSec 2h：相鄰快照缺 2 小時以上 → 斷線呈現（缺格 ≠ 低谷） */}
+            <TimeseriesSparkline data={inSeries} unit="人" lineColor="#10b981" height={70} gapSec={2 * 3600} />
+            <TimeseriesSparkline data={outSeries} unit="人" lineColor="#fb7185" height={70} gapSec={2 * 3600} />
           </>
         )}
         <div style={{ fontSize: FONT_SIZE.xs, color: COLORS.textDim }}>

--- a/src/components/intel/monitor/MonitorPanel.tsx
+++ b/src/components/intel/monitor/MonitorPanel.tsx
@@ -567,7 +567,7 @@ export function MonitorPanel({
       />
 
       {/* body: feed (left) + indicators (right) */}
-      <div style={{ flex: 1, minHeight: 0, display: "flex" }}>
+      <div style={{ flex: 1, minHeight: 180, display: "flex" }}>
         {/* News Feed column (reuses IntelCard + IntelFilters) */}
         <div
           style={{
@@ -708,15 +708,17 @@ export function MonitorPanel({
         />
       </div>
 
-      {/* 警政司法民防 — 2 張新卡（與 IndicatorPanel 同層底下） */}
-      <div style={{ marginTop: 12, display: "grid", gridTemplateColumns: "1fr 1fr", gap: 12 }}>
-        <PrisonCard latest={prisonLatest} />
-        <AirportPaxCard open={open} />
-      </div>
+      <div className="mtp-scroll" style={{ marginTop: 12, flex: "0 1 auto", minHeight: 0, overflowY: "auto" }}>
+        {/* 警政司法民防 — 2 張新卡（與 IndicatorPanel 同層底下） */}
+        <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 12 }}>
+          <PrisonCard latest={prisonLatest} />
+          <AirportPaxCard open={open} />
+        </div>
 
-      {/* 急診壅塞 — 選區 + 醫院 tab + 24h 折線（另起整列，需較寬空間） */}
-      <div style={{ marginTop: 12 }}>
-        <ERCard open={open} />
+        {/* 急診壅塞 — 選區 + 醫院 tab + 24h 折線（另起整列，需較寬空間） */}
+        <div style={{ marginTop: 12 }}>
+          <ERCard open={open} />
+        </div>
       </div>
 
       <style>{`


### PR DESCRIPTION
## Summary
- 修復監看模式「圖表巨大化 + 內容消失」：兩個獨立版面缺陷疊加，另移植未合併分支 88cb2f4 的圖表品質修正

## Changes
- `TimeseriesSparkline.tsx`：SVG 無 height 屬性 → 寬容器下按 viewBox 256:h 固有比例放大 4-8 倍。改 ResizeObserver 動態 viewBox（1 SVG 單位 = 1px）；並移植 88cb2f4：y 下界 clamp、刻度依步距格式化（20000→20k）、x 軸整點 tick、gapSec 斷線分段
- `MonitorPanel.tsx`：body row flex-basis:0 收縮權重 0，溢出時被壓到 0px（News Feed + IndicatorPanel 消失）。minHeight 0→180 保底；底部三卡包進可收縮 + 內部捲動 wrapper
- `AirportPaxCard.tsx`：剔除方向性缺格假 0 點 + gapSec=2h（缺格畫斷線不畫低谷）

## Test
- [x] npx tsc -b 通過（0 error）
- [x] pnpm test 通過（18 files / 197 tests）
- [x] Browser 驗收：agent-browser 2000px viewport 截圖確認圖表回正常尺寸、News Feed/戰情概覽重現、機場卡 y 軸 k 縮寫 + x 軸整點 + 假 0 谷消失；popup 場景（水位站等 5 處）逐條驗證無回歸

## Risk / Rollback
- 風險低：TimeseriesSparkline 共 7 處使用，popup 場景 viewBox 寬≈實寬，視覺幾乎不變；水位小數刻度反而修正（5 個相同 35.7 → 35.70~35.74）
- 回滾：revert 單一 squash commit 即可

## Related
- 根因時間線：卡片 6/30 新增觸發潛伏 bug；7/8-7/9 已在 fix/monitor-airport-card / feat/monitor-grid-layout 分支修過但未 merge，本 PR 取代前者（可刪），後者的 monitor v2 改造（14 commits）仍未被取代
🤖 Generated with [Claude Code](https://claude.com/claude-code)