### PR TITLE
feat(embed): 嵌入版 popup + 分享面板收尾 + feature 文件

### DIFF
--- a/.claude/memory/BACKLOG.md
+++ b/.claude/memory/BACKLOG.md
@@ -4,38 +4,27 @@
 
 ## 進行中 / 待辦
 
-### 可嵌入地圖（EM 系列，2026-08-03 規劃 / 08-04 Phase 1 完成，branch `feat/embeddable-map` 未 commit）
+### 可嵌入地圖（EM 系列，2026-08-03~05 上線；**尚未部署**）
 
-> SSOT 四份：`docs/proposal/embeddable-map.md`（目標／費用／風險）· `embeddable-map-impl.md`（逐檔工作項）·
-> `embed-basemap-osm.md`（免費底圖路線）· `embed-prototype/`（可跑的原型 + README）·
-> `embed-dynamic-layers.md`（動態／歷史圖層規劃）。
-> **成本關鍵**：Mapbox 計費單位是 map load（=`Map` 初始化一次）= 文章 PV 數，**與 tile 來源無關** →
-> 只換 OSM 圖磚省不到錢，必須連函式庫換成 MapLibre。
+> **SSOT 全部移到 [`docs/features/embeddable-map/`](../../docs/features/embeddable-map/)**
+> （README／backlog／changelog／handoff 四件套）。本區只留索引，**不再更新細節**。
 >
-> **2026-08-04 owner 拍板**：底圖美觀度驗收通過 → Phase 2 走 **MapLibre + Protomaps**；
-> frame-ancestors 採「全開」；分享按鈕**不做**；Mapbox 月用量因走 MapLibre 不再是阻塞項。
+> 一句話：一條網址重現畫面（相機／圖層／底圖／日期）+ `/embed` 供文章 iframe 嵌入。
+> 嵌入版走 MapLibre + 自託管 Protomaps 底圖 → **不論被讀幾次都不產生 Mapbox 費用**。
+>
+> 💰 最反直覺的一條：**Mapbox 計費 = `Map` 初始化 = 文章 PV 數，與圖磚來源無關** ——
+> 只換 OSM tile 省不到錢，必須連函式庫一起換。
 
-| ID | 優先級 | 項目 | 狀態 | 備註 |
-|---|---|---|---|---|
-| EM-10 | **P0** | 🔴 **nginx `location /religion/` 缺閉合括號**（master 既有，非本次引入） | **已修待 merge** | `nginx -t` emerg → **一 redeploy 就整站起不來**。修在 `feat/embeddable-map`；**建議獨立 hotfix 進 master**，不要等本 feature |
-| EM-01 | P1 | 底圖 spike：抽台灣 extract + MapLibre 驗證 | **done** | 台灣 z0–15 = **283 MB**（原估 500MB 偏高）；中文地名完整到「里」層級；owner 驗收通過 |
-| EM-02 | P1 | 解除 iframe 封鎖（nginx.conf） | **done** | 刪 `X-Frame-Options` + 加 enforcing CSP `frame-ancestors *`；Report-Only 那條同步改（否則未來轉正式又擋住）；`nginx -t` 通過 |
-| EM-03 | P1 | `src/lib/urlState.ts` + 接進 App（相機／layers／date） | **done** | 35 測試綠；端到端驗證相機精準命中 + gated 35 層全擋；主站**不支援** `p.*`（見 impl §2） |
-| EM-09 | P1 | 嵌入原型 + 示範文章頁 | **done** | `docs/proposal/embed-prototype/` — 已驗證 iframe 嵌入效果、魚塭疊圖、開關對比 |
-| EM-05 | P1 | `overlayManager` 型別泛化（支援雙引擎） | **done** | 改結構介面（union 會讓每個呼叫點 TS2349）+ `pmtilesSource` 注入點；主站行為零改動；加編譯期斷言守門 |
-| EM-06 | P1 | `/embed` 正式版 | **done** | 145 靜態圖層全可嵌；bundle embed 1.1MB + LegendPanel 787KB（gzip 505KB）vs 主站 4.4MB；**`pk.eyJ` 在 embed chunk 出現 0 次**；底圖落 `public/base_map/`，部署三處零額外接線 |
-| EM-11 | P2 | 底圖改放 R2（選配）+ 每月重抽排程 | open | **目前走 public/base_map/ 已可運作**（沿用既有 S3→容器管線）。改 R2 只需設 `VITE_EMBED_BASEMAP_URL`；R2 egress 免費，高流量時較划算 |
-| EM-12 | P3 | Protomaps 字型／sprite 自託管 | open | 目前指向 `protomaps.github.io`（已加進 CSP）。自託管可去掉最後一個外部依賴 |
-| EM-14 | P2 | A 類設施圖層可嵌（風機/光電/離岸風場/地熱/充電站/離島電網/北市再生 7 層） | **done** | 發現快照**早就做完了**（`public/static-rpc/` 25 檔），缺的只是 embed 怎麼吃 → `EMBED_CDN_LAYERS` 明確清單 + 通用 `rowsToGeoJSON`。**零主站改動**（不動 `dynamicData` 旗標）。實測 supabase 請求 0 |
-| EM-15 | P2 | 按需歷史快照 pilot（`plaActivity` 共機） | **done** | `scripts/export/export-embed-snapshot.sh <layer> <date>`（psql 直出 GeoJSON）+ `src/embed/snapshotLayers.ts` 單日靜態版 spec + 部署三處接線。實測 2026-07-30 正常、supabase 0 |
-| EM-16 | — | Three.js 圖層（船舶/班機/鐵路/公車）嵌入 | **待討論**（owner 2026-08-04：C 之後再談） | embed 刻意不掛 Three.js；即時感圖層嵌進靜態文章敘事價值低、移植成本最高。替代：截圖 + 連結 |
-| EM-17 | P3 | 補 `get_gas_station_layers` 快照（加油站 5 層才能嵌） | open | loader 已用 `staticRpc` 但 `public/static-rpc/` 無此檔 → 一直靜默 fallback 打 RPC。export 腳本已列該 RPC，需確認 migration 已套用後重跑 |
-| EM-18 | P3 | 更多歷史快照圖層（B 類：`earthquakeReplay` 等） | open | 樣板已成形（EM-15），照 `snapshotLayers.ts` + export 腳本 case 加即可 |
-| EM-13 | P2 | `/embed` 上線驗收：實機 iframe + 行動裝置 + Cloudflare 快取規則 | open | 部署後才能做；底圖 283MB 首次 pull 需留意 Zeabur 啟動時間 |
-| EM-07 | P3 | facade 模式（先縮圖、點擊才載入） | open | 走 MapLibre 後成本已歸零 → **降級為純效能優化** |
-| EM-08 | P3 | 嵌入碼防腐：`layerAliases.ts` + 守門測試 | open | layer key 改名會讓既有文章的地圖全壞且無通知 |
-| EM-04 | — | 分享／嵌入按鈕（吐 iframe 代碼） | **不做**（2026-08-04 owner 決定） | 日後要撈：複用既有 `getCamera()`/`getVisibleLayerKeys()`（App.tsx:1763-1774） |
-| — | — | **不做**：oEmbed / 動態 OG / 第三方 JS SDK / embed 會員功能 / 全站改 MapLibre | — | 見 impl §9 |
+| ID | 優先級 | 項目 | 狀態 |
+|---|---|---|---|
+| EM-21 | **P0** | **底圖（283MB）+ 快照上 S3 並部署** —— 沒做的話正式站 `/embed` 是壞的 | open |
+| EM-13 | P1 | 部署後驗收（實機 iframe / 行動裝置 / Cloudflare 快取規則） | open |
+| EM-01~06, 09, 10, 14, 15, 19, 20 | — | 規劃／底圖／URL／`/embed`／CDN 層／歷史快照／分享面板／popup | **done** |
+| EM-16 | — | Three.js 圖層（船舶/班機/鐵路/公車）嵌入 | **待討論**（owner 2026-08-04：之後再談） |
+| EM-07/08/11/12/17/18/22 | P2–P3 | 加油站快照補檔、更多歷史快照層、底圖改 R2、字型自託管、facade、嵌入碼防腐、popup 標籤 | open |
+
+> ⚠️ EM-17 順帶發現的既有問題：`get_gas_station_layers` 的 loader 已改用 `staticRpc`，
+> 但 `public/static-rpc/` **沒有該檔** → 主站一直靜默 fallback 打 RPC（非本功能引入）。
 
 ### 架構改造（AR 系列，2026-07-03 — 全系統審計後五階段計畫）
 

--- a/docs/features/embeddable-map/README.md
+++ b/docs/features/embeddable-map/README.md
@@ -1,0 +1,126 @@
+# Embeddable Map（可嵌入地圖 / EM 系列）
+
+> **Slug**：`embeddable-map`
+> **狀態**：✅ shipped（2026-08-04/05；**尚未部署到正式站**，見 §部署需求）
+> **Owner**：migu
+> **上線時分支**：`feat/embeddable-map`（PR #105）+ `feat/embed-popup-share`
+> **規劃文件**：[`../../proposal/embeddable-map.md`](../../proposal/embeddable-map.md)（目標／費用／風險）·
+> [`embeddable-map-impl.md`](../../proposal/embeddable-map-impl.md)（逐檔工作項）·
+> [`embed-basemap-osm.md`](../../proposal/embed-basemap-osm.md)（免費底圖路線）·
+> [`embed-dynamic-layers.md`](../../proposal/embed-dynamic-layers.md)（動態／歷史圖層）
+
+## 一句話說明
+
+一條網址就能重現特定畫面（相機／圖層／底圖／日期），並提供 `/embed` 極簡版供文章以
+`<iframe>` 嵌入 —— 嵌入版走 **MapLibre + 自託管 Protomaps 底圖**，
+**不論文章被讀幾次都不產生 Mapbox 費用**。
+
+## 💰 成本模型（本功能的存在理由）
+
+> **Mapbox 的計費單位是 `Map` 物件初始化一次 = 文章的 PV 數，與載入誰的圖磚無關。**
+
+所以「保留 mapbox-gl、只把底圖換成 OSM」**省不到任何錢**。要真的歸零，必須連地圖函式庫
+一起換掉。這是整個 EM 系列最反直覺、也最關鍵的一條。
+
+| 情境 | 月成本 |
+|---|---|
+| 10 篇文章 × 5,000 PV，嵌入走 mapbox-gl | **+$250**（超出 50k 免費額度後 $5/1k） |
+| 同上，嵌入走 MapLibre + 自託管底圖 | **$0** |
+| 底圖儲存（R2 或既有 S3 管線） | 283 MB → 免費額度內 |
+
+> ⚠️ 查證誠實標記：查不到 Mapbox **明文禁止**搭第三方圖磚（ToS 與 pricing 頁皆未提及）。
+> 走 MapLibre 的真正理由是**繞開這個灰色地帶**，不是「被禁止」。
+
+## 三個入口
+
+| 入口 | 網址 | 用途 |
+|---|---|---|
+| 主站 deep link | `/?v=1&lng=…&lat=…&z=…&layers=…&style=…` | 分享畫面 |
+| 嵌入版 | `/embed?v=1&…` | 文章 `<iframe>` |
+| Share 按鈕 | 主站 header（桌機 + 精簡工具列各一） | 產出上面兩者 + 複製 |
+
+主站網址由 `moveend` 與圖層／底圖變動時自動同步（`replaceState`），所以按 Share 之前
+網址列已經是最新狀態。
+
+## 網址參數
+
+| 參數 | 說明 | 主站 | `/embed` |
+|---|---|---|---|
+| `v=1` | schema 版本。**缺它整組不解析**（舊嵌入碼防腐） | ✅ | ✅ |
+| `lng` / `lat` / `z` | 相機（缺一則整組相機 drop） | ✅ | ✅ |
+| `pitch` / `bearing` | 非 0 才寫入 | ✅ | ✅ |
+| `layers` | 逗號分隔的 layer key | ✅ | ✅ |
+| `style` | 主站底圖 id（7 種）。embed 用它推明暗 | ✅ | ✅ |
+| `date` / `h` | 凍結日期（YYYY-MM-DD）+ 小時 0–23 | ✅ | ✅（需有快照） |
+| `p.<key>` | overlayParams 覆寫 | ❌ | ✅ |
+| `theme` | `dark`\|`light`（style 未給時的回退） | — | ✅ |
+
+**主站不支援 `p.*` 是刻意的**：主站有 sidebar，URL override 會與使用者拉 slider 打架
+（`useTransportParams` 3028 行、數百個 hardcode `useState`，無法注入初始值）。
+
+## 嵌入版可用的圖層（三層白名單）
+
+| 類別 | 數量 | 來源 | 說明 |
+|---|---|---|---|
+| 靜態 | **145** | `overlayRegistry` 扣掉 dynamicData 與 gated | 自動派生，新增圖層不必改程式 |
+| 動態但已 CDN 化 | **7** | `/static-rpc/*.json` | 風機/光電/離岸風場/地熱/充電站/離島電網/北市再生 |
+| 歷史快照 | **1** | `/embed-snapshots/<layer>/<date>.geojson` | `plaActivity`（共機），需帶 `date=` |
+
+🔒 **35 個 owner-gated 圖層一律排除**，且不只是「不顯示」——實測 URL 硬塞 gated key 時，
+對應的資料檔**連一個 byte 都不會下載**（source 根本不建立）。
+
+**不支援**：Three.js CustomLayer（`ships` / `flights` / `rail` / `busLive`），
+embed 刻意不掛 Three.js。詳見 [`embed-dynamic-layers.md`](../../proposal/embed-dynamic-layers.md) §2。
+
+## 檔案地圖
+
+| 檔案 | 職責 |
+|---|---|
+| `src/lib/urlState.ts` | 網址 ↔ 狀態（`parseUrlState` / `buildUrl`）；版本閘門 + 靜默降級 |
+| `src/embed/EmbedApp.tsx` | 嵌入版主體（MapLibre）。不呼叫 `useTransportParams`、不掛 Three.js |
+| `src/embed/embedWhitelist.ts` | 三層白名單派生 |
+| `src/embed/maplibreAdapters.ts` | PMTiles protocol（兩引擎唯一的**實質**差異） |
+| `src/embed/basemapStyle.ts` | Protomaps style；底圖位置可由 `VITE_EMBED_BASEMAP_URL` 覆寫 |
+| `src/embed/dynamicCdnLayers.ts` | CDN 例外清單 + 通用 `rowsToGeoJSON` |
+| `src/embed/snapshotLayers.ts` | 歷史快照層的單日靜態 spec |
+| `src/embed/embedPopup.ts` | 通用 popup（欄位過濾 + XSS escape） |
+| `src/map/overlayManager.ts` | **雙引擎共用**：結構介面 `OverlayMap` + `pmtilesSource` 注入點 |
+| `src/components/ShareModal.tsx` | 分享面板 |
+| `scripts/export/export-embed-snapshot.sh` | 產歷史快照（psql 直出 GeoJSON） |
+| `embed.html` / `vite.config.ts` | 獨立 entry（多入口） |
+
+## Bundle
+
+| | 未壓縮 | gzip |
+|---|---|---|
+| 主站 | 4.4 MB | 1.2 MB |
+| `/embed` | 1.1 MB + 共用 LegendPanel 787 KB | **505 KB** |
+
+驗證方式：搜尋 build 產物中的 Mapbox token 特徵字串 `pk.eyJ` —— **embed chunk 出現 0 次**、
+主站 1 次，確認嵌入版完全不載入 mapbox-gl。
+
+## ⚠️ 部署需求（尚未完成）
+
+1. **底圖檔**：`public/base_map/taiwan_basemap.pmtiles`（283 MB，已 gitignore）
+   需上 S3 → 容器。既有 `upload/pull/nginx` 三處**零額外接線**（放對目錄的結果）。
+   產法見 [`../../proposal/embed-prototype/README.md`](../../proposal/embed-prototype/README.md)。
+2. **歷史快照**：`public/embed-snapshots/`（同上，走既有管線）
+3. **Zeabur 首次啟動**：283 MB 首拉需留意健康檢查時間（EM-13）
+4. **Cloudflare**：`/embed-snapshots/` 與 `/base_map/` 的快取規則
+
+## 驗收紀錄
+
+- `npx tsc -b` 綠 / **311 tests** 綠（EM 系列新增 ~60）
+- `nginx -t` 通過
+- 端到端（agent-browser 實測）：
+  - 相機參數精準命中、只開指定圖層（6 個兄弟層維持 none）
+  - gated 圖層零下載
+  - 嵌入版三種資料源（PMTiles / CDN 快照 / 歷史快照）皆正常渲染
+  - popup 點擊、hover 游標、明暗主題
+  - 文章嵌入排版（`docs/proposal/embed-prototype/demo-religion.html`）
+
+## 相關
+
+- 原型與重建步驟：[`../../proposal/embed-prototype/README.md`](../../proposal/embed-prototype/README.md)
+- 剩餘待辦：[`backlog.md`](./backlog.md)
+- 接手入口：[`handoff.md`](./handoff.md)

--- a/docs/features/embeddable-map/backlog.md
+++ b/docs/features/embeddable-map/backlog.md
@@ -1,0 +1,38 @@
+# Embeddable Map — Backlog
+
+> SSOT。`.claude/memory/BACKLOG.md` 的 EM 系列只留索引，細節看這裡。
+> 優先級：**P0** 阻塞 / **P1** 規劃期內 / **P2** 穩定後 / **P3** nice-to-have
+
+## 上線前必做
+
+| ID | 優先級 | 項目 | 備註 |
+|---|---|---|---|
+| EM-21 | **P0** | **底圖 + 快照上 S3 並部署** | `public/base_map/taiwan_basemap.pmtiles`（283 MB）與 `public/embed-snapshots/`。跑 `scripts/deploy/upload-deploy-assets.sh`；三處接線已就緒無需改腳本 |
+| EM-13 | P1 | 部署後驗收：實機 iframe（非 localhost）+ 行動裝置 + Cloudflare 快取規則 | 283 MB 首拉留意 Zeabur 健康檢查逾時 |
+
+## 功能待辦
+
+| ID | 優先級 | 項目 | 備註 |
+|---|---|---|---|
+| EM-17 | P2 | 補 `get_gas_station_layers` 快照 → 加油站 5 層可嵌 | loader 已用 `staticRpc` 但 `public/static-rpc/` 無此檔 → **主站一直靜默 fallback 打 RPC**。export 腳本已列該 RPC，需確認 migration 已套用後重跑。補完把 key 加進 `EMBED_CDN_LAYERS`（有測試守門擋「加了 key 但沒檔」） |
+| EM-18 | P2 | 更多歷史快照圖層（`earthquakeReplay` 等） | 樣板已成形：`snapshotLayers.ts` 加 spec + export 腳本加 case |
+| EM-11 | P2 | 底圖改放 Cloudflare R2（選配） | 目前走 `public/base_map/` 既有管線已可運作。改 R2 只需設 `VITE_EMBED_BASEMAP_URL`；R2 egress 免費，高流量時較划算 |
+| EM-12 | P3 | Protomaps 字型／sprite 自託管 | 目前指向 `protomaps.github.io`（已加進 CSP）。自託管可去掉最後一個外部依賴 |
+| EM-07 | P3 | facade 模式（先縮圖、點擊才載入） | 走 MapLibre 後成本已歸零 → **降級為純效能優化** |
+| EM-08 | P3 | 嵌入碼防腐：`layerAliases.ts` + 守門測試 | layer key 改名會讓既有文章的地圖全壞且無通知 |
+| EM-22 | P3 | popup 欄位標籤擴充 | `FIELD_LABELS` 目前約 25 個常見欄位；其餘顯示原始英文 key。值的中文化（如 `catholic`）刻意不做 —— 無底洞 |
+
+## 待討論
+
+| ID | 項目 | 現況 |
+|---|---|---|
+| EM-16 | Three.js 圖層（船舶／班機／鐵路／公車）嵌入 | **owner 2026-08-04：之後再談**。embed 刻意不掛 Three.js；即時感圖層嵌進靜態文章敘事價值低、移植成本最高。替代方案：截圖 + 連結 |
+
+## 明確不做
+
+- oEmbed endpoint / 動態 OG 圖（需動態後端，等真有第三方 CMS 需求）
+- 給第三方的 JS SDK（iframe 已足夠，且 iframe 內 JS 跑在自己 origin，token 不外流）
+- embed 的會員功能（iframe 內第三方 cookie 被瀏覽器封鎖，登入態不存在）
+- 讓 `/embed` 直接打任何 Supabase RPC（違反本功能的成本前提）
+- 即時類圖層嵌入（閃電／停車位／急診壅塞 —— 文章永久性與即時資料語意衝突）
+- 全站改 MapLibre（主站要保留 Mapbox 的好底圖；Three.js CustomLayer 遷移風險高）

--- a/docs/features/embeddable-map/changelog.md
+++ b/docs/features/embeddable-map/changelog.md
@@ -1,0 +1,53 @@
+# Embeddable Map — Changelog
+
+## 2026-08-05 — popup + 分享面板收尾（`feat/embed-popup-share`）
+
+- **通用 popup**（EM-20）：所有圖層可點。不複用主站 `useMapInteraction` + 30 檔／7379 行
+  客製面板（撐大 bundle 且只覆蓋 38 種 layerType）
+  - 欄位過濾逐輪收斂：內部 id → 硬名單；資料血緣後設 → **pattern**（逐個列舉擋不完）；
+    **布林 `false` 不顯示**（「不是古蹟」沒有資訊量），`true` 顯示為「是」；
+    空值含 MVT 常見的 `"[]"` / `"{}"`；上限 8 欄
+  - 🔒 key／value／圖層名全 escape，3 個 XSS 測試守門
+- **修**：嵌入版明暗改為同時吃 `style=` 與 `theme=` —— Share 產出的是 `style=`（主站底圖 id），
+  EmbedApp 原本只讀 `theme=` → 選淺色底圖分享出去仍是暗的
+- 加 `window.__embedMap` 診斷把手（同主站 `window.__map` 慣例）
+
+## 2026-08-04 — 分享面板 + 網址雙向同步（EM-19，取代原 EM-04）
+
+- `style=`（底圖 id）與 `h=`（0–23 小時）進 schema
+- `moveend` + 圖層／底圖變動時 `replaceState`；**不是 pushState、不綁 move、不進 React state**
+- ShareModal：連結 + iframe 代碼雙欄複製，標示網址包含哪些參數
+- ⚠️ 修掉自己寫錯的判準：原用 `timeMode !== "live"` 決定是否寫日期，但 `TimeMode` 只有
+  `"replay" | "live"` 且**預設就是 replay** → 每條分享連結都被凍上今天的日期。
+  改為比對「時間軸日期 vs 今天（台北時區）」
+
+## 2026-08-04 — 動態／歷史圖層（Phase A + B）
+
+- **EM-14**：`dynamicData` 但已 CDN 化的 7 層可嵌。發現快照**早就做完了**
+  （`public/static-rpc/` 25 檔），缺的只是 embed 怎麼吃 → 明確清單 + 通用 `rowsToGeoJSON`。
+  **零主站改動**
+- **EM-15**：按需歷史快照 pilot（`plaActivity`）。「文章要哪天就凍結哪天」，
+  不做 AR-14~16 的全量 per-day 匯出。`export-embed-snapshot.sh` psql 直出 GeoJSON
+  - 踩雷：psql `-c` 不做 `:'var'` 插值；`.env` 含未引號特殊字元、bash `source` 會當指令執行
+
+## 2026-08-03/04 — `/embed` 正式版（EM-05/06，PR #105）
+
+- `overlayManager` 泛化支援雙引擎：結構介面（union 會讓每個呼叫點 TS2349）+
+  `pmtilesSource` 注入點。主站行為零改動，另加編譯期斷言守門
+- Vite 多入口 + MapLibre 薄殼 + LegendPanel 複用 + 出處標示（不可由 `ui=` 移除）
+- nginx `location = /embed`（⚠️ `add_header` 不繼承，安全 header 須重複宣告）
+- 底圖落 `public/base_map/`：既有 upload/pull/nginx **零額外接線**
+
+## 2026-08-03 — URL 深連結 + 解除 iframe 封鎖（EM-02/03）
+
+- `src/lib/urlState.ts`：版本閘門 + 靜默降級 + gated 硬排除
+- nginx：移除 `X-Frame-Options`（不支援白名單語法），改 enforcing CSP `frame-ancestors *`
+  - ⚠️ `frame-ancestors` 在 `-Report-Only` 下**不生效**，故必須另立一條
+- 順手修 master 既有的 nginx 語法錯誤（`location /religion/` 缺閉合括號 → 一 redeploy 整站起不來）
+
+## 2026-08-03 — 規劃與底圖 spike（EM-01/09）
+
+- 關鍵發現：Mapbox 計費 = `Map` 初始化 = 文章 PV，**與圖磚來源無關** →
+  只換 OSM tile 省不到錢，必須連函式庫換成 MapLibre
+- 台灣 z0–15 Protomaps extract = **283 MB**（原估 500 MB 偏高），中文地名完整到「里」層級
+- owner 驗收底圖美觀度通過 → 定案走 MapLibre + Protomaps

--- a/docs/features/embeddable-map/handoff.md
+++ b/docs/features/embeddable-map/handoff.md
@@ -1,0 +1,163 @@
+# Embeddable Map — Handoff
+
+> 給「另一個 session／另一個人」接手用。目標是**不用回問**就能繼續做。
+> 全貌看 [`README.md`](./README.md)，剩餘工作看 [`backlog.md`](./backlog.md)。
+
+## 0. 現在最該做的一件事
+
+**底圖與快照還沒上 S3，所以正式站的 `/embed` 是壞的**（會載不到底圖）。
+
+```bash
+# 1. 確認本機有底圖（283 MB，gitignore；沒有的話照 docs/proposal/embed-prototype/README.md 重抽）
+ls -lh public/base_map/taiwan_basemap.pmtiles
+
+# 2. 上傳（三處接線已就緒，不必改腳本）
+./scripts/deploy/upload-deploy-assets.sh
+
+# 3. 部署後驗收
+#    - https://mini-taiwan-pulse.itsmigu.com/embed?v=1&lng=120.13&lat=23.09&z=11.2&layers=aquaculturePonds
+#    - 外站 iframe 實測（非 localhost）
+#    - Network 應只見 /base_map/ 與圖層檔，**不得出現 api.mapbox.com**
+```
+
+## 1. 架構一句話
+
+**共用資料與圖層邏輯，不共用地圖引擎與 UI。**
+
+```
+overlayRegistry (189 圖層定義)  ─┬─→ 主站 MapView (mapbox-gl) + App.tsx 3000 行狀態機
+overlayManager  (source/layer)  ─┤
+LegendPanel                     ─┴─→ /embed EmbedApp (MapLibre) 極簡 UI
+```
+
+`overlayManager` 是雙引擎共用的關鍵。它**只用兩者共有的 8 個 map 方法**，差異只有兩處：
+
+1. **型別**：`OverlayMap` 是結構介面，不是 `MapboxMap | MaplibreMap` union
+   —— union 會讓每個呼叫點都 TS2349（兩者 `getSource`/`addLayer` 泛型簽名分家）。
+   檔內有兩行編譯期斷言，任一引擎改簽名就會紅。
+2. **PMTiles source**：Mapbox 走 `mapbox-pmtiles` 的 `Style.setSourceType()`（Mapbox 專有 API），
+   MapLibre 走 `addProtocol("pmtiles", …)`。由 `OverlayEngineOptions.pmtilesSource` 注入。
+
+## 2. 網址 schema（`src/lib/urlState.ts`）
+
+```ts
+export interface UrlState {
+  camera?: { center: [number, number]; zoom: number; pitch: number; bearing: number };
+  layers?: (keyof LayerVisibility)[];
+  params?: Record<string, number>;   // 僅 /embed 消費
+  date?: string;                     // YYYY-MM-DD
+  hour?: number;                     // 0–23
+  style?: string;                    // 主站底圖 id
+  theme?: "dark" | "light";
+  ui?: string[];
+}
+
+export function parseUrlState(search: string, opts?: { allowedLayers?: ReadonlySet<string> }): UrlState;
+export function buildUrl(state: UrlState, base: string): string;
+```
+
+**改 schema 時的鐵則**：
+
+- `v=1` 是版本閘門，缺它或不符一律回空物件 → 舊嵌入碼不會被新解析器誤讀。
+  **要破壞相容性時應該升版號並保留舊版解析路徑**，不是直接改欄位語意。
+- 一切驗證失敗都**靜默 drop**，絕不 throw —— 嵌入碼散落在別人的文章裡，白屏是最糟的失敗模式。
+- `GATED_LAYERS` 的 key 一律 drop（`parseLayers` 內），這是私人資料的第一道防線。
+
+## 3. 白名單怎麼派生（`src/embed/embedWhitelist.ts`）
+
+```ts
+EMBED_ALLOWED_CONFIGS = OVERLAY_REGISTRY.filter(
+  (o) => (!o.dynamicData || o.id in EMBED_CDN_LAYERS) && !GATED_LAYERS.has(o.id)
+);
+EMBED_ALLOWED = new Set([...EMBED_ALLOWED_CONFIGS.map(o => o.id), ...SNAPSHOT_KEYS]);
+```
+
+**新增靜態圖層不必動這裡**（自動派生）。要放行一個動態圖層時：
+
+1. 先確認它有 CDN 快照（`public/static-rpc/<rpc>.json`）
+2. 加進 `EMBED_CDN_LAYERS`（key → rpc 名）
+3. 測試會自動驗「快照檔真的存在」與「不是 gated」
+
+## 4. 歷史快照怎麼加一層（`snapshotLayers.ts` + export 腳本）
+
+以 `plaActivity` 為樣板，兩處要改：
+
+**(a) 匯出**：`scripts/export/export-embed-snapshot.sh` 的 `case "$LAYER"` 加一個分支，
+SQL 直接組 GeoJSON。注意兩個既有踩雷：
+
+- psql 的 `-c` **不做** `:'var'` 插值 → 用 `__DATE__` 佔位符 + shell 端替換（日期已 regex 驗過）
+- `.env` 含未引號特殊字元 → **不要 `source .env`**，只 grep 需要的那一行
+
+**(b) 前端**：`SNAPSHOT_LAYERS` 加一個 `SnapshotLayerSpec`（sourceId + layers）。
+樣式要對齊主站的 hook，但**只做單日靜態版** —— 不做多日疊加／回放／ageFade。
+
+```bash
+./scripts/export/export-embed-snapshot.sh plaActivity 2026-07-30
+# → [export] ✅ features=4  size=4.0K
+```
+
+⚠️ **產出後一定要看 features 數**。BACKLOG BL-25 記著幾條上游死管線
+（`get_flight_trails` retention ≈9 天、`get_waste_trails_matched_day` 全日期 0 rows、
+`get_youbike_h3_*` matview 停更於 04-09）—— **RPC 有回應不代表那天真有資料**。
+
+## 5. 相關 RPC signature
+
+歷史快照 pilot 用的：
+
+```sql
+public.get_pla_tracks_range(p_end_date date, p_days int, p_include_review boolean)
+  RETURNS TABLE (
+    report_date date, days_ago int, shape_no int,
+    geom_geojson jsonb,          -- Polygon
+    shape_kind text,             -- 'rect'（走廊）| 'poly'（活動區）
+    vertices int, needs_review boolean, guided boolean, ...
+  )
+```
+
+顏色對照（與 `src/data/plaTracksLoader.ts` 的 `PLA_KIND_COLORS` 一致，改動要同步）：
+`rect → #38bdf8`、`poly → #a855f7`。
+
+## 6. 驗證嵌入版真的沒碰 Mapbox
+
+這是本功能的成本前提，每次改動後都該重驗：
+
+```bash
+npm run build
+grep -c "pk.eyJ" dist/assets/embed-*.js   # 必須是 0
+grep -c "pk.eyJ" dist/assets/main-*.js    # 主站會是 1
+```
+
+執行期驗證（瀏覽器 console）：
+
+```js
+performance.getEntriesByType('resource').filter(e => /mapbox|supabase\.co/.test(e.name))
+// 嵌入頁應為空陣列
+```
+
+## 7. 用 agent-browser 驗收的注意事項
+
+`/embed` 是 WebGL 頁面，踩到的坑與主站相同（全域 memory `agent-browser-mapbox-verify`）：
+
+- **daemon 導航後會遺失 WebGL context**（報 `Failed to initialize WebGL`、整頁空白但 UI 正常）。
+  本 feature 開發期間踩了 3 次。解法：`agent-browser close` 後帶 launch args 重開 session，
+  並**在同一輪 bash 呼叫內**完成 open → eval → screenshot。
+- 點擊 popup 要用真實滑鼠：`mouse move X Y` → `mouse down` → `mouse up`
+  （沒有 `mouse click` 子命令；MapLibre 的手勢處理不吃合成事件）。
+- 先用 `window.__embedMap.queryRenderedFeatures({layers})` + `map.project()` 找到
+  真的有圖徵的螢幕座標再點，否則會點在空白處誤判成「popup 壞了」。
+
+## 8. 本機跑起來
+
+```bash
+# dev server（用 subshell 起，否則會被背景任務管理清掉）
+(npm run dev > /tmp/vite-pulse.log 2>&1 &)
+
+# 主站（Share 按鈕在右上）
+open "http://localhost:3721/"
+
+# 嵌入版
+open "http://localhost:3721/embed.html?v=1&lng=120.2&lat=23.0&z=12.5&layers=religionTemples,religionChurches"
+
+# 文章嵌入效果（需另起 8900 供檔，見 docs/proposal/embed-prototype/README.md）
+open "http://localhost:8900/demo-religion.html"
+```

--- a/docs/proposal/embed-prototype/demo-religion.html
+++ b/docs/proposal/embed-prototype/demo-religion.html
@@ -1,0 +1,112 @@
+<!doctype html>
+<html lang="zh-Hant">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>示範：嵌入宗教場所地圖</title>
+<style>
+  :root { --ink:#1a1d21; --dim:#5b636b; --line:#e3e6ea; --accent:#9a5b2c; }
+  * { box-sizing:border-box; }
+  body {
+    margin:0; background:#fbfbfc; color:var(--ink);
+    font-family:-apple-system, "Noto Serif TC", Georgia, serif;
+    line-height:1.85; font-size:17px;
+  }
+  .wrap { max-width:720px; margin:0 auto; padding:52px 20px 90px; }
+  .kicker { font-family:system-ui, sans-serif; font-size:12px; letter-spacing:2px;
+            color:var(--accent); font-weight:700; }
+  h1 { font-size:33px; line-height:1.32; margin:10px 0 14px; letter-spacing:-.3px; }
+  .byline { font-family:system-ui, sans-serif; font-size:13px; color:var(--dim);
+            padding-bottom:20px; border-bottom:1px solid var(--line); margin-bottom:28px; }
+  p { margin:0 0 20px; }
+  h2 { font-size:21px; margin:36px 0 12px; }
+
+  figure.embed { margin:32px 0; }
+  figure.embed .frame {
+    position:relative; width:100%; aspect-ratio:16/10;
+    border:1px solid var(--line); border-radius:10px; overflow:hidden;
+    box-shadow:0 2px 14px rgba(20,25,32,.08); background:#0d0f12;
+  }
+  @media (max-width:640px){ figure.embed .frame { aspect-ratio:4/5; } }
+  figure.embed iframe { width:100%; height:100%; border:0; display:block; }
+  figcaption { font-family:system-ui, sans-serif; font-size:13px; color:var(--dim);
+               margin-top:9px; line-height:1.6; }
+
+  .note { font-family:system-ui, sans-serif; font-size:13.5px; background:#faf3ec;
+          border-left:3px solid var(--accent); padding:14px 16px; border-radius:0 6px 6px 0;
+          color:#2c3338; margin:28px 0; }
+  .note b { color:var(--accent); }
+  .note code { background:rgba(0,0,0,.06); }
+  code { font-family:ui-monospace, SFMono-Regular, Menlo, monospace; font-size:12.5px;
+         background:#eef1f4; padding:1.5px 5px; border-radius:4px; }
+  pre { background:#1e2228; color:#dfe6ee; padding:14px 16px; border-radius:8px;
+        overflow-x:auto; font-size:12.5px; line-height:1.7;
+        font-family:ui-monospace, SFMono-Regular, Menlo, monospace; }
+  .hl { color:#7ee0ef; }
+</style>
+</head>
+<body>
+<div class="wrap">
+
+  <div class="kicker">示範文章</div>
+  <h1>廟宇與教堂，在台灣畫出兩張不一樣的分布圖</h1>
+  <div class="byline">2026-08-05 · 假文章，用來檢視 Share 按鈕產出的嵌入效果</div>
+
+  <p>
+    如果把全台的廟宇和教堂同時標在一張圖上，兩者的疏密會呈現明顯不同的紋理——
+    一種沿著西部平原的聚落密集分布，另一種在都會區與東部原鄉各自成群。
+  </p>
+
+  <p>
+    下面這張地圖是<strong>活的</strong>：可以拖曳、縮放，右上角能開啟完整站台。
+    它是用主站的 Share 按鈕直接產生的，參數原封不動。
+  </p>
+
+  <figure class="embed">
+    <div class="frame">
+      <!-- ⚠️ 本機預覽版：src 指向 localhost:3721。正式代碼見文末 -->
+      <iframe
+        src="http://localhost:3721/embed.html?v=1&lng=120.3689&lat=23.6141&z=8.89&layers=religionTemples%2CreligionChurches&style=dark"
+        width="100%" height="480"
+        loading="lazy"
+        title="全台廟宇與教堂分布 — Mini Taiwan Pulse"
+        allowfullscreen></iframe>
+    </div>
+    <figcaption>
+      全台廟宇（PMTiles，含數萬點）與教堂分布。底圖 © OpenStreetMap；
+      資料來自內政部宗教場所登記。拖曳可移動，右上角開啟完整站台。
+    </figcaption>
+  </figure>
+
+  <p>
+    放大到城市尺度時，廟宇的密度會沿著老市街的軸線排開；切到東部，
+    教堂的比例則明顯上升。這種「同一張圖上兩種分布」的對照，是靜態截圖做不到的。
+  </p>
+
+  <h2>這篇文章實際貼的代碼</h2>
+
+  <p>
+    上面用的是本機預覽網址。等 <code>/embed</code> 部署到正式站之後，
+    你從 Share 按鈕複製到的就是這一段，可以直接貼進任何文章：
+  </p>
+
+<pre>&lt;iframe
+  src="https://mini-taiwan-pulse.itsmigu.com/embed<span class="hl">?v=1&amp;lng=120.3689&amp;lat=23.6141&amp;z=8.89&amp;layers=religionTemples%2CreligionChurches&amp;style=dark</span>"
+  width="100%" height="480" style="border:0;border-radius:10px"
+  loading="lazy" title="Mini Taiwan Pulse"&gt;&lt;/iframe&gt;</pre>
+
+  <div class="note">
+    <b>目前狀態</b>：<code>/embed</code> 尚未部署到正式站，所以上面那段正式代碼現在還打不開。
+    本頁的地圖走 <code>localhost:3721</code>，需要 dev server 開著。
+    嵌入版使用 <b>MapLibre + Protomaps 免費底圖</b>，不論這篇文章被讀幾次都<b>不產生 Mapbox 費用</b>。
+  </div>
+
+  <p>
+    最後放一段文字，讓你看到嵌入區塊夾在段落之間的排版效果，
+    以及捲動時 iframe 的行為是否自然。宗教場所的分布往往比行政區界更能反映
+    早期移民的路線與族群邊界，這也是把它疊在地圖上而不是做成表格的理由。
+  </p>
+
+</div>
+</body>
+</html>

--- a/src/embed/EmbedApp.tsx
+++ b/src/embed/EmbedApp.tsx
@@ -19,6 +19,9 @@ import { EMBED_ALLOWED, buildEmbedVisibility, configsFor } from "./embedWhitelis
 import { registerPmtilesProtocolOnce, maplibrePmtilesSource } from "./maplibreAdapters";
 import { EMBED_CDN_LAYERS, fetchCdnLayer } from "./dynamicCdnLayers";
 import { SNAPSHOT_LAYERS, fetchSnapshot } from "./snapshotLayers";
+import { buildPopupHtml, POPUP_CSS, POPUP_CSS_LIGHT } from "./embedPopup";
+import { LAYER_LABELS } from "../components/sidebar/layerCatalog";
+import type { LayerVisibility } from "../types";
 import { buildBasemapStyle } from "./basemapStyle";
 import {
   addAllOverlays, hydrateOverlayIfNeeded, updateAllOverlayThemes,
@@ -70,12 +73,20 @@ export function EmbedApp() {
     mapRef.current = map;
     map.addControl(new maplibregl.NavigationControl({ showCompass: false }), "bottom-right");
 
+    // EM-20 popup：layer id → layer key。snapshot 層是非同步加入的，故用外層 Map 累加。
+    const layerIdToKey = new Map<string, keyof LayerVisibility>();
+
     const onStyleLoad = () => {
       // 只註冊「這次真的要顯示」的圖層 —— 不必為 145 個白名單圖層都建 source
       const configs = configsFor(layerKeys);
       addAllOverlays(map, configs, isDark, visibility, params, {
         pmtilesSource: maplibrePmtilesSource,
       });
+      for (const config of configs) {
+        for (const spec of config.layers) {
+          layerIdToKey.set(`${config.sourceId}-${spec.suffix}`, config.id);
+        }
+      }
       for (const config of configs) {
         void hydrateOverlayIfNeeded(map, config);   // 靜態 GeoJSON 才會真的 fetch
       }
@@ -103,6 +114,7 @@ export function EmbedApp() {
             map.addSource(spec.sourceId, { type: "geojson", data: fc });
             for (const layer of spec.layers) {
               if (!map.getLayer(layer.id)) map.addLayer(layer);
+              layerIdToKey.set(layer.id, key);
             }
           });
         }
@@ -112,12 +124,45 @@ export function EmbedApp() {
       setReady(true);
     };
 
+    // EM-20：點擊彈出 popup。主站那套 30 檔／7379 行的客製面板不適合嵌入版
+    // （體積 + 只覆蓋 38 種 layerType），改為通用欄位列表，所有圖層皆可點。
+    const hitLayers = () => [...layerIdToKey.keys()].filter((id) => map.getLayer(id));
+
+    const onClick = (e: maplibregl.MapMouseEvent) => {
+      const ids = hitLayers();
+      if (!ids.length) return;
+      const feats = map.queryRenderedFeatures(e.point, { layers: ids });
+      const f = feats[0];
+      if (!f) return;
+      const key = layerIdToKey.get(f.layer.id);
+      const label = (key ? LAYER_LABELS[key] : undefined) ?? key ?? "";
+      new maplibregl.Popup({ closeButton: true, maxWidth: "280px", offset: 8 })
+        .setLngLat(e.lngLat)
+        .setHTML(buildPopupHtml(label, (f.properties ?? {}) as Record<string, unknown>, isDark))
+        .addTo(map);
+    };
+
+    // 游標提示「這裡可以點」
+    const onMove = (e: maplibregl.MapMouseEvent) => {
+      const ids = hitLayers();
+      const hit = ids.length > 0 && map.queryRenderedFeatures(e.point, { layers: ids }).length > 0;
+      map.getCanvas().style.cursor = hit ? "pointer" : "";
+    };
+
+    map.on("click", onClick);
+    map.on("mousemove", onMove);
+
+    // 診斷用把手（同主站 window.__map 慣例）：方便在 console 查圖層與圖徵
+    (window as unknown as { __embedMap?: maplibregl.Map }).__embedMap = map;
+
     if (map.isStyleLoaded()) onStyleLoad();
     else map.once("style.load", onStyleLoad);
 
     map.on("error", (e) => console.error("[embed]", e?.error ?? e));
 
     return () => {
+      map.off("click", onClick);
+      map.off("mousemove", onMove);
       mapRef.current = null;
       map.remove();
     };
@@ -141,6 +186,7 @@ export function EmbedApp() {
 
   return (
     <div style={{ position: "absolute", inset: 0, background: isDark ? "#0d0f12" : "#f2f4f6" }}>
+      <style>{POPUP_CSS}{isDark ? "" : POPUP_CSS_LIGHT}</style>
       <div ref={containerRef} style={{ position: "absolute", inset: 0 }} />
 
       {/* 連回完整站台 */}

--- a/src/embed/EmbedApp.tsx
+++ b/src/embed/EmbedApp.tsx
@@ -26,6 +26,9 @@ import {
 import { LegendPanel } from "../components/LegendPanel";
 
 const SITE = "https://mini-taiwan-pulse.itsmigu.com/";
+/** 主站底圖 id 中屬於「淺色」的（與 App.tsx 的 isDarkTheme 判準一致） */
+const LIGHT_STYLE_IDS = new Set(["light", "streets"]);
+
 /** 預設視角：全台 */
 const FALLBACK_CAMERA = { center: [120.9, 23.7] as [number, number], zoom: 6.9, pitch: 0, bearing: 0 };
 
@@ -37,7 +40,10 @@ export function EmbedApp() {
   // 網址只在 mount 時解析一次（嵌入頁沒有會改變它的互動）
   const urlRef = useRef(parseUrlState(window.location.search, { allowedLayers: EMBED_ALLOWED }));
   const url = urlRef.current;
-  const isDark = url.theme !== "light";
+  // 明暗來源有兩個：`theme=`（embed 專用）與 `style=`（主站底圖 id，分享按鈕會帶）。
+  // 主站的判準是 `!["light","streets"].includes(mapStyleId)`（App.tsx），這裡對齊 ——
+  // 否則使用者在主站選了淺色底圖、分享出去的嵌入版卻仍是暗的。
+  const isDark = url.style ? !LIGHT_STYLE_IDS.has(url.style) : url.theme !== "light";
   const layerKeys = url.layers ?? [];
   const visibility = useRef(buildEmbedVisibility(layerKeys)).current;
   const params = url.params ?? {};

--- a/src/embed/__tests__/embedPopup.test.ts
+++ b/src/embed/__tests__/embedPopup.test.ts
@@ -1,0 +1,86 @@
+/**
+ * 嵌入版 popup 的欄位過濾與跳脫（EM-20）
+ *
+ * XSS 那組是**安全測試**：嵌入頁跑在別人的網站裡，properties 全部來自資料檔，
+ * 一旦有欄位帶標籤而沒跳脫，就會在對方頁面上執行。
+ */
+import { describe, it, expect } from "vitest";
+import { buildPopupHtml, escapeHtml } from "../embedPopup";
+
+const html = (props: Record<string, unknown>, limit?: number) =>
+  buildPopupHtml("測試圖層", props, true, limit);
+
+describe("escapeHtml", () => {
+  it("跳脫全部五個危險字元", () => {
+    expect(escapeHtml(`<a href="x" data='y'>&`)).toBe(
+      "&lt;a href=&quot;x&quot; data=&#39;y&#39;&gt;&amp;",
+    );
+  });
+});
+
+describe("buildPopupHtml — 安全", () => {
+  it("🔒 property 值中的標籤被跳脫，不會變成真的元素", () => {
+    const out = html({ name: `<img src=x onerror="alert(1)">` });
+    expect(out).not.toContain("<img");
+    expect(out).toContain("&lt;img");
+  });
+
+  it("🔒 property key 也會被跳脫（欄位名同樣來自資料）", () => {
+    const out = html({ "<script>": "v" });
+    expect(out).not.toContain("<script>");
+  });
+
+  it("🔒 圖層名稱被跳脫", () => {
+    expect(buildPopupHtml("<b>x</b>", { name: "a" }, true)).not.toContain("<b>x</b>");
+  });
+});
+
+describe("buildPopupHtml — 欄位過濾", () => {
+  it("隱藏內部 id 與幾何欄位", () => {
+    const out = html({ name: "廟", osm_id: 1, lon: 121, lat: 25, geom_json: {}, entity_id: "x" });
+    expect(out).toContain("廟");
+    for (const k of ["osm_id", "lon", "lat", "geom_json", "entity_id"]) {
+      expect(out, `${k} 不該出現`).not.toContain(k);
+    }
+  });
+
+  it("用 pattern 擋掉後設欄位（逐個列舉擋不完）", () => {
+    const out = html({ name: "廟", source_tier: 6, coord_source: "osm", license: "ODbL", confidence: 0.75 });
+    for (const k of ["source_tier", "coord_source", "license", "confidence"]) {
+      expect(out, `${k} 不該出現`).not.toContain(k);
+    }
+  });
+
+  it("布林 false 不顯示（「不是古蹟」沒有資訊量），true 顯示為「是」", () => {
+    const out = html({ name: "廟", heritage: true, closed: false });
+    expect(out).toContain("是");
+    expect(out).not.toContain("closed");
+  });
+
+  it("空值一律略過（含 MVT 常見的 \"[]\" / \"{}\" 字串）", () => {
+    const out = html({ name: "廟", a: "", b: null, c: "[]", d: "{}", e: [], f: "null" });
+    for (const k of ["a", "b", "c", "d", "e", "f"]) {
+      expect(out, `${k} 不該出現`).not.toMatch(new RegExp(`>${k}<`));
+    }
+  });
+
+  it("有中文標籤就用中文，沒有就用原 key", () => {
+    const out = html({ address: "台南市", weird_field: "v" });
+    expect(out).toContain("地址");
+    expect(out).toContain("weird_field");
+  });
+
+  it("數字加千分位", () => {
+    expect(html({ modules: 12345 })).toContain("12,345");
+  });
+
+  it("超過上限的欄位被截掉（小嵌入框塞不下數十欄）", () => {
+    const many = Object.fromEntries(Array.from({ length: 30 }, (_, i) => [`f${i}`, `v${i}`]));
+    const rows = (html(many, 5).match(/class="ep-row"/g) ?? []).length;
+    expect(rows).toBe(5);
+  });
+
+  it("完全沒有可顯示欄位時給提示，不是空白框", () => {
+    expect(html({ osm_id: 1, lon: 121, lat: 25 })).toContain("沒有可顯示的欄位");
+  });
+});

--- a/src/embed/embedPopup.ts
+++ b/src/embed/embedPopup.ts
@@ -1,0 +1,163 @@
+/**
+ * 嵌入版的通用 popup（EM-20）
+ *
+ * 主站的 popup 是 30 個檔、7379 行的客製面板系統（`useMapInteraction` +
+ * 各 layerType 專屬 panel），而且只覆蓋 38 種 layerType —— embed 支援 145 層，
+ * 多數本來就沒有對應面板。把那套拉進來既撐大 bundle 也蓋不全。
+ *
+ * 這裡改走通用路線：**點到哪個 feature 就列出它的欄位**。犧牲主站的排版與單位格式化，
+ * 換到「所有圖層都能點」與極小的體積。
+ *
+ * ⚠️ 安全：嵌入頁跑在別人的網站裡，properties 全部來自資料檔 ——
+ *    一律 escape 後才進 innerHTML，不得直接拼接。
+ */
+
+/** 不值得顯示給讀者的欄位：內部 id、幾何殘留、繪圖用的衍生欄位 */
+const HIDDEN_KEYS = new Set([
+  // 幾何與繪圖用的衍生欄位
+  "lon", "lat", "geom_json", "geometry", "kind_color", "days_ago", "shape_no",
+  // 各式內部 id
+  "osm_id", "id", "gid", "fid", "objectid", "entity_id", "uid", "code",
+  // 資料血緣／後設 —— 對讀者無意義（出處已統一標在右下角）
+  "source", "source_org", "source_url", "source_id", "dataset", "provider",
+  "updated_at", "created_at", "fetched_at", "ingested_at", "version",
+]);
+
+/**
+ * 用 pattern 擋後設欄位 —— 逐個列舉擋不完（各資料源的血緣欄位命名各異），
+ * 而且新資料進來時會再冒出來。
+ */
+const HIDDEN_PATTERNS: RegExp[] = [
+  /^source[_-]/, /[_-]source$/,      // source_tier / coord_source …
+  /^license$/, /^confidence$/, /^score$/, /^rank$/,
+  /[_-]tier$/, /^raw[_-]/, /[_-]id$/,
+  /^is[_-]/, /[_-]flag$/,            // 旗標類：true 才有資訊，見 isEmpty
+  /precision$/, /^geocode[_-]/,      // 地理編碼品質：內部品保用，不是給讀者看的
+];
+
+/** 常見欄位的中文標籤；查不到就用原 key（英文欄位名對讀者仍有基本可讀性） */
+const FIELD_LABELS: Record<string, string> = {
+  name: "名稱",
+  name_zh: "名稱",
+  address: "地址",
+  operator: "營運者",
+  capacity_mw: "裝置容量 (MW)",
+  area_m2: "面積 (m²)",
+  county: "縣市",
+  town: "鄉鎮",
+  type: "類型",
+  category: "類別",
+  status: "狀態",
+  year: "年份",
+  report_date: "通報日期",
+  shape_kind: "形狀類型",
+  kind_label: "類型",
+  vertices: "頂點數",
+  deity: "主祀神明",
+  religion: "宗教",
+  religion_type: "宗教類別",
+  deity_family: "神明系統",
+  main_deity: "主祀神明",
+  denomination: "教派",
+  phone: "電話",
+  plant_source: "能源類型",
+  plant_method: "發電方式",
+  modules: "模組數",
+};
+
+export function escapeHtml(v: unknown): string {
+  return String(v)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+/** 數字加千分位；其餘原樣（已 escape）。 */
+function formatValue(v: unknown): string {
+  if (v === true || v === "true") return "是";
+  if (typeof v === "number" && Number.isFinite(v)) {
+    return escapeHtml(Number.isInteger(v) ? v.toLocaleString("en-US") : v.toFixed(2));
+  }
+  return escapeHtml(v);
+}
+
+function isEmpty(v: unknown): boolean {
+  if (v === null || v === undefined) return true;
+  // 布林 false 是噪音：「不是古蹟」「不在名錄」對讀者沒有資訊量，只有 true 值得列
+  if (v === false || v === "false") return true;
+  if (Array.isArray(v)) return v.length === 0;
+  const t = typeof v === "string" ? v.trim() : v;
+  // MVT/GeoJSON 常把空集合塞成字串；"[]" / "{}" 對讀者等同沒有值
+  return t === "" || t === "null" || t === "[]" || t === "{}" || t === "undefined";
+}
+
+/**
+ * 組 popup 的 HTML。最多列 `limit` 個欄位 —— 有些圖層帶數十個欄位，
+ * 全列出來會把小小的嵌入框塞滿。
+ */
+export function buildPopupHtml(
+  layerLabel: string,
+  properties: Record<string, unknown>,
+  isDark: boolean,
+  limit = 8,
+): string {
+  const rows = Object.entries(properties)
+    .filter(([k, v]) =>
+      !HIDDEN_KEYS.has(k) &&
+      !k.startsWith("_") &&
+      !HIDDEN_PATTERNS.some((re) => re.test(k)) &&
+      !isEmpty(v))
+    .slice(0, limit)
+    .map(([k, v]) => {
+      const label = escapeHtml(FIELD_LABELS[k] ?? k);
+      return `<div class="ep-row"><span class="ep-k">${label}</span><span class="ep-v">${formatValue(v)}</span></div>`;
+    })
+    .join("");
+
+  const body = rows || `<div class="ep-empty">此圖徵沒有可顯示的欄位</div>`;
+  return (
+    `<div class="ep-wrap${isDark ? "" : " ep-light"}">` +
+    `<div class="ep-title">${escapeHtml(layerLabel)}</div>` +
+    body +
+    `</div>`
+  );
+}
+
+/** popup 樣式。MapLibre 原生 popup 預設是白底，暗色主題要整組覆寫。 */
+export const POPUP_CSS = `
+.maplibregl-popup-content {
+  padding: 0; border-radius: 8px; overflow: hidden;
+  box-shadow: 0 4px 18px rgba(0,0,0,.35);
+  background: rgba(16,20,26,.96);
+}
+.maplibregl-popup-tip { border-top-color: rgba(16,20,26,.96) !important; border-bottom-color: rgba(16,20,26,.96) !important; }
+.maplibregl-popup-close-button { color: #8b949e; font-size: 17px; padding: 2px 7px; }
+.maplibregl-popup-close-button:hover { background: transparent; color: #fff; }
+.ep-wrap {
+  min-width: 168px; max-width: 264px; padding: 9px 11px 10px;
+  font-family: system-ui, -apple-system, "Noto Sans TC", sans-serif;
+  font-size: 12px; line-height: 1.5; color: #d7dee6;
+}
+.ep-title {
+  font-weight: 700; font-size: 12.5px; color: #4fc3f7;
+  margin-bottom: 6px; padding-bottom: 5px;
+  border-bottom: 1px solid rgba(255,255,255,.1);
+}
+.ep-row { display: flex; gap: 10px; justify-content: space-between; padding: 1.5px 0; }
+.ep-k { color: #8b949e; flex-shrink: 0; }
+.ep-v { text-align: right; word-break: break-word; }
+.ep-empty { color: #8b949e; }
+.ep-light .ep-title { color: #0b5f8a; border-bottom-color: rgba(0,0,0,.1); }
+.ep-light { color: #23292f; }
+.ep-light .ep-k, .ep-light .ep-empty { color: #6b737b; }
+`;
+
+/** 淺色主題時，連 popup 外殼一起換色 */
+export const POPUP_CSS_LIGHT = `
+.maplibregl-popup-content { background: rgba(255,255,255,.97); }
+.maplibregl-popup-tip { border-top-color: rgba(255,255,255,.97) !important; border-bottom-color: rgba(255,255,255,.97) !important; }
+.maplibregl-popup-close-button { color: #888; }
+.maplibregl-popup-close-button:hover { color: #222; }
+`;


### PR DESCRIPTION
承 #105，把可嵌入地圖功能收尾。

## 做了什麼

### 1. 嵌入版點擊 popup（EM-20）
所有圖層都可點擊查看欄位。**沒有複用主站那套** —— `useMapInteraction` + 30 檔／7379 行的客製面板，既撐大 embed bundle 又只覆蓋 38 種 layerType（embed 支援 145 層）。改走通用欄位列表。

欄位過濾是實際點下去逐輪收斂的：
- 內部 id／幾何殘留 → 硬名單
- 資料血緣後設（`source_tier`／`coord_source`／`license`／`confidence`／`*_precision`）→ **用 pattern 擋**，逐個列舉擋不完
- **布林 `false` 不顯示** —— 「不是古蹟」「不在名錄」對讀者沒有資訊量，只有 `true` 值得列
- 空值含 MVT 常見的 `"[]"` / `"{}"` 字串；上限 8 欄

🔒 嵌入頁跑在別人網站上，key／value／圖層名一律 escape 後才進 `innerHTML`，3 個 XSS 測試守門。

### 2. 修：嵌入版明暗吃錯參數
Share 產出的是 `style=`（主站底圖 id），但 EmbedApp 只讀 `theme=` → **選淺色底圖分享出去仍是暗的**。改為 style 優先、對齊 `App.tsx` 既有判準。

### 3. 補齊 feature 文件
`docs/features/embeddable-map/` 四件套。BACKLOG 的 EM 段落照 pla-activity 慣例改為索引，細節不再雙寫。

## 驗收
- `npx tsc -b` 綠 · **311 tests** 綠（本 PR 新增 14）
- 實測點擊臺南教會 → 標題「教會 Churches」+ 名稱/縣市/鄉鎮/宗教類別/教派/地址，hover 游標變 pointer
- 明暗主題、關閉鈕、文章內嵌排版皆正常

## ⚠️ 合併後仍未完成
**底圖（283MB）與快照尚未上 S3，正式站的 `/embed` 目前是壞的**（載不到底圖）。步驟見 `docs/features/embeddable-map/handoff.md` §0（BACKLOG EM-21）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)