### PR TITLE
feat(earthquake-replay): 地震回放圖層（清單 RPC + 分層五步回放 + 沙灘球自繪）

### DIFF
--- a/docs/features/earthquake-replay/README.md
+++ b/docs/features/earthquake-replay/README.md
@@ -1,0 +1,37 @@
+# Earthquake Replay（地震回放）
+
+> **Slug**：`earthquakeReplay`
+> **狀態**：done（agent-browser 端到端驗收通過，2026-07-31 PR merge）
+> **Owner**：migu
+> **上線時分支**：`feat/earthquake-replay`
+> **memory 時點**：2026-07-31
+
+## 一句話說明
+
+選一起地震重播它的擴散過程：震央爆開 → 測站依 S 波抵達順序（`epicenter_distance_km / 3.5`）逐顆亮起 → 等震度網格由震央向外展開 → 鄉鎮面量圖定格 → 沙灘球收尾。依素材完整度分兩級：**Tier A**（有 town+grid，完整五步）／**Tier B**（僅測站，簡化三步：震央→測站→沙灘球）。
+
+## 圖層清單（1 個 key、5 個視覺元件）
+
+| Layer key | 視覺元件 | 資料源 |
+|---|---|---|
+| `earthquakeReplay` | 震央 burst / S 波前圈 / 測站 circle / 網格 fill / 鄉鎮 choropleth / 沙灘球 Marker | Supabase 清單 RPC + 四張明細表（見資料契約） |
+
+## 關鍵檔案
+
+- 清單+明細 loader：`src/data/earthquakeReplayLoader.ts`（RPC cachedOnce 15min + per-event keyedThunkCache 30min，全包 withLoading）
+- 色階/型別 SSOT：`src/data/earthquakeReplayTypes.ts`（CWA 震度 0-7 含 5弱/5強/6弱/6強 + `townCodeToPmtilesCode` + haversine + `eventTier`）
+- Layer factory：`src/map/earthquakeReplayLayerFactory.ts`（5 元件 source/layer + 沙灘球 Marker）
+- Hook / 回放引擎：`src/hooks/useEarthquakeReplayLayer.ts`
+- 回放時鐘：`src/state/earthquakeReplayClock.ts`（external store，比照 timeStore 慣例；通知節流 10Hz）
+- UI：`src/components/EarthquakeReplayPanel.tsx`（左側浮動面板，比照 PropertyValuePanel；事件清單 + Tier badge + play/pause/scrub/重播）
+- 沙灘球 SVG：`src/lib/beachball.ts`（strike/dip/rake → 下半球等面積投影自繪；對 tecdc 官方圖 4/4 方位驗證；aux plane 公式對真實資料誤差 <0.01°）
+
+## 資料契約摘要
+
+- 事件清單：`supabase.rpc("earthquake_replay_events")`（gis-platform mig 324）。**resolved key 契約**：`has_x = true ⟺ x_key 非 NULL ⟺ 用該 key 等值查明細一定撈得到列`。±90s（grid）/±5s（town）時間窗配對全在 DB 端，**前端禁止自己做時間窗**。
+- 明細（全等值查詢）：測站 `eq(event_id)`；鄉鎮 `eq(origin_time, town_origin_time)`；網格 `eq(event_time, grid_event_time).gt(intensity, 0)`（~3,300 列，partial index）；機制解 `eq(origin_time_utc, tensor_origin_utc)`，**A 解優先 fallback R**（庫內目前全 R 是常態）。
+- 鄉鎮 choropleth：自建 source `eq-replay-township`（`township_boundary.pmtiles` + `promoteId: {township_boundary: "TOWNCODE"}`），**不走 overlayManager**（比照 useRoadCongestionLayer）。CWA 7 碼 → PMTiles 8 碼轉換規則見 `earthquakeReplayTypes.ts`（368/368 逐筆驗證）。
+
+## 回放引擎
+
+時鐘單位=「震後真實秒數」，RAF 以 `dt × rate` 推進（rate = duration ÷ 26s 牆鐘目標，clamp 0.4–4），存 external store 不進 React deps → 回放期間 App 零 re-render。所有視覺都是當前時鐘的**純函數**（feature-state 每幀重算、量化去抖），所以 scrub = set 時鐘即可。播畢 clamp + 回呼關 playing。獨立 scoped 播放器，**不掛全域 timeStore**（時間尺度不同：秒級 vs 日級）。

--- a/docs/features/earthquake-replay/backlog.md
+++ b/docs/features/earthquake-replay/backlog.md
@@ -1,0 +1,11 @@
+# Earthquake Replay — Backlog
+
+| # | 項目 | 備註 |
+|---|---|---|
+| 1 | 海嘯註記 | `tsunami_alerts`（80 筆，2023 起）尚未接；可在事件清單/回放加海嘯 badge + WarningArea/TsuStation popup（注意兩種子結構 optional chaining） |
+| 2 | 選事件自動 flyTo 震央 | 本次刻意不做（預設全景可看完整動畫）；若用戶反映找不到震央再加 |
+| 3 | 既有 earthquakes ripple ↔ 回放銜接 | 規劃時的構想：earthquakes popup 加「回放這起」按鈕直接開回放；本次未做 |
+| 4 | 沙灘球 SVG 平滑化 | 目前 raster 掃描 + RLE 矩形，有鋸齒；可改解析節面曲線路徑（功能無礙，純美觀） |
+| 5 | moment_tensor A 修訂解驗證 | 庫內目前全是 R 快解；首次出現 A 解時驗證「A 優先 fallback R」實際行為 |
+| 6 | town_intensity autovacuum 觀察 | 該表從未 vacuum，RPC 的 Index Only Scan 有 Heap Fetches 736；autovacuum 跑過自動歸零，無需動作，僅記錄 |
+| 7 | 回放事件累積後的清單 UX | 事件數成長到 100+ 時考慮分頁/篩選（規模門檻、只看 Tier A） |

--- a/docs/features/earthquake-replay/changelog.md
+++ b/docs/features/earthquake-replay/changelog.md
@@ -1,0 +1,12 @@
+# Earthquake Replay — Changelog
+
+## 2026-07-31 初版上線（feat/earthquake-replay）
+
+- `earthquakeReplay` 圖層：事件清單（34 起，Tier A/B badge）+ scoped 播放器（play/pause/scrub/重播，×0.4–4 自動壓縮倍率）
+- Tier A 五步編排（震央→測站 S 波亮起→網格波前展開→鄉鎮定格→沙灘球）；Tier B 三步
+- 專案首個「統計值 join 行政區 polygon」choropleth（township PMTiles promoteId + feature-state）
+- 沙灘球 strike/dip/rake 自繪 SVG（`src/lib/beachball.ts`，對官方圖 4/4 方位驗證）
+- gis-platform mig 324 清單 RPC（resolved key 模式，時間窗封裝 DB 端）
+- **順手修**：本土 `earthquakes` 圖層補 click popup（現存四鐵則違規；ripple 動畫圈刻意不做點擊目標避免搶點擊；本土 CWA 排 USGS 之前）
+- 四鐵則全接：opacity slider / CWA 震度圖例 / 測站+鄉鎮 popup / select
+- 驗證：tsc -b 零錯、212 測試全綠、agent-browser 端到端（楠西五步、scrub、dispose 無殘影）

--- a/docs/features/earthquake-replay/handoff.md
+++ b/docs/features/earthquake-replay/handoff.md
@@ -1,0 +1,24 @@
+# Earthquake Replay — 跨 repo handoff（反向引用）
+
+> 資料側 SSOT：`../../../../taipei-gis-analytics/docs/handoff/earthquake-replay.md`（2026-07-31 已修正 town join 約定）
+
+## 跨 repo 對照
+
+| Repo | 內容 | Commit/PR |
+|---|---|---|
+| data-collectors | `earthquake_town_intensity.py`（CWA E-A0015-005）+ `earthquake_shakemap_grid.py`（NCDR EQ1），15min cycle，Zeabur | PR #40（2026-07-29 上線） |
+| gis-platform | mig 321 六表 + mig 324 `earthquake_replay_events()` 清單 RPC | PR #43 / PR #45 |
+| taipei-gis-analytics | handoff 文件 + api-platforms/{cwa,tecdc,ncdr} + systems/seismic_tic.md | PR #28 + f935e95（handoff 修正） |
+| mini-taiwan-pulse | 本 feature（前端全部） | feat/earthquake-replay PR |
+
+## 上游查證結論（2026-07-31，實查 collector 程式碼 + DB）
+
+1. **pipeline 自動累積已實證**：115053（07-30 台東成功 M4.7）零人工介入、發震後 10~24 分鐘自動進庫（town+grid+tensor 全到）。
+2. **上線前事件永久缺 town+grid**：CWA/NCDR 源頭是「只留最新一次」的無狀態快照，07-29 上線前的事件（如 115051 雙溪 M5.6）已被覆寫、**不可回補**。非深源問題、非 bug。
+3. **town origin_time 有初報/修訂 1 秒漂移**（115053 實測）：mig 324 用 ±5s 窗吸收並回傳 resolved key，前端等值查詢即可。
+
+## 前端硬依賴（上游改動時要跟）
+
+- RPC `earthquake_replay_events()` 的 signature（resolved key 欄位名）
+- 四張明細表欄位：station_obs（epicenter_distance_km/intensity_value/pga_int）、town_intensity（town_code/intensity_value）、shakemap_grid（lon/lat/intensity + partial index `intensity > 0`）、moment_tensor（strike/dip/rake ×2 + solution_type）
+- `township_boundary.pmtiles` 的 source-layer 名 `township_boundary` 與 `TOWNCODE` 屬性（8 碼格式）

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -37,6 +37,7 @@ import { useNewsEventsLayer } from "./hooks/useNewsEventsLayer";
 import { useSelectedFeatureHalo } from "./hooks/useSelectedFeatureHalo";
 import { useSatellitesLayer } from "./hooks/useSatellitesLayer";
 import { useEarthquakeLayer } from "./hooks/useEarthquakeLayer";
+import { useEarthquakeReplayLayer } from "./hooks/useEarthquakeReplayLayer";
 import { useEarthquakesGlobalLayer } from "./hooks/useEarthquakesGlobalLayer";
 import { useWorldTrashDebrisLayer } from "./hooks/useWorldTrashDebrisLayer";
 import { useTyphoonTracksLayer, type TyphoonSource } from "./hooks/useTyphoonTracksLayer";
@@ -130,6 +131,8 @@ import { IntelPanel } from "./components/intel/IntelPanel";
 import { MonitorPanel } from "./components/intel/monitor/MonitorPanel";
 import { SatelliteConsole } from "./components/satelliteConsole/SatelliteConsole";
 import { PropertyValuePanel } from "./components/PropertyValuePanel";
+import { EarthquakeReplayPanel } from "./components/EarthquakeReplayPanel";
+import { earthquakeReplayClock } from "./state/earthquakeReplayClock";
 import { satelliteConsoleStore, useSatelliteConsole } from "./state/satelliteConsoleStore";
 import { useSatelliteManeuvers } from "./hooks/useSatelliteManeuvers";
 import { TimelineControls } from "./components/TimelineControls";
@@ -1039,6 +1042,18 @@ export default function App() {
     layerVisibility.earthquakes,
     transportParams.eqOpacity,
     transportParams.eqShowHistory,
+  );
+
+  // ── 地震回放（scoped 播放器，時鐘在 earthquakeReplayClock，不掛 timeStore）──
+  const [eqReplaySelectedId, setEqReplaySelectedId] = useState<string | null>(null);
+  const [eqReplayPlaying, setEqReplayPlaying] = useState(false);
+  useEarthquakeReplayLayer(
+    mapRef,
+    layerVisibility.earthquakeReplay,
+    transportParams.eqReplayOpacity,
+    eqReplaySelectedId,
+    eqReplayPlaying,
+    useCallback(() => setEqReplayPlaying(false), []),
   );
 
   // ── 全球氣候 GLOBAL CLIMATE（migration 261）──
@@ -2036,6 +2051,24 @@ export default function App() {
           <PropertyValuePanel
             open={propertyValueOpen}
             onClose={() => setPropertyValueOpen(false)}
+          />
+
+          {/* 🌋 地震回放 Earthquake Replay（事件清單 + 播放控制） */}
+          <EarthquakeReplayPanel
+            open={layerVisibility.earthquakeReplay}
+            onClose={() => setLayerVisibility((prev) => ({ ...prev, earthquakeReplay: false }))}
+            selectedId={eqReplaySelectedId}
+            onSelect={(ev) => {
+              setEqReplaySelectedId(ev.event_id);
+              setEqReplayPlaying(true);
+              earthquakeReplayClock.reset();
+            }}
+            playing={eqReplayPlaying}
+            onTogglePlay={() => setEqReplayPlaying((p) => !p)}
+            onReplay={() => {
+              earthquakeReplayClock.reset();
+              setEqReplayPlaying(true);
+            }}
           />
 
           {/* 即時情報 Intel Panel */}

--- a/src/components/EarthquakeReplayPanel.tsx
+++ b/src/components/EarthquakeReplayPanel.tsx
@@ -1,0 +1,293 @@
+/**
+ * EarthquakeReplayPanel — 地震回放事件清單 + 播放控制
+ *
+ * 左 docked 面板，幾何 / token 沿用 PropertyValuePanel（left:64 top:98 bottom:130）；
+ * 播放控制列的排版沿用 intel/IntelReplay（play/pause + scrub + 時間標籤）。
+ *
+ * 分層回放（見 earthquakeReplayTypes.eventTier）：
+ * - Tier A（有鄉鎮震度 + 等震度網格）→ 五步完整回放，badge「完整」
+ * - Tier B（只有測站）→ 三步簡化回放，badge「測站」
+ *
+ * 進度條走 `earthquakeReplayClock` external store（通知節流 10Hz），
+ * 只有本面板重繪；回放引擎的 RAF 不會讓 App.tsx re-render。
+ */
+import { useEffect, useState, useSyncExternalStore } from "react";
+import { Rewind, Play, Pause, RotateCcw, X } from "lucide-react";
+import { COLORS, FONT_CJK, FONT_DATA, RADIUS, FONT_SIZE } from "../styles/designTokens";
+import { fetchReplayEvents } from "../data/earthquakeReplayLoader";
+import { eventTier, type EarthquakeReplayEvent } from "../data/earthquakeReplayTypes";
+import { earthquakeReplayClock } from "../state/earthquakeReplayClock";
+
+const PANEL_WIDTH = 322;
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  selectedId: string | null;
+  onSelect: (ev: EarthquakeReplayEvent) => void;
+  playing: boolean;
+  onTogglePlay: () => void;
+  onReplay: () => void;
+}
+
+function magColor(m: number): string {
+  if (m >= 6) return "#dc2626";
+  if (m >= 5) return "#f97316";
+  if (m >= 4) return "#facc15";
+  return "#94a3b8";
+}
+
+function fmtTaipei(iso: string): string {
+  try {
+    return new Date(iso).toLocaleString("zh-TW", {
+      timeZone: "Asia/Taipei",
+      month: "2-digit",
+      day: "2-digit",
+      hour: "2-digit",
+      minute: "2-digit",
+      hour12: false,
+    });
+  } catch {
+    return iso;
+  }
+}
+
+/** 「臺南市政府東北東方 36.7 公里 (位於臺南市楠西區)」→「臺南市楠西區」 */
+function shortLocation(loc: string): string {
+  const m = /位於(.+?)\)/.exec(loc);
+  return (m?.[1] ?? loc).trim();
+}
+
+export function EarthquakeReplayPanel({
+  open, onClose, selectedId, onSelect, playing, onTogglePlay, onReplay,
+}: Props) {
+  const [events, setEvents] = useState<EarthquakeReplayEvent[] | null>(null);
+  const [failed, setFailed] = useState(false);
+
+  const clock = useSyncExternalStore(
+    earthquakeReplayClock.subscribe,
+    earthquakeReplayClock.getSnapshot,
+    earthquakeReplayClock.getSnapshot,
+  );
+
+  useEffect(() => {
+    if (!open || events) return;
+    let alive = true;
+    fetchReplayEvents()
+      .then((d) => { if (alive) setEvents(d); })
+      .catch((e) => {
+        console.warn("[EarthquakeReplay] 事件清單載入失敗:", e);
+        if (alive) setFailed(true);
+      });
+    return () => { alive = false; };
+  }, [open, events]);
+
+  if (!open) return null;
+
+  const hasTimeline = clock.duration > 0;
+
+  return (
+    <div
+      style={{
+        position: "fixed",
+        left: 64,
+        top: 98,
+        bottom: 130,
+        width: PANEL_WIDTH,
+        background: COLORS.panelBg,
+        backdropFilter: "blur(16px)",
+        WebkitBackdropFilter: "blur(16px)",
+        border: `1px solid ${COLORS.panelBorder}`,
+        boxShadow: "0 12px 40px rgba(0,0,0,0.45)",
+        borderRadius: RADIUS.xl,
+        zIndex: 30,
+        display: "flex",
+        flexDirection: "column",
+        overflow: "hidden",
+        pointerEvents: "auto",
+        color: COLORS.textDefault,
+        fontFamily: FONT_CJK,
+      }}
+    >
+      {/* ── Header ── */}
+      <div
+        style={{
+          display: "flex", alignItems: "center", gap: 9,
+          padding: "13px 14px 11px",
+          borderBottom: `1px solid ${COLORS.panelBorder}`,
+          flexShrink: 0,
+        }}
+      >
+        <Rewind size={17} color={COLORS.accent} strokeWidth={1.6} style={{ flexShrink: 0 }} />
+        <div style={{ display: "flex", flexDirection: "column", lineHeight: 1.15 }}>
+          <span style={{ fontSize: 13.5, fontWeight: 700, color: COLORS.textStrong }}>地震回放</span>
+          <span style={{ fontFamily: FONT_DATA, fontSize: FONT_SIZE.xs, letterSpacing: "2.5px", color: COLORS.textDim }}>
+            EARTHQUAKE REPLAY
+          </span>
+        </div>
+        <div style={{ flex: 1 }} />
+        <button
+          onClick={onClose}
+          aria-label="close"
+          style={{
+            width: 24, height: 24, borderRadius: RADIUS.md, border: "none",
+            background: "transparent", color: COLORS.textDim,
+            display: "flex", alignItems: "center", justifyContent: "center", cursor: "pointer",
+          }}
+        >
+          <X size={14} />
+        </button>
+      </div>
+
+      {/* ── 事件清單 ── */}
+      <div className="layer-sidebar-scroll" style={{ flex: 1, overflowY: "auto", padding: "8px 8px 10px" }}>
+        {failed && (
+          <div style={{ fontSize: FONT_SIZE.base, color: COLORS.textFaint, padding: "10px 6px" }}>
+            ⚠ 事件清單載入失敗（earthquake_replay_events）
+          </div>
+        )}
+        {!failed && !events && (
+          <div style={{ fontSize: FONT_SIZE.base, color: COLORS.textFaint, padding: "10px 6px" }}>載入中…</div>
+        )}
+        {events?.length === 0 && (
+          <div style={{ fontSize: FONT_SIZE.base, color: COLORS.textFaint, padding: "10px 6px" }}>目前沒有可回放的地震</div>
+        )}
+
+        {events?.map((ev) => {
+          const tier = eventTier(ev);
+          const active = ev.event_id === selectedId;
+          return (
+            <button
+              key={ev.event_id}
+              onClick={() => onSelect(ev)}
+              style={{
+                width: "100%",
+                display: "flex",
+                alignItems: "center",
+                gap: 8,
+                padding: "7px 8px",
+                marginBottom: 3,
+                textAlign: "left",
+                cursor: "pointer",
+                borderRadius: RADIUS.lg,
+                border: `1px solid ${active ? COLORS.borderAccent : "transparent"}`,
+                background: active ? COLORS.accentFaint : "rgba(255,255,255,0.03)",
+                color: COLORS.textDefault,
+                fontFamily: FONT_CJK,
+              }}
+            >
+              <span
+                style={{
+                  fontFamily: FONT_DATA,
+                  fontSize: FONT_SIZE.md,
+                  fontWeight: 700,
+                  color: magColor(ev.magnitude),
+                  width: 34,
+                  flexShrink: 0,
+                }}
+              >
+                M{ev.magnitude.toFixed(1)}
+              </span>
+              <span style={{ flex: 1, minWidth: 0, display: "flex", flexDirection: "column", gap: 1 }}>
+                <span
+                  style={{
+                    fontSize: FONT_SIZE.base,
+                    color: active ? COLORS.textStrong : COLORS.textDefault,
+                    whiteSpace: "nowrap",
+                    overflow: "hidden",
+                    textOverflow: "ellipsis",
+                  }}
+                >
+                  {shortLocation(ev.location)}
+                </span>
+                <span style={{ fontFamily: FONT_DATA, fontSize: FONT_SIZE.xs, color: COLORS.textDim }}>
+                  {fmtTaipei(ev.occurred_at)} · {ev.station_count} 站 · {ev.depth_km.toFixed(0)}km
+                </span>
+              </span>
+              <span
+                title={tier === "A" ? "鄉鎮震度 + 等震度網格 + 測站（五步回放）" : "僅測站（三步回放）"}
+                style={{
+                  flexShrink: 0,
+                  fontSize: FONT_SIZE.xs,
+                  fontWeight: 700,
+                  padding: "2px 5px",
+                  borderRadius: RADIUS.sm,
+                  color: tier === "A" ? "#0f172a" : COLORS.textMuted,
+                  background: tier === "A" ? "#fbbf24" : "rgba(255,255,255,0.08)",
+                }}
+              >
+                {tier === "A" ? "完整" : "測站"}
+              </span>
+            </button>
+          );
+        })}
+      </div>
+
+      {/* ── 播放控制（仿 intel/IntelReplay）── */}
+      <div
+        style={{
+          flexShrink: 0,
+          padding: "9px 12px 11px",
+          borderTop: `1px solid ${COLORS.panelBorder}`,
+          background: "rgba(0,0,0,0.3)",
+          display: "flex",
+          flexDirection: "column",
+          gap: 6,
+        }}
+      >
+        <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+          <span style={{ fontFamily: FONT_DATA, fontSize: FONT_SIZE.xs, letterSpacing: "1.5px", color: COLORS.textFaint }}>
+            震後 T+
+          </span>
+          <span style={{ fontFamily: FONT_DATA, fontSize: 11.5, fontWeight: 700, color: hasTimeline ? COLORS.statusWarn : COLORS.textFaint }}>
+            {hasTimeline ? `${clock.clock.toFixed(1)}s` : "—"}
+          </span>
+          <span style={{ fontFamily: FONT_DATA, fontSize: FONT_SIZE.xs, color: COLORS.textDim }}>
+            {hasTimeline ? `/ ${clock.duration.toFixed(0)}s · ×${clock.rate.toFixed(1)}` : "選一起地震"}
+          </span>
+          <div style={{ flex: 1 }} />
+          <button
+            onClick={onTogglePlay}
+            disabled={!hasTimeline}
+            title="play / pause"
+            style={{
+              width: 24, height: 24, borderRadius: RADIUS.md,
+              border: `1px solid ${COLORS.borderMid}`,
+              background: "rgba(255,255,255,0.05)",
+              color: hasTimeline ? COLORS.textDefault : COLORS.textFaint,
+              cursor: hasTimeline ? "pointer" : "default",
+              display: "flex", alignItems: "center", justifyContent: "center",
+            }}
+          >
+            {playing ? <Pause size={11} /> : <Play size={11} />}
+          </button>
+          <button
+            onClick={onReplay}
+            disabled={!hasTimeline}
+            title="重播"
+            style={{
+              width: 24, height: 24, borderRadius: RADIUS.md,
+              border: `1px solid ${COLORS.borderMid}`,
+              background: "rgba(255,255,255,0.05)",
+              color: hasTimeline ? COLORS.textDefault : COLORS.textFaint,
+              cursor: hasTimeline ? "pointer" : "default",
+              display: "flex", alignItems: "center", justifyContent: "center",
+            }}
+          >
+            <RotateCcw size={11} />
+          </button>
+        </div>
+        <input
+          type="range"
+          min={0}
+          max={Math.max(1, clock.duration)}
+          step={0.1}
+          value={clock.clock}
+          disabled={!hasTimeline}
+          onChange={(ev) => earthquakeReplayClock.set(Number(ev.target.value), true)}
+          style={{ width: "100%", height: 3, accentColor: COLORS.accent, cursor: hasTimeline ? "pointer" : "default" }}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/components/IconRailSidebar.tsx
+++ b/src/components/IconRailSidebar.tsx
@@ -24,7 +24,7 @@ import {
   // ENERGY icons
   Zap, PlugZap, Power, Spline, TowerControl, Sun, Sparkles, Building2, Fuel, LayoutGrid,
   // HAZARD icons
-  CloudLightning, Atom,
+  CloudLightning, Atom, Rewind,
   // GLOBAL CLIMATE icons
   Tornado,
   // POLICE / JUSTICE / CIVIL DEFENSE icons（新增；既有 Shield/Search/MapPinned/PlaneTakeoff/Anchor/AlertTriangle/AlertCircle 已 import 復用）
@@ -114,6 +114,7 @@ const LAYER_ICONS: Record<keyof LayerVisibility, LucideIcon> = {
   newsEvents: Radio,
   youbikeFullness: Bike,
   earthquakes: Activity,
+  earthquakeReplay: Rewind,
   lifelineAlerts: Lightbulb,
   floodAlerts: Waves,
   weatherAlerts: CloudRain,

--- a/src/components/LegendPanel.tsx
+++ b/src/components/LegendPanel.tsx
@@ -11,6 +11,7 @@ import { ALERT_GROUPS, ALERT_GROUP_KEYS } from "../data/disasterAlertTypes";
 import { NEWS_CATEGORIES } from "../data/newsEventTypes";
 import { ECO_NETWORK_ZONE_TYPES } from "../data/ecoNetworkZoneTypes";
 import { TEMPERATURE_GRID_BANDS } from "../data/temperatureGridTypes";
+import { CWA_INTENSITY_BANDS } from "../data/earthquakeReplayTypes";
 import { resolveMicroSensorMode, MICRO_SENSOR_NO_DATA_COLOR } from "../data/microSensorTypes";
 import {
   resolveUrbanHeatMode, urbanHeatLegendGradient, urbanHeatStopPercent,
@@ -201,6 +202,7 @@ export interface LegendEntry {
  */
 export const LEGEND_REGISTRY: LegendEntry[] = [
   { keys: ["earthquakes"], render: () => <EarthquakeLegend /> },
+  { keys: ["earthquakeReplay"], render: () => <EarthquakeReplayLegend /> },
   { keys: ["earthquakesGlobal"], render: () => <EarthquakeGlobalLegend /> },
   { keys: ["worldTrashDebris"], render: () => <WorldTrashDebrisLegend /> },
   { keys: ["typhoonTracks"], render: () => <TyphoonTrackLegend /> },
@@ -1930,6 +1932,32 @@ function EarthquakeLegend() {
             );
           })}
         </div>
+      </div>
+    </div>
+  );
+}
+
+// ── 地震回放：CWA 震度色階（測站 circle / 等震度網格 / 鄉鎮面量圖三處同色）──
+
+function EarthquakeReplayLegend() {
+  const t = useLegendTheme();
+  return (
+    <div>
+      <div style={{ fontSize: FONT_SIZE.xs, color: t.textDim, letterSpacing: 1, marginBottom: 4 }}>
+        震度 CWA INTENSITY
+      </div>
+      <div style={{ display: "flex", flexDirection: "column", gap: 1 }}>
+        {CWA_INTENSITY_BANDS.map((band) => (
+          <div key={band.label} style={{ display: "flex", alignItems: "center", gap: 6 }}>
+            <div style={{ width: 14, height: 9, borderRadius: 2, background: band.color, flexShrink: 0 }} />
+            <span style={{ fontSize: FONT_SIZE.xs, color: t.textMuted }}>{band.label}</span>
+          </div>
+        ))}
+      </div>
+      <div style={{ fontSize: FONT_SIZE.xs, color: t.textDim, marginTop: 3, lineHeight: 1.4 }}>
+        圓點 = 測站（大小依 PGA）· 方格 = 2.5km 等震度網格 · 面 = 鄉鎮震度
+        <br />
+        波前依 S 波 3.5 km/s 由震央外擴
       </div>
     </div>
   );

--- a/src/components/featureInfo/hazardPanels.tsx
+++ b/src/components/featureInfo/hazardPanels.tsx
@@ -8,6 +8,7 @@ import {
   classifyNuclearDose, nuclearDoseColor,
   NUCLEAR_LEVEL_LABELS, NUCLEAR_DOSE_THRESHOLDS,
 } from "../../data/nuclearLoader";
+import { intensityColor, intensityLabel } from "../../data/earthquakeReplayTypes";
 
 function fmtAge(ts: unknown): string {
   if (typeof ts !== "number" || !Number.isFinite(ts)) return "—";
@@ -27,6 +28,34 @@ function fmtTime(ts: unknown): string {
     hour: "2-digit", minute: "2-digit", second: "2-digit",
     hour12: false,
   });
+}
+
+/** 發生時間強制以台灣時區顯示（不依賴瀏覽器本地時區） */
+function fmtTimeTaipei(ts: unknown): string {
+  if (typeof ts !== "number" || !Number.isFinite(ts)) return "—";
+  return new Date(ts * 1000).toLocaleString("zh-TW", {
+    year: "numeric", month: "2-digit", day: "2-digit",
+    hour: "2-digit", minute: "2-digit",
+    hour12: false,
+    timeZone: "Asia/Taipei",
+  });
+}
+
+function magBadgeColor(mag: number): string {
+  if (mag >= 7) return "#dc2626";
+  if (mag >= 6) return "#ef4444";
+  if (mag >= 5) return "#f97316";
+  if (mag >= 4) return "#facc15";
+  return "#94a3b8";
+}
+
+// 與 useEarthquakeLayer 的 COLOR_EXPR 同步（依深度分級）
+function depthColor(depth: number): string {
+  if (depth <= 30) return "#ff3b30";
+  if (depth <= 70) return "#ff9500";
+  if (depth <= 150) return "#ffcc00";
+  if (depth <= 300) return "#42a5f5";
+  return "#3949ab";
 }
 
 export function LightningStrikePanel({ props }: { props: Record<string, unknown> }) {
@@ -90,6 +119,73 @@ export function NuclearStationPanel({ props }: { props: Record<string, unknown> 
           ⚠️ 已達 AEC 警戒閾值（&gt; {NUCLEAR_DOSE_THRESHOLDS.warning} µSv/h），建議交叉確認原能會即時頁面。
         </div>
       )}
+    </div>
+  );
+}
+
+/**
+ * 本土地震（CWA earthquake_events，useEarthquakeLayer 的 pre/post 兩態）。
+ * ripple 動畫圈不接 click（見 useMapInteraction GIS_LAYERS 註解）。
+ */
+export function EarthquakePanel({ props }: { props: Record<string, unknown> }) {
+  const t = useFeatureTheme();
+  const mag = typeof props.magnitude === "number" ? props.magnitude : null;
+  const depth = typeof props.depth_km === "number" ? props.depth_km : null;
+  const magColor = mag != null ? magBadgeColor(mag) : t.textDim;
+  const dColor = depth != null ? depthColor(depth) : t.textDim;
+  return (
+    <div>
+      <Row label="規模 (M)" value={mag != null ? `M ${mag.toFixed(1)}` : "—"} color={magColor} />
+      <Row label="深度" value={depth != null ? `${depth.toFixed(1)} km` : "—"} color={dColor} />
+      <Row label="發生時間" value={fmtTimeTaipei(props.occurred_ts)} />
+      <Row label="震央位置" value={String(props.location_desc || "—")} />
+      <Row label="報告類型" value={String(props.report_type || "—")} />
+    </div>
+  );
+}
+
+/**
+ * 地震回放 — 強震測站（earthquake_station_obs）。
+ * 震度色階與網格 / 鄉鎮面量圖同源（earthquakeReplayTypes.CWA_INTENSITY_BANDS）。
+ */
+export function EarthquakeReplayStationPanel({ props }: { props: Record<string, unknown> }) {
+  const iv = typeof props.intensity_value === "number" ? props.intensity_value : null;
+  const pga = typeof props.pga_int === "number" ? props.pga_int : null;
+  const dist = typeof props.epicenter_distance_km === "number" ? props.epicenter_distance_km : null;
+  return (
+    <div>
+      <Row label="測站" value={String(props.station_id ?? "—")} />
+      <Row
+        label="震度"
+        value={iv != null ? intensityLabel(iv) : "—"}
+        color={iv != null ? intensityColor(iv) : undefined}
+      />
+      <Row label="PGA" value={pga != null ? `${pga.toFixed(1)} gal` : "—"} />
+      <Row label="震央距" value={dist != null ? `${dist.toFixed(1)} km` : "—"} />
+      <Row
+        label="S 波抵達"
+        value={dist != null ? `震後 ${(dist / 3.5).toFixed(1)} 秒` : "—"}
+      />
+    </div>
+  );
+}
+
+/**
+ * 地震回放 — 鄉鎮震度（earthquake_town_intensity join 鄉鎮 polygon）。
+ * 震度值來自 feature-state `eqi`（PMTiles 幾何本身沒有震度屬性）。
+ */
+export function EarthquakeReplayTownPanel({ props }: { props: Record<string, unknown> }) {
+  const iv = typeof props.eqi === "number" ? props.eqi : null;
+  return (
+    <div>
+      <Row label="鄉鎮市區" value={String(props.TOWNNAME ?? "—")} />
+      <Row label="縣市" value={String(props.COUNTYNAME ?? "—")} />
+      <Row
+        label="震度"
+        value={iv != null ? intensityLabel(iv) : "—"}
+        color={iv != null ? intensityColor(iv) : undefined}
+      />
+      <Row label="來源" value="CWA 鄉鎮震度報告" />
     </div>
   );
 }

--- a/src/components/featureInfo/registry.tsx
+++ b/src/components/featureInfo/registry.tsx
@@ -64,7 +64,10 @@ import { PowerPlantPanel, OsmSubstationPanel, OsmPowerLinePanel, OsmPowerTowerPa
   GasCoverageAllPanel, GasCoverageCpcPanel, GasCoverageFpccPanel, GasCoverageTaisugarPanel,
   EvIslandPanel,
 } from "./energyPanels";
-import { LightningStrikePanel, NuclearStationPanel } from "./hazardPanels";
+import {
+  LightningStrikePanel, NuclearStationPanel, EarthquakePanel,
+  EarthquakeReplayStationPanel, EarthquakeReplayTownPanel,
+} from "./hazardPanels";
 import { EarthquakeGlobalPanel, TyphoonTrackPanel, ClimateFieldPanel, WorldTrashDebrisPanel } from "./globalClimatePanels";
 import {
   CountyBoundaryPanel, TownshipBoundaryPanel, VillageBoundaryPanel,
@@ -205,6 +208,9 @@ export const PANEL_REGISTRY: Partial<Record<FeatureInfo["layerType"], FC<PanelPr
   evIsland: EvIslandPanel,
   lightningStrike: LightningStrikePanel,
   nuclearStation: NuclearStationPanel,
+  earthquakes: EarthquakePanel,
+  earthquakeReplayStation: EarthquakeReplayStationPanel,
+  earthquakeReplayTown: EarthquakeReplayTownPanel,
   earthquakeGlobal: EarthquakeGlobalPanel,
   typhoonTrack: TyphoonTrackPanel,
   climateField: ClimateFieldPanel,
@@ -458,6 +464,9 @@ export const HEADER_LABELS: Record<FeatureInfo["layerType"], string> = {
   evIsland: "充電站 30km 孤島",
   lightningStrike: "落雷",
   nuclearStation: "核安觀測站",
+  earthquakes: "地震",
+  earthquakeReplayStation: "地震回放 強震測站",
+  earthquakeReplayTown: "地震回放 鄉鎮震度",
   earthquakeGlobal: "全球地震 USGS",
   typhoonTrack: "颱風軌跡",
   climateField: "氣候場讀值",

--- a/src/components/sidebar/layerCatalog.ts
+++ b/src/components/sidebar/layerCatalog.ts
@@ -76,6 +76,7 @@ export const LAYER_COLORS: Record<keyof LayerVisibility, string> = {
   newsEvents: "#ff9800",
   youbikeFullness: "#f57c00",
   earthquakes: "#ff3b30",
+  earthquakeReplay: "#e11d48",
   // 全球氣候 GLOBAL CLIMATE
   earthquakesGlobal: "#dc2626",
   typhoonTracks: "#a855f7",
@@ -956,6 +957,7 @@ export const THEMES: ThemeDef[] = [
         title: "地震 / 斷層",
         layers: [
           { key: "earthquakes", label: "地震 Earthquake", expandable: true },
+          { key: "earthquakeReplay", label: "地震回放 EQ Replay", expandable: true },
           { key: "activeFaults", label: "活動斷層 Fault Zone", expandable: true },
         ],
       },

--- a/src/data/earthquakeReplayLoader.ts
+++ b/src/data/earthquakeReplayLoader.ts
@@ -1,0 +1,217 @@
+import { supabase } from "../lib/supabase";
+import { withLoading } from "../lib/loadingRegistry";
+import { cachedOnce, keyedThunkCache } from "../lib/loaderCache";
+import {
+  S_WAVE_KM_S,
+  eventTier,
+  haversineKm,
+  townCodeToPmtilesCode,
+  type EarthquakeReplayEvent,
+  type EqReplayDetail,
+  type EqReplayGridCell,
+  type EqReplayStation,
+  type EqReplayTensor,
+  type EqReplayTown,
+} from "./earthquakeReplayTypes";
+
+/**
+ * 地震回放 loader — 清單 RPC + 四種明細。
+ *
+ * ⚠️ 明細一律用 RPC 給的 key **等值查詢**（±90s / ±5s 時間窗配對已做在 DB 端）。
+ * 清單 15min TTL 快取、明細 per-event 快取（切回同一起地震不重打 DB）。
+ * 全部包 withLoading（開發規則 §2）。
+ */
+
+// ── 事件清單 ────────────────────────────────────────────────────────
+
+interface RawEventRow {
+  event_id: string;
+  occurred_at: string;
+  magnitude: number | null;
+  depth_km: number | null;
+  epicenter_lat: number | null;
+  epicenter_lng: number | null;
+  location: string | null;
+  station_count: number | null;
+  has_town: boolean | null;
+  town_origin_time: string | null;
+  has_grid: boolean | null;
+  grid_event_time: string | null;
+  has_tensor: boolean | null;
+  tensor_origin_utc: string | null;
+}
+
+async function fetchReplayEventsUncached(): Promise<EarthquakeReplayEvent[]> {
+  const { data, error } = await withLoading(
+    "earthquake-replay-events",
+    "地震回放事件清單",
+    supabase.rpc("earthquake_replay_events"),
+  );
+  if (error) throw new Error(`Supabase earthquake_replay_events: ${error.message}`);
+
+  const rows = (data ?? []) as RawEventRow[];
+  const out: EarthquakeReplayEvent[] = [];
+  for (const r of rows) {
+    if (r.epicenter_lat == null || r.epicenter_lng == null) continue;
+    out.push({
+      event_id: r.event_id,
+      occurred_at: r.occurred_at,
+      magnitude: Number(r.magnitude ?? 0),
+      depth_km: Number(r.depth_km ?? 0),
+      epicenter_lat: Number(r.epicenter_lat),
+      epicenter_lng: Number(r.epicenter_lng),
+      location: r.location ?? "",
+      station_count: Number(r.station_count ?? 0),
+      has_town: r.has_town === true,
+      town_origin_time: r.town_origin_time,
+      has_grid: r.has_grid === true,
+      grid_event_time: r.grid_event_time,
+      has_tensor: r.has_tensor === true,
+      tensor_origin_utc: r.tensor_origin_utc,
+    });
+  }
+  return out;
+}
+
+const fetchReplayEventsCached = cachedOnce(fetchReplayEventsUncached, 15 * 60_000);
+
+/** 有回放素材的地震清單（新→舊）。15min TTL，重複開圖層不重抓。 */
+export function fetchReplayEvents(): Promise<EarthquakeReplayEvent[]> {
+  return fetchReplayEventsCached();
+}
+
+// ── 明細（測站 / 鄉鎮 / 網格 / 機制解）─────────────────────────────
+
+async function fetchStations(ev: EarthquakeReplayEvent): Promise<EqReplayStation[]> {
+  const { data, error } = await withLoading(
+    `eq-replay-stations:${ev.event_id}`,
+    `地震回放 測站 ${ev.event_id}`,
+    supabase
+      .from("earthquake_station_obs")
+      .select("station_id, lat, lon, epicenter_distance_km, intensity_value, pga_int")
+      .eq("event_id", ev.event_id)
+      .order("epicenter_distance_km"),
+  );
+  if (error) throw new Error(`Supabase earthquake_station_obs: ${error.message}`);
+  const out: EqReplayStation[] = [];
+  for (const r of (data ?? []) as Record<string, unknown>[]) {
+    const lat = Number(r.lat);
+    const lon = Number(r.lon);
+    if (!Number.isFinite(lat) || !Number.isFinite(lon)) continue;
+    const dist = Number(r.epicenter_distance_km ?? 0);
+    out.push({
+      station_id: String(r.station_id ?? ""),
+      lat,
+      lon,
+      epicenter_distance_km: dist,
+      intensity_value: Number(r.intensity_value ?? 0),
+      pga_int: Number(r.pga_int ?? 0),
+      arrivalSec: dist / S_WAVE_KM_S,
+    });
+  }
+  return out;
+}
+
+async function fetchTowns(ev: EarthquakeReplayEvent): Promise<EqReplayTown[]> {
+  if (!ev.has_town || !ev.town_origin_time) return [];
+  const { data, error } = await withLoading(
+    `eq-replay-towns:${ev.event_id}`,
+    `地震回放 鄉鎮震度 ${ev.event_id}`,
+    supabase
+      .from("earthquake_town_intensity")
+      .select("town_code, town_name, county_name, intensity, intensity_value")
+      .eq("origin_time", ev.town_origin_time),
+  );
+  if (error) throw new Error(`Supabase earthquake_town_intensity: ${error.message}`);
+  const out: EqReplayTown[] = [];
+  for (const r of (data ?? []) as Record<string, unknown>[]) {
+    const code = String(r.town_code ?? "");
+    if (!code) continue;
+    out.push({
+      town_code: code,
+      town_name: String(r.town_name ?? ""),
+      county_name: String(r.county_name ?? ""),
+      intensity: String(r.intensity ?? ""),
+      intensity_value: Number(r.intensity_value ?? 0),
+      pmtilesCode: townCodeToPmtilesCode(code),
+    });
+  }
+  return out;
+}
+
+async function fetchGrid(ev: EarthquakeReplayEvent): Promise<EqReplayGridCell[]> {
+  if (!ev.has_grid || !ev.grid_event_time) return [];
+  // intensity > 0 才拉（DB 有 partial index）：全量 4,377 含大量 0 值外海格，畫了也是透明
+  const { data, error } = await withLoading(
+    `eq-replay-grid:${ev.event_id}`,
+    `地震回放 等震度網格 ${ev.event_id}`,
+    supabase
+      .from("earthquake_shakemap_grid")
+      .select("lon, lat, pga, intensity")
+      .eq("event_time", ev.grid_event_time)
+      .gt("intensity", 0),
+  );
+  if (error) throw new Error(`Supabase earthquake_shakemap_grid: ${error.message}`);
+  const out: EqReplayGridCell[] = [];
+  for (const r of (data ?? []) as Record<string, unknown>[]) {
+    const lon = Number(r.lon);
+    const lat = Number(r.lat);
+    if (!Number.isFinite(lon) || !Number.isFinite(lat)) continue;
+    const distKm = haversineKm(ev.epicenter_lng, ev.epicenter_lat, lon, lat);
+    out.push({
+      lon,
+      lat,
+      pga: Number(r.pga ?? 0),
+      intensity: Number(r.intensity ?? 0),
+      arrivalSec: distKm / S_WAVE_KM_S,
+    });
+  }
+  return out;
+}
+
+async function fetchTensor(ev: EarthquakeReplayEvent): Promise<EqReplayTensor | null> {
+  if (!ev.has_tensor || !ev.tensor_origin_utc) return null;
+  const { data, error } = await withLoading(
+    `eq-replay-tensor:${ev.event_id}`,
+    `地震回放 震源機制解 ${ev.event_id}`,
+    supabase
+      .from("earthquake_moment_tensor")
+      .select("strike1, dip1, rake1, strike2, dip2, rake2, mw, centroid_depth, beachball_url, solution_type")
+      .eq("origin_time_utc", ev.tensor_origin_utc),
+  );
+  if (error) throw new Error(`Supabase earthquake_moment_tensor: ${error.message}`);
+  const rows = (data ?? []) as Record<string, unknown>[];
+  if (rows.length === 0) return null;
+  // 一事件可能兩列（R = 快解 / A = 修訂解）→ A 優先、fallback R（目前庫裡全是 R）
+  const picked = rows.find((r) => String(r.solution_type ?? "") === "A") ?? rows[0]!;
+  return {
+    strike1: Number(picked.strike1 ?? 0),
+    dip1: Number(picked.dip1 ?? 0),
+    rake1: Number(picked.rake1 ?? 0),
+    strike2: Number(picked.strike2 ?? 0),
+    dip2: Number(picked.dip2 ?? 0),
+    rake2: Number(picked.rake2 ?? 0),
+    mw: picked.mw == null ? null : Number(picked.mw),
+    centroid_depth: picked.centroid_depth == null ? null : Number(picked.centroid_depth),
+    beachball_url: picked.beachball_url == null ? null : String(picked.beachball_url),
+    solution_type: String(picked.solution_type ?? ""),
+  };
+}
+
+const detailCache = keyedThunkCache<EqReplayDetail>(30 * 60_000, 12);
+
+/** 某事件的完整回放素材（per-event 快取，切回同一起不重打 DB） */
+export function fetchReplayDetail(ev: EarthquakeReplayEvent): Promise<EqReplayDetail> {
+  return detailCache(ev.event_id, async () => {
+    const [stations, towns, grid, tensor] = await Promise.all([
+      fetchStations(ev),
+      fetchTowns(ev),
+      fetchGrid(ev),
+      fetchTensor(ev),
+    ]);
+    let maxDistKm = 0;
+    for (const s of stations) maxDistKm = Math.max(maxDistKm, s.epicenter_distance_km);
+    for (const c of grid) maxDistKm = Math.max(maxDistKm, c.arrivalSec * S_WAVE_KM_S);
+    return { event: ev, tier: eventTier(ev), stations, towns, grid, tensor, maxDistKm };
+  });
+}

--- a/src/data/earthquakeReplayTypes.ts
+++ b/src/data/earthquakeReplayTypes.ts
@@ -1,0 +1,188 @@
+/**
+ * earthquakeReplayTypes.ts — 地震回放（earthquakeReplay）型別 + CWA 震度色階單一資料源
+ *
+ * 四邊共用（開發規則 §4a 規則 2）：
+ *   1. `src/map/earthquakeReplayLayerFactory.ts` 的 fill/circle color step 表達式
+ *   2. `src/components/LegendPanel.tsx` 的 EarthquakeReplayLegend
+ *   3. `src/components/featureInfo/hazardPanels.tsx` 的測站 / 鄉鎮 panel
+ *   4. `src/components/EarthquakeReplayPanel.tsx` 的事件清單 badge
+ *
+ * 資料鏈：CWA/NCDR/中研院 → Supabase（gis-platform migration 321）。
+ * 契約與踩雷見 `../taipei-gis-analytics/docs/handoff/earthquake-replay.md`。
+ */
+
+// ── CWA 震度色階（0–7 級，含 5弱/5強/6弱/6強）────────────────────────────
+//
+// `intensity_value` 數值化規則（上游已算好，前端只消費）：
+//   5弱 = 5.0 / 5強 = 5.5 / 6弱 = 6.0 / 6強 = 6.5
+// 色系依 CWA 慣例由「無感灰 → 綠 → 黃 → 橙 → 紅 → 紫」推進。
+
+export interface IntensityBand {
+  /** 該級的下界（intensity_value）；step 表達式依此展開，必須嚴格遞增 */
+  value: number;
+  /** CWA 標示（「5弱」而非「5.0」） */
+  label: string;
+  color: string;
+}
+
+export const CWA_INTENSITY_BANDS: IntensityBand[] = [
+  { value: 0,   label: "0級",  color: "#9ca3af" },
+  { value: 1,   label: "1級",  color: "#4ade80" },
+  { value: 2,   label: "2級",  color: "#a3e635" },
+  { value: 3,   label: "3級",  color: "#fde047" },
+  { value: 4,   label: "4級",  color: "#fbbf24" },
+  { value: 5,   label: "5弱",  color: "#f97316" },
+  { value: 5.5, label: "5強",  color: "#ea580c" },
+  { value: 6,   label: "6弱",  color: "#ef4444" },
+  { value: 6.5, label: "6強",  color: "#b91c1c" },
+  { value: 7,   label: "7級",  color: "#a855f7" },
+];
+
+/** intensity_value → 色碼（給 popup / legend；paint 端走 step 表達式，見 factory） */
+export function intensityColor(v: number): string {
+  let out = CWA_INTENSITY_BANDS[0]!.color;
+  for (const band of CWA_INTENSITY_BANDS) {
+    if (v >= band.value) out = band.color;
+  }
+  return out;
+}
+
+/** intensity_value → CWA 標示（5.0 → 「5弱」） */
+export function intensityLabel(v: number): string {
+  let out = CWA_INTENSITY_BANDS[0]!.label;
+  for (const band of CWA_INTENSITY_BANDS) {
+    if (v >= band.value) out = band.label;
+  }
+  return out;
+}
+
+// ── CWA 7 碼 town_code → PMTiles 8 碼 TOWNCODE ─────────────────────────
+//
+// `public/base_map/township_boundary.pmtiles`（source-layer `township_boundary`）
+// 的 TOWNCODE = 「內政部 COUNTYCODE(5) + 鄉鎮序號(2) + '0'」，
+// 而 CWA town_code 是 7 碼且六都與其他縣市格式不對稱：
+//   六都（前 3 碼 630/640/650/660/670/680，COUNTYCODE 實為 63000 等）
+//       6300400 → 630 + '00' + '04' + '0' = 63000040
+//   其他縣市（COUNTYCODE 本身就是前 5 碼）
+//       1000204 → 10002 + '04' + '0'       = 10002040
+// 368/368 已逐筆比對驗證。
+
+const SIX_MUNICIPALITY_PREFIXES = new Set(["630", "640", "650", "660", "670", "680"]);
+
+export function townCodeToPmtilesCode(townCode: string): string {
+  const c = String(townCode);
+  if (SIX_MUNICIPALITY_PREFIXES.has(c.slice(0, 3))) {
+    return `${c.slice(0, 3)}00${c.slice(3, 5)}0`;
+  }
+  return `${c.slice(0, 5)}${c.slice(5, 7)}0`;
+}
+
+// ── 回放物理常數 ────────────────────────────────────────────────────
+/** S 波近似速度（km/s）：測站/網格的「震後抵達秒數」= 震央距 ÷ 此值 */
+export const S_WAVE_KM_S = 3.5;
+/** NCDR 等震度網格解析度（度）；cell 以格點為中心 ±half 展開 */
+export const SHAKEMAP_CELL_DEG = 0.025;
+
+/** 兩點球面距離（km），用於網格 cell → 震央距離（DB 未存） */
+export function haversineKm(lon1: number, lat1: number, lon2: number, lat2: number): number {
+  const R = 6371;
+  const toRad = (d: number) => (d * Math.PI) / 180;
+  const dLat = toRad(lat2 - lat1);
+  const dLon = toRad(lon2 - lon1);
+  const a =
+    Math.sin(dLat / 2) ** 2 +
+    Math.cos(toRad(lat1)) * Math.cos(toRad(lat2)) * Math.sin(dLon / 2) ** 2;
+  return 2 * R * Math.asin(Math.min(1, Math.sqrt(a)));
+}
+
+// ── 資料型別 ────────────────────────────────────────────────────────
+
+/**
+ * `public.earthquake_replay_events()` RPC 一列。
+ *
+ * ⚠️ 契約：`has_x === true ⟺ x 對應的 key 非 null ⟺ 用該 key **等值查詢**必有列。
+ * ±90s / ±5s 時間窗配對已全做在 DB 端，前端一律等值查，禁止自己算時間窗。
+ * `event_id` 為 opaque string（格式不對稱，不要 parse）。
+ */
+export interface EarthquakeReplayEvent {
+  event_id: string;
+  occurred_at: string;
+  magnitude: number;
+  depth_km: number;
+  epicenter_lat: number;
+  epicenter_lng: number;
+  location: string;
+  station_count: number;
+  has_town: boolean;
+  town_origin_time: string | null;
+  has_grid: boolean;
+  grid_event_time: string | null;
+  has_tensor: boolean;
+  tensor_origin_utc: string | null;
+}
+
+export interface EqReplayStation {
+  station_id: string;
+  lat: number;
+  lon: number;
+  epicenter_distance_km: number;
+  intensity_value: number;
+  pga_int: number;
+  /** 震後抵達秒數（= epicenter_distance_km / S_WAVE_KM_S），loader 端算好 */
+  arrivalSec: number;
+}
+
+export interface EqReplayTown {
+  town_code: string;
+  town_name: string;
+  county_name: string;
+  intensity: string;
+  intensity_value: number;
+  /** PMTiles feature id（promoteId: TOWNCODE） */
+  pmtilesCode: string;
+}
+
+export interface EqReplayGridCell {
+  lon: number;
+  lat: number;
+  pga: number;
+  intensity: number;
+  /** 震後抵達秒數（cell 中心到震央距離 ÷ S 波速），loader 端算好 */
+  arrivalSec: number;
+}
+
+export interface EqReplayTensor {
+  strike1: number;
+  dip1: number;
+  rake1: number;
+  strike2: number;
+  dip2: number;
+  rake2: number;
+  mw: number | null;
+  centroid_depth: number | null;
+  beachball_url: string | null;
+  solution_type: string;
+}
+
+/**
+ * 分層回放：
+ * - Tier A（has_town && has_grid）：五步完整回放（震央→測站→網格波前→鄉鎮定格→沙灘球）
+ * - Tier B（其餘）：三步簡化（震央→測站→沙灘球）
+ */
+export type EqReplayTier = "A" | "B";
+
+export function eventTier(ev: EarthquakeReplayEvent): EqReplayTier {
+  return ev.has_town && ev.has_grid ? "A" : "B";
+}
+
+export interface EqReplayDetail {
+  event: EarthquakeReplayEvent;
+  tier: EqReplayTier;
+  stations: EqReplayStation[];
+  towns: EqReplayTown[];
+  grid: EqReplayGridCell[];
+  /** A 解優先、fallback R 解；無機制解為 null */
+  tensor: EqReplayTensor | null;
+  /** 測站 + 網格的最遠震央距（km），回放長度由此反推 */
+  maxDistKm: number;
+}

--- a/src/data/upstreamRegistry.ts
+++ b/src/data/upstreamRegistry.ts
@@ -389,6 +389,11 @@ export const UPSTREAM_REGISTRY: Record<keyof LayerVisibility, UpstreamRef> = {
     status: 'verified',
     datasets: [{ datasetId: 'earthquake', confidence: 'HIGH' }],
   },
+  earthquakeReplay: {
+    status: 'verified',
+    datasets: [{ datasetId: 'earthquake', confidence: 'HIGH' }],
+    processing: 'CWA/NCDR/中研院五件套（事件 / 逐站 PGA / 368 鄉鎮震度 / 2.5km 等震度網格 / 震源機制解）合成單一事件回放動畫',
+  },
   activeFaults: {
     status: 'verified',
     datasets: [{ datasetId: 'earthquake', confidence: 'LOW' }],

--- a/src/hooks/useEarthquakeReplayLayer.ts
+++ b/src/hooks/useEarthquakeReplayLayer.ts
@@ -1,0 +1,355 @@
+import { useEffect, useRef, useState } from "react";
+import type { Map as MapboxMap } from "mapbox-gl";
+import { fetchReplayDetail, fetchReplayEvents } from "../data/earthquakeReplayLoader";
+import {
+  S_WAVE_KM_S,
+  type EqReplayDetail,
+} from "../data/earthquakeReplayTypes";
+import { earthquakeReplayClock } from "../state/earthquakeReplayClock";
+import {
+  EQ_REPLAY_EPICENTER_LAYER,
+  EQ_REPLAY_GRID_SOURCE,
+  EQ_REPLAY_STATION_SOURCE,
+  EQ_REPLAY_TOWN_SOURCE,
+  EQ_REPLAY_TOWN_SOURCE_LAYER,
+  createBeachballMarker,
+  ensureEarthquakeReplayLayers,
+  epicenterToGeoJSON,
+  gridToGeoJSON,
+  metersToPixels,
+  removeBeachballMarker,
+  removeEarthquakeReplayLayers,
+  setEarthquakeReplayVisible,
+  setReplayEpicenterData,
+  setReplayEpicenterFrame,
+  setReplayGridData,
+  setReplayGridOpacity,
+  setReplayStationData,
+  setReplayStationOpacity,
+  setReplayTownOpacity,
+  stationsToGeoJSON,
+  updateBeachball,
+  type BeachballHandle,
+} from "../map/earthquakeReplayLayerFactory";
+
+/**
+ * 地震回放（earthquakeReplay）— 生命週期 + 回放引擎。
+ *
+ * ⚠️ 這是**獨立 scoped 播放器**，刻意不掛全域 timeStore：
+ * 回放時鐘的單位是「震後真實秒數」，跟 timeline 的 unix 秒無關（開發規則 §8 約束的是
+ * 消費 timeline 的圖層）。時鐘存 `earthquakeReplayClock`（external store，見該檔說明），
+ * 由本檔自帶 RAF 推進（比照 useEarthquakeLayer 的 ripple 自帶 RAF），
+ * **不進 React state deps**，所以整個回放期間 App.tsx 不會 re-render。
+ *
+ * 所有視覺都是「當前時鐘」的純函數 → scrub 只要把時鐘設到任意值，下一幀畫面自動正確。
+ *
+ * 五步編排（Tier A：has_town && has_grid）
+ *   t=0        震央爆開（規模定大小）+ S 波前圈由震央向外擴張
+ *   t=d/3.5    測站依震央距逐顆亮起（色=intensity_value / 大小=pga_int）
+ *   同步        等震度網格 cell 隨同一波前淡入（cell 到震央距 ÷ 3.5 = 出現時刻）
+ *   波前掃完    368 鄉鎮面量圖定格淡入（網格同時壓暗，讓面量圖讀得出來）
+ *   收尾        震央彈出沙灘球（有 moment tensor 才有）
+ * Tier B（只有測站）= 震央 → 測站 → 沙灘球 三步。
+ */
+
+/** 目標牆鐘播放長度（秒）；壓縮倍率由「回放總長 ÷ 此值」反推 */
+const TARGET_WALL_SEC = 26;
+const RATE_MIN = 0.4;
+const RATE_MAX = 4;
+/** 鄉鎮面量圖淡入時長（回放時鐘秒） */
+const TOWN_FADE_SEC = 6;
+/** 沙灘球彈出時長（回放時鐘秒） */
+const BEACH_POP_SEC = 3;
+/** 收尾定格（回放時鐘秒） */
+const TAIL_SEC = 2.5;
+/** 震央爆開時長（回放時鐘秒） */
+const BURST_SEC = 1.2;
+
+interface ReplayTimeline {
+  waveEndSec: number;
+  townStartSec: number;
+  townFadeSec: number;
+  beachStartSec: number;
+  beachPopSec: number;
+  durationSec: number;
+  /** 回放時鐘秒 / 牆鐘秒 */
+  rate: number;
+  /** 測站淡入 / 彈跳時長（回放時鐘秒，隨 rate 縮放讓牆鐘觀感一致） */
+  stationFadeSec: number;
+  stationFlashSec: number;
+  gridFadeSec: number;
+}
+
+function buildTimeline(d: EqReplayDetail): ReplayTimeline {
+  const waveEndSec = Math.max(4, d.maxDistKm / S_WAVE_KM_S);
+  const hasTown = d.tier === "A" && d.towns.length > 0;
+  const townStartSec = waveEndSec;
+  const townFadeSec = hasTown ? TOWN_FADE_SEC : 0;
+  const beachStartSec = townStartSec + townFadeSec;
+  const beachPopSec = d.tensor ? BEACH_POP_SEC : 0;
+  const durationSec = beachStartSec + beachPopSec + TAIL_SEC;
+  const rate = Math.min(RATE_MAX, Math.max(RATE_MIN, durationSec / TARGET_WALL_SEC));
+  return {
+    waveEndSec,
+    townStartSec,
+    townFadeSec,
+    beachStartSec,
+    beachPopSec,
+    durationSec,
+    rate,
+    stationFadeSec: 0.6 * rate,
+    stationFlashSec: 1.8 * rate,
+    gridFadeSec: 1.0 * rate,
+  };
+}
+
+function clamp01(v: number): number {
+  return v < 0 ? 0 : v > 1 ? 1 : v;
+}
+
+/** 震央圈半徑（px）依規模 */
+function magRadiusPx(m: number): number {
+  const stops: [number, number][] = [[2, 6], [4, 11], [5, 15], [6, 21], [7, 29]];
+  if (m <= stops[0]![0]) return stops[0]![1];
+  for (let i = 1; i < stops.length; i++) {
+    const [x1, y1] = stops[i]!;
+    const [x0, y0] = stops[i - 1]!;
+    if (m <= x1) return y0 + ((m - x0) / (x1 - x0)) * (y1 - y0);
+  }
+  return stops[stops.length - 1]![1];
+}
+
+export function useEarthquakeReplayLayer(
+  mapRef: React.RefObject<MapboxMap | null>,
+  visible: boolean,
+  opacity: number,
+  selectedEventId: string | null,
+  playing: boolean,
+  onEnded?: () => void,
+) {
+  const [detail, setDetail] = useState<EqReplayDetail | null>(null);
+  /** mapRef 還沒填時的重試 tick（production 首載 map "load" 可能晚於資料就緒） */
+  const [mapRetry, setMapRetry] = useState(0);
+
+  const playingRef = useRef(playing);
+  playingRef.current = playing;
+  const opacityRef = useRef(opacity);
+  opacityRef.current = opacity;
+  const onEndedRef = useRef(onEnded);
+  onEndedRef.current = onEnded;
+
+  const timelineRef = useRef<ReplayTimeline | null>(null);
+  const beachballRef = useRef<BeachballHandle | null>(null);
+  /** 各 feature 上次已套用的量化值（-1 = 從未寫入） */
+  const stationAppliedRef = useRef<Int16Array | null>(null);
+  const gridAppliedRef = useRef<Int16Array | null>(null);
+  const townStateDoneRef = useRef(false);
+  const lastTownBucketRef = useRef(-1);
+
+  // ── 選中事件 → 載明細 ──
+  useEffect(() => {
+    if (!visible || !selectedEventId) {
+      setDetail(null);
+      return;
+    }
+    let cancelled = false;
+    fetchReplayEvents()
+      .then((events) => {
+        const ev = events.find((e) => e.event_id === selectedEventId);
+        if (!ev) throw new Error(`event ${selectedEventId} not in replay list`);
+        return fetchReplayDetail(ev);
+      })
+      .then((d) => {
+        if (!cancelled) setDetail(d);
+      })
+      .catch((err) => {
+        console.warn("[EarthquakeReplay] detail load failed:", err);
+        if (!cancelled) setDetail(null);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [visible, selectedEventId]);
+
+  // ── 建圖層 + 灌幾何 + 回放引擎（RAF）──
+  useEffect(() => {
+    const map = mapRef.current;
+    if (!map) {
+      if (!visible) return;
+      const timer = setInterval(() => {
+        if (mapRef.current) setMapRetry((v) => v + 1);
+      }, 200);
+      return () => clearInterval(timer);
+    }
+
+    if (!visible || !detail) {
+      // 圖層關閉 / 未選事件 → 清乾淨，不留殘影
+      removeBeachballMarker(beachballRef.current);
+      beachballRef.current = null;
+      if (map.getLayer(EQ_REPLAY_EPICENTER_LAYER)) setEarthquakeReplayVisible(map, false);
+      earthquakeReplayClock.clear();
+      return;
+    }
+
+    if (!ensureEarthquakeReplayLayers(map, opacityRef.current)) return;
+
+    const tl = buildTimeline(detail);
+    timelineRef.current = tl;
+    earthquakeReplayClock.setTimeline(tl.durationSec, tl.rate);
+
+    const { event, stations, towns, grid, tensor } = detail;
+    setReplayEpicenterData(map, epicenterToGeoJSON(event));
+    setReplayStationData(map, stationsToGeoJSON(stations));
+    setReplayGridData(map, gridToGeoJSON(grid));
+
+    // 換事件：舊 feature-state 全清（不清會讓上一起地震的顏色殘留在網格 / 鄉鎮）
+    map.removeFeatureState({ source: EQ_REPLAY_STATION_SOURCE });
+    map.removeFeatureState({ source: EQ_REPLAY_GRID_SOURCE });
+    map.removeFeatureState({ source: EQ_REPLAY_TOWN_SOURCE, sourceLayer: EQ_REPLAY_TOWN_SOURCE_LAYER });
+    stationAppliedRef.current = new Int16Array(stations.length).fill(-1);
+    gridAppliedRef.current = new Int16Array(grid.length).fill(-1);
+    townStateDoneRef.current = false;
+    lastTownBucketRef.current = -1;
+
+    setEarthquakeReplayVisible(map, true);
+    setReplayStationOpacity(map, opacityRef.current);
+    setReplayGridOpacity(map, opacityRef.current, 1);
+    setReplayTownOpacity(map, opacityRef.current, 0);
+
+    // 沙灘球（有機制解才有；節面 1 即可畫，double-couple 對偶性見 beachball.ts）
+    if (tensor) {
+      beachballRef.current = createBeachballMarker(
+        map,
+        [event.epicenter_lng, event.epicenter_lat],
+        { strike: tensor.strike1, dip: tensor.dip1, rake: tensor.rake1 },
+      );
+    }
+
+    /** 368 鄉鎮 feature-state 一次寫完（顯示與否純靠 fill-opacity 淡入），source loaded 後才可靠 */
+    const flushTownState = () => {
+      if (townStateDoneRef.current || towns.length === 0) return;
+      if (!map.isSourceLoaded(EQ_REPLAY_TOWN_SOURCE)) return;
+      for (const t of towns) {
+        map.setFeatureState(
+          { source: EQ_REPLAY_TOWN_SOURCE, sourceLayer: EQ_REPLAY_TOWN_SOURCE_LAYER, id: t.pmtilesCode },
+          { eqi: t.intensity_value },
+        );
+      }
+      townStateDoneRef.current = true;
+    };
+
+    /** 把時鐘 t（震後真實秒數）對應的畫面套上去 —— 純函數，scrub 直接復用 */
+    const render = (t: number) => {
+      // 1) 震央爆開 + S 波前
+      const burst = clamp01(t / BURST_SEC);
+      const baseR = magRadiusPx(event.magnitude);
+      const overshoot = 1 + 0.45 * Math.sin(Math.PI * burst);
+      const waveKm = S_WAVE_KM_S * t;
+      const waveLifetime = tl.waveEndSec + 2;
+      setReplayEpicenterFrame(map, {
+        coreRadiusPx: baseR * (0.25 + 0.75 * burst) * overshoot,
+        coreOpacity: 0.85 * burst * opacityRef.current,
+        waveRadiusPx: t <= 0 ? 0 : metersToPixels(waveKm * 1000, event.epicenter_lat, map.getZoom()),
+        waveOpacity: t <= 0 ? 0 : 0.7 * clamp01(1 - t / waveLifetime) * opacityRef.current,
+        waveWidth: 1 + 2.2 * clamp01(1 - t / waveLifetime),
+      });
+
+      // 2) 測站逐顆亮起（量化到 1/50，只寫差異）
+      const stApplied = stationAppliedRef.current;
+      if (stApplied && map.isSourceLoaded(EQ_REPLAY_STATION_SOURCE)) {
+        for (let i = 0; i < stations.length; i++) {
+          const age = t - stations[i]!.arrivalSec;
+          const lit = clamp01(age / tl.stationFadeSec);
+          const flash = age < 0 ? 0 : clamp01(1 - age / tl.stationFlashSec);
+          // lit / flash 各 0–50 打包成一個整數，省一個陣列
+          const packed = Math.round(lit * 50) * 64 + Math.round(flash * 50);
+          if (stApplied[i] === packed) continue;
+          stApplied[i] = packed;
+          map.setFeatureState(
+            { source: EQ_REPLAY_STATION_SOURCE, id: i },
+            { lit, flash },
+          );
+        }
+      }
+
+      // 3) 網格 cell 隨波前淡入（量化到 1/10；未到波前的 cell 從不寫入 → 預設全透明）
+      const gApplied = gridAppliedRef.current;
+      if (gApplied && grid.length > 0 && map.isSourceLoaded(EQ_REPLAY_GRID_SOURCE)) {
+        for (let i = 0; i < grid.length; i++) {
+          const on = clamp01((t - grid[i]!.arrivalSec) / tl.gridFadeSec);
+          const q = Math.round(on * 10);
+          if (gApplied[i] === q) continue;
+          if (gApplied[i] === -1 && q === 0) continue; // 預設已透明，不必寫
+          gApplied[i] = q;
+          map.setFeatureState({ source: EQ_REPLAY_GRID_SOURCE, id: i }, { on: q / 10 });
+        }
+      }
+
+      // 4) 鄉鎮面量圖定格淡入（網格同步壓暗）
+      if (tl.townFadeSec > 0) {
+        flushTownState();
+        const fade = clamp01((t - tl.townStartSec) / tl.townFadeSec);
+        const bucket = Math.round(fade * 40);
+        if (bucket !== lastTownBucketRef.current) {
+          lastTownBucketRef.current = bucket;
+          const f = bucket / 40;
+          setReplayTownOpacity(map, opacityRef.current, f);
+          setReplayGridOpacity(map, opacityRef.current, 1 - 0.55 * f);
+        }
+      }
+
+      // 5) 沙灘球彈出
+      const bb = beachballRef.current;
+      if (bb) {
+        const pop = tl.beachPopSec > 0 ? clamp01((t - tl.beachStartSec) / tl.beachPopSec) : 0;
+        updateBeachball(bb, pop, opacityRef.current);
+      }
+    };
+
+    // RAF：時鐘推進 + 每幀重算（暫停時仍跑，讓 scrub 立即反映）
+    let raf = 0;
+    let lastMs = performance.now();
+    const tick = (now: number) => {
+      raf = requestAnimationFrame(tick);
+      const dt = Math.min(0.25, (now - lastMs) / 1000); // 分頁切回來時 dt 可能極大 → clamp
+      lastMs = now;
+      if (playingRef.current) {
+        const next = earthquakeReplayClock.get() + dt * tl.rate;
+        if (next >= tl.durationSec) {
+          earthquakeReplayClock.set(tl.durationSec, true);
+          onEndedRef.current?.();
+        } else {
+          earthquakeReplayClock.set(next);
+        }
+      }
+      render(earthquakeReplayClock.get());
+    };
+    raf = requestAnimationFrame(tick);
+    // 註：不另接 sourcedata —— RAF 每幀都會 render，且 render 內部已用 isSourceLoaded
+    //     把「source 尚未就緒」的 feature-state 寫入延到下一幀，自然重試。
+
+    return () => {
+      cancelAnimationFrame(raf);
+      removeBeachballMarker(beachballRef.current);
+      beachballRef.current = null;
+      if (map.getLayer(EQ_REPLAY_EPICENTER_LAYER)) setEarthquakeReplayVisible(map, false);
+    };
+  }, [mapRef, visible, detail, mapRetry]);
+
+  // ── 圖層關閉：source / layer 一併拆掉，dispose 乾淨 ──
+  useEffect(() => {
+    if (visible) return;
+    const map = mapRef.current;
+    if (!map) return;
+    removeEarthquakeReplayLayers(map);
+    earthquakeReplayClock.clear();
+  }, [mapRef, visible]);
+
+  // ── 透明度 slider ──
+  useEffect(() => {
+    const map = mapRef.current;
+    if (!map || !visible) return;
+    setReplayStationOpacity(map, opacity);
+    setReplayGridOpacity(map, opacity, 1 - 0.55 * clamp01(lastTownBucketRef.current / 40));
+  }, [mapRef, opacity, visible, detail]);
+}

--- a/src/hooks/useMapInteraction.ts
+++ b/src/hooks/useMapInteraction.ts
@@ -271,6 +271,11 @@ export function useMapInteraction(
           { layers: ["coverage-ev-island-line"], type: "evIsland" },
           { layers: ["hazard-lightning-core", "hazard-lightning-halo"], type: "lightningStrike" },
           { layers: ["hazard-nuclear-core", "hazard-nuclear-halo"], type: "nuclearStation" },
+          // 本土地震（useEarthquakeLayer 的 pre/post 兩態，穩定半徑可點；
+          // ripple 動畫圈半徑會瞬時放大到 60~80px+ 且持續變動，納入點擊會蓋過其他層的既有命中範圍，故不收）
+          { layers: ["earthquake-post", "earthquake-pre"], type: "earthquakes" },
+          // 地震回放：測站點層可點；鄉鎮面量圖是大面積 fill → 排到最後段（見下方 GIS_LAYERS 末尾）
+          { layers: ["eq-replay-station-circle"], type: "earthquakeReplayStation" },
           // 全球氣候 GLOBAL CLIMATE
           { layers: ["earthquakes-global-circle"], type: "earthquakeGlobal" },
           // 🌍 世界 WORLD
@@ -448,6 +453,8 @@ export function useMapInteraction(
           { layers: ["police-iso-substation-fill", "police-iso-substation-line"], type: "policeIsoSubstation" },
           { layers: ["police-iso-precinct-fill", "police-iso-precinct-line"], type: "policeIsoPrecinct" },
           { layers: ["police-iso-city-dept-fill", "police-iso-city-dept-line"], type: "policeIsoCityDept" },
+          // 地震回放 鄉鎮面量圖：368 鄉鎮大面積 fill → 排在點/線層之後
+          { layers: ["eq-replay-town-fill"], type: "earthquakeReplayTown" },
           // 溫度網格 2D：鋪滿全台陸地的大面積 fill → 放最末，不擋任何點/線層
           { layers: ["temperature-grid-fill"], type: "temperatureGrid" },
         ];
@@ -471,11 +478,14 @@ export function useMapInteraction(
               }
             }
             if (!coords) coords = [e.lngLat.lng, e.lngLat.lat];
-            // roadCongestion 的 level / temperatureGrid 的 temp 在 feature-state
-            //（非 baked properties）→ 併入
-            const properties = type === "roadCongestion" || type === "temperatureGrid"
-              ? { ...(f.properties ?? {}), ...(f.state ?? {}) }
-              : (f.properties ?? {});
+            // roadCongestion 的 level / temperatureGrid 的 temp / earthquakeReplayTown 的 eqi
+            // 在 feature-state（非 baked properties）→ 併入
+            const properties =
+              type === "roadCongestion" ||
+              type === "temperatureGrid" ||
+              type === "earthquakeReplayTown"
+                ? { ...(f.properties ?? {}), ...(f.state ?? {}) }
+                : (f.properties ?? {});
             setFeatureInfo({ layerType: type, properties, coords });
             sessionTracker.log("feature_click", { layerType: type });
             found = true;

--- a/src/hooks/useTransportParams.ts
+++ b/src/hooks/useTransportParams.ts
@@ -519,6 +519,8 @@ export function useTransportParams() {
   // Earthquake
   const [eqOpacity, setEqOpacity] = useState(1.0);
   const [eqShowHistory, setEqShowHistory] = useState(false);
+  // 地震回放（earthquakeReplay）
+  const [eqReplayOpacity, setEqReplayOpacity] = useState(0.95);
   // Disaster Alerts
   const [daOpacity, setDaOpacity] = useState(1.0);
   // Road Events
@@ -1799,6 +1801,10 @@ export function useTransportParams() {
         { label: `Opacity ${eqOpacity.toFixed(2)}`, value: eqOpacity, min: 0, max: 1, step: 0.05, onChange: setEqOpacity },
         { type: "select" as const, label: "Mode", value: eqShowHistory ? "history" : "timeline", options: [{ label: "Timeline", value: "timeline" }, { label: "History", value: "history" }], onChange: (v: string) => setEqShowHistory(v === "history") },
       ];
+      // 事件選擇 / 播放控制在 EarthquakeReplayPanel（清單 + scrub 塞不進 240px sidebar，鐵則 4）
+      case "earthquakeReplay": return [
+        { label: `透明度 ${eqReplayOpacity.toFixed(2)}`, value: eqReplayOpacity, min: 0, max: 1, step: 0.05, onChange: setEqReplayOpacity },
+      ];
       // ── 全球氣候 GLOBAL CLIMATE ──
       case "earthquakesGlobal": return [
         { label: `透明度 ${earthquakesGlobalOpacity.toFixed(2)}`, value: earthquakesGlobalOpacity, min: 0, max: 1, step: 0.05, onChange: setEarthquakesGlobalOpacity },
@@ -2884,6 +2890,7 @@ export function useTransportParams() {
     tempGridOpacity,
     eqOpacity,
     eqShowHistory,
+    eqReplayOpacity,
     daOpacity,
     reOpacity,
     satOpacity,

--- a/src/lib/__tests__/beachball.test.ts
+++ b/src/lib/__tests__/beachball.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from "vitest";
+import { beachballSvg, nodalVectors, auxiliaryPlane, isCompressional } from "../beachball";
+
+describe("nodalVectors", () => {
+  it("normal 與 slip 互相垂直（單位向量）", () => {
+    const { normal, slip } = nodalVectors({ strike: 41.62, dip: 36.35, rake: 117.37 });
+    const dot = normal[0] * slip[0] + normal[1] * slip[1] + normal[2] * slip[2];
+    expect(Math.abs(dot)).toBeLessThan(1e-9);
+  });
+
+  it("dip=90 / rake=±90 / rake=0,180 邊界情況不產生 NaN", () => {
+    const cases = [
+      { strike: 30, dip: 90, rake: 45 },
+      { strike: 10, dip: 45, rake: 90 },
+      { strike: 10, dip: 45, rake: -90 },
+      { strike: 10, dip: 45, rake: 0 },
+      { strike: 10, dip: 45, rake: 180 },
+      { strike: 0, dip: 90, rake: 0 },
+    ];
+    for (const c of cases) {
+      const { normal, slip } = nodalVectors(c);
+      for (const v of [...normal, ...slip]) {
+        expect(Number.isNaN(v)).toBe(false);
+      }
+    }
+  });
+});
+
+describe("auxiliaryPlane", () => {
+  // 用 Supabase earthquake_moment_tensor 4 筆真實解驗證（strike1/dip1/rake1 反推
+  // 應接近資料庫給的 strike2/dip2/rake2）
+  const realEvents: Array<{ plane1: { strike: number; dip: number; rake: number }; plane2: { strike: number; dip: number; rake: number } }> = [
+    { plane1: { strike: 41.62, dip: 36.35, rake: 117.37 }, plane2: { strike: 188.89, dip: 58.24, rake: 71.31 } },
+    { plane1: { strike: 356.71, dip: 17.05, rake: 70.85 }, plane2: { strike: 196.67, dip: 73.92, rake: 95.75 } },
+    { plane1: { strike: 62.45, dip: 50.94, rake: 149.62 }, plane2: { strike: 172.72, dip: 66.88, rake: 43.25 } },
+    { plane1: { strike: 82.57, dip: 24.04, rake: 134.77 }, plane2: { strike: 215.2, dip: 73.19, rake: 72.56 } },
+  ];
+
+  it.each(realEvents)("由 plane1 算出的 aux plane 接近真實 plane2 ($plane1.strike)", ({ plane1, plane2 }) => {
+    const aux = auxiliaryPlane(plane1);
+    expect(aux.strike).toBeCloseTo(plane2.strike, 0);
+    expect(aux.dip).toBeCloseTo(plane2.dip, 0);
+    expect(aux.rake).toBeCloseTo(plane2.rake, 0);
+  });
+});
+
+describe("isCompressional — 象限方位", () => {
+  it("純走滑（0,90,0）呈棋盤格四象限（NE/SW 同號，SE/NW 同號但與 NE/SW 相反）", () => {
+    const m = { strike: 0, dip: 90, rake: 0 };
+    const ne = isCompressional(m, 0.5, 0.5);
+    const se = isCompressional(m, 0.5, -0.5);
+    const sw = isCompressional(m, -0.5, -0.5);
+    const nw = isCompressional(m, -0.5, 0.5);
+    expect(ne).toBe(sw);
+    expect(se).toBe(nw);
+    expect(ne).not.toBe(se);
+  });
+
+  it("純逆斷層（0,45,90）與純正斷層（0,45,-90）中心區域壓縮/拉張相反", () => {
+    const thrust = { strike: 0, dip: 45, rake: 90 };
+    const normalFault = { strike: 0, dip: 45, rake: -90 };
+    // 中心 (0,0) 剛好在等值線上時方向不穩定，取靠近中心的一點代表「中心區域」
+    const thrustCenter = isCompressional(thrust, 0.01, 0.01);
+    const normalCenter = isCompressional(normalFault, 0.01, 0.01);
+    expect(thrustCenter).toBe(true); // 逆斷層：中心為壓縮
+    expect(normalCenter).toBe(false); // 正斷層：中心為拉張
+    expect(thrustCenter).not.toBe(normalCenter);
+  });
+});
+
+describe("beachballSvg", () => {
+  const cases: Array<[string, { strike: number; dip: number; rake: number }]> = [
+    ["純走滑", { strike: 0, dip: 90, rake: 0 }],
+    ["純逆斷層", { strike: 0, dip: 45, rake: 90 }],
+    ["純正斷層", { strike: 0, dip: 45, rake: -90 }],
+    ["垂直斷層+斜滑", { strike: 30, dip: 90, rake: 45 }],
+    ["rake=180 右移純走滑", { strike: 10, dip: 90, rake: 180 }],
+    ["真實事件 1", { strike: 41.62, dip: 36.35, rake: 117.37 }],
+  ];
+
+  it.each(cases)("%s：輸出合法 SVG 字串（含 svg 標籤、無 NaN）", (_label, mechanism) => {
+    const svg = beachballSvg(mechanism);
+    expect(svg.startsWith("<svg")).toBe(true);
+    expect(svg.trim().endsWith("</svg>")).toBe(true);
+    expect(svg).not.toMatch(/NaN/);
+    expect(svg).toContain("<circle");
+  });
+
+  it("size / fillColor / bgColor / strokeColor 選項會反映到輸出字串", () => {
+    const svg = beachballSvg(
+      { strike: 10, dip: 60, rake: 30 },
+      { size: 80, fillColor: "#ff0000", bgColor: "#00ff00", strokeColor: "#0000ff" },
+    );
+    expect(svg).toContain('width="80"');
+    expect(svg).toContain('height="80"');
+    expect(svg).toContain("#ff0000");
+    expect(svg).toContain("#00ff00");
+    expect(svg).toContain("#0000ff");
+  });
+});

--- a/src/lib/beachball.ts
+++ b/src/lib/beachball.ts
@@ -1,0 +1,261 @@
+/**
+ * 震源機制解沙灘球（focal mechanism beachball）純函式模組。零依賴，純數學 + 字串組裝。
+ *
+ * 座標慣例：N（北）= x, E（東）= y, D（垂直向下）= z（NED，右手座標系）。
+ * 繪圖慣例：北上東右（standard map view）。
+ *
+ * 演算法（double-couple 標準沙灘球）：
+ * 1. 由 strike/dip/rake 求斷層面法向量 n̂ 與滑動向量 d̂（Aki & Richards 慣例）。
+ * 2. Double-couple 的對偶性質：d̂ 同時是第二節面（auxiliary plane）的法向量，
+ *    n̂ 同時是第二節面的滑動向量 —— 因此不需要另外求 strike2/dip2/rake2 也能畫圖，
+ *    但仍提供 auxiliaryPlane() 供顯示 / 驗證用。
+ * 3. 下半球等面積投影（Lower-hemisphere equal-area / Schmidt）：對投影圓盤上每一點，
+ *    反推其在焦點球面上對應的方向向量 r̂，以 sign((n̂·r̂)(d̂·r̂)) 判斷該方向是壓縮（P 波初動
+ *    離源，正）還是拉張（負）。正值＝壓縮象限＝填 fillColor；負值＝拉張＝留白（bgColor）。
+ * 4. 以掃描 raster grid + 同列連續格 RLE 合併成矩形，組出壓縮區塊的 SVG path，
+ *    再用 <clipPath> 裁成正圓，避免格線在圓周留下鋸齒。
+ *
+ * 此法對任何 strike/dip/rake 組合都是純數值運算（點積 + 反三角函數），不會因為
+ * dip=90（垂直斷層）、rake=±90（純逆/正斷層）、rake=0/180（純走滑）而出現除以零或 NaN。
+ */
+
+/** 震源機制解輸入（單一節面的 strike/dip/rake，度） */
+export interface FocalMechanism {
+  /** 走向，度，0-360，由北順時針量起 */
+  strike: number;
+  /** 傾角，度，0-90 */
+  dip: number;
+  /** 滑動角，度，-180~180（Aki-Richards 慣例：0=左移、±180=右移、90=逆斷層、-90=正斷層） */
+  rake: number;
+}
+
+/** 節面參數（strike/dip/rake），auxiliaryPlane() 回傳型別，與 FocalMechanism 同形狀 */
+export type NodalPlane = FocalMechanism;
+
+export interface BeachballOptions {
+  /** SVG 邊長（正方形），預設 60 */
+  size?: number;
+  /** 壓縮象限填色，預設深灰藍 */
+  fillColor?: string;
+  /** 拉張象限（背景圓盤）填色，預設白色 */
+  bgColor?: string;
+  /** 外圍圓框線色，預設同 fillColor */
+  strokeColor?: string;
+  /** raster 網格解析度（越高越平滑但字串越長），預設 96 */
+  resolution?: number;
+}
+
+/** NED 座標系下的 3D 單位向量 */
+type Vec3 = readonly [number, number, number];
+
+function toRad(deg: number): number {
+  return (deg * Math.PI) / 180;
+}
+
+function toDeg(rad: number): number {
+  return (rad * 180) / Math.PI;
+}
+
+function dot(a: Vec3, b: Vec3): number {
+  return a[0] * b[0] + a[1] * b[1] + a[2] * b[2];
+}
+
+function clamp(x: number, lo: number, hi: number): number {
+  return Math.max(lo, Math.min(hi, x));
+}
+
+/**
+ * 由 strike/dip/rake 求斷層面法向量 n̂ 與滑動向量 d̂（NED 座標，單位向量）。
+ *
+ * 推導：走向向量 ŝ = (cosφ, sinφ, 0)；下傾向量 d̂dip = (-cosδ sinφ, cosδ cosφ, sinδ)
+ * （水平方位角為走向+90°、再往下傾 δ 角）；兩者正交張出斷層面。
+ * 法向量 n̂ 與滑動向量的公式為 Aki & Richards (1980) 標準式，已用 4 筆真實地震
+ * moment tensor 資料（strike1/dip1/rake1 → 反推 strike2/dip2/rake2）數值驗證一致。
+ */
+export function nodalVectors(mechanism: FocalMechanism): { normal: Vec3; slip: Vec3 } {
+  const phi = toRad(mechanism.strike);
+  const delta = toRad(mechanism.dip);
+  const lambda = toRad(mechanism.rake);
+
+  const sinD = Math.sin(delta);
+  const cosD = Math.cos(delta);
+  const sinP = Math.sin(phi);
+  const cosP = Math.cos(phi);
+  const sinL = Math.sin(lambda);
+  const cosL = Math.cos(lambda);
+
+  const normal: Vec3 = [-sinD * sinP, sinD * cosP, -cosD];
+  const slip: Vec3 = [
+    cosL * cosP + cosD * sinL * sinP,
+    cosL * sinP - cosD * sinL * cosP,
+    -sinL * sinD,
+  ];
+  return { normal, slip };
+}
+
+/**
+ * 由節面 1 的法向量反推 strike/dip（供 auxiliaryPlane 重用）。
+ * n 的 D 分量須 ≤ 0（對應 dip ∈ [0,90]）；若給的向量 D 分量 > 0，呼叫端需自行先取反。
+ */
+function strikeDipFromNormal(n: Vec3): { strike: number; dip: number } {
+  const cosDip = clamp(-n[2], -1, 1);
+  const dip = Math.acos(cosDip);
+  const strike = Math.atan2(-n[0], n[1]);
+  return { strike: toDeg(strike), dip: toDeg(dip) };
+}
+
+/**
+ * 求第二節面（auxiliary plane）。
+ *
+ * Double-couple 對偶性質：節面 1 的滑動向量 d̂ 即為節面 2 的法向量；節面 1 的法向量 n̂
+ * 即為節面 2 的滑動向量。法向量方向本身有正負號自由度（同一平面兩個法向量互為反向），
+ * 為符合 dip ∈ [0,90] 的慣例，若 d̂ 的垂直分量 > 0 則整組（法向量＋對應滑動向量）一起
+ * 取反，維持兩者相對關係不變。
+ */
+export function auxiliaryPlane(mechanism: FocalMechanism): NodalPlane {
+  const { normal, slip } = nodalVectors(mechanism);
+
+  let n2 = slip;
+  let slip2 = normal;
+  if (n2[2] > 0) {
+    n2 = [-n2[0], -n2[1], -n2[2]];
+    slip2 = [-slip2[0], -slip2[1], -slip2[2]];
+  }
+
+  const { strike: strike2, dip: dip2 } = strikeDipFromNormal(n2);
+  const phi2 = toRad(strike2);
+  const delta2 = toRad(dip2);
+
+  // 節面 2 自己的走向向量、下傾向量，用來把 slip2 分解出 rake2
+  const s2: Vec3 = [Math.cos(phi2), Math.sin(phi2), 0];
+  const dDip2: Vec3 = [-Math.cos(delta2) * Math.sin(phi2), Math.cos(delta2) * Math.cos(phi2), Math.sin(delta2)];
+
+  const cosLam2 = dot(slip2, s2);
+  const sinLam2 = -dot(slip2, dDip2);
+  const rake2 = toDeg(Math.atan2(sinLam2, cosLam2));
+
+  return { strike: (strike2 + 360) % 360, dip: dip2, rake: rake2 };
+}
+
+/** 一個壓縮象限的矩形（normalized 座標，u=東, v=北, 皆為 [-1,1]） */
+interface FillRect {
+  u0: number;
+  u1: number;
+  v0: number;
+  v1: number;
+}
+
+/**
+ * 下半球等面積（Schmidt）投影：把圓盤內 normalized 座標 (u,v)（u=東, v=北, 半徑 ≤1）
+ * 反推成焦點球面下半球方向向量 r̂ = (N,E,D)。
+ *
+ * r(ψ) = √2 · sin(ψ/2)，ψ 為與正下方（nadir）的夾角，ψ=0 對應圓心（正下方），
+ * ψ=90° 對應圓周（水平方向）。方位角 θ 為北順時針量起的羅盤方位。
+ */
+function unprojectLowerHemisphere(u: number, v: number): Vec3 {
+  const r = Math.min(1, Math.hypot(u, v)); // clamp 避免浮點誤差略超過 1
+  const psi = 2 * Math.asin(r / Math.SQRT2);
+  const theta = Math.atan2(u, v); // 北=0，順時針往東增加
+  const sinPsi = Math.sin(psi);
+  const cosPsi = Math.cos(psi);
+  return [sinPsi * Math.cos(theta), sinPsi * Math.sin(theta), cosPsi];
+}
+
+/**
+ * 掃描 raster grid，判斷圓盤內每格屬於壓縮還是拉張象限，同列連續格合併成矩形（RLE），
+ * 回傳壓縮象限的矩形清單（normalized -1..1 座標）。
+ */
+function computeCompressionRects(mechanism: FocalMechanism, resolution: number): FillRect[] {
+  const { normal, slip } = nodalVectors(mechanism);
+  const rects: FillRect[] = [];
+  const step = 2 / resolution;
+
+  for (let row = 0; row < resolution; row++) {
+    // v: 由上（北, +1）掃到下（南, -1）
+    const v = 1 - (row + 0.5) * step;
+    const vTop = 1 - row * step;
+    const vBottom = vTop - step;
+
+    let runStart: number | null = null;
+    for (let col = 0; col < resolution; col++) {
+      const u = -1 + (col + 0.5) * step;
+      const inDisk = u * u + v * v <= 1;
+      let compressional = false;
+      if (inDisk) {
+        const r = unprojectLowerHemisphere(u, v);
+        const fn = dot(normal, r);
+        const fd = dot(slip, r);
+        compressional = fn * fd > 0;
+      }
+
+      if (compressional && runStart === null) {
+        runStart = col;
+      } else if (!compressional && runStart !== null) {
+        rects.push({ u0: -1 + runStart * step, u1: -1 + col * step, v0: vBottom, v1: vTop });
+        runStart = null;
+      }
+    }
+    if (runStart !== null) {
+      rects.push({ u0: -1 + runStart * step, u1: 1, v0: vBottom, v1: vTop });
+    }
+  }
+  return rects;
+}
+
+/**
+ * 判斷投影圓盤內某 normalized 座標 (u=東, v=北, 皆為 [-1,1]) 是否落在壓縮象限。
+ * 供測試 / 除錯使用，核心繪圖邏輯（computeCompressionRects）內部也是靠同一判斷式掃描。
+ */
+export function isCompressional(mechanism: FocalMechanism, u: number, v: number): boolean {
+  const { normal, slip } = nodalVectors(mechanism);
+  const r = unprojectLowerHemisphere(u, v);
+  return dot(normal, r) * dot(slip, r) > 0;
+}
+
+let uidCounter = 0;
+
+/** 組出完整 `<svg>...</svg>` 字串。可直接用於 `<img src="data:image/svg+xml;utf8,...">` 或 dangerouslySetInnerHTML。 */
+export function beachballSvg(mechanism: FocalMechanism, options: BeachballOptions = {}): string {
+  const size = options.size ?? 60;
+  const fillColor = options.fillColor ?? "#1e293b";
+  const bgColor = options.bgColor ?? "#ffffff";
+  const strokeColor = options.strokeColor ?? fillColor;
+  const resolution = options.resolution ?? 96;
+
+  const cx = size / 2;
+  const cy = size / 2;
+  const strokeWidth = Math.max(1, size * 0.03);
+  const R = size / 2 - strokeWidth / 2;
+
+  const rects = computeCompressionRects(mechanism, resolution);
+  // normalized (u,v) -> SVG 座標：x 右移、y 反向（SVG y 往下為正，v=北=上）
+  const toX = (u: number) => cx + u * R;
+  const toY = (v: number) => cy - v * R;
+
+  const fillPathD = rects
+    .map((r) => {
+      const x0 = toX(r.u0).toFixed(3);
+      const x1 = toX(r.u1).toFixed(3);
+      const y0 = toY(r.v1).toFixed(3); // v1（較大）對應較小的 svg y
+      const y1 = toY(r.v0).toFixed(3);
+      return `M${x0} ${y0}H${x1}V${y1}H${x0}Z`;
+    })
+    .join("");
+
+  const uid = `bb${uidCounter++}`;
+
+  return [
+    `<svg xmlns="http://www.w3.org/2000/svg" width="${size}" height="${size}" viewBox="0 0 ${size} ${size}">`,
+    `<defs><clipPath id="${uid}-clip"><circle cx="${cx}" cy="${cy}" r="${R}"/></clipPath></defs>`,
+    `<circle cx="${cx}" cy="${cy}" r="${R}" fill="${bgColor}" stroke="${strokeColor}" stroke-width="${strokeWidth}"/>`,
+    fillPathD ? `<path d="${fillPathD}" fill="${fillColor}" clip-path="url(#${uid}-clip)"/>` : "",
+    `<circle cx="${cx}" cy="${cy}" r="${R}" fill="none" stroke="${strokeColor}" stroke-width="${strokeWidth}"/>`,
+    `</svg>`,
+  ].join("");
+}
+
+/** 包成 `data:image/svg+xml` URI，供 `<img src>` 或 Mapbox marker element 直接使用 */
+export function beachballDataUri(mechanism: FocalMechanism, options: BeachballOptions = {}): string {
+  const svg = beachballSvg(mechanism, options);
+  return `data:image/svg+xml;utf8,${encodeURIComponent(svg)}`;
+}

--- a/src/map/earthquakeReplayLayerFactory.ts
+++ b/src/map/earthquakeReplayLayerFactory.ts
@@ -1,0 +1,448 @@
+import mapboxgl from "mapbox-gl";
+import type {
+  Map as MapboxMap,
+  CircleLayer,
+  ExpressionSpecification,
+  FillLayerSpecification,
+} from "mapbox-gl";
+import {
+  CWA_INTENSITY_BANDS,
+  SHAKEMAP_CELL_DEG,
+  type EqReplayGridCell,
+  type EqReplayStation,
+  type EarthquakeReplayEvent,
+} from "../data/earthquakeReplayTypes";
+import { beachballSvg, type FocalMechanism } from "../lib/beachball";
+import { registerPmtilesSourceTypeOnce } from "./pmtilesSourceType";
+import { PMTILES_SOURCE_TYPE } from "./pmtilesConstants";
+
+/**
+ * 地震回放（earthquakeReplay）— Mapbox source / layer 組裝。
+ *
+ * 五個視覺元件，全部是「回放時鐘的純函數」（見 useEarthquakeReplayLayer）：
+ *   1. 震央核心 + S 波前圈（單一 feature，直接寫 paint 數值，不用表達式）
+ *   2. 測站 circle（GeoJSON，feature id = index，feature-state `lit` / `flash`）
+ *   3. 等震度網格 fill（GeoJSON polygon，幾何**只建一次**，feature-state `on` 控淡入）
+ *   4. 鄉鎮面量圖 fill（PMTiles 幾何 + promoteId TOWNCODE，feature-state `eqi`）
+ *   5. 沙灘球 Marker（beachball.ts 純 SVG，走 mapboxgl.Marker 不進 style）
+ *
+ * ⚠️ 鄉鎮走**自建 source**（不進 overlayManager / overlayRegistry 的通用路徑）——
+ * 比照 useRoadCongestionLayer：通用路徑不支援 promoteId + feature-state 染色。
+ * ⚠️ 網格 3,300+ polygon：時間變化一律只走 setFeatureState，絕不 setData（會卡死）。
+ */
+
+export const EQ_REPLAY_EPICENTER_SOURCE = "eq-replay-epicenter";
+export const EQ_REPLAY_STATION_SOURCE = "eq-replay-stations";
+export const EQ_REPLAY_GRID_SOURCE = "eq-replay-grid";
+export const EQ_REPLAY_TOWN_SOURCE = "eq-replay-township";
+export const EQ_REPLAY_TOWN_SOURCE_LAYER = "township_boundary";
+const EQ_REPLAY_TOWN_URL = "./base_map/township_boundary.pmtiles";
+
+export const EQ_REPLAY_GRID_LAYER = "eq-replay-grid-fill";
+export const EQ_REPLAY_TOWN_LAYER = "eq-replay-town-fill";
+export const EQ_REPLAY_STATION_LAYER = "eq-replay-station-circle";
+export const EQ_REPLAY_WAVE_LAYER = "eq-replay-wavefront";
+export const EQ_REPLAY_EPICENTER_LAYER = "eq-replay-epicenter-core";
+
+/** 由下而上；dispose 時反向移除 */
+const ALL_LAYERS = [
+  EQ_REPLAY_GRID_LAYER,
+  EQ_REPLAY_TOWN_LAYER,
+  EQ_REPLAY_STATION_LAYER,
+  EQ_REPLAY_WAVE_LAYER,
+  EQ_REPLAY_EPICENTER_LAYER,
+];
+const ALL_SOURCES = [
+  EQ_REPLAY_EPICENTER_SOURCE,
+  EQ_REPLAY_STATION_SOURCE,
+  EQ_REPLAY_GRID_SOURCE,
+  EQ_REPLAY_TOWN_SOURCE,
+];
+
+const EMPTY_FC: GeoJSON.FeatureCollection = { type: "FeatureCollection", features: [] };
+
+/** 網格底色壓一階，避免蓋掉測站 / 鄉鎮 */
+const GRID_BASE_ALPHA = 0.62;
+
+// ── 色階表達式（CWA_INTENSITY_BANDS 單一資料源）────────────────────
+
+function buildIntensityStep(input: ExpressionSpecification): ExpressionSpecification {
+  const step: unknown[] = ["step", input, CWA_INTENSITY_BANDS[0]!.color];
+  for (let i = 1; i < CWA_INTENSITY_BANDS.length; i++) {
+    step.push(CWA_INTENSITY_BANDS[i]!.value, CWA_INTENSITY_BANDS[i]!.color);
+  }
+  return step as unknown as ExpressionSpecification;
+}
+
+const GRID_COLOR_EXPR = buildIntensityStep(["get", "intensity"] as unknown as ExpressionSpecification);
+const STATION_COLOR_EXPR = buildIntensityStep(
+  ["get", "intensity_value"] as unknown as ExpressionSpecification,
+);
+const TOWN_COLOR_EXPR = buildIntensityStep(
+  ["coalesce", ["feature-state", "eqi"], 0] as unknown as ExpressionSpecification,
+);
+
+/** 未淡入的 cell 直接透明（feature-state 尚未寫入 → coalesce 0） */
+function gridOpacityExpr(opacity: number): ExpressionSpecification {
+  return ["*", opacity, ["coalesce", ["feature-state", "on"], 0]] as unknown as ExpressionSpecification;
+}
+
+/** 只染有感（≥ 1 級）鄉鎮；0 級與尚未寫入 state 的鄉鎮全透明 */
+function townOpacityExpr(opacity: number): ExpressionSpecification {
+  return [
+    "case",
+    ["<", ["coalesce", ["feature-state", "eqi"], -1], 0.5],
+    0,
+    opacity,
+  ] as unknown as ExpressionSpecification;
+}
+
+/** 半徑依 PGA（gal）；`flash` 給抵達瞬間的彈跳、`lit` 給淡入 */
+const STATION_RADIUS_EXPR = [
+  "*",
+  ["interpolate", ["linear"], ["get", "pga_int"], 0, 3.5, 10, 5, 50, 8, 200, 13, 500, 19],
+  [
+    "+",
+    0.45,
+    ["*", 0.55, ["coalesce", ["feature-state", "lit"], 0]],
+    ["*", 0.9, ["coalesce", ["feature-state", "flash"], 0]],
+  ],
+] as unknown as ExpressionSpecification;
+
+function stationOpacityExpr(opacity: number): ExpressionSpecification {
+  return ["*", opacity, ["coalesce", ["feature-state", "lit"], 0]] as unknown as ExpressionSpecification;
+}
+
+/** 底圖之上、地名標籤之下（同 temperatureGridLayerFactory） */
+function firstSymbolLayerId(map: MapboxMap): string | undefined {
+  try {
+    const layers = map.getStyle()?.layers;
+    if (!layers) return undefined;
+    for (const l of layers) {
+      if (l.type === "symbol") return l.id;
+    }
+  } catch {
+    // setStyle 進行中 getStyle() 會 throw → 當作沒有 beforeId
+  }
+  return undefined;
+}
+
+// ── GeoJSON 組裝 ────────────────────────────────────────────────────
+
+export function epicenterToGeoJSON(ev: EarthquakeReplayEvent): GeoJSON.FeatureCollection {
+  return {
+    type: "FeatureCollection",
+    features: [
+      {
+        type: "Feature",
+        id: 0,
+        geometry: { type: "Point", coordinates: [ev.epicenter_lng, ev.epicenter_lat] },
+        properties: { event_id: ev.event_id, magnitude: ev.magnitude, depth_km: ev.depth_km },
+      },
+    ],
+  };
+}
+
+/** feature id = 陣列 index（供 setFeatureState 定位） */
+export function stationsToGeoJSON(stations: EqReplayStation[]): GeoJSON.FeatureCollection {
+  return {
+    type: "FeatureCollection",
+    features: stations.map((s, i) => ({
+      type: "Feature" as const,
+      id: i,
+      geometry: { type: "Point" as const, coordinates: [s.lon, s.lat] },
+      properties: {
+        station_id: s.station_id,
+        intensity_value: s.intensity_value,
+        pga_int: s.pga_int,
+        epicenter_distance_km: s.epicenter_distance_km,
+      },
+    })),
+  };
+}
+
+/** 每 cell 一個 0.025° 方格（lon/lat 為格點中心，±half 展開）；feature id = index */
+export function gridToGeoJSON(cells: EqReplayGridCell[]): GeoJSON.FeatureCollection {
+  const half = SHAKEMAP_CELL_DEG / 2;
+  return {
+    type: "FeatureCollection",
+    features: cells.map((c, i) => {
+      const w = c.lon - half;
+      const e = c.lon + half;
+      const s = c.lat - half;
+      const n = c.lat + half;
+      return {
+        type: "Feature" as const,
+        id: i,
+        properties: { intensity: c.intensity, pga: c.pga },
+        geometry: {
+          type: "Polygon" as const,
+          coordinates: [[[w, s], [e, s], [e, n], [w, n], [w, s]]],
+        },
+      };
+    }),
+  };
+}
+
+// ── 建 / 拆 ─────────────────────────────────────────────────────────
+
+/** 確保 source + 5 個 layer 存在（idempotent，底圖切換後可重呼）；回傳是否就緒 */
+export function ensureEarthquakeReplayLayers(map: MapboxMap, opacity: number): boolean {
+  registerPmtilesSourceTypeOnce();
+
+  for (const id of [EQ_REPLAY_EPICENTER_SOURCE, EQ_REPLAY_STATION_SOURCE, EQ_REPLAY_GRID_SOURCE]) {
+    if (!map.getSource(id)) map.addSource(id, { type: "geojson", data: EMPTY_FC });
+  }
+  if (!map.getSource(EQ_REPLAY_TOWN_SOURCE)) {
+    map.addSource(EQ_REPLAY_TOWN_SOURCE, {
+      type: PMTILES_SOURCE_TYPE,
+      url: EQ_REPLAY_TOWN_URL,
+      minzoom: 6,
+      maxzoom: 13,
+      // feature-state 染色鍵：feature id = TOWNCODE（8 碼；CWA 7 碼轉換見 types 檔）
+      promoteId: { [EQ_REPLAY_TOWN_SOURCE_LAYER]: "TOWNCODE" },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+  }
+
+  const before = firstSymbolLayerId(map);
+
+  if (!map.getLayer(EQ_REPLAY_GRID_LAYER)) {
+    map.addLayer(
+      {
+        id: EQ_REPLAY_GRID_LAYER,
+        type: "fill",
+        source: EQ_REPLAY_GRID_SOURCE,
+        layout: { visibility: "none" },
+        paint: {
+          "fill-color": GRID_COLOR_EXPR,
+          "fill-opacity": gridOpacityExpr(opacity * GRID_BASE_ALPHA),
+          // 相鄰格點連續鋪滿，開 antialias 會在格線留白邊
+          "fill-antialias": false,
+        },
+      } as FillLayerSpecification,
+      before,
+    );
+  }
+  if (!map.getLayer(EQ_REPLAY_TOWN_LAYER)) {
+    map.addLayer(
+      {
+        id: EQ_REPLAY_TOWN_LAYER,
+        type: "fill",
+        source: EQ_REPLAY_TOWN_SOURCE,
+        "source-layer": EQ_REPLAY_TOWN_SOURCE_LAYER,
+        layout: { visibility: "none" },
+        paint: {
+          "fill-color": TOWN_COLOR_EXPR,
+          "fill-opacity": townOpacityExpr(0),
+          "fill-outline-color": "rgba(0,0,0,0.25)",
+        },
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any,
+      before,
+    );
+  }
+  if (!map.getLayer(EQ_REPLAY_STATION_LAYER)) {
+    map.addLayer(
+      {
+        id: EQ_REPLAY_STATION_LAYER,
+        type: "circle",
+        source: EQ_REPLAY_STATION_SOURCE,
+        layout: { visibility: "none" },
+        paint: {
+          "circle-radius": STATION_RADIUS_EXPR,
+          "circle-color": STATION_COLOR_EXPR,
+          "circle-opacity": stationOpacityExpr(opacity * 0.85),
+          "circle-stroke-color": "#ffffff",
+          "circle-stroke-width": 1,
+          "circle-stroke-opacity": stationOpacityExpr(opacity * 0.55),
+        },
+      } as CircleLayer,
+      before,
+    );
+  }
+  if (!map.getLayer(EQ_REPLAY_WAVE_LAYER)) {
+    map.addLayer(
+      {
+        id: EQ_REPLAY_WAVE_LAYER,
+        type: "circle",
+        source: EQ_REPLAY_EPICENTER_SOURCE,
+        layout: { visibility: "none" },
+        paint: {
+          "circle-radius": 0,
+          "circle-color": "rgba(0,0,0,0)",
+          "circle-stroke-color": "#fca5a5",
+          "circle-stroke-width": 2,
+          "circle-stroke-opacity": 0,
+        },
+      } as CircleLayer,
+      before,
+    );
+  }
+  if (!map.getLayer(EQ_REPLAY_EPICENTER_LAYER)) {
+    map.addLayer(
+      {
+        id: EQ_REPLAY_EPICENTER_LAYER,
+        type: "circle",
+        source: EQ_REPLAY_EPICENTER_SOURCE,
+        layout: { visibility: "none" },
+        paint: {
+          "circle-radius": 0,
+          "circle-color": "#ef4444",
+          "circle-opacity": 0,
+          "circle-stroke-color": "#fee2e2",
+          "circle-stroke-width": 1.5,
+          "circle-stroke-opacity": 0,
+        },
+      } as CircleLayer,
+      before,
+    );
+  }
+
+  return !!map.getLayer(EQ_REPLAY_EPICENTER_LAYER);
+}
+
+export function removeEarthquakeReplayLayers(map: MapboxMap): void {
+  for (let i = ALL_LAYERS.length - 1; i >= 0; i--) {
+    const id = ALL_LAYERS[i]!;
+    if (map.getLayer(id)) map.removeLayer(id);
+  }
+  for (const id of ALL_SOURCES) {
+    if (map.getSource(id)) map.removeSource(id);
+  }
+}
+
+export function setEarthquakeReplayVisible(map: MapboxMap, visible: boolean): void {
+  for (const id of ALL_LAYERS) {
+    if (map.getLayer(id)) map.setLayoutProperty(id, "visibility", visible ? "visible" : "none");
+  }
+}
+
+function setGeoJSON(map: MapboxMap, sourceId: string, data: GeoJSON.FeatureCollection): void {
+  const src = map.getSource(sourceId);
+  if (!src || src.type !== "geojson") return;
+  src.setData(data);
+}
+
+export function setReplayEpicenterData(map: MapboxMap, data: GeoJSON.FeatureCollection): void {
+  setGeoJSON(map, EQ_REPLAY_EPICENTER_SOURCE, data);
+}
+export function setReplayStationData(map: MapboxMap, data: GeoJSON.FeatureCollection): void {
+  setGeoJSON(map, EQ_REPLAY_STATION_SOURCE, data);
+}
+export function setReplayGridData(map: MapboxMap, data: GeoJSON.FeatureCollection): void {
+  setGeoJSON(map, EQ_REPLAY_GRID_SOURCE, data);
+}
+
+/** 網格整體透明度（`dim` 供鄉鎮定格時把網格壓暗，讓面量圖讀得出來） */
+export function setReplayGridOpacity(map: MapboxMap, opacity: number, dim: number): void {
+  if (!map.getLayer(EQ_REPLAY_GRID_LAYER)) return;
+  map.setPaintProperty(
+    EQ_REPLAY_GRID_LAYER,
+    "fill-opacity",
+    gridOpacityExpr(opacity * GRID_BASE_ALPHA * dim),
+  );
+}
+
+/** 鄉鎮面量圖淡入（fade 0→1） */
+export function setReplayTownOpacity(map: MapboxMap, opacity: number, fade: number): void {
+  if (!map.getLayer(EQ_REPLAY_TOWN_LAYER)) return;
+  map.setPaintProperty(EQ_REPLAY_TOWN_LAYER, "fill-opacity", townOpacityExpr(opacity * 0.8 * fade));
+}
+
+export function setReplayStationOpacity(map: MapboxMap, opacity: number): void {
+  if (!map.getLayer(EQ_REPLAY_STATION_LAYER)) return;
+  map.setPaintProperty(EQ_REPLAY_STATION_LAYER, "circle-opacity", stationOpacityExpr(opacity * 0.85));
+  map.setPaintProperty(
+    EQ_REPLAY_STATION_LAYER,
+    "circle-stroke-opacity",
+    stationOpacityExpr(opacity * 0.55),
+  );
+}
+
+export interface EpicenterFrame {
+  coreRadiusPx: number;
+  coreOpacity: number;
+  waveRadiusPx: number;
+  waveOpacity: number;
+  waveWidth: number;
+}
+
+/** 震央 + S 波前每幀更新（單一 feature，直接寫數值最省） */
+export function setReplayEpicenterFrame(map: MapboxMap, f: EpicenterFrame): void {
+  if (map.getLayer(EQ_REPLAY_EPICENTER_LAYER)) {
+    map.setPaintProperty(EQ_REPLAY_EPICENTER_LAYER, "circle-radius", f.coreRadiusPx);
+    map.setPaintProperty(EQ_REPLAY_EPICENTER_LAYER, "circle-opacity", f.coreOpacity);
+    map.setPaintProperty(EQ_REPLAY_EPICENTER_LAYER, "circle-stroke-opacity", f.coreOpacity * 0.9);
+  }
+  if (map.getLayer(EQ_REPLAY_WAVE_LAYER)) {
+    map.setPaintProperty(EQ_REPLAY_WAVE_LAYER, "circle-radius", f.waveRadiusPx);
+    map.setPaintProperty(EQ_REPLAY_WAVE_LAYER, "circle-stroke-opacity", f.waveOpacity);
+    map.setPaintProperty(EQ_REPLAY_WAVE_LAYER, "circle-stroke-width", f.waveWidth);
+  }
+}
+
+/**
+ * 公尺 → 螢幕 px（Mapbox GL 的 zoom 以 512px tile 定義，
+ * 故 equator resolution = 78271.517 m/px @ z0）。
+ * S 波前是「真實地理半徑」，但 circle layer 的半徑單位是 px → 每幀換算。
+ */
+export function metersToPixels(meters: number, lat: number, zoom: number): number {
+  const mPerPx = (78271.5169 * Math.cos((lat * Math.PI) / 180)) / Math.pow(2, zoom);
+  if (!Number.isFinite(mPerPx) || mPerPx <= 0) return 0;
+  return Math.min(4000, meters / mPerPx);
+}
+
+// ── 沙灘球 Marker ───────────────────────────────────────────────────
+
+export interface BeachballHandle {
+  marker: mapboxgl.Marker;
+  /** 內層才是動畫對象：Marker 會自己覆寫外層 element 的 transform（定位用） */
+  inner: HTMLDivElement;
+}
+
+/** 用 beachball.ts 自繪 SVG（tecdc 的 beachball_url 無 SLA，見 handoff §6-3） */
+export function createBeachballMarker(
+  map: MapboxMap,
+  lngLat: [number, number],
+  mechanism: FocalMechanism,
+  size = 54,
+): BeachballHandle {
+  const element = document.createElement("div");
+  element.style.width = `${size}px`;
+  element.style.height = `${size}px`;
+  element.style.pointerEvents = "none";
+
+  const inner = document.createElement("div");
+  inner.style.width = "100%";
+  inner.style.height = "100%";
+  inner.style.opacity = "0";
+  inner.style.transformOrigin = "center";
+  inner.style.willChange = "transform, opacity";
+  inner.style.filter = "drop-shadow(0 2px 6px rgba(0,0,0,0.55))";
+  inner.innerHTML = beachballSvg(mechanism, {
+    size,
+    fillColor: "#1e293b",
+    bgColor: "#f8fafc",
+    strokeColor: "#0f172a",
+  });
+  element.appendChild(inner);
+
+  const marker = new mapboxgl.Marker({ element, anchor: "center" })
+    .setLngLat(lngLat)
+    .addTo(map);
+  return { marker, inner };
+}
+
+/** 彈出動畫：opacity 0→1（再乘圖層 opacity）、scale 0.4→1.15→1（純 style，不進 React） */
+export function updateBeachball(handle: BeachballHandle, progress: number, opacity: number): void {
+  const p = Math.max(0, Math.min(1, progress));
+  const overshoot = 1 + 0.25 * Math.sin(Math.PI * Math.min(1, p * 1.4));
+  const scale = p === 0 ? 0.4 : 0.4 + 0.6 * p * overshoot;
+  handle.inner.style.opacity = String(p * opacity);
+  handle.inner.style.transform = `scale(${scale.toFixed(3)})`;
+}
+
+export function removeBeachballMarker(handle: BeachballHandle | null): void {
+  handle?.marker.remove();
+}

--- a/src/state/earthquakeReplayClock.ts
+++ b/src/state/earthquakeReplayClock.ts
@@ -1,0 +1,70 @@
+/**
+ * 地震回放的 scoped 播放時鐘（**不掛全域 timeStore**）。
+ *
+ * 為什麼要獨立 store：
+ * - 回放時鐘的單位是「震後真實秒數」，跟 timeline 的 unix 秒是兩件事，
+ *   掛上去會讓其他動態圖層跟著地震回放跑（開發規則 §8 只約束消費 timeline 的圖層）。
+ * - 引擎（useEarthquakeReplayLayer 的 RAF）每幀寫時鐘，若走 React state 會讓
+ *   整個 App.tsx 每幀 re-render。這裡用 external store：寫入永遠即時（引擎讀 `get()`），
+ *   **通知**節流到 10Hz，只有訂閱的小面板（進度條）會重繪。
+ *
+ * 所有視覺都是時鐘的純函數 → scrub 只要 `set(t)`，下一幀畫面自動正確。
+ */
+
+const NOTIFY_INTERVAL_MS = 100;
+
+interface ClockSnapshot {
+  /** 震後真實秒數（回放時鐘） */
+  clock: number;
+  /** 本次回放總長（震後真實秒數）；0 = 尚未載入 */
+  duration: number;
+  /** 播放速率（回放時鐘秒 / 牆鐘秒），僅供 UI 顯示 */
+  rate: number;
+}
+
+let snapshot: ClockSnapshot = { clock: 0, duration: 0, rate: 1 };
+let lastNotifyMs = 0;
+const listeners = new Set<() => void>();
+
+function notify(): void {
+  lastNotifyMs = performance.now();
+  for (const l of listeners) l();
+}
+
+export const earthquakeReplayClock = {
+  /** 引擎每幀同步讀（不經 React） */
+  get(): number {
+    return snapshot.clock;
+  },
+  getDuration(): number {
+    return snapshot.duration;
+  },
+  /** 引擎每幀寫；通知節流 10Hz。`force` 用於 scrub / reset 等需要立即反映的情境。 */
+  set(clock: number, force = false): void {
+    if (snapshot.clock === clock && !force) return;
+    snapshot = { ...snapshot, clock };
+    if (force || performance.now() - lastNotifyMs >= NOTIFY_INTERVAL_MS) notify();
+  },
+  /** 換事件 / 明細載入完成時設定總長與速率（低頻，一律立即通知） */
+  setTimeline(duration: number, rate: number): void {
+    snapshot = { clock: 0, duration, rate };
+    notify();
+  },
+  reset(): void {
+    snapshot = { ...snapshot, clock: 0 };
+    notify();
+  },
+  clear(): void {
+    snapshot = { clock: 0, duration: 0, rate: 1 };
+    notify();
+  },
+  getSnapshot(): ClockSnapshot {
+    return snapshot;
+  },
+  subscribe(cb: () => void): () => void {
+    listeners.add(cb);
+    return () => {
+      listeners.delete(cb);
+    };
+  },
+};

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -105,6 +105,7 @@ export type ExpandableLayerKey =
   | "publicLibraries" | "welfareCenters" | "retailMarkets" | "publicToilets"
   | "submarineCables" | "landingStations"
   | "activeFaults"
+  | "earthquakeReplay"
   | "newsEvents"
   | "livestockFarmPig" | "livestockFarmChicken" | "livestockFarmCattle"
   | "livestockFarmDuck" | "livestockFarmGoose" | "livestockFarmSheep" | "livestockFarmOther"
@@ -142,6 +143,7 @@ export type ExpandableLayerKey =
   | "aqiStations"
   | "aqiMicroSensors"
   | "earthquakes"
+  | "earthquakeReplay"
   | "earthquakesGlobal"
   | "typhoonTracks"
   | "dustForecast"
@@ -715,7 +717,9 @@ export interface FeatureInfo {
     | "gasCoverageAll" | "gasCoverageCpc" | "gasCoverageFpcc" | "gasCoverageTaisugar"
     | "evIsland"
     | "lightningStrike" | "nuclearStation"
-    | "earthquakeGlobal" | "typhoonTrack" | "climateField"
+    | "earthquakes" | "earthquakeGlobal" | "typhoonTrack" | "climateField"
+    // 地震回放：測站逐顆亮起 / 368 鄉鎮面量圖（皆走 feature-state 上色）
+    | "earthquakeReplayStation" | "earthquakeReplayTown"
     | "temperatureGrid"
     // Base map（PMTiles 來自 taipei-gis-analytics）
     | "countyBoundary" | "townshipBoundary" | "villageBoundary"
@@ -798,6 +802,8 @@ export interface LayerVisibility {
   newsEvents: boolean;
   youbikeFullness: boolean;
   earthquakes: boolean;
+  /** 地震回放：單一事件的震央→測站→等震度網格→鄉鎮面量圖→沙灘球五步動畫 */
+  earthquakeReplay: boolean;
   // ── 全球氣候 GLOBAL CLIMATE（USGS / JMA / JTWC / CMEMS / CAMS / NOAA GFS）──
   earthquakesGlobal: boolean;    // USGS 全球地震（hourly）
   typhoonTracks: boolean;        // JMA / JTWC 颱風軌跡（observed + forecast）


### PR DESCRIPTION
## Summary

新增 `earthquakeReplay` 圖層：選一起地震重播擴散過程（震央爆開 → 測站依 S 波距離逐顆亮起 → 等震度網格波前展開 → 鄉鎮面量圖定格 → 沙灘球收尾），依素材完整度分 Tier A（完整五步）/ Tier B（測站三步）——因為官方源只留最新一次地震，我們的庫是唯一歷史，這是它的第一個回放介面。

## Changes

- **回放核心**：`earthquakeReplayLoader/Types` + `earthquakeReplayLayerFactory`（5 視覺元件）+ `useEarthquakeReplayLayer`（回放引擎）+ `earthquakeReplayClock`（external store，比照 timeStore；回放期間 App 零 re-render）+ `EarthquakeReplayPanel`（清單 + play/pause/scrub）
- **專案首個行政區 choropleth**：township PMTiles 自建 promoteId source + feature-state（不動 overlayManager；CWA 7 碼→TOWNCODE 8 碼轉換 368/368 逐筆驗證）
- **沙灘球自繪**：`src/lib/beachball.ts` strike/dip/rake → 下半球等面積投影 SVG（對 tecdc 官方圖 4/4 方位驗證、aux plane 對真實資料誤差 <0.01°；不依賴無 SLA 的外站圖）
- **順手修**：本土 `earthquakes` 圖層補 click popup（現存四鐵則違規；ripple 動畫圈刻意不做點擊目標）
- **SSOT 全接**：LayerVisibility / LAYER_COLORS+SECTIONS / LAYER_ICONS / LEGEND_REGISTRY / PANEL_REGISTRY / GIS_LAYERS / upstreamRegistry / opacity slider
- docs/features/earthquake-replay/ 四件套

## Test

- [x] `npx tsc -b` 通過
- [x] `pnpm test` 通過（19 檔 212 測試，含 `layerConsistency` + registry ratchet）
- [x] Browser 驗收 — 楠西 115052 五步動畫 / scrub 定格 / 測站+鄉鎮 popup / 圖例 / 關圖層無殘影（layers=0 sources=0 markers=0）
- [x] Supabase RPC：mig 324 `earthquake_replay_events()` EXPLAIN 全 Index Only Scan、2.7ms、34 列

## Risk / Rollback

- 新圖層預設關閉，不影響既有行為；earthquakes popup 為純增量（GIS_LAYERS 插入位置已考量 first-hit-wins）
- 回滾：revert 本 PR 即可；DB 端 RPC 獨立（`DROP FUNCTION public.earthquake_replay_events()`），無 schema 變更

## Related

- Feature: `docs/features/earthquake-replay/`
- Upstream handoff: `taipei-gis-analytics/docs/handoff/earthquake-replay.md`（f935e95 已修正 town join 1 秒漂移）
- Related PR: gis-platform #45（mig 324，已 merge）；data-collectors #40 / gis-platform #43 / analytics #28（資料鏈上線）

## Checklist (依 CLAUDE.md §Git Workflow)

- [x] Branch 名符合 `feat/<slug>`
- [x] Commit prefix 走 Conventional Commits
- [x] 動 layer → 四鐵則 + SSOT 三處 + layerConsistency 守門全過
- [x] 動資料契約 → upstream handoff 已更新（analytics f935e95）
- [x] `docs/features/earthquake-replay/changelog.md` 已加本 PR 段落

🤖 Generated with [Claude Code](https://claude.com/claude-code)