### PR TITLE
feat: LASS 微感測三模式上色（PM2.5/溫度/濕度）+ site_name 貫通

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1229,7 +1229,7 @@ export default function App() {
     opacity: transportParams.aqiImageryOpacity,
   });
   useAqiStationsLayer(mapRef, layerVisibility.aqiStations, isDarkTheme);
-  useMicroSensorsLayer(mapRef, layerVisibility.aqiMicroSensors, isDarkTheme, transportParams.aqiMicroCluster);
+  useMicroSensorsLayer(mapRef, layerVisibility.aqiMicroSensors, isDarkTheme, transportParams.aqiMicroCluster, transportParams.aqiMicroModeIdx);
 
   // ── Freeway congestion (動態 timeline 回放) ──
   useFreewayLayer(
@@ -2876,7 +2876,9 @@ export default function App() {
             />
           </div>
         )}
-        {(layerVisibility.aqiImagery || layerVisibility.aqiStations || layerVisibility.aqiMicroSensors) && (
+        {/* LASS 微感測改走 LegendPanel 的 MicroSensorLegend（三模式各自色階），
+            不再借 AqiLegend + caption 說明配色 */}
+        {(layerVisibility.aqiImagery || layerVisibility.aqiStations) && (
           <>
             {layerVisibility.aqiImagery && (
               <div style={{ pointerEvents: "auto" }}>
@@ -2888,10 +2890,7 @@ export default function App() {
               </div>
             )}
             <div style={{ pointerEvents: "auto" }}>
-              <AqiLegend
-                isDark={isDarkTheme}
-                caption={layerVisibility.aqiMicroSensors ? "LASS 點位以 PM2.5 濃度配色" : undefined}
-              />
+              <AqiLegend isDark={isDarkTheme} />
             </div>
           </>
         )}

--- a/src/components/LegendPanel.tsx
+++ b/src/components/LegendPanel.tsx
@@ -11,6 +11,7 @@ import { ALERT_GROUPS, ALERT_GROUP_KEYS } from "../data/disasterAlertTypes";
 import { NEWS_CATEGORIES } from "../data/newsEventTypes";
 import { ECO_NETWORK_ZONE_TYPES } from "../data/ecoNetworkZoneTypes";
 import { TEMPERATURE_GRID_BANDS } from "../data/temperatureGridTypes";
+import { resolveMicroSensorMode, MICRO_SENSOR_NO_DATA_COLOR } from "../data/microSensorTypes";
 import { FOREST_RESERVE_TYPES } from "../data/forestReserveTypes";
 import { RE_PALETTES } from "../map/overlayRegistry";
 import {
@@ -201,6 +202,7 @@ export const LEGEND_REGISTRY: LegendEntry[] = [
   { keys: ["oceanCurrents"], render: () => <OceanCurrentsLegend /> },
   { keys: ["dustForecast"], render: () => <DustForecastLegend /> },
   { keys: ["temperatureGrid"], render: () => <TemperatureGridLegend /> },
+  { keys: ["aqiMicroSensors"], render: ({ overlayParams }) => <MicroSensorLegend modeIdx={overlayParams.aqiMicroModeIdx ?? 0} /> },
   { keys: ["lifelineAlerts", "floodAlerts", "weatherAlerts", "transitAlerts", "safetyAlerts"], render: ({ visibility }) => <DisasterAlertLegend visibility={visibility} /> },
   { keys: ["roadEvents"], render: () => <RoadEventsLegend /> },
   { keys: ["roadCongestion"], render: () => <RoadCongestionLegend /> },
@@ -2125,6 +2127,37 @@ function TemperatureGridLegend() {
       </div>
       <div style={{ fontSize: FONT_SIZE.xs, color: t.textDim, marginTop: 3, lineHeight: 1.4 }}>
         CWA 0.03° 逐時觀測分析格點
+      </div>
+    </div>
+  );
+}
+
+// LASS 微型感測：三模式共用同一份圖例框，依當前顯示模式換色階列
+// （色票 SSOT = data/microSensorTypes.ts，與 loader 預烤進 properties 的顏色同源；
+//  溫度模式直接吃 TEMPERATURE_GRID_BANDS，與溫度網格 2D 跨圖層一致）。
+function MicroSensorLegend({ modeIdx = 0 }: { modeIdx?: number }) {
+  const t = useLegendTheme();
+  const mode = resolveMicroSensorMode(modeIdx);
+  return (
+    <div>
+      <div style={{ fontSize: FONT_SIZE.xs, color: t.textDim, letterSpacing: 1, marginBottom: 4 }}>
+        微型感測 LASS AIRBOX
+      </div>
+      <div style={{ fontSize: FONT_SIZE.xs, color: t.textMuted, marginBottom: 3 }}>{mode.note}</div>
+      <div style={{ display: "flex", flexDirection: "column", gap: 1 }}>
+        {mode.legend.map((band) => (
+          <div key={band.label} style={{ display: "flex", alignItems: "center", gap: 6 }}>
+            <div style={{ width: 10, height: 10, borderRadius: RADIUS.full, background: band.color, flexShrink: 0 }} />
+            <span style={{ fontSize: FONT_SIZE.xs, color: t.textMuted }}>{band.label}</span>
+          </div>
+        ))}
+        <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
+          <div style={{ width: 10, height: 10, borderRadius: RADIUS.full, background: MICRO_SENSOR_NO_DATA_COLOR, flexShrink: 0 }} />
+          <span style={{ fontSize: FONT_SIZE.xs, color: t.textMuted }}>無資料</span>
+        </div>
+      </div>
+      <div style={{ fontSize: FONT_SIZE.xs, color: t.textDim, marginTop: 3, lineHeight: 1.4 }}>
+        LASS AirBox / 環境部微感測 · 最新 15 分鐘快照
       </div>
     </div>
   );

--- a/src/components/featureInfo/airPanels.tsx
+++ b/src/components/featureInfo/airPanels.tsx
@@ -60,16 +60,20 @@ export function AqiStationPanel({ props }: { props: Record<string, unknown> }) {
 export function MicroSensorPanel({ props }: { props: Record<string, unknown> }) {
   const t = useFeatureTheme();
   const pm25 = numOrNull(props.pm25);
-  const color = String(props.color ?? "#707070");
+  // 標題色點對齊面板主數值（PM2.5），故固定用 colorPm25，不隨圖層顯示模式跑
+  const color = String(props.colorPm25 ?? "#707070");
   const temperature = Number(props.temperature);
   const tempStr = Number.isFinite(temperature) && temperature > -100 ? `${temperature.toFixed(1)} °C` : "";
   const observedAt = String(props.observedAt ?? "");
+  // site_name 是 RPC 升級後才有的欄位 → 空字串/未定義時 fallback deviceId
+  const siteName = String(props.siteName ?? "").trim();
+  const title = siteName || String(props.deviceId ?? "LASS Device");
   return (
     <>
       <div style={{ display: "flex", alignItems: "center", gap: 6, marginBottom: 6 }}>
         <div style={{ width: 10, height: 10, borderRadius: RADIUS.sm, background: color, flexShrink: 0 }} />
         <div style={{ fontSize: FONT_SIZE.lg, fontWeight: 700, color: t.textStrong, letterSpacing: 0.5 }}>
-          {String(props.deviceId ?? "LASS Device")}
+          {title}
         </div>
       </div>
       <div
@@ -88,6 +92,8 @@ export function MicroSensorPanel({ props }: { props: Record<string, unknown> }) 
         </span>
         <span style={{ fontSize: FONT_SIZE.sm, color: t.textDefault }}>PM2.5 µg/m³</span>
       </div>
+      {/* 標題被站名佔走時，device_id 改用一列補回，避免資訊遺失 */}
+      {siteName && <Row label="裝置 ID" value={String(props.deviceId ?? "")} />}
       <Row label="來源" value={String(props.source ?? "")} />
       <Row label="裝置" value={String(props.app ?? "")} />
       <Row label="地區" value={String(props.area ?? "")} />

--- a/src/components/sidebar/__tests__/layerConsistency.test.ts
+++ b/src/components/sidebar/__tests__/layerConsistency.test.ts
@@ -81,7 +81,8 @@ const BASELINE_NO_LEGEND = new Set([
   // 公共設施 Batch 2：圖書館 / 社福 / 市場 皆單色 POI（鐵則 2 不適用）；publicToilets grade 4 級分色 → 接 PublicToiletLegend
   "publicLibraries", "welfareCenters", "retailMarkets",
   "activeFaults", "youbikeFullness", "cwaCloudImagery",
-  "cwaRadarImagery", "aqiImagery", "aqiStations", "aqiMicroSensors",
+  // aqiMicroSensors 已升級三模式上色（PM2.5/溫度/濕度）→ 接 MicroSensorLegend，不再列 baseline
+  "cwaRadarImagery", "aqiImagery", "aqiStations",
   "busLive", "busIntercityLive", "waterBasins", "waterRivers", "waterLevees",
   "waterProtectionZones", "waterReservoirs", "waterFacilities",
   "waterMonitorStations", "waterFloodExtreme", "waterDetentionBasins",

--- a/src/data/microSensorTypes.ts
+++ b/src/data/microSensorTypes.ts
@@ -1,0 +1,105 @@
+/**
+ * microSensorTypes.ts — LASS 微型感測（aqiMicroSensors）三模式上色的色階 SSOT
+ *
+ * 三邊共用（開發規則 §4a 規則 2）：
+ *   1. `src/data/microSensorsLoader.ts` — build GeoJSON 時把三種顏色都烤進 properties
+ *   2. `src/hooks/useMicroSensorsLayer.ts` — 切模式只 setPaintProperty 換 ["get", colorField]
+ *   3. `src/components/LegendPanel.tsx` 的 MicroSensorLegend — 依當前 mode 出對應圖例
+ *
+ * 溫度刻意直接 import `temperatureGridTypes` 的 11 級色階：與溫度網格 2D 圖層
+ * 跨圖層同色 = 兩層疊看時「同一個溫度 = 同一個顏色」。
+ * 濕度色階移植自 weather_change（Windy 風格 7 級）。
+ */
+
+import { TEMPERATURE_GRID_BANDS, temperatureGridColor } from "./temperatureGridTypes";
+
+export interface MicroSensorBand {
+  /** 該級上界（不含）；最後一級為 null（無上界） */
+  max: number | null;
+  color: string;
+  label: string;
+}
+
+/** 缺值統一中性灰（loader 端 null、properties 端 temperature=-999 / humidity=-1 哨兵） */
+export const MICRO_SENSOR_NO_DATA_COLOR = "#707070";
+
+/**
+ * PM2.5 5 級（斷點沿用原 pm25ToColor）：對應 PM2.5 AQI sub-index 常用分級。
+ * 這是針對「PM2.5 濃度」而非 AQI 的近似色。
+ */
+export const MICRO_SENSOR_PM25_BANDS: MicroSensorBand[] = [
+  { max: 15,   color: "#009966", label: "0–15 µg/m³" },
+  { max: 35,   color: "#FFDE33", label: "15–35 µg/m³" },
+  { max: 54,   color: "#FF9933", label: "35–54 µg/m³" },
+  { max: 150,  color: "#CC0033", label: "54–150 µg/m³" },
+  { max: null, color: "#660099", label: "≥ 150 µg/m³" },
+];
+
+/** 濕度 7 級（移植 weather_change `getHumidityColor()`，Windy 風格棕→綠→藍→紫） */
+export const MICRO_SENSOR_HUMIDITY_BANDS: MicroSensorBand[] = [
+  { max: 40,   color: "#b48f60", label: "< 40%（極乾）" },
+  { max: 50,   color: "#d6bb7e", label: "40–50%（乾燥）" },
+  { max: 60,   color: "#e6dfaa", label: "50–60%（稍乾）" },
+  { max: 70,   color: "#b6d69f", label: "60–70%（舒適）" },
+  { max: 80,   color: "#64b6e1", label: "70–80%（濕潤）" },
+  { max: 90,   color: "#5a6fc2", label: "80–90%（潮濕）" },
+  { max: null, color: "#5e3a86", label: "≥ 90%（極濕）" },
+];
+
+function bandColor(bands: MicroSensorBand[], v: number): string {
+  for (const band of bands) {
+    if (band.max === null || v < band.max) return band.color;
+  }
+  return bands[bands.length - 1]!.color;
+}
+
+/** PM2.5（µg/m³）→ 色碼；null / 非有限 / 負值（哨兵 -1）→ 中性灰 */
+export function microSensorPm25Color(pm25: number | null | undefined): string {
+  if (pm25 == null || !Number.isFinite(pm25) || pm25 < 0) return MICRO_SENSOR_NO_DATA_COLOR;
+  return bandColor(MICRO_SENSOR_PM25_BANDS, pm25);
+}
+
+/** 濕度（%）→ 色碼；null / 非有限 / 負值（哨兵 -1）→ 中性灰 */
+export function microSensorHumidityColor(humidity: number | null | undefined): string {
+  if (humidity == null || !Number.isFinite(humidity) || humidity < 0) return MICRO_SENSOR_NO_DATA_COLOR;
+  return bandColor(MICRO_SENSOR_HUMIDITY_BANDS, humidity);
+}
+
+/**
+ * 溫度（°C）→ 色碼，直接走溫度網格 2D 的 11 級色階。
+ * ⚠️ 不能用 `< 0` 當無效判準（山區可能低於 0°C）；哨兵是 -999 → 用 ≤ -100 過濾。
+ */
+export function microSensorTemperatureColor(tempC: number | null | undefined): string {
+  if (tempC == null || !Number.isFinite(tempC) || tempC <= -100) return MICRO_SENSOR_NO_DATA_COLOR;
+  return temperatureGridColor(tempC);
+}
+
+/** GeoJSON properties 裡預烤的顏色欄位名（切模式只換這個 key） */
+export type MicroSensorColorField = "colorPm25" | "colorTemp" | "colorHum";
+
+export interface MicroSensorMode {
+  /** select value；index 對齊 overlayParams 的 aqiMicroModeIdx */
+  value: string;
+  label: string;
+  colorField: MicroSensorColorField;
+  /** 圖例列（只需 color + label；溫度直接吃 TEMPERATURE_GRID_BANDS） */
+  legend: readonly { color: string; label: string }[];
+  /** 圖例底下的一行說明 */
+  note: string;
+}
+
+/** 顯示模式 select 選項；index 對齊 overlayParams 的 aqiMicroModeIdx。預設 0=PM2.5。 */
+export const MICRO_SENSOR_MODES: MicroSensorMode[] = [
+  { value: "0", label: "PM2.5", colorField: "colorPm25", legend: MICRO_SENSOR_PM25_BANDS, note: "PM2.5 濃度（µg/m³）" },
+  { value: "1", label: "溫度",  colorField: "colorTemp", legend: TEMPERATURE_GRID_BANDS,  note: "溫度（°C）· 與溫度網格 2D 同色階" },
+  { value: "2", label: "濕度",  colorField: "colorHum",  legend: MICRO_SENSOR_HUMIDITY_BANDS, note: "相對濕度（%）" },
+];
+
+export function resolveMicroSensorMode(modeIdx: number): MicroSensorMode {
+  return MICRO_SENSOR_MODES[modeIdx] ?? MICRO_SENSOR_MODES[0]!;
+}
+
+/** 依當前模式取 circle-color 表達式（顏色已預烤進 properties，這裡只換欄位） */
+export function microSensorColorExpr(modeIdx: number): unknown[] {
+  return ["get", resolveMicroSensorMode(modeIdx).colorField];
+}

--- a/src/data/microSensorsLoader.ts
+++ b/src/data/microSensorsLoader.ts
@@ -8,6 +8,11 @@
 import { supabase } from "../lib/supabase";
 import { withLoading } from "../lib/loadingRegistry";
 import { cachedOnce } from "../lib/loaderCache";
+import {
+  microSensorPm25Color,
+  microSensorTemperatureColor,
+  microSensorHumidityColor,
+} from "./microSensorTypes";
 import type { MicroSensor } from "../types";
 
 interface RawRow {
@@ -15,6 +20,8 @@ interface RawRow {
   source: string;
   area: string | null;
   app: string | null;
+  /** 站名。DB live.micro_sensor_readings 有存，但 RPC 升級前不會回傳 → 必須 null-safe */
+  site_name?: string | null;
   lon: number;
   lat: number;
   observed_at: string;
@@ -28,6 +35,7 @@ interface RawRow {
 function toSensor(r: RawRow): MicroSensor {
   return {
     deviceId: r.device_id,
+    siteName: r.site_name ?? null,
     source: r.source,
     area: r.area,
     app: r.app,
@@ -60,19 +68,10 @@ export function fetchMicroSensorsLatest(): Promise<MicroSensor[]> {
 }
 
 /**
- * LASS 色階：以 PM2.5 為主，對應 PM2.5 AQI sub-index 常用分級
- * 0-15 綠 / 15-35 黃 / 35-54 橙 / 54-150 紅 / 150+ 紫
- * 這是針對「PM2.5 濃度」而非 AQI 的近似色；實際供 circle-color 用。
+ * 三種顯示模式的顏色一次全烤進 properties（色階 SSOT = data/microSensorTypes.ts）：
+ * 切模式時 hook 只需 setPaintProperty 換 `["get", colorPm25|colorTemp|colorHum]`，
+ * 不必重建 GeoJSON。缺值一律吃 MICRO_SENSOR_NO_DATA_COLOR 中性灰。
  */
-export function pm25ToColor(pm25: number | null): string {
-  if (pm25 == null || !Number.isFinite(pm25)) return "#707070";
-  if (pm25 <= 15) return "#009966";
-  if (pm25 <= 35) return "#FFDE33";
-  if (pm25 <= 54) return "#FF9933";
-  if (pm25 <= 150) return "#CC0033";
-  return "#660099";
-}
-
 export function buildMicroSensorsGeoJSON(sensors: MicroSensor[]): GeoJSON.FeatureCollection {
   return {
     type: "FeatureCollection",
@@ -81,6 +80,7 @@ export function buildMicroSensorsGeoJSON(sensors: MicroSensor[]): GeoJSON.Featur
       geometry: { type: "Point", coordinates: [s.lon, s.lat] },
       properties: {
         deviceId: s.deviceId,
+        siteName: s.siteName ?? "",
         source: s.source,
         area: s.area ?? "",
         app: s.app ?? "",
@@ -90,7 +90,9 @@ export function buildMicroSensorsGeoJSON(sensors: MicroSensor[]): GeoJSON.Featur
         pm1: s.pm1 ?? -1,
         temperature: s.temperature ?? -999,
         humidity: s.humidity ?? -1,
-        color: pm25ToColor(s.pm25),
+        colorPm25: microSensorPm25Color(s.pm25),
+        colorTemp: microSensorTemperatureColor(s.temperature),
+        colorHum: microSensorHumidityColor(s.humidity),
       },
     })),
   };

--- a/src/hooks/useMicroSensorsLayer.ts
+++ b/src/hooks/useMicroSensorsLayer.ts
@@ -7,6 +7,11 @@
  *
  * 切換 cluster 時 Mapbox source 必須重建，故 effect 的 deps 帶 cluster。
  *
+ * 顯示模式（modeIdx：0=PM2.5 / 1=溫度 / 2=濕度）：
+ *  三種顏色 loader 已預烤進 properties，切模式只 setPaintProperty 換欄位，
+ *  **不重建 GeoJSON、不進 layer 生命週期 deps**（否則會整層重繪閃爍）。
+ *  聚合圓（cluster 模式的 point_count 圓）維持紫色不受模式影響。
+ *
  * 即時行為：
  *  - 圖層開啟時首次載入，之後每 5 分鐘（對齊 collector 頻率）自動 refetch 最新快照
  *  - 不跟 timeline replay（資料量大，Phase 2 會做 hourly pre-aggregate 再支援）
@@ -20,6 +25,7 @@ import {
   fetchMicroSensorsLatest,
   buildMicroSensorsGeoJSON,
 } from "../data/microSensorsLoader";
+import { microSensorColorExpr } from "../data/microSensorTypes";
 import { keepLoadingUntilMapIdle } from "../lib/loadingRegistry";
 import type { MicroSensor } from "../types";
 
@@ -28,7 +34,7 @@ const LAYER_CLUSTER = "aqi-micro-cluster";
 const LAYER_CLUSTER_COUNT = "aqi-micro-cluster-count";
 const LAYER_POINT = "aqi-micro-circle";
 
-function ensureLayers(map: MapboxMap, isDark: boolean, cluster: boolean) {
+function ensureLayers(map: MapboxMap, isDark: boolean, cluster: boolean, modeIdx: number) {
   if (!map.getSource(SOURCE_ID)) {
     map.addSource(SOURCE_ID, {
       type: "geojson",
@@ -84,7 +90,7 @@ function ensureLayers(map: MapboxMap, isDark: boolean, cluster: boolean) {
         "circle-radius": cluster
           ? ["interpolate", ["linear"], ["zoom"], 9, 2, 12, 4, 15, 6, 18, 10]
           : ["interpolate", ["linear"], ["zoom"], 5, 1.5, 8, 2.5, 11, 4, 15, 7, 18, 11],
-        "circle-color": ["get", "color"],
+        "circle-color": microSensorColorExpr(modeIdx) as unknown as mapboxgl.ExpressionSpecification,
         "circle-stroke-width": cluster ? 0.5 : 0.3,
         "circle-stroke-color": isDark ? "rgba(255,255,255,0.6)" : "rgba(0,0,0,0.3)",
         "circle-opacity": cluster ? 0.9 : 0.85,
@@ -105,10 +111,13 @@ export function useMicroSensorsLayer(
   visible: boolean,
   isDark: boolean,
   cluster: boolean,
+  modeIdx: number,
 ) {
   const loadedRef = useRef(false);
   const dataRef = useRef<MicroSensor[]>([]);
   const loadingRef = useRef(false);
+  // modeIdx 走 ref 餵 ensureLayers：不進 layer 生命週期 deps，避免切模式重建整層
+  const modeIdxRef = useRef(modeIdx);
 
   // ── Loader：首次開啟時載入 + 每 5 分鐘自動 refetch 最新快照 ──
   useEffect(() => {
@@ -162,7 +171,7 @@ export function useMicroSensorsLayer(
       // 不管是關閉或切 cluster 模式都先移除乾淨再重建（Mapbox cluster 設定不能動態改）
       removeLayers(m);
       if (!visible) return;
-      ensureLayers(m, isDark, cluster);
+      ensureLayers(m, isDark, cluster, modeIdxRef.current);
       if (loadedRef.current && dataRef.current.length > 0) {
         const src = m.getSource(SOURCE_ID) as GeoJSONSource | undefined;
         if (src) {
@@ -181,6 +190,20 @@ export function useMicroSensorsLayer(
     }
     apply();
   }, [mapRef, visible, isDark, cluster]);
+
+  // ── 顯示模式切換：只換 circle-color 欄位，不動 source / 不重建 layer ──
+  useEffect(() => {
+    // ref 先更新（layer 尚未建立時 ensureLayers 之後才讀得到正確模式）
+    modeIdxRef.current = modeIdx;
+    const map = mapRef.current;
+    if (!map || !visible) return;
+    if (!map.isStyleLoaded() || !map.getLayer(LAYER_POINT)) return;
+    map.setPaintProperty(
+      LAYER_POINT,
+      "circle-color",
+      microSensorColorExpr(modeIdx) as unknown as mapboxgl.ExpressionSpecification,
+    );
+  }, [mapRef, visible, modeIdx]);
 
   // ── Unmount 清理 ──
   useEffect(() => {

--- a/src/hooks/useTransportParams.ts
+++ b/src/hooks/useTransportParams.ts
@@ -20,6 +20,7 @@ import {
 } from "../data/urbanOpenSpaceTypes";
 import { BUILDINGS_GBA_MODES } from "../data/buildingsGbaTypes";
 import { URBAN_FORM_GRID_MODES } from "../data/urbanFormGridTypes";
+import { MICRO_SENSOR_MODES } from "../data/microSensorTypes";
 import { PROPERTY_VALUE_SCALES } from "../data/propertyValueTypes";
 import { URBAN_ZONING_CATEGORIES } from "../data/urbanZoningTypes";
 import { CULTURAL_FACILITY_TYPES, CULTURAL_MUSEUM_TYPES } from "../data/cultureTypes";
@@ -528,6 +529,8 @@ export function useTransportParams() {
   const [ybResolution, setYbResolution] = useState(7);
   // LASS 微型感測器：cluster on/off
   const [aqiMicroCluster, setAqiMicroCluster] = useState(true);
+  // LASS 微型感測器：點位上色依據（0=PM2.5 / 1=溫度 / 2=濕度，見 microSensorTypes）
+  const [aqiMicroModeIdx, setAqiMicroModeIdx] = useState(0);
   // 淹水最小深度篩選：0 = 全部, 0.5 / 1 / 2 / 3 = 只顯示大於等於該深度的分級
   const [floodMinDepth, setFloodMinDepth] = useState<0 | 0.5 | 1 | 2 | 3>(0);
   // 水庫：僅保留 Three.js 水位計的高度縮放（2026-04-22 砍掉光球 + 靜態 pillar
@@ -1382,6 +1385,8 @@ export function useTransportParams() {
     worldTrashDebrisOpacity,
     realEstateOpacity,
     realEstateExcludeTaipei: realEstateExcludeTaipei ? 1 : 0,
+    // LASS 微感測顯示模式（只供 LegendPanel 選對應圖例；paint 端走 hook 的 setPaintProperty）
+    aqiMicroModeIdx,
     // Base map
     countyBoundaryOpacity, countyBoundaryWidth,
     townshipBoundaryOpacity, townshipBoundaryWidth,
@@ -1435,7 +1440,8 @@ export function useTransportParams() {
     tourFactoriesOpacity, tourFactoriesScale, tourAmusementParksOpacity, tourAmusementParksScale,
     tourCampingOpacity, tourCampingScale,
     tourHotelsOpacity, tourHotelsScale, tourHotelsClass,
-    tourRestaurantsOpacity, tourRestaurantsScale]);
+    tourRestaurantsOpacity, tourRestaurantsScale,
+    aqiMicroModeIdx]);
 
   const getControls = (layer: ExpandableLayerKey): ParamControl[] => {
     switch (layer) {
@@ -1857,6 +1863,7 @@ export function useTransportParams() {
       ];
       case "aqiStations": return [];
       case "aqiMicroSensors": return [
+        { type: "select" as const, label: "顯示模式", value: String(aqiMicroModeIdx), options: [...MICRO_SENSOR_MODES], onChange: (v: string) => setAqiMicroModeIdx(parseInt(v, 10)) },
         { type: "toggle" as const, label: "Cluster", value: aqiMicroCluster, onChange: setAqiMicroCluster },
       ];
       case "waterBasins": return [
@@ -2859,6 +2866,7 @@ export function useTransportParams() {
     reOpacity,
     satOpacity,
     aqiMicroCluster,
+    aqiMicroModeIdx,
     aqiImageryOpacity,
     hillshadeOpacity,
     slopeVectorOpacity,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1133,6 +1133,8 @@ export interface AqiStation {
 /** LASS AirBox / 環境部微感測 */
 export interface MicroSensor {
   deviceId: string;
+  /** 站名（RPC 升級前為 null；popup 標題有值優先顯示、否則 fallback deviceId） */
+  siteName: string | null;
   source: string;
   area: string | null;
   app: string | null;


### PR DESCRIPTION
## Summary
- 接手 #93（原 PR 因 base branch feat/temperature-grid-2d squash 後刪除被 GitHub 自動關閉、無法重開）；內容不變，base 改 master。

## Changes
- 同 #93：LASS 微感測圖層三模式上色（PM2.5/溫度/濕度）+ site_name 貫通（commit fd6189b）。
- 溫度網格部分與 master 上 #92 的 squash 內容相同，squash 後只會留 LASS 差異。

## Test
- [x] 同 #93（該 session 已驗證）

## Related
- 原 PR：#93
🤖 Generated with [Claude Code](https://claude.com/claude-code)