### PR TITLE
feat: 人均市值上色模式（450m/1.5km）+ 圖層改名「不動產總市值網格」

### DIFF
--- a/docs/features/property-value/handoff.md
+++ b/docs/features/property-value/handoff.md
@@ -59,6 +59,18 @@ S3 `deploy-assets/urban/buildings_3d_taiwan.pmtiles` 已無人引用，可刪（
 | `n_bld` / `gfa` / `ps_dom` / `grid_id` | int / float m² / str / str | popup |
 | `v_all` | int 萬元 | **前端不顯示、不相減**（未套 GFA 校正 → 可能 < `v_mkt`）|
 
+**layer `grid_value_450m` / `grid_value_1500m` 追加欄位**（2026-07-29 契約，上游平行處理中）
+
+| 欄位 | 型別 | 前端用途 |
+|---|---|---|
+| `pop` | int 人（最小統計區**面積加權**；`0` = 無人口資料或無人） | 人均市值模式染色（`v_mkt / pop`，萬元/人）+ popup「人口」「人均市值」兩列；`pop < 10` 視為統計不可靠 → 灰 `#555` 半透明（不隱藏，保留可點查）|
+
+⚠️ **`grid_value_150m` 沒有 `pop`** → 人均模式在 150m 尺度 disabled（select 選項灰掉並註明
+「僅 450m / 1.5km 提供」，**不自動跳尺度**；有效模式統一由 `resolvePropertyValueGridMode()`
+回退總市值）。上游磚**尚未帶 `pop`** 期間：popup 兩列自動隱藏（`pop` 缺 → NaN 判掉）；
+人均模式上色會整片灰半透明（缺欄位 `to-number` 成 0 → 落入不可靠門檻）——誠實呈現「還沒有
+人口資料」，磚換新後自動恢復，不需改前端。
+
 **`property_value_admin.json`**：`meta.total_trillion`（headline）/ `meta.limitations`（摺疊必露）/
 `meta.license_note` / `county[].value_market_corrected`（⭐ 長條圖主數字，**單位是元不是萬元**）。
 
@@ -175,6 +187,31 @@ inferno 是 perceptually-uniform 色圖、亮度嚴格單調（L\* 0.22 → 0.98
 3D 立起來吃同一套色。`v_mkt=0` 的 1,808 格仍走 opacity 0.04 淡出，不進色階。
 圖例 swatch 由 `UrbanDotRow` 提供 1px 白 60% 細邊框，前兩級深紫在深色 panel 上才不會糊掉。
 
+## propertyValueGrid 的上色模式（總市值 / 人均市值，2026-07-29）
+
+「上色模式」select（照 LASS 微感測 fd6189b 的模式範式）：`propertyValueGridModeIdx`
+（0=總市值預設 / 1=人均市值），存在 `useTransportParams` state → 走 `overlayParams` 傳進
+paint function，切模式 = param 變動 → `updateOverlayTheme` diff `setPaintProperty`，不重建 layer。
+
+- **有效模式判斷單一入口** `resolvePropertyValueGridMode(scaleIdx, modeIdx)`（SSOT
+  `propertyValueTypes.ts`）：人均只在 `hasPop`（450m / 1.5km）尺度生效，150m 選了人均一律
+  回退總市值 —— paint / 圖例 / UI disabled 三邊同源，不會出現「圖例說人均、地圖畫總市值」。
+- **配色**：8 級 viridis（`PROPERTY_VALUE_VIRIDIS_8`，紫→藍→青→綠→黃），刻意與總市值
+  inferno 及 buildingsGba YlOrRd 區分。`pop < 10` → `#555` + opacity ×0.45（不隱藏，可點查）。
+- **✅ 斷點已按實算分位數校準（2026-07-29）**：`PROPERTY_VALUE_PER_CAPITA_BREAKS_WAN =
+  [100, 250, 550, 1000, 2000, 4000, 10000]`（萬元/人）。依上游 pop>=10 格實算：450m
+  p50=549 / p90=3179 / p95=6178；1.5km p50=560 / p90=2373 / p95=4263。中位數落第 4 級、
+  頂級 >10000 約 2%（長尾 = 工業區/機場等低人口格）。級距標籤與 expression 都從這一個陣列
+  衍生，再校準只改它。兩尺度分佈實算相近 → 共用同一組，不拆 per-scale。
+- **3D 高度 = 量體、顏色 = 強度（刻意設計）**：人均模式下 extrusion 高度**維持 `v_mkt` 總量**，
+  只有顏色換人均 —— 高黃 = 人少錢多、高紫 = 人多攤薄，兩通道疊出密度語意。灰格（pop<10）照常
+  用 v_mkt 立高度（總值本身可信，只是人均不可靠）；`fill-extrusion-opacity` 不支援 data-driven，
+  3D 下灰格半透明做不到，僅靠色相標示。
+- **人均模式不做 v_mkt=0 淡出**：pop ≥ 10 而 v_mkt=0 是「有人住但格內僅非市場建物」，
+  0 萬/人落第 1 級是誠實低值不是缺值。
+- **popup 跟尺度走、不跟模式走**：450m/1.5km 一律顯示「人口」「人均市值」兩列
+  （總市值模式點查也看得到），150m 不顯示。
+
 ## propertyValueGrid 的 3D 高度映射
 
 控件組**照人口網格**（`h3Population` / `popCount`，SSOT `src/map/h3LayerFactory.ts`）：
@@ -235,6 +272,7 @@ inferno 是 perceptually-uniform 色圖、亮度嚴格單調（L\* 0.22 → 0.98
 | 上游改動 | 下游動作 |
 |---|---|
 | 實價網格新一季重跑（預計每季）| 重跑上游兩支腳本 → `cp` 五個檔 → 跑 `upload-deploy-assets.sh` 上 S3；**前端程式不用改**（斷點/高度錨值會略微失準但不會壞，要精準就回填 `PROPERTY_VALUE_SCALES`）|
+| 人口新年度重跑（上游 03 → 重烤 450/1500 磚）| `cp` 兩個 pmtiles → 上 S3；若人均分佈大幅改變再回填 `PROPERTY_VALUE_PER_CAPITA_BREAKS_WAN` 一個陣列（標籤/expression 自動衍生）|
 | `h`/`v`/`ps`/`nm`/`v_mkt` 任一改名 | `propertyValueTypes.ts` + `buildingsGbaTypes.ts` + overlayRegistry filter/paint + panels 一起改 |
 | `v_mkt` 分佈大幅改變（如改幣別／改單位）| `PROPERTY_VALUE_GRID_BANDS`（9 級斷點）與 `PROPERTY_VALUE_HEIGHT_FLOOR_WAN` / `PROPERTY_VALUE_HEIGHT_MAX_WAN`（3D 上下錨）都要重取；FLOOR 刻意 = 色階第 1 級上界（1,000 萬），改色階時要跟著改 |
 | 排除非住宅量體（限制 1 落地，38 兆會下修）| headline 數字自動跟 json 走；`PROPERTY_VALUE_APPROX_NOTE` 與圖例的「≈ 204 兆」文案要跟改 |
@@ -247,3 +285,19 @@ inferno 是 perceptually-uniform 色圖、亮度嚴格單調（L\* 0.22 → 0.98
 3. `meta.limitations` 三條必須在面板內可讀（`<details>` 可摺，但不可只放 tooltip）
 4. GBA **CC BY-NC 4.0 禁商用**：圖例 + 面板 `license_note` 都要露出；本層衍生品不得入
    Supabase 對外服務
+5. 人均模式 `pop < 10` 一律灰 + 半透明「統計不可靠」，popup 標「樣本不足」，不給人均數字
+
+## Changelog
+
+- **2026-07-29 人均市值模式**：新增第二種上色模式 `propertyValueGridModeIdx`
+  （0=總市值 / 1=人均 `v_mkt/pop` 萬元/人，僅 450m/1.5km；150m 無 `pop` → select disabled
+  不跳尺度）。8 級 viridis + `pop<10` 灰半透明；3D 高度維持 v_mkt（高度=量體、顏色=強度）；
+  popup 450m/1.5km 加「人口」「人均市值」兩列。斷點 `PROPERTY_VALUE_PER_CAPITA_BREAKS_WAN =
+  [100, 250, 550, 1000, 2000, 4000, 10000]` 已按上游實算分位數校準。改動：`propertyValueTypes.ts`
+  （模式/色票/expression SSOT）、`overlayRegistry.ts`（paint 隨 modeIdx 切）、
+  `useTransportParams.ts`（state + 上色模式 select）、`IconRailSidebar.tsx` / `LayerSidebar.tsx`
+  （SelectConfig options 新增 `disabled` 支援）、`LegendPanel.tsx`（兩模式圖例）、
+  `urbanPanels.tsx`（popup 兩列）。
+- **2026-07-27 v2**：150m PMTiles 改 z4-14；6 級 BuPu → 9 級 inferno；3D 不封頂；
+  三尺度（150m/450m/1.5km）手動切換上線。
+- **2026-07-27 v1**：初版接線（見全文）。

--- a/src/components/IconRailSidebar.tsx
+++ b/src/components/IconRailSidebar.tsx
@@ -1405,7 +1405,7 @@ function ExpandedControls({
                       }}
                     >
                       {ctrl.options.map((opt) => (
-                        <option key={opt.value} value={opt.value} style={{ background: OPTION_BG }}>
+                        <option key={opt.value} value={opt.value} disabled={opt.disabled} style={{ background: OPTION_BG }}>
                           {opt.label}
                         </option>
                       ))}
@@ -1425,7 +1425,8 @@ function ExpandedControls({
                   {ctrl.options.map((opt) => (
                     <button
                       key={opt.value}
-                      onClick={() => ctrl.onChange(opt.value)}
+                      disabled={opt.disabled}
+                      onClick={() => { if (!opt.disabled) ctrl.onChange(opt.value); }}
                       style={{
                         ...btnBase,
                         fontSize: FONT_SIZE.xs,
@@ -1437,6 +1438,8 @@ function ExpandedControls({
                           ? `1px solid ${CTRL_ACTIVE_BORDER}`
                           : `1px solid ${CTRL_INACTIVE_BORDER}`,
                         color: ctrl.value === opt.value ? TEXT_STRONG : DIM,
+                        // disabled（如人均模式在 150m 尺度）：降不透明度 + 禁用游標，label 已自帶原因
+                        ...(opt.disabled ? { opacity: 0.4, cursor: "not-allowed" } : {}),
                       }}
                     >
                       {opt.label}

--- a/src/components/LayerSidebar.tsx
+++ b/src/components/LayerSidebar.tsx
@@ -559,7 +559,7 @@ function ExpandedPanel({
                       }}
                     >
                       {ctrl.options.map((opt) => (
-                        <option key={opt.value} value={opt.value}>{opt.label}</option>
+                        <option key={opt.value} value={opt.value} disabled={opt.disabled}>{opt.label}</option>
                       ))}
                     </select>
                   </div>
@@ -581,7 +581,8 @@ function ExpandedPanel({
                   {ctrl.options.map((opt) => (
                     <button
                       key={opt.value}
-                      onClick={() => ctrl.onChange(opt.value)}
+                      disabled={opt.disabled}
+                      onClick={() => { if (!opt.disabled) ctrl.onChange(opt.value); }}
                       style={{
                         ...btnBase,
                         fontSize: FONT_SIZE.xs,
@@ -595,6 +596,8 @@ function ExpandedPanel({
                         color: ctrl.value === opt.value
                           ? (isDarkTheme ? "#fff" : "#000")
                           : (isDarkTheme ? "rgba(255,255,255,0.4)" : "rgba(0,0,0,0.4)"),
+                        // disabled（如人均模式在 150m 尺度）：降不透明度 + 禁用游標，label 已自帶原因
+                        ...(opt.disabled ? { opacity: 0.4, cursor: "not-allowed" } : {}),
                       }}
                     >
                       {opt.label}

--- a/src/components/LegendPanel.tsx
+++ b/src/components/LegendPanel.tsx
@@ -48,6 +48,8 @@ import {
 import {
   BUILDING_VALUE_BANDS, BUILDING_VALUE_NON_MARKET_COLOR,
   PROPERTY_VALUE_ATTRIBUTION, resolvePropertyValueScale, formatWanTwd,
+  resolvePropertyValueGridMode, PROPERTY_VALUE_PER_CAPITA_BANDS,
+  PROPERTY_VALUE_PER_CAPITA_LOW_POP_COLOR, PROPERTY_VALUE_PER_CAPITA_MIN_POP,
 } from "../data/propertyValueTypes";
 import {
   URBAN_FORM_GRID_MODES, URBAN_FORM_GRID_ATTRIBUTION_GBA, URBAN_FORM_GRID_ATTRIBUTION_META,
@@ -234,7 +236,7 @@ export const LEGEND_REGISTRY: LegendEntry[] = [
   { keys: ["treePitsTaipei"], render: () => <TreePitsTaipeiLegend /> },
   { keys: ["buildingsGba"], render: ({ overlayParams }) => <BuildingsGbaLegend modeIdx={overlayParams.buildingsGbaModeIdx ?? 0} /> },
   { keys: ["urbanFormGrid"], render: ({ overlayParams }) => <UrbanFormGridLegend modeIdx={overlayParams.urbanFormGridModeIdx ?? 5} /> },
-  { keys: ["propertyValueGrid"], render: ({ overlayParams }) => <PropertyValueGridLegend scaleIdx={overlayParams.propertyValueGridScaleIdx ?? 0} extruded={(overlayParams.propertyValueGridExtruded ?? 0) === 1} /> },
+  { keys: ["propertyValueGrid"], render: ({ overlayParams }) => <PropertyValueGridLegend scaleIdx={overlayParams.propertyValueGridScaleIdx ?? 0} modeIdx={overlayParams.propertyValueGridModeIdx ?? 0} extruded={(overlayParams.propertyValueGridExtruded ?? 0) === 1} /> },
   { keys: ["urbanZoningTaipei", "urbanZoningNewTaipei"], render: () => <UrbanZoningLegend /> },
   { keys: ["canopyHeight"], render: () => <CanopyHeightLegend /> },
   { keys: ["canopyGiants"], render: () => <CanopyGiantsLegend /> },
@@ -1101,15 +1103,47 @@ function BuildingsGbaLegend({ modeIdx = 0 }: { modeIdx?: number }) {
   );
 }
 
-// 🏢 房地產總市值網格圖例：v_mkt 9 級 inferno 色階 + 「總量 ≠ 單價」語意說明 + 雙署名。
-// 級距標籤與 3D 高度錨都**隨手動選的網格大小換**（粗格值域整體右移，共用細格斷點會全部爆頂）。
-function PropertyValueGridLegend({ scaleIdx = 0, extruded = false }: { scaleIdx?: number; extruded?: boolean }) {
+// 🏢 房地產總市值網格圖例：兩種上色模式（SSOT propertyValueTypes.ts）——
+//   0 總市值：v_mkt 9 級 inferno，級距標籤與 3D 高度錨**隨手動選的網格大小換**
+//     （粗格值域整體右移，共用細格斷點會全部爆頂）
+//   1 人均市值：v_mkt/pop 8 級 viridis（僅 450m/1.5km；150m 磚無 pop，
+//     resolvePropertyValueGridMode 會回退成總市值 → 圖例跟 paint 永遠同步）
+function PropertyValueGridLegend({ scaleIdx = 0, modeIdx = 0, extruded = false }: { scaleIdx?: number; modeIdx?: number; extruded?: boolean }) {
   const t = useLegendTheme();
   const scale = resolvePropertyValueScale(scaleIdx);
+  const perCapita = resolvePropertyValueGridMode(scaleIdx, modeIdx) === 1;
+  if (perCapita) {
+    return (
+      <div>
+        <div style={{ fontSize: FONT_SIZE.xs, color: t.textDim, letterSpacing: 1, marginBottom: 4 }}>
+          人均市值網格 PER-CAPITA VALUE · {scale.shortLabel}
+        </div>
+        <div style={{ fontSize: FONT_SIZE.xs, color: t.textMuted, marginBottom: 3 }}>
+          每 {scale.shortLabel} 格總市值 ÷ 人口（萬元/人）
+        </div>
+        <div style={{ display: "flex", flexDirection: "column", gap: 2 }}>
+          <UrbanDotRow color={PROPERTY_VALUE_PER_CAPITA_LOW_POP_COLOR} label={`人口 < ${PROPERTY_VALUE_PER_CAPITA_MIN_POP}（統計不可靠，半透明）`} />
+          {PROPERTY_VALUE_PER_CAPITA_BANDS.map((b) => <UrbanDotRow key={b.label} color={b.color} label={b.label} />)}
+        </div>
+        <div style={{ fontSize: FONT_SIZE.xs, color: t.textDim, marginTop: 4, lineHeight: 1.4 }}>
+          越黃 = 平均每人名下壓的房產越多（人少錢多）；越紫 = 人多攤薄。
+          人口為最小統計區面積加權估計。
+        </div>
+        {extruded && (
+          <div style={{ fontSize: FONT_SIZE.xs, color: t.textDim, marginTop: 4, lineHeight: 1.4 }}>
+            3D 高度仍是「總市值」（量體）、顏色才是人均（強度）—— 高黃 = 人少錢多、高紫 = 人多攤薄。
+          </div>
+        )}
+        <div style={{ fontSize: FONT_SIZE.xs, color: t.textDim, marginTop: 4, lineHeight: 1.4 }}>
+          {PROPERTY_VALUE_ATTRIBUTION}
+        </div>
+      </div>
+    );
+  }
   return (
     <div>
       <div style={{ fontSize: FONT_SIZE.xs, color: t.textDim, letterSpacing: 1, marginBottom: 4 }}>
-        總市值網格 PROPERTY VALUE · {scale.shortLabel}
+        不動產總市值網格 PROPERTY VALUE · {scale.shortLabel}
       </div>
       <div style={{ fontSize: FONT_SIZE.xs, color: t.textMuted, marginBottom: 3 }}>
         每 {scale.shortLabel} 格總市值（不是單價）{extruded ? " · 3D 高度同步" : ""}

--- a/src/components/featureInfo/registry.tsx
+++ b/src/components/featureInfo/registry.tsx
@@ -394,7 +394,7 @@ export const HEADER_LABELS: Record<FeatureInfo["layerType"], string> = {
   treePitsTaipei: "人行道樹穴",
   buildingsGba: "建物",
   urbanFormGrid: "都市紋理",
-  propertyValueGrid: "總市值網格",
+  propertyValueGrid: "不動產總市值網格",
   urbanZoningTaipei: "土地使用分區",
   urbanZoningNewTaipei: "土地使用分區",
   sportsVenue: "運動場館",

--- a/src/components/featureInfo/urbanPanels.tsx
+++ b/src/components/featureInfo/urbanPanels.tsx
@@ -8,6 +8,7 @@ import {
 import { buildingHeightBandColor } from "../../data/buildingsGbaTypes";
 import {
   BUILDING_VALUE_NON_MARKET_COLOR, PROPERTY_VALUE_APPROX_NOTE,
+  PROPERTY_VALUE_PER_CAPITA_MIN_POP,
   formatWanTwd, priceSourceLabel, propertyValueBandColor, scaleFromGridId,
 } from "../../data/propertyValueTypes";
 import { GG_INDEX_BANDS, gridBandColor, URBAN_FORM_GRID_APPROX_NOTE } from "../../data/urbanFormGridTypes";
@@ -309,6 +310,9 @@ export function BuildingsGbaPanel({ props }: { props: Record<string, unknown> })
 /**
  * 總市值網格：v_mkt 主數字 + 棟數 / 總樓地板面積 / 主要價格來源。三尺度共用本 panel，
  * 目前是哪個尺度由 `grid_id` 前綴反推（`G_` / `G450_` / `G1500_`），不必額外傳參。
+ * 450m/1.5km（scale.hasPop）加「人口」「人均市值」兩列——**跟尺度走、不跟上色模式走**，
+ * 總市值模式下點查也看得到人均；150m 磚無 pop，不顯示。
+ * pop < PROPERTY_VALUE_PER_CAPITA_MIN_POP 人均標「樣本不足」（跟地圖灰格同一套門檻）。
  * ⚠️ 不顯示 v_all，也不做 v_mkt − v_all：v_all 未套 GFA 校正係數，可能小於 v_mkt，
  *    相減沒有意義（上游 admin_value.json meta.field_notes 明文警告）。
  */
@@ -316,10 +320,22 @@ export function PropertyValueGridPanel({ props }: { props: Record<string, unknow
   const vMkt = Number(props.v_mkt);
   const scale = scaleFromGridId(props.grid_id);
   const color = propertyValueBandColor(scale.bands, vMkt);
+  const pop = Number(props.pop);
+  const hasPop = scale.hasPop && Number.isFinite(pop);
+  const perCapitaValue = !hasPop ? ""
+    : pop < PROPERTY_VALUE_PER_CAPITA_MIN_POP ? `樣本不足（人口 < ${PROPERTY_VALUE_PER_CAPITA_MIN_POP}）`
+    : vMkt > 0 ? `${formatWanTwd(vMkt / pop)}/人`
+    : "0";
   return (
     <>
-      <Title color={color}>{`總市值網格 ${scale.shortLabel}`}</Title>
+      <Title color={color}>{`不動產總市值網格 ${scale.shortLabel}`}</Title>
       <Row label="總市值" value={Number.isFinite(vMkt) && vMkt > 0 ? formatWanTwd(vMkt) : "0（格內僅非市場建物）"} />
+      {hasPop && (
+        <>
+          <Row label="人口" value={pop > 0 ? `≈ ${Math.round(pop).toLocaleString()} 人` : "0（無人口資料或無人）"} />
+          <Row label="人均市值" value={perCapitaValue} />
+        </>
+      )}
       <Row label="建物棟數" value={numUnit(props.n_bld, "棟")} />
       <Row label="總樓地板面積" value={numUnit(props.gfa, "m²")} />
       <Row label="主要價格來源" value={priceSourceLabel(props.ps_dom)} />

--- a/src/components/sidebar/layerCatalog.ts
+++ b/src/components/sidebar/layerCatalog.ts
@@ -611,7 +611,7 @@ export const THEMES: ThemeDef[] = [
         // 上三組是「單價」（每 m² 多貴），本組是「總量」（這格壓了多少錢）——語意不同，見圖例
         title: "總市值",
         layers: [
-          { key: "propertyValueGrid", label: "總市值網格 Value Grid", labelMobile: "總市值網格", expandable: true },
+          { key: "propertyValueGrid", label: "不動產總市值網格 Value Grid", labelMobile: "不動產總市值網格", expandable: true },
         ],
       },
     ],

--- a/src/data/propertyValueTypes.ts
+++ b/src/data/propertyValueTypes.ts
@@ -150,6 +150,11 @@ export interface PropertyValueScale {
   heightFloorWan: number;
   /** 3D 高度上錨（萬元）= 該尺度資料真實最大格；**不封頂**，超過就刺出滿格 */
   heightMaxWan: number;
+  /**
+   * 該尺度 PMTiles 是否帶 `pop` 屬性（人口，最小統計區面積加權；0 = 無人口資料或無人）。
+   * 上游只烤進 450m / 1.5km 兩份磚，**150m 沒有** → 人均模式在 150m 停用（UI disabled）。
+   */
+  hasPop: boolean;
 }
 
 // 逐級占比（上游 grid_value_150m.parquet 實算，2026-07-27）：
@@ -165,7 +170,7 @@ export const PROPERTY_VALUE_SCALES: PropertyValueScale[] = [
     value: "0", label: "150m 細格", shortLabel: "150m",
     sourceId: "property-value-grid-150",
     sourceUrl: "./urban/property_value_grid_150m.pmtiles",
-    sourceLayer: "grid_value_150m", minzoom: 4, maxzoom: 14, idPrefix: "G_",
+    sourceLayer: "grid_value_150m", minzoom: 4, maxzoom: 14, idPrefix: "G_", hasPop: false,
     bands: infernoBands(
       [1_000, 3_000, 10_000, 30_000, 100_000, 300_000, 1_000_000, 3_000_000],
       ["< 0.1 億", "0.1 – 0.3 億", "0.3 – 1 億", "1 – 3 億", "3 – 10 億", "10 – 30 億", "30 – 100 億", "100 – 300 億", "> 300 億"],
@@ -177,7 +182,7 @@ export const PROPERTY_VALUE_SCALES: PropertyValueScale[] = [
     value: "1", label: "450m 中格", shortLabel: "450m",
     sourceId: "property-value-grid-450",
     sourceUrl: "./urban/property_value_grid_450m.pmtiles",
-    sourceLayer: "grid_value_450m", minzoom: 4, maxzoom: 13, idPrefix: "G450_",
+    sourceLayer: "grid_value_450m", minzoom: 4, maxzoom: 13, idPrefix: "G450_", hasPop: true,
     bands: infernoBands(
       [3_000, 10_000, 30_000, 100_000, 300_000, 1_000_000, 3_000_000, 10_000_000],
       ["< 0.3 億", "0.3 – 1 億", "1 – 3 億", "3 – 10 億", "10 – 30 億", "30 – 100 億", "100 – 300 億", "300 – 1,000 億", "> 1,000 億"],
@@ -189,7 +194,7 @@ export const PROPERTY_VALUE_SCALES: PropertyValueScale[] = [
     value: "2", label: "1.5km 粗格", shortLabel: "1.5km",
     sourceId: "property-value-grid-1500",
     sourceUrl: "./urban/property_value_grid_1500m.pmtiles",
-    sourceLayer: "grid_value_1500m", minzoom: 4, maxzoom: 12, idPrefix: "G1500_",
+    sourceLayer: "grid_value_1500m", minzoom: 4, maxzoom: 12, idPrefix: "G1500_", hasPop: true,
     bands: infernoBands(
       [30_000, 100_000, 300_000, 1_000_000, 3_000_000, 10_000_000, 30_000_000, 100_000_000],
       ["< 3 億", "3 – 10 億", "10 – 30 億", "30 – 100 億", "100 – 300 億", "300 – 1,000 億", "1,000 – 3,000 億", "3,000 – 1 兆", "> 1 兆"],
@@ -235,6 +240,107 @@ export function propertyValueGridColorExpr(scaleIdx: number): unknown[] {
  */
 export function propertyValueGridOpacityExpr(baseOpacity: number): unknown[] {
   return ["case", ["<=", ["to-number", ["get", "v_mkt"], 0], 0], 0.04, baseOpacity];
+}
+
+// ── 上色模式：總市值（0，預設）/ 人均市值（1）────────────────────
+//
+// 人均市值 = `v_mkt / pop`（萬元/人）。`pop` 只存在於 450m / 1.5km 兩份磚（150m 沒有）
+// → 150m 時人均選項 disabled（不自動跳尺度），paint 端由 resolvePropertyValueGridMode()
+// 統一回退成總市值，UI / 圖例 / paint 三邊都吃同一個 helper，不會各自為政。
+//
+// 配色：**viridis 8 級**（perceptually-uniform；紫→藍→青→綠→黃）。刻意選一條與總市值
+// 模式的 inferno（紫→紅→橙→黃）中段區分得開的色帶——兩模式切換時一眼看得出「換了語意」，
+// 且與 buildingsGba 估值 YlOrRd 也不撞。
+//
+// pop < PROPERTY_VALUE_PER_CAPITA_MIN_POP 的格視為統計不可靠（分母太小，一棟豪宅配
+// 兩個人會爆表）→ 上灰 #555 + 半透明，**不隱藏**（保留可點查，popup 會講明樣本不足）。
+
+/** 顯示模式 select 選項；index 對齊 overlayParams.propertyValueGridModeIdx。預設 0=總市值。 */
+export const PROPERTY_VALUE_GRID_MODES = [
+  { value: "0", label: "總市值" },
+  { value: "1", label: "人均市值" },
+] as const;
+
+/** 人均統計可靠門檻（人）：pop < 10 → 灰色不分級（含 pop=0 = 無人口資料或無人） */
+export const PROPERTY_VALUE_PER_CAPITA_MIN_POP = 10;
+
+/** pop < 門檻的格用色（半透明處理在 opacity expr，這裡只管色相） */
+export const PROPERTY_VALUE_PER_CAPITA_LOW_POP_COLOR = "#555555";
+
+/**
+ * 人均市值斷點（萬元/人），已依上游實算分位數校準（2026-07-29，pop>=10 格）：
+ *   450m  p5 50 / p25 261 / p50 549 / p75 1235 / p90 3179 / p95 6178 / p99 28730
+ *   1.5km p5 63 / p25 310 / p50 560 / p75 1073 / p90 2373 / p95 4263 / p99 20090
+ * 中位數 ~550 落第 4 級、頂級 >10000 約佔 2%（長尾主要是工業區/機場等低人口格）。
+ * 級距標籤與 mapbox expression 都從這裡自動衍生，再校準只改這一個陣列。
+ * 兩尺度共用同一組（人均是強度量、已被人口正規化，實算分佈確認相近，不拆 per-scale）。
+ */
+export const PROPERTY_VALUE_PER_CAPITA_BREAKS_WAN: number[] = [100, 250, 550, 1000, 2000, 4000, 10000];
+
+/** viridis 8 級（低→高）；與總市值 inferno 9 級明確區分（見上方模式段註解） */
+export const PROPERTY_VALUE_VIRIDIS_8 = [
+  "#440154", "#46327e", "#365c8d", "#277f8e", "#1fa187", "#4ac16d", "#a0da39", "#fde725",
+] as const;
+
+/** 斷點 → 人均 band（標籤自動衍生，校準只動 BREAKS 陣列） */
+function perCapitaBands(): GridColorBand[] {
+  const br = PROPERTY_VALUE_PER_CAPITA_BREAKS_WAN;
+  const fmt = (n: number) => n.toLocaleString();
+  return PROPERTY_VALUE_VIRIDIS_8.map((color, i) => ({
+    max: i < br.length ? br[i]! : null,
+    color,
+    label:
+      i === 0 ? `< ${fmt(br[0]!)} 萬/人`
+      : i < br.length ? `${fmt(br[i - 1]!)} – ${fmt(br[i]!)} 萬/人`
+      : `> ${fmt(br[br.length - 1]!)} 萬/人`,
+  }));
+}
+
+/** 人均市值 8 級 band（圖例 / popup Title 上色共用） */
+export const PROPERTY_VALUE_PER_CAPITA_BANDS: GridColorBand[] = perCapitaBands();
+
+/**
+ * scaleIdx + modeIdx → **有效**模式（0=總市值 / 1=人均）。
+ * 人均只在帶 pop 的尺度（450m / 1.5km）有效；150m 選了人均一律回退總市值 ——
+ * paint / 圖例 / popup 的模式判斷都必須走這裡，不可自己讀 raw modeIdx。
+ */
+export function resolvePropertyValueGridMode(scaleIdx: number, modeIdx: number): number {
+  return modeIdx === 1 && resolvePropertyValueScale(scaleIdx).hasPop ? 1 : 0;
+}
+
+/**
+ * 人均市值 fill-color：pop < 門檻（含 0）→ 灰；否則依 `v_mkt / pop` 8 級 viridis step。
+ * 除法只發生在 pop ≥ 門檻的分支，不會除以 0。
+ */
+export function propertyValueGridPerCapitaColorExpr(): unknown[] {
+  const bands = PROPERTY_VALUE_PER_CAPITA_BANDS;
+  const perCapita: unknown[] = [
+    "/", ["to-number", ["get", "v_mkt"], 0], ["to-number", ["get", "pop"], 0],
+  ];
+  const step: unknown[] = ["step", perCapita, bands[0]!.color];
+  for (let i = 1; i < bands.length; i++) {
+    step.push(bands[i - 1]!.max as number, bands[i]!.color);
+  }
+  return [
+    "case",
+    ["<", ["to-number", ["get", "pop"], 0], PROPERTY_VALUE_PER_CAPITA_MIN_POP],
+    PROPERTY_VALUE_PER_CAPITA_LOW_POP_COLOR,
+    step,
+  ];
+}
+
+/**
+ * 人均市值 fill-opacity：pop < 門檻的灰格半透明（×0.45），其餘吃 baseOpacity。
+ * 不做 v_mkt=0 淡出——人均模式下 pop ≥ 門檻而 v_mkt=0 是「有人住但格內僅非市場建物」，
+ * 0 萬/人落在第 1 級是誠實的低值，不是缺值。
+ */
+export function propertyValueGridPerCapitaOpacityExpr(baseOpacity: number): unknown[] {
+  return [
+    "case",
+    ["<", ["to-number", ["get", "pop"], 0], PROPERTY_VALUE_PER_CAPITA_MIN_POP],
+    baseOpacity * 0.45,
+    baseOpacity,
+  ];
 }
 
 // ── 3D 立體高度映射（照人口網格 h3LayerFactory 的 log + gamma 慣例）──────

--- a/src/hooks/useTransportParams.ts
+++ b/src/hooks/useTransportParams.ts
@@ -21,7 +21,7 @@ import {
 import { BUILDINGS_GBA_MODES } from "../data/buildingsGbaTypes";
 import { URBAN_FORM_GRID_MODES } from "../data/urbanFormGridTypes";
 import { MICRO_SENSOR_MODES } from "../data/microSensorTypes";
-import { PROPERTY_VALUE_SCALES } from "../data/propertyValueTypes";
+import { PROPERTY_VALUE_SCALES, PROPERTY_VALUE_GRID_MODES } from "../data/propertyValueTypes";
 import { URBAN_ZONING_CATEGORIES } from "../data/urbanZoningTypes";
 import { CULTURAL_FACILITY_TYPES, CULTURAL_MUSEUM_TYPES } from "../data/cultureTypes";
 
@@ -46,7 +46,8 @@ export interface SelectConfig {
   type: "select";
   label: string;
   value: string;
-  options: { label: string; value: string }[];
+  /** disabled：該選項當下不可選（如 propertyValueGrid 人均模式在 150m 尺度）；label 自帶原因說明 */
+  options: { label: string; value: string; disabled?: boolean }[];
   onChange: (v: string) => void;
 }
 
@@ -285,6 +286,9 @@ export function useTransportParams() {
   // 三份 PMTiles 各自的斷點與 3D 高度錨見 PROPERTY_VALUE_SCALES；
   // 切尺度不重置 Contrast/Height（正規化各吃各的錨，滑桿語意跨尺度一致）。
   const [propertyValueGridScaleIdx, setPropertyValueGridScaleIdx] = useState(0);
+  // 上色模式：0=總市值（預設）/ 1=人均市值。人均只在帶 pop 的 450m/1.5km 有效；
+  // 150m 時選項 disabled（**不自動跳尺度**），有效模式由 resolvePropertyValueGridMode() 回退。
+  const [propertyValueGridModeIdx, setPropertyValueGridModeIdx] = useState(0);
   const [propertyValueGridOpacity, setPropertyValueGridOpacity] = useState(0.7);
   const [propertyValueGridContrast, setPropertyValueGridContrast] = useState(1.8);
   const [propertyValueGridExtruded, setPropertyValueGridExtruded] = useState(false);
@@ -1045,7 +1049,7 @@ export function useTransportParams() {
     treePitsTaipeiTypeIdx: ["all", ...TREE_PIT_TYPES.map((t) => t.name)].indexOf(treePitsTaipeiType),
     buildingsGbaModeIdx, buildingsGbaMinHeight, buildingsGbaOpacity, buildingsGbaBloomMinHeight,
     urbanFormGridModeIdx, urbanFormGridOpacity,
-    propertyValueGridScaleIdx,
+    propertyValueGridScaleIdx, propertyValueGridModeIdx,
     propertyValueGridOpacity, propertyValueGridContrast, propertyValueGridElevationScale,
     propertyValueGridExtruded: propertyValueGridExtruded ? 1 : 0,
     // 🗺️ 土地使用分區：category select 編成 Idx 餵 filter（overlayParams 只收數字，0=全部 1..9 單類）
@@ -1419,7 +1423,7 @@ export function useTransportParams() {
     treePitsTaipeiOpacity, treePitsTaipeiType,
     buildingsGbaModeIdx, buildingsGbaMinHeight, buildingsGbaOpacity, buildingsGbaBloomMinHeight,
     urbanFormGridModeIdx, urbanFormGridOpacity,
-    propertyValueGridScaleIdx, propertyValueGridOpacity, propertyValueGridContrast, propertyValueGridExtruded, propertyValueGridElevationScale,
+    propertyValueGridScaleIdx, propertyValueGridModeIdx, propertyValueGridOpacity, propertyValueGridContrast, propertyValueGridExtruded, propertyValueGridElevationScale,
     urbanZoningTaipeiOpacity, urbanZoningTaipeiCategory,
     urbanZoningNewTaipeiOpacity, urbanZoningNewTaipeiCategory,
     crimeAreaMonthlyOpacity, theftTaoyuanOpacity, theftTaoyuanScale,
@@ -2668,6 +2672,12 @@ export function useTransportParams() {
       // 2D 時常駐會是「拉了沒反應」的死控件。
       case "propertyValueGrid": return [
         { type: "select" as const, label: "網格大小", value: String(propertyValueGridScaleIdx), options: PROPERTY_VALUE_SCALES.map((sc) => ({ label: sc.label, value: sc.value })), onChange: (v: string) => setPropertyValueGridScaleIdx(parseInt(v, 10)) },
+        // 人均市值只有 450m/1.5km 磚帶 pop（150m 沒有）→ 150m 時 disabled 並在 label 講明，
+        // 不自動跳尺度；此時 paint/圖例已由 resolvePropertyValueGridMode() 回退成總市值
+        { type: "select" as const, label: "上色模式", value: String(propertyValueGridModeIdx), options: PROPERTY_VALUE_GRID_MODES.map((m) => {
+          const disabled = m.value === "1" && !(PROPERTY_VALUE_SCALES[propertyValueGridScaleIdx]?.hasPop ?? false);
+          return { label: disabled ? `${m.label}（僅 450m / 1.5km 提供）` : m.label, value: m.value, disabled };
+        }), onChange: (v: string) => setPropertyValueGridModeIdx(parseInt(v, 10)) },
         { label: `填色透明度 ${propertyValueGridOpacity.toFixed(2)}`, value: propertyValueGridOpacity, min: 0, max: 1, step: 0.05, onChange: setPropertyValueGridOpacity },
         { type: "toggle" as const, label: "3D 立體", value: propertyValueGridExtruded, onChange: setPropertyValueGridExtruded },
         ...(propertyValueGridExtruded

--- a/src/map/overlayRegistry.ts
+++ b/src/map/overlayRegistry.ts
@@ -40,6 +40,7 @@ import { buildingHeightColorExpr, buildingSrcColorExpr, buildingNightLightColorE
 import {
   buildingValueColorExpr, propertyValueGridColorExpr, propertyValueGridOpacityExpr,
   propertyValueGridHeightExpr, PROPERTY_VALUE_SCALES, type PropertyValueScale,
+  resolvePropertyValueGridMode, propertyValueGridPerCapitaColorExpr, propertyValueGridPerCapitaOpacityExpr,
 } from "../data/propertyValueTypes";
 import { canopyGiantDistColorExpr } from "../data/canopyGiantsTypes";
 import { urbanFormGridColorExpr, urbanFormGridOpacityExpr } from "../data/urbanFormGridTypes";
@@ -395,14 +396,21 @@ function propertyValueGridOverlay(scale: PropertyValueScale): OverlayConfig {
         suffix: "fill",
         type: "fill",
         paint: (_isDark, p) => {
+          // 有效模式（0=總市值 / 1=人均）：150m 磚沒有 pop → helper 統一回退總市值，
+          // 與 UI disabled / 圖例判斷同源（SSOT propertyValueTypes.ts）
+          const modeIdx = resolvePropertyValueGridMode(scaleIdx, p?.propertyValueGridModeIdx ?? 0);
           const extruded = (p?.propertyValueGridExtruded ?? 0) === 1;
           const op = p?.propertyValueGridOpacity ?? 0.7;
           return {
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            "fill-color": propertyValueGridColorExpr(scaleIdx) as any,
+            "fill-color": (modeIdx === 1
+              ? propertyValueGridPerCapitaColorExpr()
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+              : propertyValueGridColorExpr(scaleIdx)) as any,
             // 3D 模式交棒給 extrusion（壓 0 隱藏，避免與立體塊 z-fighting）
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            "fill-opacity": (extruded ? 0 : propertyValueGridOpacityExpr(op)) as any,
+            "fill-opacity": (extruded ? 0
+              : modeIdx === 1 ? propertyValueGridPerCapitaOpacityExpr(op)
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+              : propertyValueGridOpacityExpr(op)) as any,
           };
         },
       },
@@ -410,10 +418,18 @@ function propertyValueGridOverlay(scale: PropertyValueScale): OverlayConfig {
         suffix: "extrusion",
         type: "fill-extrusion",
         paint: (_isDark, p) => {
+          const modeIdx = resolvePropertyValueGridMode(scaleIdx, p?.propertyValueGridModeIdx ?? 0);
           const extruded = (p?.propertyValueGridExtruded ?? 0) === 1;
           return {
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            "fill-extrusion-color": propertyValueGridColorExpr(scaleIdx) as any,
+            // 人均模式只換「顏色」，extrusion 高度**維持 v_mkt**（見下方 height 註解）
+            "fill-extrusion-color": (modeIdx === 1
+              ? propertyValueGridPerCapitaColorExpr()
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+              : propertyValueGridColorExpr(scaleIdx)) as any,
+            // 🔵 高度=量體、顏色=強度（刻意設計，兩模式共用）：3D 高度永遠是 v_mkt 總量 ——
+            //    「這格壓了多少錢」的天際線不隨模式消失；人均模式下顏色改答「平均每人多有錢」，
+            //    高黃=人少錢多、高紫=人多攤薄，兩通道疊出密度語意。pop<10 灰格照常用
+            //    v_mkt 立高度（值本身可信，只是人均不可靠）。
             "fill-extrusion-height": propertyValueGridHeightExpr(
               scaleIdx,
               p?.propertyValueGridContrast ?? 1.8,
@@ -422,7 +438,8 @@ function propertyValueGridOverlay(scale: PropertyValueScale): OverlayConfig {
             ) as any,
             "fill-extrusion-base": 0,
             // ⚠️ fill-extrusion-opacity 不支援 data-driven → 只能給純數字（非 3D 模式壓 0 隱藏）；
-            //    v_mkt=0 的格 height 恰為 0（FLOOR 以下 → norm 夾成 0），自然貼地不需另外淡出
+            //    v_mkt=0 的格 height 恰為 0（FLOOR 以下 → norm 夾成 0），自然貼地不需另外淡出；
+            //    人均灰格的「半透明」在 3D 同樣做不到 data-driven，僅靠 #555 色相標示
             "fill-extrusion-opacity": extruded ? (p?.propertyValueGridOpacity ?? 0.7) : 0,
           };
         },


### PR DESCRIPTION
## Summary
- 不動產總市值網格新增「人均市值」上色模式（`v_mkt/pop` 萬元/人，僅 450m/1.5km），並將圖層名稱改為「不動產總市值網格 Value Grid」。

## Changes
- `src/data/propertyValueTypes.ts` — 模式 SSOT：`PROPERTY_VALUE_GRID_MODES`、`hasPop`、viridis 8 級、斷點 `[100,250,550,1000,2000,4000,10000]`（已按上游實算分位數校準）、`resolvePropertyValueGridMode()`、人均 color/opacity expr
- `src/map/overlayRegistry.ts` — paint 隨 `propertyValueGridModeIdx` 切換；3D 高度維持 v_mkt（高度=量體、顏色=強度）
- `src/hooks/useTransportParams.ts` — 模式 state + 「上色模式」select（150m 時人均 disabled 附說明）
- `src/components/IconRailSidebar.tsx` / `LayerSidebar.tsx` — SelectConfig options 支援 `disabled`
- `src/components/LegendPanel.tsx` — 人均圖例分支（viridis + 灰格說明 + 3D 註記）
- `src/components/featureInfo/urbanPanels.tsx` — popup 450m/1.5km 加「人口」「人均市值」兩列（pop<10 標樣本不足）
- 圖層改名四處：`layerCatalog.ts` / `LegendPanel.tsx` / `urbanPanels.tsx` / `featureInfo/registry.tsx`
- `docs/features/property-value/handoff.md` — pop 契約、模式章節、changelog

## Test
- [x] npx tsc -b 通過
- [x] pnpm test 通過（197 tests 含 layerConsistency）
- [x] Browser 驗收 9/9 PASS（模式切換 / 圖例 / popup 對帳 / 150m 回退 / 3D 高色分離 / console 乾淨）

## Risk / Rollback
- 依賴 450m/1.5km 新磚的 `pop` 欄（本機已換、S3 未上傳）；舊磚下人均模式整片灰半透明（誠實呈現，不會壞）
- 回滾：revert 本 squash commit 即可，資料磚向下相容（純加欄）

## Related
- Feature: docs/features/property-value/
- Upstream handoff: taipei-gis-analytics/docs/handoff/property-value.md（PR ianlkl11234s/taipei-gis-analytics#30 已 merge）

🤖 Generated with [Claude Code](https://claude.com/claude-code)