### PR TITLE
feat(monitor): 食品價格監測板（四指數 2×2 × 180 天）

### DIFF
--- a/src/components/intel/monitor/FoodPriceBoard.tsx
+++ b/src/components/intel/monitor/FoodPriceBoard.tsx
@@ -1,0 +1,305 @@
+import { useEffect, useMemo, useState } from "react";
+import { COLORS, FONT_CJK, FONT_DATA } from "../intelTokens";
+import { RADIUS, FONT_SIZE } from "../../../styles/designTokens";
+import { SectionLabel } from "./PressureRing";
+import {
+  fetchFoodPriceDaily, fetchFoodPriceSummary,
+  FOOD_LABELS, FOOD_COLORS, FOOD_SCOPE, FOOD_ALERT_HIGH, FOOD_ALERT_LOW,
+  type FoodPriceDay, type FoodPriceSummary, type FoodIndicator,
+} from "../../../data/intelLoaders";
+
+/**
+ * 食品價格監測（migration 334/335）
+ *
+ * 四個指數 2×2：VPI 菜 / FPI 魚 / MPI 豬雞肉 / EPI 蛋，各看近 180 天。
+ *
+ * ⚠️ 畫面上四件不可省的誠實標註：
+ *  1. **異常有方向**：偏高（紅）是民生壓力、偏低（青）是供給過剩／產地崩盤。
+ *     兩者都是紅燈但意義相反，用同一顏色會誤導。
+ *  2. **看的是偏離常態不是價位高低** —— 10 月青蔥貴是季節常態，5 月青蔥貴才是事件。
+ *     所以卡片主指標給「偏離 %」而不是只給指數值。
+ *  3. `low_coverage`（當日資料未齊）折線要**斷開**，不可補值連過去。
+ *  4. **不含牛肉** —— 台灣國產牛量太小無拍賣機制，農業部無此 API（結構性缺口非漏抓）。
+ */
+
+const WINDOW = 180;
+const ORDER: FoodIndicator[] = ["VPI", "FPI", "MPI", "EPI"];
+
+interface Props { open: boolean }
+
+export function FoodPriceBoard({ open }: Props) {
+  const [days, setDays] = useState<FoodPriceDay[]>([]);
+  const [summary, setSummary] = useState<FoodPriceSummary[]>([]);
+
+  useEffect(() => {
+    if (!open) return;
+    let cancelled = false;
+    const tick = () => {
+      fetchFoodPriceDaily(WINDOW)
+        .then((r) => { if (!cancelled) setDays(r); })
+        .catch((e) => console.warn("[FoodPriceBoard] daily", e));
+      fetchFoodPriceSummary(WINDOW)
+        .then((r) => { if (!cancelled) setSummary(r); })
+        .catch((e) => console.warn("[FoodPriceBoard] summary", e));
+    };
+    tick();
+    const id = window.setInterval(tick, 60 * 60_000);   // 來源 T+1，一小時一次已遠快於需要
+    return () => { cancelled = true; window.clearInterval(id); };
+  }, [open]);
+
+  const byIndicator = useMemo(() => {
+    const m = new Map<FoodIndicator, FoodPriceDay[]>();
+    for (const d of days) {
+      const arr = m.get(d.indicator);
+      if (arr) arr.push(d); else m.set(d.indicator, [d]);
+    }
+    return m;
+  }, [days]);
+
+  const totalAlerts = summary.reduce((s, x) => s + x.highAlertDays + x.lowAlertDays, 0);
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 10 }}>
+      <SectionLabel color="#5fbf6d">食品價格 · FOOD PRICE MONITOR</SectionLabel>
+      <div
+        style={{
+          borderRadius: RADIUS.xl,
+          border: `1px solid ${COLORS.panelBorder}`,
+          background: "linear-gradient(160deg, rgba(95,191,109,0.06), rgba(255,255,255,0.012))",
+          padding: "12px 14px",
+          display: "flex", flexDirection: "column", gap: 11,
+        }}
+      >
+        {!summary.length ? (
+          <div style={{ fontFamily: FONT_CJK, fontSize: FONT_SIZE.sm, color: COLORS.textFaint, padding: "10px 0" }}>
+            資料載入中…
+          </div>
+        ) : (
+          <>
+            <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 9 }}>
+              {ORDER.map((key) => {
+                const s = summary.find((x) => x.indicator === key);
+                if (!s) return null;
+                return <IndexCell key={key} s={s} series={byIndicator.get(key) ?? []} />;
+              })}
+            </div>
+            <Legend />
+            <div style={{ fontSize: FONT_SIZE.xs, color: COLORS.textDim, lineHeight: 1.5 }}>
+              農業部批發拍賣成交價 · 每日 T+1 · 基期 2024-2025 = 100 ·
+              近 {WINDOW} 天{totalAlerts > 0 ? ` · 期間 ${totalAlerts} 個異常日` : " · 期間無異常日"} ·
+              ⚠️ 肉價不含牛（台灣無牛肉交易行情）
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/* ── 單一指數格 ─────────────────────────────────────────── */
+
+function IndexCell({ s, series }: { s: FoodPriceSummary; series: FoodPriceDay[] }) {
+  const color = FOOD_COLORS[s.indicator];
+  const dev = s.latestDev;
+  // 主指標是「偏離常態」而非價位 —— 價位高低本身不是訊號
+  const devColor = dev === null ? COLORS.textFaint
+    : dev >= 10 ? FOOD_ALERT_HIGH : dev <= -10 ? FOOD_ALERT_LOW : COLORS.textDefault;
+  const stale = s.latestLight === "low_coverage";
+
+  return (
+    <div
+      style={{
+        borderRadius: RADIUS.lg,
+        border: `1px solid ${color}33`,
+        background: `${color}0d`,
+        padding: "8px 9px 7px",
+        display: "flex", flexDirection: "column", gap: 5, minWidth: 0,
+      }}
+    >
+      {/* 標題列 */}
+      <div style={{ display: "flex", alignItems: "baseline", gap: 5, minWidth: 0 }}>
+        <span style={{ fontFamily: FONT_CJK, fontSize: 12.5, fontWeight: 700, color: COLORS.textStrong }}>
+          {FOOD_LABELS[s.indicator]}
+        </span>
+        <span style={{ fontFamily: FONT_DATA, fontSize: 8.5, letterSpacing: "0.8px", color, opacity: 0.85 }}>
+          {s.indicator}
+        </span>
+        <StatusDot light={s.latestLight} dev={dev} />
+      </div>
+
+      {/* 涵蓋範圍 —— 只給代碼看不出這條線是誰算出來的 */}
+      <div
+        style={{
+          fontFamily: FONT_CJK, fontSize: 8.5, color: COLORS.textFaint,
+          marginTop: -3, whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis",
+        }}
+        title={FOOD_SCOPE[s.indicator]}
+      >
+        {FOOD_SCOPE[s.indicator]}
+      </div>
+
+      {/* 主數值：指數 + 偏離 */}
+      <div style={{ display: "flex", alignItems: "baseline", gap: 6, flexWrap: "wrap" }}>
+        <span style={{ fontFamily: FONT_DATA, fontSize: 21, fontWeight: 600, color: COLORS.textStrong, lineHeight: 1 }}>
+          {s.latestVal.toFixed(1)}
+        </span>
+        <span style={{ fontFamily: FONT_DATA, fontSize: 11, fontWeight: 600, color: devColor }}>
+          {dev === null ? "—" : `${dev > 0 ? "+" : ""}${dev.toFixed(1)}%`}
+        </span>
+        <span style={{ fontFamily: FONT_CJK, fontSize: 8.5, color: COLORS.textFaint }}>vs 常態</span>
+      </div>
+
+      <Sparkline series={series} color={color} />
+
+      {/* 底部：異常天數（方向分離）+ YoY */}
+      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", gap: 4 }}>
+        <div style={{ display: "flex", gap: 5, fontFamily: FONT_DATA, fontSize: 8.5 }}>
+          {s.highAlertDays > 0 && (
+            <span style={{ color: FOOD_ALERT_HIGH }} title="價格異常偏高的天數（民生壓力）">
+              ▲{s.highAlertDays}
+            </span>
+          )}
+          {s.lowAlertDays > 0 && (
+            <span style={{ color: FOOD_ALERT_LOW }} title="價格異常偏低的天數（供給過剩／產地崩盤）">
+              ▼{s.lowAlertDays}
+            </span>
+          )}
+          {s.highAlertDays === 0 && s.lowAlertDays === 0 && (
+            <span style={{ color: COLORS.textFaint }}>無異常日</span>
+          )}
+          {s.warnDays > 0 && (
+            <span style={{ color: COLORS.textDim }} title="黃燈（注意）天數">
+              ·{s.warnDays} 注意
+            </span>
+          )}
+        </div>
+        <span
+          style={{ fontFamily: FONT_DATA, fontSize: 8.5, color: COLORS.textDim }}
+          title={`最新 ${s.latestDate}${stale ? "（當日資料未齊，已取前一交易日）" : ""}`}
+        >
+          {s.yoyPct === null ? "" : `年增 ${s.yoyPct > 0 ? "+" : ""}${s.yoyPct.toFixed(1)}%`}
+        </span>
+      </div>
+    </div>
+  );
+}
+
+/* ── 燈號圓點 ───────────────────────────────────────────── */
+
+function StatusDot({ light, dev }: { light: FoodPriceSummary["latestLight"]; dev: number | null }) {
+  // 紅燈要再看方向：偏高與偏低是相反的事
+  const { c, t } =
+    light === "red"
+      ? (dev !== null && dev < 0
+          ? { c: FOOD_ALERT_LOW, t: "異常偏低（供給過剩）" }
+          : { c: FOOD_ALERT_HIGH, t: "異常偏高（民生壓力）" })
+      : light === "amber" ? { c: "#e0a63c", t: "注意" }
+      : light === "low_coverage" ? { c: COLORS.textFaint, t: "當日資料未齊" }
+      : { c: "#63b26a", t: "常態" };
+  return (
+    <span
+      title={t}
+      style={{
+        marginLeft: "auto", width: 7, height: 7, borderRadius: "50%",
+        background: c, boxShadow: `0 0 5px ${c}88`, flex: "none",
+      }}
+    />
+  );
+}
+
+/* ── 180 天迷你走勢 ─────────────────────────────────────── */
+
+const SPARK_H = 34;
+
+function Sparkline({ series, color }: { series: FoodPriceDay[]; color: string }) {
+  const geom = useMemo(() => {
+    const pts = series.filter((d) => Number.isFinite(d.indexVal));
+    if (pts.length < 2) return null;
+    const vals = pts.map((d) => d.indexVal);
+    const mn = Math.min(...vals), mx = Math.max(...vals);
+    const rg = mx - mn || 1;
+    const x = (i: number) => (i / (pts.length - 1)) * 100;
+    const y = (v: number) => SPARK_H - 2 - ((v - mn) / rg) * (SPARK_H - 4);
+
+    // ⚠️ low_coverage 折線斷開，不補值連過去
+    let d = "";
+    let pen = false;
+    pts.forEach((p, i) => {
+      if (p.light === "low_coverage") { pen = false; return; }
+      d += `${pen ? "L" : "M"}${x(i).toFixed(2)},${y(p.indexVal).toFixed(2)}`;
+      pen = true;
+    });
+
+    // 異常區段（依方向分色）
+    const bands: { x0: number; x1: number; up: boolean }[] = [];
+    let run: { i0: number; up: boolean } | null = null;
+    pts.forEach((p, i) => {
+      const isAlert = p.light === "red";
+      const up = (p.devPct ?? 0) >= 0;
+      if (isAlert && (!run || run.up !== up)) {
+        if (run) bands.push({ x0: x(run.i0), x1: x(i - 1), up: run.up });
+        run = { i0: i, up };
+      } else if (!isAlert && run) {
+        bands.push({ x0: x(run.i0), x1: x(i - 1), up: run.up });
+        run = null;
+      }
+    });
+    if (run) bands.push({ x0: x((run as { i0: number }).i0), x1: 100, up: (run as { up: boolean }).up });
+
+    const last = pts[pts.length - 1]!;
+    return { d, bands, lastX: x(pts.length - 1), lastY: y(last.indexVal), mn, mx };
+  }, [series]);
+
+  if (!geom) {
+    return <div style={{ height: SPARK_H, display: "flex", alignItems: "center", fontFamily: FONT_DATA, fontSize: 8.5, color: COLORS.textGhost }}>資料不足</div>;
+  }
+
+  return (
+    <svg
+      viewBox={`0 0 100 ${SPARK_H}`}
+      preserveAspectRatio="none"
+      style={{ width: "100%", height: SPARK_H, display: "block", overflow: "visible" }}
+      role="img"
+      aria-label={`近 180 天走勢，區間 ${geom.mn.toFixed(0)} 至 ${geom.mx.toFixed(0)}`}
+    >
+      {/* 異常區段底色：紅=偏高、青=偏低 */}
+      {geom.bands.map((b, i) => (
+        <rect
+          key={i}
+          x={b.x0} y={0}
+          width={Math.max(b.x1 - b.x0, 0.6)} height={SPARK_H}
+          fill={b.up ? FOOD_ALERT_HIGH : FOOD_ALERT_LOW}
+          opacity={0.22}
+        />
+      ))}
+      {/* 基期 100 參考線 */}
+      <line x1={0} x2={100} y1={SPARK_H - 2} y2={SPARK_H - 2} stroke="rgba(255,255,255,0.10)" strokeWidth={0.5} vectorEffect="non-scaling-stroke" />
+      <path d={geom.d} fill="none" stroke={color} strokeWidth={1.4} vectorEffect="non-scaling-stroke" strokeLinejoin="round" strokeLinecap="round" />
+      <circle cx={geom.lastX} cy={geom.lastY} r={1.6} fill={color} vectorEffect="non-scaling-stroke" />
+    </svg>
+  );
+}
+
+/* ── 圖例 ───────────────────────────────────────────────── */
+
+function Legend() {
+  const items = [
+    { c: FOOD_ALERT_HIGH, label: "異常偏高（民生壓力）" },
+    { c: FOOD_ALERT_LOW, label: "異常偏低（供給過剩）" },
+    { c: "#e0a63c", label: "注意" },
+    { c: "#63b26a", label: "常態" },
+  ];
+  return (
+    <div style={{ display: "flex", flexWrap: "wrap", gap: "3px 11px", alignItems: "center" }}>
+      {items.map((it) => (
+        <span key={it.label} style={{ display: "inline-flex", alignItems: "center", gap: 4 }}>
+          <span style={{ width: 8, height: 5, borderRadius: 1.5, background: it.c, flex: "none" }} />
+          <span style={{ fontFamily: FONT_CJK, fontSize: 8.5, color: COLORS.textDim }}>{it.label}</span>
+        </span>
+      ))}
+      <span style={{ marginLeft: "auto", fontFamily: FONT_CJK, fontSize: 8.5, color: COLORS.textFaint }}>
+        看的是偏離季節常態，不是價位高低
+      </span>
+    </div>
+  );
+}

--- a/src/components/intel/monitor/FoodPriceBoard.tsx
+++ b/src/components/intel/monitor/FoodPriceBoard.tsx
@@ -9,7 +9,7 @@ import {
 } from "../../../data/intelLoaders";
 
 /**
- * 食品價格監測（migration 334/335）
+ * 食品價格監測（migration 334/336）
  *
  * 四個指數 2×2：VPI 菜 / FPI 魚 / MPI 豬雞肉 / EPI 蛋，各看近 180 天。
  *

--- a/src/components/intel/monitor/MonitorPanel.tsx
+++ b/src/components/intel/monitor/MonitorPanel.tsx
@@ -39,6 +39,7 @@ import { PrisonCard, type PrisonDay } from "./PrisonCard";
 import { AirportPaxCard } from "./AirportPaxCard";
 import { ERCard } from "./ERCard";
 import { PlaBoard } from "./PlaBoard";
+import { FoodPriceBoard } from "./FoodPriceBoard";
 import {
   MONITOR_VISIBLE_LAYOUT, MONITOR_GRID_COLS,
   MONITOR_GRID_ROW_HEIGHT, MONITOR_GRID_GAP,
@@ -534,6 +535,7 @@ export function MonitorPanel({
     liveWall: <LiveWall />,
     situationCards: <SituationCards health={health} />,
     plaBoard: <PlaBoard open={open} />,
+    foodPriceBoard: <FoodPriceBoard open={open} />,
     hazardStrip: <HazardWatchStrip />,
     powerCard: <PowerCard dashboard={powerDashboard} day={powerDay} />,
     erCongestion: <ERCard open={open} />,

--- a/src/components/intel/monitor/monitorLayout.ts
+++ b/src/components/intel/monitor/monitorLayout.ts
@@ -20,6 +20,7 @@ export type MonitorWidgetId =
   | "liveWall"
   | "situationCards"
   | "plaBoard"
+  | "foodPriceBoard"
   | "hazardStrip"
   | "powerCard"
   | "erCongestion"
@@ -46,7 +47,11 @@ export const MONITOR_GRID_ROW_HEIGHT = 40;
 /** 格線間距 px（沙盒 margin） */
 export const MONITOR_GRID_GAP = 10;
 
-/** 沙盒定稿佈局（2026-08-03 六版 — PLA 拆出獨立戰情板，與 ER 同寬同高 w5 h15） */
+/**
+ * 沙盒定稿佈局
+ * - 2026-08-03 六版 — PLA 拆出獨立戰情板，與 ER 同寬同高 w5 h15
+ * - 2026-08-05 七版 — 新增 foodPriceBoard（食品價格監測）
+ */
 export const MONITOR_LAYOUT: MonitorGridItem[] = [
   { i: "newsFeed", x: 0, y: 0, w: 4, h: 12 },
   { i: "alertBoard", x: 4, y: 0, w: 3, h: 7 },
@@ -65,6 +70,11 @@ export const MONITOR_LAYOUT: MonitorGridItem[] = [
   { i: "powerCard", x: 5, y: 34, w: 7, h: 14 },
   { i: "prison", x: 0, y: 50, w: 2, h: 4 },
   { i: "airportPax", x: 2, y: 50, w: 3, h: 6 },
+  // 食品價格監測（2026-08-05）：四指數 2×2 × 180 天。
+  // 走右欄 w7 而非比照 PLA 的 w5 —— 2×2 在 w5 每格只剩 ~190px，
+  // 迷你走勢圖會擠到看不出形狀；w7 每格約 280px 才讀得出趨勢。
+  // 接在 powerCard（y34 h14 → 佔到 y48）之後，不推移任何既有 widget。
+  { i: "foodPriceBoard", x: 5, y: 48, w: 7, h: 9 },
 ];
 
 /** 沙盒 hidden 清單 — 列在這裡的 widget 不渲染（histogram 與時間軸新聞密度重複，2026-07-26 移除） */

--- a/src/data/intelLoaders.ts
+++ b/src/data/intelLoaders.ts
@@ -635,3 +635,137 @@ const kindCache = cachedByKey((k: string) => _fetchPlaKindSummary(Number(k)), TT
 export function fetchPlaKindSummary(windowDays = 120): Promise<PlaKindStat[]> {
   return kindCache(String(windowDays));
 }
+
+/* ──────────────────────────────────────────────────────────
+ * 食品價格監測（migration 334/335）
+ *
+ * 四個指數：VPI 菜 / FPI 魚 / MPI 豬雞肉（⚠️ 不含牛，台灣無牛肉交易行情）/ EPI 蛋
+ *
+ * ⚠️ 兩件呼叫端必須知道的事：
+ *  1. **異常有方向性**：light='red' 且 dev>0 是價格異常偏高（民生壓力），
+ *     dev<0 是異常偏低（供給過剩／產地崩盤）。兩者都是紅燈但意義相反，不可混用同一顏色。
+ *  2. `low_coverage` 是「當日資料未齊」不是低點 —— 畫圖要跳過，不可當 0 或當正常值。
+ * ────────────────────────────────────────────────────────── */
+
+export type FoodIndicator = "VPI" | "FPI" | "MPI" | "EPI";
+export type FoodLight = "green" | "amber" | "red" | "low_coverage";
+
+export interface FoodPriceDay {
+  tradeDate: string;
+  indicator: FoodIndicator;
+  indexVal: number;
+  indexSa: number | null;
+  z: number | null;
+  devPct: number | null;
+  light: FoodLight;
+}
+
+export interface FoodPriceSummary {
+  indicator: FoodIndicator;
+  latestDate: string;
+  latestVal: number;
+  latestLight: FoodLight;
+  latestDev: number | null;
+  latestZ: number | null;
+  yoyPct: number | null;
+  minVal: number;
+  maxVal: number;
+  highAlertDays: number;
+  lowAlertDays: number;
+  warnDays: number;
+  spanFrom: string;
+  spanTo: string;
+  nDays: number;
+}
+
+export const FOOD_LABELS: Record<FoodIndicator, string> = {
+  VPI: "菜價", FPI: "魚價", MPI: "豬雞肉價", EPI: "蛋價",
+};
+
+/** 各指數主色 —— 取自品類本身（葉綠／冰藍／肉褐／蛋黃），非隨機配色 */
+export const FOOD_COLORS: Record<FoodIndicator, string> = {
+  VPI: "#5fbf6d", FPI: "#4aa3c7", MPI: "#cc7a6d", EPI: "#d9a845",
+};
+
+/** 涵蓋範圍註腳（避免畫面上只有代碼、看不出來源是什麼） */
+export const FOOD_SCOPE: Record<FoodIndicator, string> = {
+  VPI: "19 市場 · 307 品項",
+  FPI: "22 魚市場 · 507 魚種",
+  MPI: "毛豬拍賣 + 白肉雞",
+  EPI: "雞蛋 + 鴨蛋產地價",
+};
+
+/** 異常方向色 —— 偏高＝民生壓力，偏低＝供給過剩，兩者必須可區分 */
+export const FOOD_ALERT_HIGH = "#ef4444";
+export const FOOD_ALERT_LOW = "#38bdf8";
+
+const FOOD_ORDER: FoodIndicator[] = ["VPI", "FPI", "MPI", "EPI"];
+const isFoodIndicator = (v: unknown): v is FoodIndicator =>
+  typeof v === "string" && (FOOD_ORDER as string[]).includes(v);
+
+async function _fetchFoodPriceDaily(days: number): Promise<FoodPriceDay[]> {
+  if (!supabaseConfigured) return [];
+  const { data, error } = await withLoading(
+    `food:daily:${days}`,
+    "食品價格指數",
+    supabase.rpc("get_food_price_daily", { p_days: days }),
+  );
+  if (error) {
+    console.warn("[Intel] get_food_price_daily failed:", error.message);
+    return [];
+  }
+  return ((data ?? []) as Record<string, unknown>[])
+    .filter((r) => isFoodIndicator(r.indicator))
+    .map((r) => ({
+      tradeDate: String(r.trade_date),
+      indicator: r.indicator as FoodIndicator,
+      indexVal: Number(r.index_val),
+      indexSa: num(r.index_sa),
+      z: num(r.z_score),
+      devPct: num(r.dev_pct),
+      light: (String(r.light ?? "green") as FoodLight),
+    }));
+}
+
+async function _fetchFoodPriceSummary(days: number): Promise<FoodPriceSummary[]> {
+  if (!supabaseConfigured) return [];
+  const { data, error } = await withLoading(
+    `food:summary:${days}`,
+    "食品價格摘要",
+    supabase.rpc("get_food_price_summary", { p_days: days }),
+  );
+  if (error) {
+    console.warn("[Intel] get_food_price_summary failed:", error.message);
+    return [];
+  }
+  return ((data ?? []) as Record<string, unknown>[])
+    .filter((r) => isFoodIndicator(r.indicator))
+    .map((r) => ({
+      indicator: r.indicator as FoodIndicator,
+      latestDate: String(r.latest_date),
+      latestVal: Number(r.latest_val),
+      latestLight: String(r.latest_light ?? "green") as FoodLight,
+      latestDev: num(r.latest_dev),
+      latestZ: num(r.latest_z),
+      yoyPct: num(r.yoy_pct),
+      minVal: Number(r.min_val),
+      maxVal: Number(r.max_val),
+      highAlertDays: Number(r.high_alert_days ?? 0),
+      lowAlertDays: Number(r.low_alert_days ?? 0),
+      warnDays: Number(r.warn_days ?? 0),
+      spanFrom: String(r.span_from),
+      spanTo: String(r.span_to),
+      nDays: Number(r.n_days ?? 0),
+    }))
+    .sort((a, b) => FOOD_ORDER.indexOf(a.indicator) - FOOD_ORDER.indexOf(b.indicator));
+}
+
+const foodDailyCache = cachedByKey((k: string) => _fetchFoodPriceDaily(Number(k)), TTL_DAILY);
+export function fetchFoodPriceDaily(days = 180): Promise<FoodPriceDay[]> {
+  return foodDailyCache(String(days));
+}
+
+const foodSummaryCache = cachedByKey((k: string) => _fetchFoodPriceSummary(Number(k)), TTL_DAILY);
+export function fetchFoodPriceSummary(days = 180): Promise<FoodPriceSummary[]> {
+  return foodSummaryCache(String(days));
+}

--- a/src/data/intelLoaders.ts
+++ b/src/data/intelLoaders.ts
@@ -637,7 +637,7 @@ export function fetchPlaKindSummary(windowDays = 120): Promise<PlaKindStat[]> {
 }
 
 /* ──────────────────────────────────────────────────────────
- * 食品價格監測（migration 334/335）
+ * 食品價格監測（migration 334/336）
  *
  * 四個指數：VPI 菜 / FPI 魚 / MPI 豬雞肉（⚠️ 不含牛，台灣無牛肉交易行情）/ EPI 蛋
  *


### PR DESCRIPTION
## 做了什麼

Monitor 面板新增「食品價格監測板」：VPI 菜／FPI 魚／MPI 豬雞肉／EPI 蛋 四個指數的 180 天走勢與異常標示，2×2 格。

| 檔案 | 內容 |
|---|---|
| `src/components/intel/monitor/FoodPriceBoard.tsx` | 新元件（305 行） |
| `src/components/intel/monitor/MonitorPanel.tsx` | 掛載 |
| `src/components/intel/monitor/monitorLayout.ts` | 版面配置 |
| `src/data/intelLoaders.ts` | 兩個 RPC 的 loader |

## 🔴 依賴上游 migration，必須後 merge

需要 `gis-platform` 的 `public.get_food_price_daily()` / `get_food_price_summary()`——
見 **gis-platform PR #48**（migration 336）。

照 CLAUDE.md 跨 repo 順序：**#48 先 merge 並 apply，本 PR 才 merge**，
否則上線時前端硬依賴的 RPC 不存在。

## migration 編號

原本寫 335，與 `335_funeral.sql` 撞號 → 第二個 commit 改為 336。已確認 main 上 336 未被佔用。

## 呼叫端注意（來自 migration 檔頭契約）

- 序列前 365 日的 `z_score` / `dev_pct` / `light` 不可信（rolling 1095 日 median baseline 未成形）
- 異常有方向性：`red` + `dev_pct > 0` 是價格異常偏高、`< 0` 是異常偏低，意義相反須分開呈現
- `low_coverage` 是「當日資料未齊」不是正常值，最新值要取最後一個非 low_coverage 的交易日

## 驗證

`npx tsc -b` 綠、316 tests 過（已 rebase 到最新 master）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)