### PR TITLE
memory: wrap-up 2026-07-29~31（溫度三部曲 session）

### DIFF
--- a/.claude/memory/BACKLOG.md
+++ b/.claude/memory/BACKLOG.md
@@ -120,6 +120,19 @@
 | TY-2 | P3 | JMA 強度資料缺（氣壓/風速） | open | bosai 端點只有位置；需另接 JMA 強度來源（data-collectors） |
 | TY-4/5/6 | P1 | 現在位置圈 + 跳點斷線 + 預測/實際差異 + 資料源選擇器 + 同時刻去重 | **done** | PR #42 |
 
+### 微氣候 / 衛星遙測（MC 系列，2026-07-31 加 — 溫度三部曲後續）
+
+> 已上線：溫度網格 2D（#92）/ LASS 三模式（#94）/ 都市熱島 LST（#96，年更靜態）。
+> 方法論 SSOT：`taipei-gis-analytics/docs/topic-research/remote_sensing/urban-heat-lst-methodology.md`。
+
+| ID | 優先級 | 項目 | 狀態 | 備註 |
+|---|---|---|---|---|
+| MC-1 | P2 | 接環境部 IoT 微感測（10,983 點 = LASS 22 倍） | open | 端點已遷 `sta.colife.org.tw`（2026-07-29 實測可通；collector 註解的 sta.ci.taiwan.gov.tw 已死）。SensorThings OData；每站 PM2.5+溫濕 ~1min/筆；上游只留 2.5h rolling window 須自落庫；`areaType` 部署情境分類（工業/交通/社區/敏感，部分縣市未填）。三 repo 8 步 SOP + **落庫聚合設計必先做**（10,983 點高頻勿無腦全存）；collector TODO `fetch_moenv_iot()` 現在可解 |
+| MC-2 | P3 | ECOSTRESS 夜間熱島（70m，含夜間/午後過境） | open | 補 Landsat 只有上午 10:20 的缺口；日/夜熱島對比是敘事最有力部分。需用戶註冊免費 NASA Earthdata 帳號 |
+| MC-3 | P3 | LST valid-count 診斷模式 | open | PMTiles B 通道還空著，可編每像元有效觀測數；回應「坑洞成因」FAQ（方法論 §8a）；前端多一個 mix 通道 + 色帶即可 |
+| MC-4 | P3 | LASS collector 補 `SiteAddr` 完整地址 | open | 原始 feed 有、`_normalize()` 沒抓 + DB 缺欄；popup 細節用。死欄位（hcho/model/gps_alt/c_d0）已盤清不做 |
+| MC-5 | P3 | LST 年更（2026-10 後） | open | 納入 2026 暖季重跑 median；檔名不帶日期 → 重跑 pipeline + S3 覆蓋 + redeploy 即可零程式改動；順手核對 P2–P98 色階值域有無漂移 |
+
 ### 一般待辦
 
 | ID | 優先級 | 項目 | 狀態 | 備註 |
@@ -137,6 +150,7 @@
 | G013 | P1 | KHH collector 檔 SCP 上 HiCloud VM | open | 2026-07-26 KHH1/KHH5 端點修正已 push（data-collectors `a2f158a`），但生產實跑的是 VM（210.61.15.74）cron 版、手動 SCP 不接 git；未更新前 KHH 資料停在 7/26 一次性回填。照 `external/immigration_apis_airport_vm/README` 覆蓋 `/opt/immigration-apis-airport/immigration_apis_airport_collect.py` 即生效 |
 | G014 | P1 | gis-platform migration 301/318/319/320 commit + push | **done 2026-07-29** | 318/319/320 以 gis-platform PR #42（merge `6937d2b`，保留兩顆 atomic commits）收納；301 查證早已在 main（`0f2b878` 含於先前 merge）。三支 RPC/policy 自 7/26 起即在 production 運行 |
 | G015 | P3 | feat/monitor-grid-layout 分支（14 commits Monitor v2）復活評估 | open | 2026-07-26 靜態網格（PR #90）只取代了其中 2 個修 bug commit；RGL 可拖曳畫布 + widget registry + 版面持久化 + 會員 gating 未被取代。若要生產環境拖拉版面再議 rebase；沙盒 Artifact + monitorLayout.ts 流程（PB-30）已滿足目前需求 |
+| G016 | P2 | weather_change/.env 明文 AWS S3 key 輪替 | open | 2026-07-29 探索時發現（未進 git、僅本機磁碟，.gitignore 有擋）。輪替該組 key + 清 .env；該 repo 的 S3 舊流程 2026-02 已廢，可能可直接註銷憑證。詳 INCIDENTS 2026-07-29/31 事件 D |
 
 ### 結構 / 部署 Review（2026-05-25 全專案結構審查 — G004~G010）
 

--- a/.claude/memory/DATA_SCOPE.md
+++ b/.claude/memory/DATA_SCOPE.md
@@ -1,6 +1,6 @@
 # Data Scope
 
-**最後更新**：2026-07-24（+觀光 12 檔靜態快照）
+**最後更新**：2026-07-31（+衛星 LST raster PMTiles / micro sensor RPC +site_name）
 
 盤點專案持有的資料範圍：Supabase DB、前端靜態 GeoJSON、S3 deploy-assets。
 更新時機：新 collector 上線 / 新 seed 跑完 / 新前端圖層接入後。
@@ -542,3 +542,14 @@ civil_defense_shelters(3.4M) / crime_area_monthly(2.3M) / court_jurisdictions(29
 - C 類 9 檔進 git；D 類 3 檔（attractions 6,070 / hotels 15,654 / restaurants 3,688）走 S3 `deploy-assets/tourism/` → `/data/tourism/`（G012 已上傳上線 2026-07-24）
 - 亮點欄位：attractions `annual_visitors_2024`（263/6,070 有值，null=非統計據點非 0）；hotels `hotel_classes` 單碼 1~4；activities `start_time/end_time` ISO 時間戳
 - 更新機制：觀光署家族 4 源上游每日更 → 本站 monthly 手動重跑快照（C 類重 copy 進 git + D 類重傳 S3）
+
+## 環境 — 衛星地表溫度 LST（靜態 raster PMTiles，2026-07-31 上線）
+
+| 資產 | 內容 | 位置 |
+|---|---|---|
+| `urban_heat_lst_taiwan.pmtiles` | 30MB、z6–11@512；R=ΔT（0.2K 精度）/ G=絕對°C（0.25°C）/ B=保留 / A=mask；Landsat 8/9 C2L2、5 path/row 193 景 2019–2025 暖季 median、60m、陸地覆蓋 82.9%；**不含澎湖**（上游 ST 產品對小島不出值） | S3 `deploy-assets/environment/` + pulse `public/environment/`（gitignored）|
+| 上游 pipeline | Planetary Computer STAC/data API 取 ST_B10+QA；**年更**（每年 10 月納入當年暖季重跑） | `taipei-gis-analytics/pipelines/environment/urban_heat_lst/` |
+| 郊區背景遮罩 | WorldCover cropland ∧ 純度≥80% ∧ DEM≤500m，790,854 px（建一次年更不重建） | analytics `data/intermediate/environment/urban_heat_lst/mask/` |
+| 契約 | 量化參數 / raster-color-mix 係數 | analytics `docs/handoff/urban_heat_lst.md` + `output/urban_heat_lst_encoding.json` |
+
+另：`get_micro_sensors_latest()` 自 2026-07-31（migration 322）起多回 `site_name`；LASS AirBox 實測 ~480 台在線（loader 註解寫 ~500，實際 476-482 浮動）。

--- a/.claude/memory/GLOSSARY.md
+++ b/.claude/memory/GLOSSARY.md
@@ -331,3 +331,14 @@
 - **lock_type**：`gated_layers.lock_type`（`'ui'`|`'full'`）。`full`=乾淨鎖（DB REVOKE anon、資料真鎖，機密用）；`ui`=UI 鎖（不 REVOKE、資料公開，未登入顯示鎖頭引導登入、登入即開，非機密引導註冊用）。純宣告欄位，後台改它不動 DB grant（防誤公開）。
 - **gated_layers**：`public.gated_layers` 治理表，圖層鎖定的 DB SSOT（layer_key/category/required_tier/enabled/lock_type）。公開 RPC `get_layer_gates()` 回前 3+lock_type 供前端動態 gating（不含地理資料）。
 - **enforce_layer_access**：鎖定 RPC 的守門 helper，查 profiles.tier vs gated_layers.required_tier，granted 寫 access_audit_log、denied RAISE 42501 + server log。SECURITY DEFINER，故被它守的 RPC 必 VOLATILE。
+
+## 衛星遙測 LST（2026-07-31 加）
+
+- **LST**（Land Surface Temperature）：地表「皮膚」溫度，≠ 氣溫 ≠ 體感；Landsat C2 L2 ST_B10 產品，`°C = DN×0.00341802 + 149 − 273.15`（DN=0 為 nodata）
+- **ΔT（熱島強度）**：像元 LST − 郊區背景中位數（WorldCover cropland 遮罩）；跨日期可比，絕對溫度不可比
+- **STAC**：衛星影像統一目錄 API；Planetary Computer 免帳號可讀 bytes（earth-search 只有 metadata 免費，bytes 在 requester-pays bucket）
+- **COG**：Cloud-Optimized GeoTIFF，支援 HTTP Range 窗格讀取 + 內建 overview 金字塔
+- **WRS-2 path/row**：Landsat 軌道網格；台灣本島 5 景（117/043-045、118/043-044），L8+L9 合併重訪 8 天、過境當地 ~10:20
+- **QA_PIXEL**：逐像元 16-bit 品質旗標；熱島應用剔 bit 0-4（fill/雲系/雲影）+ bit 7（水體，避免拉偏背景）
+- **ST_QA**：逐像元溫度不確定度（存 ×0.01 K）；門檻用 per-path/row 分位數（P75），不用絕對常數（北台暖季中位數就 3.76K）
+- **raster-color-mix**：mapbox raster 動態上色的通道係數 = 物理斜率 ×255（詳 PRINCIPLES）

--- a/.claude/memory/INCIDENTS.md
+++ b/.claude/memory/INCIDENTS.md
@@ -1336,3 +1336,21 @@ drive 5min radius 2739m，榮興偏移 5306m > radius → polygon 完全不在 s
 ### 事件 D：KHH 機場無資料 = collector ENDPOINTS 漏收 + VM 手動部署陷阱
 高雄 KHH1（入境）/KHH5（出境）端點從未列入 ENDPOINTS（前端/RPC 都正確；curl 驗證端點活著格式一致）。補上後本地跑一輪 1,289 筆進 DB、commit `a2f158a` 已 push。⚠ 生產實跑的是 HiCloud VM（210.61.15.74）cron 版，檔案手動 SCP 不接 git——**git push 不會生效**；Zeabur 版因移民署 API 擋國際雲商 IP 而 enabled=false。VM 更新待用戶執行（G013），未更新前 KHH 只有 7/26 一次性資料。
 **教訓**：`external/` 目錄的 collector 先讀部署說明再談上線；「push 了」≠「部署了」。
+
+---
+
+## 2026-07-29/31 — 溫度三部曲（溫度網格 / 微感測模式 / 都市熱島 LST）
+
+### 事件 A：raster-color-mix 係數 shader 推導翻車 → 像素取樣定案
+實作 agent 讀 mapbox-gl 3.9 原始碼（`computeRasterColorMix` 帶 ×255 factor）推導出「mix 係數作用在 0–255 原始 DN」，據此推翻上游 handoff 的 ×255 寫法、連帶宣判既有 canopyHeight 也是壞的；主 agent code review + tsc + 197 tests 全放行。瀏覽器驗收像素取樣戳破：全島單色飽和在 range 下限（(35,86,139) 無漸層），而 canopy 對照組漸層正常 → 正確模型是「texture 取樣正規化 0–1，係數 = 物理斜率 ×255」（51=255/5、63.75=255/4）。修正後複驗：三都會 RGB 各異、山脈藍系、海面/澎湖透明。
+- 教訓：shader 換算鏈太長（style→computeRasterColorMix→uniform→GLSL），單看原始碼片段推導必翻車；係數對錯以畫面像素實測為準；**推翻 working 範本前先實測 working 範本**。→ PRINCIPLES 新增。
+- 附帶小修：popup 溫度是點擊快照但「時間」欄讀 module 層 live 值 → 開著面板拖時間軸出現時溫錯配，改 `useMemo(..., [props])` 凍結同刻。
+
+### 事件 B：#92 squash merge 刪 base branch → stacked PR #93 被 GitHub 自動關閉
+#93（base=feat/temperature-grid-2d）在 #92 merge + branch 刪除後被**自動 CLOSED**（GitHub 不 retarget 到 master、直接關），內容未進 master；用戶手動重發 #94 才補上。#96 記取教訓：`git rebase --onto origin/master <舊base尖>` 落到最新 master 再發 PR（過程解掉與 #95 的 import 衝突）。→ PRINCIPLES 新增。
+
+### 事件 C：LST pipeline 三個資料層教訓（SSOT：analytics 方法論文件）
+① 直讀 COG 實測 30–50KB/s + GDAL 27 reader 並行壅塞崩潰 → 改 Planetary Computer server-side crop API（快 10 倍；限流表現為「收下連線永不回應」→ timeout 150s + 退避；並行 6→16 實測 0 失敗，監看要看耗時分布不是 error log）。② ST_QA 絕對門檻 3K 在北台暖季丟 85% 像元 → 改 per-path/row P75 相對分位數（南部 5.1–5.2K vs 北部 4.4K，實證必要）。③ 逐景背景中位數被雲遮罩取樣偏差綁架（35 景背景散布 21K）→ 全島版用 WorldCover cropland 統一背景遮罩 + 景級樣本守門。詳：`taipei-gis-analytics/docs/topic-research/remote_sensing/urban-heat-lst-methodology.md`。
+
+### 事件 D：weather_change/.env 明文 AWS S3 key（未進 git，僅本機磁碟）
+探索 weather_change 時發現本機 `.env` 含明文 `S3_ACCESS_KEY`/`S3_SECRET_KEY`（`.gitignore` 有擋、未外洩；git 只追蹤 .env.example）。移植過程未複製任何憑證進 pulse。建議輪替該組 key → BACKLOG G016。

--- a/.claude/memory/PLAYBOOKS.md
+++ b/.claude/memory/PLAYBOOKS.md
@@ -1499,3 +1499,16 @@ SOP：
 5. 常數：ROW_HEIGHT 40 / GAP 10 / 堆疊斷點 1100px（容器實寬非視窗寬）；cell 高 = h×40+(h-1)×10；**堆疊模式 cell 必設 flexShrink:0**（flex column 子元素不設會被壓縮塞進容器而非溢出捲動）
 
 成效：v1→v5 每輪 <10 分鐘，用戶自助拖版、工程端只換一個檔。
+
+## PB-31 raster PMTiles 值編碼圖層（2026-07-31 定型：canopyHeight + urbanHeat 兩例）
+
+單/雙分量連續值 raster 上地圖的標準流程（完整方法論：analytics `docs/topic-research/remote_sensing/urban-heat-lst-methodology.md` §7）：
+
+1. **上游烤磚**（taipei-gis-analytics）：GeoTIFF → 值編碼 RGBA（R=量化數值、G 可放第二通道、A=nodata mask）
+   → `gdal_translate -of MBTILES TILE_FORMAT=PNG BLOCKSIZE=512` → `gdaladdo -r nearest`
+   （⚠ 值磚金字塔必 **nearest**——average 會把 nodata 的 DN=0 平均進來，海岸/雲洞長出假值邊）
+   → `pmtiles convert`。範本：`pipelines/environment/urban_heat_lst/tile_lst_pmtiles.sh`、`pipelines/forestry/canopy_height_meta/tile_canopy_pmtiles.sh`
+2. **量化參數**：`DN = round((值 − offset) × scale)`，值域用**該資料實際分布** P2–P98 訂（勿沿用試作版——POC 值域拿到全島 69% 像元貼地板）；寫進 `encoding.json` + handoff（前端硬編 mix 的契約源）
+3. **前端接線**（pulse）：overlayRegistry raster config（`pmtiles.minzoom/maxzoom` 對齊實際磚層級，z 超過 = 討不存在的磚）+ `raster-color-mix = [物理斜率×255, …, offset]`（見 PRINCIPLES）+ stop 寫物理值 + `raster-color-range` 用通道完整值域；nodata 靠 source alpha 自動透明
+4. **多模式切換** = 換 mix 通道 + 色帶 + range（零重載）；色票/值域抽 `src/data/xxxTypes.ts` SSOT，layer 與 legend 同源
+5. **驗收**：像素取樣（多點 RGB 彼此相異 + nodata 透明見底圖）+ 拿 canopy 當對照組；大檔 gitignore 走 S3 deploy-assets 三處接線 + upload script glob

--- a/.claude/memory/PRINCIPLES.md
+++ b/.claude/memory/PRINCIPLES.md
@@ -923,3 +923,27 @@ Python `json` 與 `jq` 都接受 `Infinity` / `-Infinity` / `NaN` 非標準 lite
 - 確定失效（如直播下播）→ 先補查替代，找到才換、找不到才清
 - 配 TTL（如 48h 未驗證才清）防殭屍殘留
 反例：舊 yt resolver 失敗即整列清空，在 0.3% 成功率下等於每天只有 5 分鐘有資料（TVBS 三年沒換的 ID 也活不過下一輪）。寫入層 transform 是無條件整列覆寫時，sticky 要做在 collector 層。
+
+## raster 值編碼圖層的 raster-color-mix 係數（⚠ P0，2026-07-31 實測定案）
+
+mapbox-gl 3.x 的 `raster-color-mix` 係數作用在「正規化 0–1 的 texture 取樣值」上：
+**mix = 物理 decode 斜率 ×255**（canopy `6.375=255/40`、urbanHeat `51=255/5` / `63.75=255/4`），
+offset 不變；`["raster-value"]` 與 `raster-color` stop 一律寫物理值。
+
+- **禁止**依 mapbox-gl 原始碼片段推導改用未 ×255 的物理斜率——2026-07-30 實測會讓整層飽和在
+  range 下限、單色無漸層（shader 換算鏈太長，片段推導必翻車）。
+- **驗收鐵則**：raster / shader 類實作一律以「畫面像素取樣」定案——多點 RGB 彼此相異＝有漸層、
+  nodata 區透明見底圖；不信原始碼推導、不信 code review。既有 working 圖層（canopyHeight）
+  就是現成對照組，**推翻它之前先實測它**。
+- nodata 一律靠 source alpha（mapbox 會把 A 乘進上色結果），不要加透明 stop、不要用哨兵值判斷
+  （量化後 DN=0 是合法物理值）。
+
+## Stacked PR merge 順序（2026-07-31 教訓）
+
+GitHub squash merge + **刪除 base branch** 時，以該 branch 為 base 的 stacked PR 會被
+**自動 CLOSED**（不會 retarget 到 master），內容不會進 master——#93 因此蒸發、靠手動重發 #94 補回。
+
+- Stacked PR 一律**由底往上依序 merge**；每 merge 一層，立刻把上層
+  `git rebase --onto origin/master <舊 base 尖>` 落到最新 master 再更新/重發 PR。
+- 或 merge base PR 時**先不刪 branch**，等整條鏈 merge 完再清。
+- 看到 PR 莫名 CLOSED + CONFLICTING：先查 base branch 是否已被刪，不要急著解衝突。

--- a/.claude/memory/REFLECTIONS.md
+++ b/.claude/memory/REFLECTIONS.md
@@ -1090,3 +1090,17 @@ memory commit 動 `.claude/memory/`，不會撞到 code 變動，但**不要 pus
 1. **agent 回報裡的異常描述詞要追**（「密集顯示」「意外插曲」）——自驗通過 ≠ 視覺正確，截圖必親看
 2. **登入態 bug 第一反應想「兩種身分的權限路徑差異」**：anon vs authenticated 的 GRANT/RLS 靜默分歧，SET ROLE 實測最快（→ 已入 PRINCIPLES）
 3. **寫死外部資源 ID 前先 oembed 驗身分**（常設直播 vs 單場），三秒避免殭屍（→ 已入 INCIDENTS C）
+
+## 2026-07-29/31 溫度三部曲（三圖層 + LST 衛星 pipeline 全鏈）
+
+### What went well
+- **探索先行省掉整條移植**：weather_change 兩個 agent 平行偵察發現其溫度資料源頭 = pulse 既有 `get_temperature_*` RPC → 「移植」縮成「只搬色階與呈現方式」；同一輪偵察順帶挖出 EPA IoT 端點復活（→ MC-1）與 .env 金鑰問題（→ G016）——好的偵察 prompt 產出遠超任務本身
+- **雙層驗收第三次立功**：mix 係數 bug 通過了實作 agent 的原始碼推導 + 主 agent code review + tsc/197 tests，只有瀏覽器像素取樣攔下（前兩次：Infinity JSON、tourism 0 點）
+- **對照組思維**：canopy（working 範本）被 agent 推導宣判「也是壞的」，瀏覽器一驗反殺——一個在 production 正常運作的範本，證據力高於任何原始碼推導
+- **方法論落地成教學文件**：LST 全鏈寫成可遷移方法論（STAC→位元遮罩→分位數門檻→多年 median→相對正規化→值編碼），用戶點名要學；上線後的「坑洞為什麼」問答直接回收成 §8a FAQ——被問的問題就是文件的缺口
+- **agent 有憑據的偏離值得鼓勵**：A2a 自主換傳輸方式（實測四種吞吐）、放寬 ST_QA（附分布統計）、加景級守門（接邊差 11.45K→0.79K）都對；反例是 A2b 的 mix 推導——差別在**有沒有拿實測當證據**
+
+### Next-time rules
+1. **agent 引原始碼推翻既有慣例時，先實測既有慣例再採用**——尤其結論會連帶宣判 working code 也是壞的時（→ 已入 PRINCIPLES）
+2. **raster/shader 類驗收必含像素取樣**：多點 RGB 彼此相異才算有漸層，「看起來有顏色」不夠（→ 已入 PRINCIPLES + PB-31）
+3. **stacked PR 由底往上快速 merge、勿讓 base 先被刪**；發現 PR 莫名 CLOSED 先查 base branch 存亡（→ 已入 PRINCIPLES）

--- a/.claude/memory/STATUS.md
+++ b/.claude/memory/STATUS.md
@@ -1,6 +1,26 @@
 # Status
 
-**最後更新**：2026-07-27（monitor 三部曲 PR #89/#90/#91 全 merged + migration 318-320 apply + yt resolver Data API 重寫部署）
+**最後更新**：2026-07-31（溫度三部曲 PR #92/#94/#96 全 merged + LST pipeline 上線 + migration 322 + S3 上傳；prod 差一次 redeploy）
+**mini-taiwan-pulse head**：`master` = `4e50116`（#96 urbanHeat 疊 #95 市值 `3a55e46`〔他 session〕疊 #94 微感測 `c302f4c` 疊 #92 溫度網格 `8fbcdd7`）
+**gis-platform head**：`main` = `eca0b83`（migration 322 site_name，已 apply production + push）
+**taipei-gis-analytics head**：`master` = `8b36a19`（LST pipeline + 方法論 + handoff，已 push）；**未 commit 殘留（他 session）**：部署 SOP 12 步治理 5 檔 + street_trees_4epoch `_manifest.json`
+**data-collectors head**：不變（G013 KHH VM SCP 仍 open）
+
+> ⚠️ **prod 上線最後一哩**：master + S3（`deploy-assets/environment/urban_heat_lst_taiwan.pmtiles` 30MB 已驗證存在）都就緒，**差一次 Zeabur redeploy**（pull 端 environment/ sync 早已存在）。
+> 工作樹既有未提交（他 session，勿動）：AGENTS.md / CLAUDE.md / public/climate/* / docs/git-workflow.md。
+
+## 本 session 完成（2026-07-29~31）— 溫度三部曲（溫度網格 2D / 微感測三模式 / 都市熱島 LST）
+
+- **PR #92 溫度網格 2D**（`8fbcdd7`）：CWA 0.03° 溫度網格用原生 fill layer 平面呈現（可疊圖），與 3D 溫度波**共用同一組 RPC**（任一層開啟才抓一次）；11 級固定色階移植 weather_change——偵察發現該站資料源頭就是 pulse 既有 `get_temperature_*`，零 pipeline 移植；幾何一次建成 + feature-state 染色 + timeStore lerp 三道節流；四鐵則全接、無白名單豁免
+- **PR #94 LASS 微感測三模式**（`c302f4c`）：點位上色 PM2.5/溫度/濕度 select（溫度色階直接 import `temperatureGridTypes`，跨層同源）+ 三套圖例（把 aqiMicroSensors 移出 BASELINE_NO_LEGEND）+ popup 站名（gis-platform migration 322 補 `site_name`，已 apply + push `eca0b83`）。#93 被 GitHub 自動關閉事故 → INCIDENTS 事件 B
+- **PR #96 都市熱島 Urban Heat**（`4e50116`）：Landsat 8/9 C2L2 ST_B10、5 path/row 193 景 2019–2025 暖季 median（60m 全島、WorldCover cropland 統一郊區背景、ST_QA per-path/row P75）→ 雙通道值編碼 raster PMTiles 30MB（z6–11@512，R=ΔT/G=絕對°C/A=mask）→ 前端 raster-color 雙模式切換。**mix 係數 ×255 bug 由瀏覽器像素取樣攔下**（INCIDENTS 事件 A）；澎湖上游無資料（圖例已註）；接 #95 後 rebase 解 import 衝突再 merge
+- **研究與文件**：LST 方法論教學版落地 analytics（`8b36a19`，含 §8a 坑洞成因 FAQ）+ handoff + pulse feature docs；微感測上游盤點——EPA IoT 端點已遷移 `sta.colife.org.tw` 且實測復活（10,983 點 = LASS 22 倍，→ MC-1）、LASS 死欄位盤清（hcho/model/gps_alt 不做）；魚塭遙測確認早已完整歸檔（4 個待拍板懸案留用戶）
+- **編排**：12+ agents（探索 4 / 實作 4 / 瀏覽器驗收 4），三段驗收全程（tsc/tests 獨立重跑 + diff 親審 + browser 像素取樣）；LST POC quicklook 親驗通過才放行全島版
+- 待辦：**MC-1~5**（微氣候系列，見 BACKLOG）/ **G016**（weather_change S3 key 輪替）/ prod redeploy（用戶按一下）
+
+---
+
+**前次更新**：2026-07-27（monitor 三部曲 PR #89/#90/#91 全 merged + migration 318-320 apply + yt resolver Data API 重寫部署）
 **mini-taiwan-pulse head**：`master` = `015a8b0`（#91 ER 網格+直播牆 疊 #90 靜態網格 `3888014` 疊 #89 修復 `919f695`）+ 本批 memory/docs commits 未 push
 **gis-platform head**：`main` + **未 commit：migration 318/319/320（皆已 apply production 在跑）+ 更早的 301**（BACKLOG G014）
 **data-collectors head**：`main` = `d8b6f10`（yt resolver Data API v3 + sticky，已部署 Zeabur + YOUTUBE_API_KEY）；`a2f158a`（KHH 端點）已 push 但 **生產 VM 未 SCP**（G013）


### PR DESCRIPTION
## Summary

溫度三部曲 session（#92 溫度網格 / #94 微感測三模式 / #96 都市熱島 LST）的 memory 收尾：8 檔各一顆 atomic commit（照 /wrap-up SOP），**請用 rebase merge 保留逐檔演進歷史**（squash 會壓成一顆）。

## Changes

- INCIDENTS +1 段 4 事件（mix 係數翻車 / #93 自動關閉 / LST 資料層 / S3 key）
- PRINCIPLES +2（raster-color-mix ×255 像素定案 / stacked PR merge 順序）
- PLAYBOOKS +PB-31（raster PMTiles 值編碼圖層 SOP）
- GLOSSARY +衛星遙測 8 詞
- REFLECTIONS +1 篇（3 條 next-time rules）
- BACKLOG +MC 系列 ×5 + G016
- DATA_SCOPE +衛星 LST 資產段
- STATUS rewrite（2026-07-31 現況）

## Test

- [x] 純 memory 文件，無程式碼變更

🤖 Generated with [Claude Code](https://claude.com/claude-code)