### PR TITLE
perf(embed): Cloudflare 邊緣快取 + 快照 immutable（EM-13）

### DIFF
--- a/.claude/memory/BACKLOG.md
+++ b/.claude/memory/BACKLOG.md
@@ -18,7 +18,8 @@
 | ID | 優先級 | 項目 | 狀態 |
 |---|---|---|---|
 | EM-21 | — | 底圖（297MB）+ 快照上 S3 並部署 | **done**（2026-08-05；正式站驗證 Mapbox 0 / Supabase 0） |
-| EM-13 | P1 | Cloudflare `/base_map/`、`/embed-snapshots/` 快取規則 + 行動裝置實機 | open |
+| EM-13 | — | Cloudflare 快取規則 | **done**（2026-08-05；規則內容記於 feature handoff §0b） |
+| EM-23 | P2 | 行動裝置實機驗收 | open |
 | EM-01~06, 09, 10, 14, 15, 19, 20 | — | 規劃／底圖／URL／`/embed`／CDN 層／歷史快照／分享面板／popup | **done** |
 | EM-16 | — | Three.js 圖層（船舶/班機/鐵路/公車）嵌入 | **待討論**（owner 2026-08-04：之後再談） |
 | EM-07/08/11/12/17/18/22 | P2–P3 | 加油站快照補檔、更多歷史快照層、底圖改 R2、字型自託管、facade、嵌入碼防腐、popup 標籤 | open |

--- a/docs/features/embeddable-map/backlog.md
+++ b/docs/features/embeddable-map/backlog.md
@@ -8,12 +8,13 @@
 | ID | 項目 | 結果 |
 |---|---|---|
 | EM-21 | 底圖 + 快照上 S3 並部署 | ✅ 2026-08-05。297 MB 底圖 + 共機快照上 S3；Zeabur 自動部署；正式站驗證 **Mapbox 0 / Supabase 0** |
+| EM-13 | Cloudflare 快取規則 | ✅ 2026-08-05。Cache Rule `Static map data`（設定內容記於 handoff §0b）。實測快照/PMTiles/底圖 range 全部 HIT |
 
 ## 待辦
 
 | ID | 優先級 | 項目 | 備註 |
 |---|---|---|---|
-| EM-13 | P1 | Cloudflare 對 `/base_map/`、`/embed-snapshots/` 的快取規則 + 行動裝置實機 | 部署本身已完成；快取規則未設，目前每次都回源 |
+| EM-23 | P2 | 行動裝置實機驗收 | 桌機與模擬器已驗；真機（尤其低階 Android）的 MapLibre 效能未測 |
 
 ## 功能待辦
 

--- a/docs/features/embeddable-map/changelog.md
+++ b/docs/features/embeddable-map/changelog.md
@@ -1,5 +1,16 @@
 # Embeddable Map — Changelog
 
+## 2026-08-05 — Cloudflare 邊緣快取（EM-13）
+
+- 建 Cache Rule `Static map data`（設定內容記於 [`handoff.md`](./handoff.md) §0b）——
+  Cloudflare 預設不快取 `.pmtiles` / `.geojson` 副檔名，設定前全是 `DYNAMIC`
+- nginx `/embed-snapshots/` 改 `immutable` + 1y（檔名含日期、內容永不變 = 天然 cache busting）
+- 不設 Status code TTL：Edge TTL 選「沒有 cache-control 就 bypass」+ nginx 的
+  `add_header` 無 `always` → 404 天然不被快取
+- ⚠️ **驗證踩雷**：`curl -I`（HEAD）會回 `DYNAMIC` 讓人誤判規則沒生效，一律用 GET
+- 實測：快照 HIT×3、`temples.pmtiles` MISS→HIT、**底圖 297 MB 純 range request 也 HIT**
+  （Cloudflare 自行處理大檔案分段快取，不需先完整 GET）
+
 ## 2026-08-05 — 🚀 部署上線（EM-21）
 
 - 底圖 `taiwan_basemap.pmtiles`（297 MB）+ 共機快照上 S3 `deploy-assets/`

--- a/docs/features/embeddable-map/handoff.md
+++ b/docs/features/embeddable-map/handoff.md
@@ -27,6 +27,56 @@ aws s3 cp public/base_map/taiwan_basemap.pmtiles "s3://$S3_BUCKET/deploy-assets/
 ⚠️ 容器**啟動時**才 pull S3，光上傳不會生效。要 push 觸發部署（empty commit 無效，
 Zeabur webhook 看 file diff）或用 Zeabur dashboard redeploy。
 
+## 0b. Cloudflare 快取設定（EM-13，2026-08-05 已設定）
+
+⚠️ **這是 dashboard 設定、不在程式碼裡**，故完整記於此。要重建或除錯時照抄。
+
+**Rules → Cache Rules → `Static map data`**
+
+條件（Custom filter expression）：
+
+```
+(ends_with(http.request.uri.path, ".pmtiles")) or
+(ends_with(http.request.uri.path, ".geojson")) or
+(starts_with(http.request.uri.path, "/static-rpc/")) or
+(starts_with(http.request.uri.path, "/embed-snapshots/"))
+```
+
+| 設定 | 值 |
+|---|---|
+| Cache eligibility | **Eligible for cache** |
+| Edge TTL | **Use cache-control header if present, bypass cache if not** |
+| Browser TTL | **Respect origin TTL** |
+| Status code TTL | **不設**（見下） |
+
+**為什麼要建這條規則**：Cloudflare 預設只快取特定副檔名清單（`.js`/`.css`/`.jpg`…），
+`.pmtiles` 與 `.geojson` **不在內** → 設定前全部是 `cf-cache-status: DYNAMIC`，每次都回源。
+
+**為什麼不設 Status code TTL**：Edge TTL 選的是「沒有 cache-control 就 bypass」，
+而 nginx 的 `add_header Cache-Control "public"` **沒有 `always`** → 404 回應不帶該 header
+→ Cloudflare 直接 bypass。PRINCIPLES 2026-06-02 那個「404 被釘住整個 TTL」的坑天然避開。
+**若日後把 `add_header` 改成 `always`，就必須回來補 Status code TTL（404/5xx → No cache）。**
+
+### ⚠️ 驗證快取時不要用 `curl -I`
+
+`-I` 是 HEAD 請求，Cloudflare 對 HEAD 的快取行為與 GET 不同 —— 會回 `DYNAMIC`
+讓人誤以為規則沒生效。**一律用 GET**：
+
+```bash
+curl -s -o /dev/null -D - <url> | grep -i cf-cache-status
+```
+
+2026-08-05 實測（設定後）：
+
+| 目標 | 結果 |
+|---|---|
+| 快照 GeoJSON，GET ×3 | HIT / HIT / HIT |
+| `temples.pmtiles`（12 MB） | MISS → HIT（age: 4） |
+| 底圖 297 MB，**純 Range Request** ×3 | MISS → HIT → HIT |
+
+最後一項確認了 Cloudflare 會自行處理大檔案的分段快取 —— PMTiles 的 range request
+不需要先有完整 GET 就能吃到邊緣快取。
+
 ## 1. 架構一句話
 
 **共用資料與圖層邏輯，不共用地圖引擎與 UI。**


### PR DESCRIPTION
承 #106，把 EM-13（邊緣快取）收掉。

## 問題

`/base_map/`、`/embed-snapshots/`、各資料目錄的 `.pmtiles` / `.geojson` 全部是 `cf-cache-status: DYNAMIC` —— 每一次請求都回源。

**根因**：Cloudflare 預設只快取特定副檔名清單（`.js` / `.css` / `.jpg`…），`.pmtiles` 與 `.geojson` 不在內。單改 nginx header 沒用。

## 做了什麼

1. **Cloudflare Cache Rule**（dashboard 設定，owner 已完成）—— 完整內容記進 `handoff.md` §0b，要重建或除錯時照抄
2. **nginx**：`/embed-snapshots/` 改 `immutable` + 1y。檔名含日期且內容永不改變（凍結的某一天）＝ 天然 cache busting，換內容一律換檔名

## 為何不設 Status code TTL

Edge TTL 選「沒有 cache-control 就 bypass」，而 nginx 的 `add_header Cache-Control "public"` **沒有 `always`** → 404 不帶該 header → Cloudflare 直接 bypass。PRINCIPLES 2026-06-02 那個「404 被釘住整個 TTL」的坑天然避開。

⚠️ 日後若把 `add_header` 改成 `always`，就必須回來補 Status code TTL。

## 驗證（設定後實測）

| 目標 | 結果 |
|---|---|
| 快照 GeoJSON，GET ×3 | HIT / HIT / HIT |
| `temples.pmtiles`（12 MB） | MISS → HIT（age: 4） |
| **底圖 297 MB，純 Range Request ×3** | MISS → **HIT** → **HIT** |

最後一項確認 Cloudflare 會自行處理大檔案的分段快取，PMTiles 不需要先有完整 GET 就能吃到邊緣快取。

## ⚠️ 踩雷紀錄

**驗證快取不能用 `curl -I`** —— HEAD 請求會回 `DYNAMIC`，讓人誤以為規則沒生效。我第一輪就是這樣誤判的。一律用 GET。

🤖 Generated with [Claude Code](https://claude.com/claude-code)