### PR TITLE
feat(er): 急診全醫院分區網格 + 總集摘要 + 14 天趨勢；直播牆動態過濾修復

### DIFF
--- a/docs/features/er-hospital/README.md
+++ b/docs/features/er-hospital/README.md
@@ -44,3 +44,27 @@
 
 - 上游 handoff：`../../../taipei-gis-analytics/docs/handoff/<slug>.md`
 - 開發規則：`../../development-rules.md`
+
+---
+
+## 2026-07-26 全醫院分區網格改版
+
+監看模式的 `ERCard` 從「選一家看一家」改成「59 家一次看完」，視覺語彙對齊能源卡的
+UNIT OUTPUT 區塊。
+
+- **驅動的資料契約**：`public.get_er_hospital_24h_all()`（gis-platform migration 319，
+  無參數、26ms、59 rows、每院約 84 點 `[ts, wait_see, wait_bed, wait_general, wait_icu]`）。
+  一次打包省掉「切一家 fetch 一次」的 N 次 RPC。
+- **分區**：`src/components/intel/monitor/erCardData.ts` 把 RPC 的 19 個 area_name（縣市）
+  收斂成台電四大區 **北部 / 中部 / 南部 / 東部**（宜蘭歸北部，同台電慣例）。實測資料無離島
+  縣市 —— 澎湖／金門／連江沒有重度級或兒童急救責任醫院，因此不設「離島」區；未知縣市
+  （名單年年評定會變）落「其他」保底，不吃掉資料。
+- **版面**：每區一個 section（區名 + 院數），區內小卡按「等一般病床」desc（最壅塞在前，
+  無資料墊底）。小卡 = 院名（超長截斷）+ 等床大字（`erCongestionTypes.ts` 嚴重度色）
+  + 24h `wait_general_cnt` 迷你 sparkline（沿用 `PressureRing.tsx` 的 `Sparkline`，無座標軸）。
+- **移除**：縣市 select、醫院 chip tabs、單院 `TimeseriesSparkline` 大圖、單院 24h fetch 的
+  呼叫端。`fetchErHospital24h()` 本身保留 —— popup 的 `EmergencyHospitalPanel` 仍在用。
+- **未改**：嚴重度閾值與配色 SSOT（`src/data/erCongestionTypes.ts`）、5 min 輪詢節奏、
+  地圖 circle 圖層與 popup。
+
+逐項變更看 [changelog.md](./changelog.md)。

--- a/docs/features/er-hospital/changelog.md
+++ b/docs/features/er-hospital/changelog.md
@@ -4,6 +4,15 @@
 
 ---
 
+## 2026-07-26 — ERCard 全醫院分區網格改版（branch `feat/er-hospital-grid`，PR #待補）
+
+- **上游**：gis-platform migration `319`（`public.get_er_hospital_24h_all()`，無參數、anon+authenticated、實測 26ms / 59 rows / 每院約 84 點），已 apply production。
+- Loader 新增 `fetchErHospital24hAll()`（`cachedOnce` 60s + `withLoading("er:24h:all")`）；單院 `fetchErHospital24h()` 保留（popup `EmergencyHospitalPanel` 仍在用）。
+- 新增 `src/components/intel/monitor/erCardData.ts`：19 縣市 → 台電四大區對映（宜蘭歸北部）+ `buildErRegionGroups()`。實測 area_name 無離島縣市（澎湖／金門／連江無重度級或兒童急救責任醫院），未知縣市落「其他」保底。
+- `ERCard.tsx` 改版：移除縣市 select／醫院 chip tabs／單院大圖，改為 59 院全覽 —— 北部 30 / 中部 17 / 南部 10 / 東部 2 分區 section（區名 + 院數），區內按等一般病床 desc；小卡 = 院名（截斷）+ 等床大字（嚴重度色）+ 24h `wait_general_cnt` 迷你 sparkline（沿用 PowerCard UNIT OUTPUT 的 `Sparkline`，無軸）。grid `auto-fill minmax(140px,1fr)`。
+- 嚴重度判定／配色仍走 `erCongestionTypes.ts` SSOT，未改閾值。輪詢維持 5 min。
+- **驗收**：`tsc -b` exit 0 / `vitest run` 18 files 197 綠 / browser 2000×1300（監看格）+ 900×1200（堆疊）雙尺寸親驗，console 無新 error。
+
 ## 2026-07-10 — Batch 1（branch `feat/er-hospital`，未 PR / 未 push）
 
 - 新增 `erHospital` 圖層：掛在既有「醫療 Medical」section 新增的「即時 Emergency」group。59 家重度級/兒童急救責任醫院即時急診量能，動態 GeoJSON circle 層，點色分 5 級壅塞。

--- a/src/components/TimeseriesSparkline.tsx
+++ b/src/components/TimeseriesSparkline.tsx
@@ -158,14 +158,30 @@ export function TimeseriesSparkline({
       return { pts, areaPath, single: seg.length === 1, first: seg[0]! };
     });
 
-    // X 軸時間 tick：取整點（local）、步距依範圍選 1/2/4/8h，最多 ~4 個
+    // X 軸時間 tick：≤48h 取整點（local）、步距 1/2/4/8h；>48h 取日界 00:00、
+    // 步距 1/2/4/7 天、標籤 M/D（8h 步距在多日範圍會生出數十個 tick 疊成字牆）
     const rangeH = (tMax - tMin) / 3600;
-    const stepH = rangeH <= 4 ? 1 : rangeH <= 9 ? 2 : rangeH <= 18 ? 4 : 8;
     const timeTicks: { x: number; label: string }[] = [];
-    for (let t = Math.ceil(tMin / 3600) * 3600; t <= tMax; t += 3600) {
-      const d = new Date(t * 1000);
-      if (d.getHours() % stepH !== 0 || d.getMinutes() !== 0) continue;
-      timeTicks.push({ x: xScale(t), label: `${d.getHours().toString().padStart(2, "0")}:00` });
+    if (rangeH > 48) {
+      const rangeD = rangeH / 24;
+      const stepD = rangeD <= 5 ? 1 : rangeD <= 16 ? 2 : rangeD <= 32 ? 4 : 7;
+      const cursor = new Date(tMin * 1000);
+      cursor.setHours(0, 0, 0, 0);
+      if (cursor.getTime() < tMin * 1000) cursor.setDate(cursor.getDate() + 1);
+      for (let i = 0; cursor.getTime() / 1000 <= tMax; cursor.setDate(cursor.getDate() + 1), i++) {
+        if (i % stepD !== 0) continue;
+        timeTicks.push({
+          x: xScale(cursor.getTime() / 1000),
+          label: `${cursor.getMonth() + 1}/${cursor.getDate()}`,
+        });
+      }
+    } else {
+      const stepH = rangeH <= 4 ? 1 : rangeH <= 9 ? 2 : rangeH <= 18 ? 4 : 8;
+      for (let t = Math.ceil(tMin / 3600) * 3600; t <= tMax; t += 3600) {
+        const d = new Date(t * 1000);
+        if (d.getHours() % stepH !== 0 || d.getMinutes() !== 0) continue;
+        timeTicks.push({ x: xScale(t), label: `${d.getHours().toString().padStart(2, "0")}:00` });
+      }
     }
     if (timeTicks.length === 0) {
       // 超短範圍（< 1 整點）fallback：首尾 hh:mm

--- a/src/components/intel/monitor/ERCard.tsx
+++ b/src/components/intel/monitor/ERCard.tsx
@@ -1,28 +1,21 @@
 import { useEffect, useMemo, useState } from "react";
 import { COLORS, FONT_CJK, FONT_DATA } from "../intelTokens";
 import { RADIUS, FONT_SIZE } from "../../../styles/designTokens";
-import { SectionLabel } from "./PressureRing";
-import { TimeseriesSparkline, type SparklinePoint } from "../../TimeseriesSparkline";
+import { SectionLabel, Sparkline } from "./PressureRing";
 import {
-  fetchErHospitalLatest, fetchErHospital24h, type ErHospitalLatest,
+  fetchErHospitalLatest, fetchErHospital24hAll,
+  type ErHospitalLatest, type ErHospital24hAllRow,
 } from "../../../data/erHospitalLoader";
-import {
-  classifyErCongestion, erCongestionColor, ER_LEVEL_LABELS, ER_CONGESTION_THRESHOLDS,
-} from "../../../data/erCongestionTypes";
+import { erCongestionColor, ER_LEVEL_LABELS, classifyErCongestion } from "../../../data/erCongestionTypes";
+import { buildErRegionGroups, type ErHospitalCell } from "./erCardData";
 
 interface Props { open: boolean }
 
-const ALL = "all";
-const TOP_N = 6;
-
 export function ERCard({ open }: Props) {
   const [latest, setLatest] = useState<ErHospitalLatest[]>([]);
-  const [area, setArea] = useState(ALL);
-  const [activeHospId, setActiveHospId] = useState<string | null>(null);
-  const [series, setSeries] = useState<SparklinePoint[]>([]);
-  const [loading24h, setLoading24h] = useState(false);
+  const [series, setSeries] = useState<ErHospital24hAllRow[]>([]);
 
-  // ── latest 快照（全 59 家），open 時載入 + 5min poll ──
+  // ── latest 快照 + 全院 24h，open 時載入 + 5min poll（沿用舊 ERCard 節奏）──
   useEffect(() => {
     if (!open) return;
     let cancelled = false;
@@ -30,64 +23,16 @@ export function ERCard({ open }: Props) {
       fetchErHospitalLatest()
         .then((rows) => { if (!cancelled) setLatest(rows); })
         .catch((e) => console.warn("[ERCard] latest", e));
+      fetchErHospital24hAll()
+        .then((rows) => { if (!cancelled) setSeries(rows); })
+        .catch((e) => console.warn("[ERCard] 24h all", e));
     };
     tick();
     const id = window.setInterval(tick, 5 * 60_000);
     return () => { cancelled = true; window.clearInterval(id); };
   }, [open]);
 
-  // 區域下拉選項（distinct area_name，依 area_no 排序）+ 全台
-  const areaOptions = useMemo(() => {
-    const seen = new Map<string, string>(); // area_name → area_no
-    for (const r of latest) {
-      if (r.area_name && !seen.has(r.area_name)) seen.set(r.area_name, r.area_no ?? "");
-    }
-    const opts = [...seen.entries()]
-      .sort((a, b) => a[1].localeCompare(b[1]))
-      .map(([name]) => ({ value: name, label: name }));
-    return [{ value: ALL, label: "全台" }, ...opts];
-  }, [latest]);
-
-  // 顯示的醫院 tab：全台 → 壅塞 top-6；選區 → 該區全部（壅塞排序）
-  const displayed = useMemo(() => {
-    const pool = area === ALL ? latest : latest.filter((r) => r.area_name === area);
-    const sorted = [...pool].sort(
-      (a, b) => (b.wait_general_cnt ?? -1) - (a.wait_general_cnt ?? -1),
-    );
-    return area === ALL ? sorted.slice(0, TOP_N) : sorted;
-  }, [latest, area]);
-
-  // 有效選中醫院：activeHospId 仍在清單則沿用，否則退回清單首位
-  const effectiveHospId = useMemo(() => {
-    if (activeHospId && displayed.some((h) => h.hosp_id === activeHospId)) return activeHospId;
-    return displayed[0]?.hosp_id ?? null;
-  }, [activeHospId, displayed]);
-
-  const activeHosp = useMemo(
-    () => latest.find((h) => h.hosp_id === effectiveHospId) ?? null,
-    [latest, effectiveHospId],
-  );
-
-  // 選中醫院 24h 折線（等一般病床）
-  useEffect(() => {
-    if (!open || !effectiveHospId) { setSeries([]); return; }
-    let cancelled = false;
-    setLoading24h(true);
-    fetchErHospital24h(effectiveHospId)
-      .then((rows) => {
-        if (cancelled) return;
-        setSeries(rows
-          .filter((r) => r.wait_general_cnt != null)
-          .map((r) => ({ t: Number(r.observed_ts), v: Number(r.wait_general_cnt) })));
-      })
-      .catch((e) => console.warn("[ERCard] 24h", e))
-      .finally(() => { if (!cancelled) setLoading24h(false); });
-    return () => { cancelled = true; };
-  }, [open, effectiveHospId]);
-
-  const curWait = activeHosp?.wait_general_cnt ?? null;
-  const curLevel = classifyErCongestion(curWait);
-  const dotColor = erCongestionColor(curWait);
+  const groups = useMemo(() => buildErRegionGroups(latest, series), [latest, series]);
 
   return (
     <div style={{ display: "flex", flexDirection: "column", gap: 10 }}>
@@ -98,90 +43,79 @@ export function ERCard({ open }: Props) {
           border: `1px solid ${COLORS.panelBorder}`,
           background: "linear-gradient(160deg, rgba(239,68,68,0.06), rgba(255,255,255,0.012))",
           padding: "12px 14px",
-          display: "flex", flexDirection: "column", gap: 8,
+          display: "flex", flexDirection: "column", gap: 10,
         }}
       >
-        {/* 區域下拉（原生 select，19 區 + 全台） */}
-        <select
-          value={area}
-          onChange={(e) => { setArea(e.target.value); setActiveHospId(null); }}
-          style={{
-            fontFamily: FONT_CJK, fontSize: FONT_SIZE.sm,
-            padding: "4px 8px", borderRadius: RADIUS.sm,
-            border: `1px solid ${COLORS.panelBorder}`,
-            background: "rgba(255,255,255,0.04)", color: COLORS.textStrong,
-            cursor: "pointer", width: "100%",
-          }}
-        >
-          {areaOptions.map((o) => (
-            <option key={o.value} value={o.value} style={{ background: "#111827" }}>{o.label}</option>
-          ))}
-        </select>
+        <span style={{ fontFamily: FONT_DATA, fontSize: FONT_SIZE.xs, letterSpacing: "1.2px", color: COLORS.textDim }}>
+          ER WAIT · {latest.length} 院 24h 等一般病床
+        </span>
 
-        {/* 醫院 tab（全台=壅塞 top6 / 選區=該區） */}
-        <div style={{ display: "flex", gap: 6, flexWrap: "wrap" }}>
-          {displayed.length === 0 ? (
-            <span style={{ fontSize: FONT_SIZE.xs, color: COLORS.textDim }}>資料載入中…</span>
-          ) : displayed.map((h) => {
-            const on = h.hosp_id === effectiveHospId;
-            const c = erCongestionColor(h.wait_general_cnt);
-            return (
-              <button
-                key={h.hosp_id}
-                onClick={() => setActiveHospId(h.hosp_id)}
-                style={{
-                  fontFamily: FONT_CJK, fontSize: FONT_SIZE.sm,
-                  padding: "3px 8px", borderRadius: RADIUS.sm,
-                  border: `1px solid ${on ? c : COLORS.panelBorder}`,
-                  background: on ? "rgba(239,68,68,0.14)" : "transparent",
-                  color: on ? COLORS.textStrong : COLORS.textMuted,
-                  cursor: "pointer", display: "flex", alignItems: "center", gap: 5,
-                }}
-              >
-                <span style={{ width: 7, height: 7, borderRadius: RADIUS.full, background: c, flexShrink: 0 }} />
-                {h.hosp_name}
-              </button>
-            );
-          })}
-        </div>
-
-        {/* 當前壅塞燈 + 數值 */}
-        {activeHosp && (
-          <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
-            <span style={{
-              width: 11, height: 11, borderRadius: RADIUS.full, background: dotColor,
-              boxShadow: `0 0 7px ${dotColor}`, flexShrink: 0,
-            }} />
-            <span style={{ fontFamily: FONT_CJK, fontSize: FONT_SIZE.md, fontWeight: 700, color: COLORS.textStrong }}>
-              {activeHosp.hosp_name}
-            </span>
-            <span style={{ fontSize: FONT_SIZE.sm, color: COLORS.textMuted }}>
-              {ER_LEVEL_LABELS[curLevel]} · 等一般病床
-              <span style={{ fontFamily: FONT_DATA, fontWeight: 700, color: dotColor, marginLeft: 4 }}>
-                {curWait == null ? "—" : curWait}
+        {groups.length === 0 ? (
+          <div style={{ fontFamily: FONT_CJK, fontSize: FONT_SIZE.sm, color: COLORS.textFaint, padding: "8px 0" }}>
+            資料載入中…
+          </div>
+        ) : groups.map((g) => (
+          <div key={g.region} data-testid={`er-region-${g.region}`} style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+            <div style={{ display: "flex", alignItems: "baseline", gap: 6 }}>
+              <span style={{ fontFamily: FONT_CJK, fontSize: 11, fontWeight: 700, color: COLORS.textDefault }}>
+                {g.region}
               </span>
-            </span>
+              <span style={{ fontFamily: FONT_DATA, fontSize: 9, color: COLORS.textFaint }}>
+                {g.hospitals.length} 院
+              </span>
+              <div style={{ flex: 1, height: 1, background: COLORS.borderSoft }} />
+            </div>
+            <div
+              style={{
+                display: "grid",
+                gridTemplateColumns: "repeat(auto-fill, minmax(140px, 1fr))",
+                gap: 6,
+              }}
+            >
+              {g.hospitals.map((h) => <HospitalCell key={h.hospId} cell={h} />)}
+            </div>
           </div>
-        )}
+        ))}
 
-        {loading24h ? (
-          <div style={{ fontSize: FONT_SIZE.sm, color: COLORS.textDim, textAlign: "center", padding: "8px 0" }}>
-            載入中…
-          </div>
-        ) : (
-          <TimeseriesSparkline
-            data={series}
-            unit="等一般病床"
-            lineColor={dotColor}
-            warningValue={ER_CONGESTION_THRESHOLDS.congested}
-            warningLabel="嚴重"
-            height={80}
-          />
-        )}
         <div style={{ fontSize: FONT_SIZE.xs, color: COLORS.textDim }}>
-          來源：衛福部 急診即時訂閱（get_er_hospital_latest / 24h）
+          來源：衛福部 急診即時訂閱（get_er_hospital_latest / 24h_all）
         </div>
       </div>
+    </div>
+  );
+}
+
+function HospitalCell({ cell }: { cell: ErHospitalCell }) {
+  const color = erCongestionColor(cell.wait);
+  const level = classifyErCongestion(cell.wait);
+  return (
+    <div
+      title={`${cell.name} · ${cell.areaName} · ${ER_LEVEL_LABELS[level]}`}
+      style={{
+        display: "flex", alignItems: "center", gap: 6,
+        padding: "5px 7px", borderRadius: RADIUS.md,
+        background: "rgba(255,255,255,0.025)",
+        border: `1px solid ${COLORS.borderSoft}`,
+        minWidth: 0,
+      }}
+    >
+      <div style={{ display: "flex", flexDirection: "column", minWidth: 0, flex: 1 }}>
+        <span
+          style={{
+            fontFamily: FONT_CJK, fontSize: 10.5, color: COLORS.textDefault,
+            whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis",
+          }}
+        >
+          {cell.name}
+        </span>
+        <div style={{ display: "flex", alignItems: "baseline", gap: 4 }}>
+          <span style={{ fontFamily: FONT_DATA, fontSize: 14, fontWeight: 700, color, lineHeight: 1.1 }}>
+            {cell.wait == null ? "—" : cell.wait}
+          </span>
+          <span style={{ fontFamily: FONT_CJK, fontSize: 8.5, color: COLORS.textFaint }}>等床</span>
+        </div>
+      </div>
+      <Sparkline data={cell.spark.length >= 2 ? cell.spark : [0, 0]} color={color} w={40} h={18} />
     </div>
   );
 }

--- a/src/components/intel/monitor/ERCard.tsx
+++ b/src/components/intel/monitor/ERCard.tsx
@@ -6,8 +6,8 @@ import {
   fetchErHospitalLatest, fetchErHospital24hAll,
   type ErHospitalLatest, type ErHospital24hAllRow,
 } from "../../../data/erHospitalLoader";
-import { erCongestionColor, ER_LEVEL_LABELS, classifyErCongestion } from "../../../data/erCongestionTypes";
-import { buildErRegionGroups, type ErHospitalCell } from "./erCardData";
+import { erCongestionColor, ER_LEVEL_COLORS, ER_LEVEL_LABELS, classifyErCongestion } from "../../../data/erCongestionTypes";
+import { buildErRegionGroups, buildErSummary, ER_SEVERITY_ORDER, type ErHospitalCell, type ErSummary } from "./erCardData";
 
 interface Props { open: boolean }
 
@@ -33,6 +33,8 @@ export function ERCard({ open }: Props) {
   }, [open]);
 
   const groups = useMemo(() => buildErRegionGroups(latest, series), [latest, series]);
+  const allHospitals = useMemo(() => groups.flatMap((g) => g.hospitals), [groups]);
+  const nationalSummary = useMemo(() => buildErSummary(allHospitals), [allHospitals]);
 
   return (
     <div style={{ display: "flex", flexDirection: "column", gap: 10 }}>
@@ -50,19 +52,30 @@ export function ERCard({ open }: Props) {
           ER WAIT · {latest.length} 院 24h 等一般病床
         </span>
 
+        {allHospitals.length > 0 && <ErNationalSummaryRow summary={nationalSummary} />}
+
         {groups.length === 0 ? (
           <div style={{ fontFamily: FONT_CJK, fontSize: FONT_SIZE.sm, color: COLORS.textFaint, padding: "8px 0" }}>
             資料載入中…
           </div>
-        ) : groups.map((g) => (
+        ) : groups.map((g) => {
+          const regionSummary = buildErSummary(g.hospitals);
+          return (
           <div key={g.region} data-testid={`er-region-${g.region}`} style={{ display: "flex", flexDirection: "column", gap: 6 }}>
-            <div style={{ display: "flex", alignItems: "baseline", gap: 6 }}>
+            <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
               <span style={{ fontFamily: FONT_CJK, fontSize: 11, fontWeight: 700, color: COLORS.textDefault }}>
                 {g.region}
               </span>
               <span style={{ fontFamily: FONT_DATA, fontSize: 9, color: COLORS.textFaint }}>
                 {g.hospitals.length} 院
               </span>
+              <span
+                data-testid={`er-region-total-${g.region}`}
+                style={{ fontFamily: FONT_DATA, fontSize: 9, color: COLORS.textFaint }}
+              >
+                Σ {regionSummary.total.toLocaleString()} 等床
+              </span>
+              <ErRegionMiniBar summary={regionSummary} />
               <div style={{ flex: 1, height: 1, background: COLORS.borderSoft }} />
             </div>
             <div
@@ -75,7 +88,8 @@ export function ERCard({ open }: Props) {
               {g.hospitals.map((h) => <HospitalCell key={h.hospId} cell={h} />)}
             </div>
           </div>
-        ))}
+          );
+        })}
 
         <div style={{ fontSize: FONT_SIZE.xs, color: COLORS.textDim }}>
           來源：衛福部 急診即時訂閱（get_er_hospital_latest / 24h_all）
@@ -116,6 +130,98 @@ function HospitalCell({ cell }: { cell: ErHospitalCell }) {
         </div>
       </div>
       <Sparkline data={cell.spark.length >= 2 ? cell.spark : [0, 0]} color={color} w={40} h={18} />
+    </div>
+  );
+}
+
+/** 全台總集列（卡片頂部、分區 section 之前）— 視覺密度比照能源卡標頭列 */
+function ErNationalSummaryRow({ summary }: { summary: ErSummary }) {
+  const withData = ER_SEVERITY_ORDER.reduce((sum, lv) => sum + summary.counts[lv], 0);
+  return (
+    <div
+      data-testid="er-national-summary"
+      style={{
+        display: "flex", alignItems: "center", gap: 14,
+        padding: "6px 10px", borderRadius: RADIUS.lg,
+        background: "rgba(255,255,255,0.03)",
+        border: `1px solid ${COLORS.borderSoft}`,
+      }}
+    >
+      <div style={{ display: "flex", alignItems: "baseline", gap: 5, flexShrink: 0 }}>
+        <span style={{ fontFamily: FONT_CJK, fontSize: 10, color: COLORS.textMuted }}>全台等床</span>
+        <span
+          data-testid="er-national-total"
+          style={{
+            fontFamily: FONT_DATA, fontSize: 20, fontWeight: 700, color: "#fff",
+            fontVariantNumeric: "tabular-nums", lineHeight: 1,
+          }}
+        >
+          {summary.total.toLocaleString()}
+        </span>
+        <span style={{ fontFamily: FONT_CJK, fontSize: 9, color: COLORS.textFaint }}>人</span>
+      </div>
+
+      <div style={{ flex: 1, minWidth: 0, display: "flex", flexDirection: "column", gap: 3 }}>
+        <div
+          style={{
+            display: "flex", height: 6, borderRadius: RADIUS.sm, overflow: "hidden",
+            background: "rgba(255,255,255,0.06)",
+          }}
+        >
+          {ER_SEVERITY_ORDER.map((lv) => {
+            const n = summary.counts[lv];
+            if (n === 0) return null;
+            const pct = withData > 0 ? n / withData : 0;
+            return (
+              <span
+                key={lv}
+                title={`${ER_LEVEL_LABELS[lv]} · ${n} 院 · ${(pct * 100).toFixed(0)}%`}
+                style={{ width: `${pct * 100}%`, background: ER_LEVEL_COLORS[lv] }}
+              />
+            );
+          })}
+        </div>
+        <div style={{ display: "flex", flexWrap: "wrap", gap: "2px 10px" }}>
+          {ER_SEVERITY_ORDER.map((lv) => (
+            <span
+              key={lv}
+              data-testid={`er-national-count-${lv}`}
+              style={{ display: "inline-flex", alignItems: "center", gap: 3, fontFamily: FONT_DATA, fontSize: 9, color: COLORS.textMuted }}
+            >
+              <span style={{ width: 5, height: 5, borderRadius: RADIUS.full, background: ER_LEVEL_COLORS[lv] }} />
+              {ER_LEVEL_LABELS[lv]} {summary.counts[lv]} 院
+            </span>
+          ))}
+          {summary.noData > 0 && (
+            <span style={{ fontFamily: FONT_DATA, fontSize: 9, color: COLORS.textFaint }}>
+              無資料 {summary.noData}
+            </span>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/** 區 header 小計迷你比例條（4px 高 × 80px 寬） */
+function ErRegionMiniBar({ summary }: { summary: ErSummary }) {
+  const withData = ER_SEVERITY_ORDER.reduce((sum, lv) => sum + summary.counts[lv], 0);
+  if (withData === 0) return null;
+  return (
+    <div
+      title={ER_SEVERITY_ORDER.map((lv) => `${ER_LEVEL_LABELS[lv]} ${summary.counts[lv]}`).join(" · ")}
+      style={{
+        width: 80, height: 4, borderRadius: RADIUS.sm, overflow: "hidden",
+        display: "flex", background: "rgba(255,255,255,0.08)", flexShrink: 0,
+      }}
+    >
+      {ER_SEVERITY_ORDER.map((lv) => {
+        const n = summary.counts[lv];
+        if (n === 0) return null;
+        return (
+          <span key={lv} style={{ width: `${(n / withData) * 100}%`, height: "100%", background: ER_LEVEL_COLORS[lv] }} />
+        );
+      })}
     </div>
   );
 }

--- a/src/components/intel/monitor/ERCard.tsx
+++ b/src/components/intel/monitor/ERCard.tsx
@@ -2,9 +2,10 @@ import { useEffect, useMemo, useState } from "react";
 import { COLORS, FONT_CJK, FONT_DATA } from "../intelTokens";
 import { RADIUS, FONT_SIZE } from "../../../styles/designTokens";
 import { SectionLabel, Sparkline } from "./PressureRing";
+import { TimeseriesSparkline, type SparklinePoint } from "../../TimeseriesSparkline";
 import {
-  fetchErHospitalLatest, fetchErHospital24hAll,
-  type ErHospitalLatest, type ErHospital24hAllRow,
+  fetchErHospitalLatest, fetchErHospital24hAll, fetchErWaitTotal14d,
+  type ErHospitalLatest, type ErHospital24hAllRow, type ErWaitTotal14dRow,
 } from "../../../data/erHospitalLoader";
 import { erCongestionColor, ER_LEVEL_COLORS, ER_LEVEL_LABELS, classifyErCongestion } from "../../../data/erCongestionTypes";
 import { buildErRegionGroups, buildErSummary, ER_SEVERITY_ORDER, type ErHospitalCell, type ErSummary } from "./erCardData";
@@ -14,8 +15,9 @@ interface Props { open: boolean }
 export function ERCard({ open }: Props) {
   const [latest, setLatest] = useState<ErHospitalLatest[]>([]);
   const [series, setSeries] = useState<ErHospital24hAllRow[]>([]);
+  const [trend14d, setTrend14d] = useState<ErWaitTotal14dRow[]>([]);
 
-  // ── latest 快照 + 全院 24h，open 時載入 + 5min poll（沿用舊 ERCard 節奏）──
+  // ── latest 快照 + 全院 24h + 全台 14d 趨勢，open 時載入 + 5min poll（沿用舊 ERCard 節奏）──
   useEffect(() => {
     if (!open) return;
     let cancelled = false;
@@ -26,6 +28,9 @@ export function ERCard({ open }: Props) {
       fetchErHospital24hAll()
         .then((rows) => { if (!cancelled) setSeries(rows); })
         .catch((e) => console.warn("[ERCard] 24h all", e));
+      fetchErWaitTotal14d()
+        .then((rows) => { if (!cancelled) setTrend14d(rows); })
+        .catch((e) => console.warn("[ERCard] wait total 14d", e));
     };
     tick();
     const id = window.setInterval(tick, 5 * 60_000);
@@ -35,6 +40,11 @@ export function ERCard({ open }: Props) {
   const groups = useMemo(() => buildErRegionGroups(latest, series), [latest, series]);
   const allHospitals = useMemo(() => groups.flatMap((g) => g.hospitals), [groups]);
   const nationalSummary = useMemo(() => buildErSummary(allHospitals), [allHospitals]);
+  // 第一筆是 rolling window 邊界的部分小時（樣本少會偏低）→ 捨棄首桶再畫
+  const trend14dSpark = useMemo<SparklinePoint[]>(
+    () => trend14d.slice(1).map((r) => ({ t: r.bucket_ts, v: r.total_wait })),
+    [trend14d],
+  );
 
   return (
     <div style={{ display: "flex", flexDirection: "column", gap: 10 }}>
@@ -53,6 +63,8 @@ export function ERCard({ open }: Props) {
         </span>
 
         {allHospitals.length > 0 && <ErNationalSummaryRow summary={nationalSummary} />}
+
+        {allHospitals.length > 0 && <ErWaitTrend14d spark={trend14dSpark} />}
 
         {groups.length === 0 ? (
           <div style={{ fontFamily: FONT_CJK, fontSize: FONT_SIZE.sm, color: COLORS.textFaint, padding: "8px 0" }}>
@@ -199,6 +211,24 @@ function ErNationalSummaryRow({ summary }: { summary: ErSummary }) {
           )}
         </div>
       </div>
+    </div>
+  );
+}
+
+/** 全台 14 天等床趨勢（總集列正下方）— TimeseriesSparkline 動態寬版，捨棄首桶（rolling window 邊界偏低） */
+function ErWaitTrend14d({ spark }: { spark: SparklinePoint[] }) {
+  return (
+    <div data-testid="er-wait-trend-14d" style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+      <span style={{ fontFamily: FONT_DATA, fontSize: 9, letterSpacing: "1px", color: COLORS.textFaint }}>
+        14D TREND · 全台等床
+      </span>
+      {spark.length === 0 ? (
+        <div style={{ fontFamily: FONT_CJK, fontSize: FONT_SIZE.xs, color: COLORS.textFaint, padding: "8px 0", textAlign: "center" }}>
+          載入中…
+        </div>
+      ) : (
+        <TimeseriesSparkline data={spark} unit="人" height={64} fillArea lineColor="#fb7185" />
+      )}
     </div>
   );
 }

--- a/src/components/intel/monitor/HazardWatchStrip.tsx
+++ b/src/components/intel/monitor/HazardWatchStrip.tsx
@@ -3,10 +3,15 @@
  *
  * 放兩個與災防直接相關的 24h 直播：
  *   - 台灣地震監視 KyT4qSK8lJo（地震速報 / 強震即時警報）
- *   - 台灣颱風論壇 LzOTY4mZG00（天氣即時監測 + 颱風）
+ *   - 台灣颱風論壇 ADZTiqEGT8g（天氣即時監測 + 颱風；氣溫/雨量/風力/雷達多面板 dashboard）
  *
  * 不走 collector — 直接寫死 video_id（這兩個都是長年穩定、官方公開 embed）。
  * 樣式 1:1 對齊 LiveWall 的 16:9 容器 + LIVE badge + 邊框。
+ *
+ * 2026-07-26：用戶指定更新颱風論壇格 video_id（上一支 LzOTY4mZG00 已下播，畫面顯示
+ * 「無法播放這部直播影片的錄影存檔」）。新 ID 已用 oembed + embed 實測確認可嵌入播放，
+ * 頻道仍是同一個「台灣颱風論壇」(@twtybbs2009)，內容為多面板天氣監測 dashboard（無特定
+ * 颱風命名/事件字樣）研判屬 24hr 常設直播，非單場會下播的直播 —— 暫不需接 resolver。
  */
 
 import { memo, useRef } from "react";
@@ -29,7 +34,7 @@ const HAZARD_CHANNELS: HazardCh[] = [
     hint: "地震速報 · 強震即時警報",
   },
   {
-    videoId: "LzOTY4mZG00",
+    videoId: "ADZTiqEGT8g",
     name: "台灣颱風論壇",
     en: "WEATHER LIVE",
     hint: "氣溫 · 雨量 · 雷達 · 颱風",

--- a/src/components/intel/monitor/LiveWall.tsx
+++ b/src/components/intel/monitor/LiveWall.tsx
@@ -15,12 +15,27 @@ export interface LiveChannel {
   emergency?: boolean;
   emergencyLabel?: string;
   /**
-   * 寫死可 embedded 的 video_id 備援。
-   * 部分頻道（如 cts/ftv）resolver 抓到的 primary live 會被官方關 embed
-   *   → 改用同頻道另一個公開可嵌入的長期直播
-   * 若有此值，LiveSlot 會優先使用，resolver 結果僅作為次要備援。
+   * 寫死可 embedded 的 video_id 備援，resolver 沒給 video_id（或該台 embedBlocked）
+   * 時才會用到——resolver 有結果一律優先用 resolver（見 resolveSrc）。
+   *
+   * 2026-07-26 之前 resolver 是舊版 HTML 爬蟲、成功率極低（~0.2%），fallbackVideoId
+   * 一度是「resolver 給的 primary live 常被關 embed」的主要繞路，因此當時優先序反過來。
+   * 今日新版 resolver 改走 YouTube Data API v3（見 collectors/yt_live_video_resolver.py
+   * commit d8b6f10），實測 tvbs/ebc/ftv 現在 resolver 給的 video_id 已與這裡寫死的值完全
+   * 相同；cts 則反而是 fallbackVideoId（meHTKm4XBS8）已下播、resolver 給的新 id
+   * （wM0g8EoUZ_E）才是活的——故改為 resolver 優先、fallbackVideoId 僅作安全網。
    */
   fallbackVideoId?: string;
+  /**
+   * 確認為 YouTube 官方封鎖第三方 embed（非「未開播」）→ 動態過濾會連同 resolver
+   * 給的 video_id 一併隱藏，避免渲染必壞的 iframe。若之後該台開放 embed 或提供
+   * 可嵌入的替代 video_id，改設 fallbackVideoId 或移除本 flag。
+   *
+   * 實測：2026-07-26 22:28（本地）— embed/<resolver video_id> 顯示 YouTube 官方訊息
+   *   「無法播放影片：這部影片含有『TTV』的著作權內容，而對方已禁止在這個網站上或
+   *     應用程式中播放這部影片」（ttv：@TTV_NEWS，見 embed-test3 診斷）
+   */
+  embedBlocked?: boolean;
 }
 
 /**
@@ -32,8 +47,12 @@ export interface LiveChannel {
  */
 export const LIVE_CHANNELS: LiveChannel[] = [
   { id: "pts",    name: "公視新聞", en: "PTS",       tag: "公廣", handle: "@ptslivestream", note: "公廣保底，訊號最穩" },
+  // fallbackVideoId 只在 resolver 沒給 video_id 時當安全網（見 fallbackVideoId 欄位註解）；
+  // 2026-07-26 診斷：meHTKm4XBS8 本身已下播（「無法播放這部直播影片的錄影存檔」），
+  // 現在 resolver 給的 video_id 才是活的，留著這個值只為未來 resolver 又斷線時墊底
   { id: "cts",    name: "華視新聞", en: "CTS",       tag: "公廣", handle: "@CtsTw", emergency: true, emergencyLabel: "防災直播", note: "災防可切防災直播", fallbackVideoId: "meHTKm4XBS8" },
   // tvbs/ebc fallback = 官方 24hr 常設直播（TVBS 開播 2023-05 至今未換、EBC 穩定 5+ 週）；
+  // 2026-07-26 實測這兩台 resolver 給的 video_id 現在已跟這裡寫死的值完全相同，純安全網；
   // set 刻意不設：@SETN 輪播單場直播（會下播），寫死必成殭屍 ID，交給 resolver 下播補查
   { id: "tvbs",   name: "TVBS",     en: "TVBS NEWS", tag: "綜合", handle: "@TVBSNEWS01", note: "觀看數最高", fallbackVideoId: "m_dhMSvUCIc" },
   { id: "set",    name: "三立新聞", en: "SET",       tag: "綜合", handle: "@SETN", note: "iNEWS 24h" },
@@ -41,7 +60,8 @@ export const LIVE_CHANNELS: LiveChannel[] = [
   { id: "ftv",    name: "民視新聞", en: "FTV",       tag: "綜合", handle: "@FTV_News", fallbackVideoId: "ylYJSBUgaMA" },
   { id: "era",    name: "年代新聞", en: "ERA",       tag: "綜合", handle: "@era_news" },
   { id: "mnews",  name: "鏡新聞",   en: "MIRROR",    tag: "綜合", handle: "@MnewsTw", note: "⏳ handle 待修" },
-  { id: "ttv",    name: "台視新聞", en: "TTV",       tag: "綜合", handle: "@TTV_NEWS" },
+  // embedBlocked：TTV 對第三方網站封鎖 embed（見上方 embedBlocked 欄位註解的實測證據）
+  { id: "ttv",    name: "台視新聞", en: "TTV",       tag: "綜合", handle: "@TTV_NEWS", embedBlocked: true },
   { id: "ctv",    name: "中視新聞", en: "CTV",       tag: "綜合", handle: "@twctvnews" },
   { id: "global", name: "寰宇新聞", en: "GLOBAL",    tag: "綜合", handle: "@globalnewstw" },
   { id: "ustv",   name: "非凡新聞", en: "USTV",      tag: "財經", handle: "@ustvnews", note: "⏳ handle 待修" },
@@ -52,17 +72,40 @@ function videoEmbedSrc(videoId: string): string {
   return `https://www.youtube.com/embed/${videoId}?autoplay=1&mute=1&playsinline=1`;
 }
 
-function channelEmbedSrc(channelId: string): string {
-  return `https://www.youtube.com/embed/live_stream?channel=${channelId}&autoplay=1&mute=1&playsinline=1`;
+/**
+ * 頻道目前可用的 embed src，沒有可用來源回傳 null。
+ *
+ * 優先序：resolver 給的 video_id（embedBlocked 的台跳過，不管 resolver 給了什麼 id）
+ * → fallbackVideoId（人工挑選的安全網，resolver 沒結果時墊底）。
+ *
+ * 2026-07-26 由 fallbackVideoId 優先改成 resolver 優先：新版 resolver（YouTube Data API v3，
+ * 5 min cron）實測可靠，tvbs/ebc/ftv 的 resolver video_id 現在已與人工寫死的 fallback 完全
+ * 相同；cts 則是 fallback 已下播、resolver 給的 id 才是活的——resolver 優先才不會渲染出
+ * 已下播的殭屍 fallback。
+ *
+ * 註：曾經還有第三層 `embed/live_stream?channel=` 備援，2026-07-26 診斷證實對多數頻道
+ * 不可靠（TVBS 實測跳「無法播放這部影片」，intelLoaders.ts 也早有同樣註記），且原本仰賴
+ * 這條路的中視（ctv）resolver 現在已能直接給可嵌入的 video_id，故整條移除，不再保留。
+ */
+function resolveSrc(ch: LiveChannel, resolved: YtLiveVideo | undefined): string | null {
+  if (!ch.embedBlocked && resolved?.video_id) return videoEmbedSrc(resolved.video_id);
+  if (ch.fallbackVideoId) return videoEmbedSrc(ch.fallbackVideoId);
+  return null;
+}
+
+function isChannelAvailable(ch: LiveChannel, resolved: YtLiveVideo | undefined): boolean {
+  return resolveSrc(ch, resolved) !== null;
 }
 
 interface MenuProps {
   value: string;
   onPick: (id: string) => void;
   usedIds: string[];
+  /** 只顯示目前有有效 src 的頻道（資料驅動隱藏，LIVE_CHANNELS 本體不刪減） */
+  channels: LiveChannel[];
 }
 
-function ChannelMenu({ value, onPick, usedIds }: MenuProps) {
+function ChannelMenu({ value, onPick, usedIds, channels }: MenuProps) {
   const [open, setOpen] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
   const cur = LIVE_CHANNELS.find((c) => c.id === value) ?? LIVE_CHANNELS[0]!;
@@ -137,14 +180,14 @@ function ChannelMenu({ value, onPick, usedIds }: MenuProps) {
             </span>
             <div style={{ flex: 1 }} />
             <span style={{ fontFamily: FONT_CJK, fontSize: 8.5, color: COLORS.textFaint }}>
-              {LIVE_CHANNELS.length} 家 24h 直播
+              {channels.length} 家可看
             </span>
           </div>
           <div className="mtp-scroll" style={{ maxHeight: 320, overflowY: "auto" }}>
-            {LIVE_CHANNELS.map((c, i) => {
+            {channels.map((c, i) => {
               const active = c.id === value;
               const inOther = !active && usedIds.includes(c.id);
-              const prev = LIVE_CHANNELS[i - 1];
+              const prev = channels[i - 1];
               const newGroup = i === 0 || prev?.tag !== c.tag;
               return (
                 <div key={c.id}>
@@ -165,7 +208,7 @@ function ChannelMenu({ value, onPick, usedIds }: MenuProps) {
                       </span>
                       <span style={{ flex: 1, height: 1, background: COLORS.borderSoft }} />
                       <span style={{ fontFamily: FONT_DATA, fontSize: 8, color: COLORS.textFaint }}>
-                        {LIVE_CHANNELS.filter((x) => x.tag === c.tag).length}
+                        {channels.filter((x) => x.tag === c.tag).length}
                       </span>
                     </div>
                   )}
@@ -262,24 +305,17 @@ function ChannelMenu({ value, onPick, usedIds }: MenuProps) {
 }
 
 function LiveSlot({
-  chId, onPick, usedIds, resolved,
+  chId, onPick, usedIds, resolved, channels,
 }: {
   chId: string;
   onPick: (id: string) => void;
   usedIds: string[];
   resolved: YtLiveVideo | undefined;
+  channels: LiveChannel[];
 }) {
   const ch = LIVE_CHANNELS.find((c) => c.id === chId) ?? LIVE_CHANNELS[0]!;
   const emergency = !!ch.emergency;
-  // 優先用 fallbackVideoId（人工挑選保證可 embed 的長期直播；cts/ftv 用）
-  // 其次 resolver 拿到的 video_id（embed/<videoId> 最可靠）
-  // 否則退到 channel_id（embed/live_stream?channel=UCxxx，部分頻道仍會壞）
-  // 都沒有 → 顯示等待占位
-  const src =
-    ch.fallbackVideoId ? videoEmbedSrc(ch.fallbackVideoId) :
-    resolved?.video_id ? videoEmbedSrc(resolved.video_id) :
-    resolved?.channel_id ? channelEmbedSrc(resolved.channel_id) :
-    null;
+  const src = resolveSrc(ch, resolved);
   // IntersectionObserver gate：iframe 只在 slot 首次進入視窗才掛，避免 MonitorPanel
   // 一開就把 4 個 YT player 全載起來吃 CPU/網路（rootMargin: 200px 預載）。
   const slotRef = useRef<HTMLDivElement>(null);
@@ -384,7 +420,7 @@ function LiveSlot({
           display: "flex", alignItems: "center", gap: 8, zIndex: 20,
         }}
       >
-        <ChannelMenu value={chId} onPick={onPick} usedIds={usedIds} />
+        <ChannelMenu value={chId} onPick={onPick} usedIds={usedIds} channels={channels} />
         <span
           style={{
             fontFamily: FONT_DATA, fontSize: FONT_SIZE.xs, color: COLORS.textMuted,
@@ -427,6 +463,36 @@ export const LiveWall = memo(function LiveWall() {
     return m;
   }, [resolvedRows]);
 
+  // 動態過濾：只留「有有效 src」的頻道（fallbackVideoId 或 resolver 給的可嵌入 video_id）。
+  // 沒開播 / embedBlocked 的台不進選單，開播後 resolvedRows 更新會自動回來。
+  const availableChannels = useMemo(
+    () => LIVE_CHANNELS.filter((ch) => isChannelAvailable(ch, resolvedMap.get(ch.handle))),
+    [resolvedMap],
+  );
+
+  // 目前選中的格若失效（頻道被過濾掉），自動跳到下一個可用、且未被其他格佔用的頻道，
+  // 避免白格。resolvedRows.length === 0 代表首次資料還沒回來，先不動，避免載入瞬間誤判。
+  useEffect(() => {
+    if (resolvedRows.length === 0) return;
+    setSlots((prev) => {
+      const next = [...prev];
+      const used = new Set(next);
+      let changed = false;
+      for (let i = 0; i < next.length; i++) {
+        const ch = LIVE_CHANNELS.find((c) => c.id === next[i]);
+        if (ch && isChannelAvailable(ch, resolvedMap.get(ch.handle))) continue;
+        used.delete(next[i]!);
+        const replacement = availableChannels.find((c) => !used.has(c.id));
+        if (replacement) {
+          next[i] = replacement.id;
+          used.add(replacement.id);
+          changed = true;
+        }
+      }
+      return changed ? next : prev;
+    });
+  }, [resolvedRows, resolvedMap, availableChannels]);
+
   return (
     <div
       style={{
@@ -460,7 +526,7 @@ export const LiveWall = memo(function LiveWall() {
           </span>
         ) : (
           <span style={{ fontFamily: FONT_CJK, fontSize: FONT_SIZE.xs, color: COLORS.textFaint }}>
-            4 格同步 · 可切換 {LIVE_CHANNELS.length} 家
+            4 格同步 · 可切換 {availableChannels.length} 家
           </span>
         )}
       </div>
@@ -480,6 +546,7 @@ export const LiveWall = memo(function LiveWall() {
               onPick={setSlot(i)}
               usedIds={slots}
               resolved={resolved}
+              channels={availableChannels}
             />
           );
         })}

--- a/src/components/intel/monitor/LiveWall.tsx
+++ b/src/components/intel/monitor/LiveWall.tsx
@@ -33,9 +33,11 @@ export interface LiveChannel {
 export const LIVE_CHANNELS: LiveChannel[] = [
   { id: "pts",    name: "公視新聞", en: "PTS",       tag: "公廣", handle: "@ptslivestream", note: "公廣保底，訊號最穩" },
   { id: "cts",    name: "華視新聞", en: "CTS",       tag: "公廣", handle: "@CtsTw", emergency: true, emergencyLabel: "防災直播", note: "災防可切防災直播", fallbackVideoId: "meHTKm4XBS8" },
-  { id: "tvbs",   name: "TVBS",     en: "TVBS NEWS", tag: "綜合", handle: "@TVBSNEWS01", note: "觀看數最高" },
+  // tvbs/ebc fallback = 官方 24hr 常設直播（TVBS 開播 2023-05 至今未換、EBC 穩定 5+ 週）；
+  // set 刻意不設：@SETN 輪播單場直播（會下播），寫死必成殭屍 ID，交給 resolver 下播補查
+  { id: "tvbs",   name: "TVBS",     en: "TVBS NEWS", tag: "綜合", handle: "@TVBSNEWS01", note: "觀看數最高", fallbackVideoId: "m_dhMSvUCIc" },
   { id: "set",    name: "三立新聞", en: "SET",       tag: "綜合", handle: "@SETN", note: "iNEWS 24h" },
-  { id: "ebc",    name: "東森新聞", en: "EBC",       tag: "綜合", handle: "@newsebc" },
+  { id: "ebc",    name: "東森新聞", en: "EBC",       tag: "綜合", handle: "@newsebc", fallbackVideoId: "V1p33hqPrUk" },
   { id: "ftv",    name: "民視新聞", en: "FTV",       tag: "綜合", handle: "@FTV_News", fallbackVideoId: "ylYJSBUgaMA" },
   { id: "era",    name: "年代新聞", en: "ERA",       tag: "綜合", handle: "@era_news" },
   { id: "mnews",  name: "鏡新聞",   en: "MIRROR",    tag: "綜合", handle: "@MnewsTw", note: "⏳ handle 待修" },

--- a/src/components/intel/monitor/erCardData.ts
+++ b/src/components/intel/monitor/erCardData.ts
@@ -1,4 +1,5 @@
 import type { ErHospital24hAllRow, ErHospitalLatest } from "../../../data/erHospitalLoader";
+import { classifyErCongestion, type ErCongestionLevel } from "../../../data/erCongestionTypes";
 
 /**
  * ERCard 卡片網格的資料整形（比照 powerCardData.ts）。
@@ -74,4 +75,37 @@ export function buildErRegionGroups(
       hospitals: (byRegion.get(region) ?? []).sort((a, b) => (b.wait ?? -1) - (a.wait ?? -1)),
     }))
     .filter((g) => g.hospitals.length > 0);
+}
+
+/**
+ * 總集摘要（全台 / 單區共用，`erCongestionTypes.classifyErCongestion` 沿用既有分級，
+ * 不發明新閾值）。四級對映使用者需求「紅/橘/黃/綠」：
+ *   severe(紅) / congested(橘) / light(黃) / smooth(綠)
+ * `nodata`（wait_general_cnt 為 null）不計入 counts 也不計入 total，另以 noData 回報。
+ */
+export type ErSeverityLevel = Exclude<ErCongestionLevel, "nodata">;
+
+/** 顯示順序：紅 → 橘 → 黃 → 綠（嚴重度由高到低） */
+export const ER_SEVERITY_ORDER: readonly ErSeverityLevel[] = ["severe", "congested", "light", "smooth"];
+
+export interface ErSummary {
+  /** 有資料醫院的等一般病床數合計 */
+  total: number;
+  /** 各嚴重度家數（不含 nodata） */
+  counts: Record<ErSeverityLevel, number>;
+  /** 無資料（wait_general_cnt === null）家數 */
+  noData: number;
+}
+
+/** 純函式：全台與單區共用，傳入不同醫院子集即可 */
+export function buildErSummary(hospitals: ErHospitalCell[]): ErSummary {
+  const counts: Record<ErSeverityLevel, number> = { severe: 0, congested: 0, light: 0, smooth: 0 };
+  let total = 0;
+  let noData = 0;
+  for (const h of hospitals) {
+    if (h.wait == null) { noData++; continue; }
+    counts[classifyErCongestion(h.wait) as ErSeverityLevel]++;
+    total += h.wait;
+  }
+  return { total, counts, noData };
 }

--- a/src/components/intel/monitor/erCardData.ts
+++ b/src/components/intel/monitor/erCardData.ts
@@ -1,0 +1,77 @@
+import type { ErHospital24hAllRow, ErHospitalLatest } from "../../../data/erHospitalLoader";
+
+/**
+ * ERCard 卡片網格的資料整形（比照 powerCardData.ts）。
+ *
+ * RPC 的 area_name 是 19 個縣市（實測無離島縣市 —— 澎湖／金門／連江沒有
+ * 重度級或兒童急救責任醫院）。監看卡要跟能源卡 UNIT OUTPUT 同一視覺語彙，
+ * 因此把縣市收斂成台電四大區（北／中／南／東），宜蘭歸北部（台電慣例）。
+ * 未知縣市（名單年年評定會變）落到「其他」，不吃掉資料。
+ */
+
+export const ER_REGION_ORDER = ["北部", "中部", "南部", "東部", "其他"] as const;
+export type ErRegion = (typeof ER_REGION_ORDER)[number];
+
+const AREA_TO_REGION: Record<string, ErRegion> = {
+  臺北市: "北部", 新北市: "北部", 基隆市: "北部", 桃園市: "北部",
+  新竹市: "北部", 新竹縣: "北部", 宜蘭縣: "北部",
+  苗栗縣: "中部", 臺中市: "中部", 彰化縣: "中部", 南投縣: "中部", 雲林縣: "中部",
+  嘉義市: "南部", 嘉義縣: "南部", 臺南市: "南部", 高雄市: "南部", 屏東縣: "南部",
+  花蓮縣: "東部", 臺東縣: "東部",
+};
+
+export function erRegionOf(areaName: string | null | undefined): ErRegion {
+  return (areaName && AREA_TO_REGION[areaName]) || "其他";
+}
+
+export interface ErHospitalCell {
+  hospId: string;
+  name: string;
+  areaName: string;
+  /** 當前等一般病床數（latest RPC） */
+  wait: number | null;
+  /** 24h wait_general_cnt 折線（已去除 null 點） */
+  spark: number[];
+}
+
+export interface ErRegionGroup {
+  region: ErRegion;
+  hospitals: ErHospitalCell[];
+}
+
+/** latest 快照 + 24h 打包 → 依區分組，區內按等一般病床數 desc（無資料墊底） */
+export function buildErRegionGroups(
+  latest: ErHospitalLatest[],
+  series: ErHospital24hAllRow[],
+): ErRegionGroup[] {
+  const sparkById = new Map<string, number[]>();
+  for (const row of series) {
+    const values: number[] = [];
+    for (const p of row.points ?? []) {
+      if (p[3] != null) values.push(p[3]);
+    }
+    sparkById.set(row.hosp_id, values);
+  }
+
+  const byRegion = new Map<ErRegion, ErHospitalCell[]>();
+  for (const h of latest) {
+    const region = erRegionOf(h.area_name);
+    const cell: ErHospitalCell = {
+      hospId: h.hosp_id,
+      name: h.hosp_name,
+      areaName: h.area_name,
+      wait: h.wait_general_cnt,
+      spark: sparkById.get(h.hosp_id) ?? [],
+    };
+    const bucket = byRegion.get(region);
+    if (bucket) bucket.push(cell);
+    else byRegion.set(region, [cell]);
+  }
+
+  return ER_REGION_ORDER
+    .map((region) => ({
+      region,
+      hospitals: (byRegion.get(region) ?? []).sort((a, b) => (b.wait ?? -1) - (a.wait ?? -1)),
+    }))
+    .filter((g) => g.hospitals.length > 0);
+}

--- a/src/components/intel/monitor/monitorLayout.ts
+++ b/src/components/intel/monitor/monitorLayout.ts
@@ -45,7 +45,7 @@ export const MONITOR_GRID_ROW_HEIGHT = 40;
 /** 格線間距 px（沙盒 margin） */
 export const MONITOR_GRID_GAP = 10;
 
-/** 沙盒定稿佈局（2026-07-26 四版匯出 — timeline/liveWall/hazardStrip/powerCard 加高） */
+/** 沙盒定稿佈局（2026-07-26 五版匯出 — ER 加高 h15 容納全醫院網格＋總集摘要） */
 export const MONITOR_LAYOUT: MonitorGridItem[] = [
   { i: "newsFeed", x: 0, y: 0, w: 4, h: 12 },
   { i: "alertBoard", x: 4, y: 0, w: 3, h: 7 },
@@ -55,11 +55,11 @@ export const MONITOR_LAYOUT: MonitorGridItem[] = [
   { i: "situationOverview", x: 0, y: 12, w: 5, h: 5 },
   { i: "liveWall", x: 5, y: 12, w: 7, h: 14 },
   { i: "situationCards", x: 0, y: 17, w: 5, h: 5 },
-  { i: "erCongestion", x: 0, y: 22, w: 5, h: 6 },
+  { i: "erCongestion", x: 0, y: 22, w: 5, h: 15 },
   { i: "hazardStrip", x: 5, y: 26, w: 7, h: 8 },
-  { i: "prison", x: 0, y: 28, w: 2, h: 4 },
-  { i: "airportPax", x: 2, y: 28, w: 3, h: 6 },
   { i: "powerCard", x: 5, y: 34, w: 7, h: 14 },
+  { i: "prison", x: 0, y: 37, w: 2, h: 4 },
+  { i: "airportPax", x: 2, y: 37, w: 3, h: 6 },
 ];
 
 /** 沙盒 hidden 清單 — 列在這裡的 widget 不渲染（histogram 與時間軸新聞密度重複，2026-07-26 移除） */

--- a/src/data/erHospitalLoader.ts
+++ b/src/data/erHospitalLoader.ts
@@ -6,10 +6,12 @@ import { classifyErCongestion } from "./erCongestionTypes";
 /**
  * 急診壅塞 er_hospital loader（RPC 283）
  *
- * 三支 public RPC（前端一律走 public，禁直打 realtime.*）：
+ * 四支 public RPC（前端一律走 public，禁直打 realtime.*）：
  *   - get_er_hospital_latest()          → 59 家急診即時量能快照
  *   - get_er_hospital_24h(p_hosp_id)    → 單一醫院 24h ~96 點折線（popup 用）
  *   - get_er_hospital_24h_all()         → 59 家 24h 打包（monitor 卡片網格用，實測 26ms）
+ *   - get_er_wait_total_14d()           → 全台 14 天每小時等一般病床總數（RPC 320，實測 67ms，
+ *     最多 336 rows；第一筆是 rolling window 邊界的部分小時，前端須捨棄首桶）
  *
  * 特殊點：RPC 不回座標。座標從 public/geo/medical_hospitals.geojson
  * 以 properties.facility_id === hosp_id join（實測 57/59 命中）。
@@ -52,6 +54,12 @@ export interface ErHospital24hAllRow {
   area_name: string;
   /** 時間升冪，每家約 84 點 */
   points: ErHospital24hPoint[];
+}
+
+export interface ErWaitTotal14dRow {
+  bucket_ts: number;   // epoch 秒 UTC，升冪，每小時
+  total_wait: number;  // 全台等一般病床總數
+  hosp_cnt: number;    // 該小時有回報院數
 }
 
 /**
@@ -151,3 +159,16 @@ async function fetch24hAllUncached(): Promise<ErHospital24hAllRow[]> {
 }
 const fetch24hAllCached = cachedOnce(fetch24hAllUncached, 60_000);
 export const fetchErHospital24hAll = (): Promise<ErHospital24hAllRow[]> => fetch24hAllCached();
+
+// ── 全台 14 天等床趨勢（monitor ERCard 卡片內趨勢圖，RPC 320）───────────────────
+async function fetchWaitTotal14dUncached(): Promise<ErWaitTotal14dRow[]> {
+  const { data, error } = await withLoading(
+    "er:wait-total-14d",
+    "急診全台 14 天等床趨勢",
+    supabase.rpc("get_er_wait_total_14d"),
+  );
+  if (error) throw new Error(`get_er_wait_total_14d: ${error.message}`);
+  return (data ?? []) as ErWaitTotal14dRow[];
+}
+const fetchWaitTotal14dCached = cachedOnce(fetchWaitTotal14dUncached, 30 * 60_000); // 每小時才變，快取 30min
+export const fetchErWaitTotal14d = (): Promise<ErWaitTotal14dRow[]> => fetchWaitTotal14dCached();

--- a/src/data/erHospitalLoader.ts
+++ b/src/data/erHospitalLoader.ts
@@ -6,9 +6,10 @@ import { classifyErCongestion } from "./erCongestionTypes";
 /**
  * 急診壅塞 er_hospital loader（RPC 283）
  *
- * 兩支 public RPC（前端一律走 public，禁直打 realtime.*）：
+ * 三支 public RPC（前端一律走 public，禁直打 realtime.*）：
  *   - get_er_hospital_latest()          → 59 家急診即時量能快照
- *   - get_er_hospital_24h(p_hosp_id)    → 單一醫院 24h ~96 點折線
+ *   - get_er_hospital_24h(p_hosp_id)    → 單一醫院 24h ~96 點折線（popup 用）
+ *   - get_er_hospital_24h_all()         → 59 家 24h 打包（monitor 卡片網格用，實測 26ms）
  *
  * 特殊點：RPC 不回座標。座標從 public/geo/medical_hospitals.geojson
  * 以 properties.facility_id === hosp_id join（實測 57/59 命中）。
@@ -38,6 +39,19 @@ export interface ErHospital24hRow {
   wait_bed_cnt: number | null;
   wait_general_cnt: number | null;
   wait_icu_cnt: number | null;
+}
+
+/** [observed_ts 秒, wait_see, wait_bed, wait_general, wait_icu]，欄位順序同 ErHospital24hRow */
+export type ErHospital24hPoint = [
+  number, number | null, number | null, number | null, number | null,
+];
+
+export interface ErHospital24hAllRow {
+  hosp_id: string;
+  hosp_name: string;
+  area_name: string;
+  /** 時間升冪，每家約 84 點 */
+  points: ErHospital24hPoint[];
 }
 
 /**
@@ -124,3 +138,16 @@ export async function fetchErHospital24h(hospId: string): Promise<ErHospital24hR
   if (error) throw new Error(`get_er_hospital_24h: ${error.message}`);
   return (data ?? []) as ErHospital24hRow[];
 }
+
+// ── 全院 24h 打包（monitor ERCard 網格）───────────────────────────────────────
+async function fetch24hAllUncached(): Promise<ErHospital24hAllRow[]> {
+  const { data, error } = await withLoading(
+    "er:24h:all",
+    "急診 59 院 24h 趨勢",
+    supabase.rpc("get_er_hospital_24h_all"),
+  );
+  if (error) throw new Error(`get_er_hospital_24h_all: ${error.message}`);
+  return (data ?? []) as ErHospital24hAllRow[];
+}
+const fetch24hAllCached = cachedOnce(fetch24hAllUncached, 60_000);
+export const fetchErHospital24hAll = (): Promise<ErHospital24hAllRow[]> => fetch24hAllCached();


### PR DESCRIPTION
## Summary
- 急診卡改版三部曲：59 院全醫院分區網格（UNIT OUTPUT 樣式）→ 全台/分區總集摘要 → 14 天全台等床趨勢
- 直播牆修復：resolver 復活後的動態過濾 + fallback 優先序修正 + 災防颱風論壇換活 ID

## Changes
- `erHospitalLoader.ts`：+`fetchErHospital24hAll()`（RPC migration 319）、+`fetchErWaitTotal14d()`（RPC migration 320），均含 loadingRegistry + 快取
- `erCardData.ts`（新）：縣市→北中南東對映 + 分區分組 + `buildErSummary`
- `ERCard.tsx`：全改寫——全台總集列（總等床 + 紅橘黃綠比例條）+ 分區小計 + 醫院小卡網格（嚴重度色沿用 erCongestionTypes 閾值）+ 14D TREND
- `TimeseriesSparkline.tsx`：>48h 範圍 x 軸改日界 tick（M/D），修 14 天圖 42 個 0:00 疊字牆；≤48h 行為不變
- `LiveWall.tsx`：TVBS/EBC fallbackVideoId；resolver 優先（原 fallback 優先會渲染已下播的華視殭屍 ID）；移除實證必壞的 channel= 嵌入路徑；動態過濾（無有效 src 的台不入選單）+ 失效自動換台；TTV 實測遭著作權封鎖嵌入 → embedBlocked 永久過濾
- `HazardWatchStrip.tsx`：颱風論壇換 24hr 常設多面板天氣直播 ADZTiqEGT8g（舊 ID 已下播）
- `monitorLayout.ts`：沙盒五版（ER h15）

## Test
- [x] npx tsc -b 通過（0 error）
- [x] pnpm test 通過（18 files / 197 tests）
- [x] Browser 驗收：ER 網格/總集/趨勢分段截圖 + 數字一致性 DOM 抽驗（四區 Σ=全台、家數+無資料=59）；直播牆 4 格全播、選單 9 家可看；災防雙格正常

## Risk / Rollback
- ER 資料層走已 apply 的 migration 319/320（26ms/67ms，anon+authenticated 雙角色驗證）
- 回滾：revert 單一 squash commit；RPC 為純新增不影響既有
- LiveWall 依賴 data-collectors d8b6f10（YouTube Data API resolver）已部署 Zeabur

## Related
- Feature: docs/features/er-hospital/
- 上游：gis-platform migrations 319/320（已 apply，git 收納另行處理）
- 疊在 PR #90（靜態網格）之上
🤖 Generated with [Claude Code](https://claude.com/claude-code)