### PR TITLE
fix(layers): 補上 map-ready 競態防護，修分享連結少圖層

### DIFF
--- a/src/hooks/__tests__/mapReadyTickCoverage.test.ts
+++ b/src/hooks/__tests__/mapReadyTickCoverage.test.ts
@@ -1,0 +1,69 @@
+/**
+ * layer hook 的 map-ready 競態守門（ratchet）。
+ *
+ * App 的 `mapRef.current` 要等 MapView 的 `map.on("load")` 才被填，而 production
+ * 首載可能晚達 ~30 秒。在那之前建層 effect 會這樣：
+ *
+ * ```ts
+ * const map = mapRef.current;
+ * if (!map) return;      // ← 什麼也沒建
+ * ```
+ *
+ * `mapRef` 是 ref，**`.current` 變動不觸發 re-render**，effect 不會重跑 ——
+ * 只要 `visible` 之後沒再變，這個圖層就**永遠不會被建出來**。實際會中招的兩種
+ * 情境：deep-link（`?layers=`，App 掛載時就設 visible）、以及使用者在首載
+ * 完成前就手動點開圖層。症狀是「分享連結少圖層」，沒有任何錯誤訊息。
+ *
+ * 解法是 `useMapReadyTick`：map 就緒時遞增一個 tick，放進 deps 逼 effect 重跑。
+ *
+ * 本測試用純文字比對（同 layerConsistency / overlayParamsDeps 的 heuristic 風格）：
+ * 只要一個 layer hook 檔案裡出現「deps 陣列含 mapRef」，該陣列就必須同時含
+ * `mapTick`（或舊寫法 `mapRetry`）。新增 layer hook 漏接時這裡會紅。
+ */
+import { describe, it, expect } from "vitest";
+import { readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+
+const HOOKS_DIR = "src/hooks";
+
+/** 從 `}, [ ... ]);` 抓出 deps 陣列內容 */
+const DEPS_RE = /\}, \[([^\]]*)\]\);/g;
+
+function collectDepsArrays(source: string): string[] {
+  return [...source.matchAll(DEPS_RE)].map((m) => m[1] as string);
+}
+
+describe("layer hook map-ready 競態", () => {
+  const files = readdirSync(HOOKS_DIR)
+    .filter((f) => /^use.*Layer\.ts$/.test(f))
+    .concat(["factories/timelineSliceLayer.ts"]);
+
+  it("含 mapRef 的 deps 陣列都帶上 mapTick", () => {
+    const offenders: string[] = [];
+
+    for (const f of files) {
+      const source = readFileSync(join(HOOKS_DIR, f), "utf8");
+      for (const deps of collectDepsArrays(source)) {
+        if (!/\bmapRef\b/.test(deps)) continue;
+        if (/\bmapTick\b|\bmapRetry\b/.test(deps)) continue;
+        offenders.push(`${f} → [${deps.trim()}]`);
+      }
+    }
+
+    expect(
+      offenders,
+      "這些 effect 的 deps 含 mapRef 但沒有 mapTick —— map 在首載後才就緒時，" +
+        "effect 不會重跑，圖層永遠不會建出來（deep-link 與首載期間手動 toggle 都會中招）。" +
+        "修法：`const mapTick = useMapReadyTick(mapRef, visible);` 並把 mapTick 放進 deps。\n" +
+        offenders.join("\n"),
+    ).toEqual([]);
+  });
+
+  it("useMapReadyTick 在 map 就緒後會停掉輪詢（避免常駐 timer）", () => {
+    const source = readFileSync(join(HOOKS_DIR, "useMapReadyTick.ts"), "utf8");
+    // 就緒分支必須 clearInterval 後才 setTick，否則每 200ms 空轉一輩子
+    expect(source).toMatch(/clearInterval\(timer\);\s*\n\s*setTick/);
+    // map 已就緒時完全不該建 timer
+    expect(source).toMatch(/if \(!enabled \|\| mapRef\.current\) return;/);
+  });
+});

--- a/src/hooks/factories/timelineSliceLayer.ts
+++ b/src/hooks/factories/timelineSliceLayer.ts
@@ -13,6 +13,7 @@ import { useEffect } from "react";
 import type { Map as MapboxMap, GeoJSONSource } from "mapbox-gl";
 import { keepLoadingUntilMapIdle } from "../../lib/loadingRegistry";
 import { timeStore as realTimeStore } from "../../state/timeStore";
+import { useMapReadyTick } from "../useMapReadyTick";
 
 export interface TimelineSliceLayerConfig<D> {
   sourceId: string;
@@ -156,6 +157,9 @@ export function useTimelineSliceLayer<D>(
   scale = 1,
   opacity = 1,
 ) {
+  /** map 就緒通知：mapRef 是 ref，.current 變動不觸發 re-render（見 useMapReadyTick） */
+  const mapTick = useMapReadyTick(mapRef, visible);
+
   useEffect(() => {
     if (!visible) return;
     const map = mapRef.current;
@@ -163,5 +167,5 @@ export function useTimelineSliceLayer<D>(
     return startTimelineSliceController(map, config, isDark, scale, opacity);
     // config 為模組層常數，不進 deps
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [mapRef, visible, isDark, scale, opacity]);
+  }, [mapRef, visible, isDark, scale, opacity, mapTick]);
 }

--- a/src/hooks/useA1AccidentRealtimeLayer.ts
+++ b/src/hooks/useA1AccidentRealtimeLayer.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef } from "react";
 import type { Map as MapboxMap, GeoJSONSource } from "mapbox-gl";
 import { fetchA1AccidentsRealtime } from "../data/a1AccidentRealtimeLoader";
 import { wallClock } from "../state/timeStore";
+import { useMapReadyTick } from "./useMapReadyTick";
 
 const SRC_ID = "a1-accident-realtime";
 const EMPTY_FC: GeoJSON.FeatureCollection = { type: "FeatureCollection", features: [] };
@@ -56,6 +57,9 @@ export function useA1AccidentRealtimeLayer(
   mapRef: React.RefObject<MapboxMap | null>,
   visible: boolean,
 ) {
+  /** map 就緒通知：mapRef 是 ref，.current 變動不觸發 re-render（見 useMapReadyTick） */
+  const mapTick = useMapReadyTick(mapRef, visible);
+
   const dataRef = useRef<GeoJSON.FeatureCollection | null>(null);
 
   const feed = useCallback(() => {
@@ -67,7 +71,7 @@ export function useA1AccidentRealtimeLayer(
     if (!fc) { src.setData(EMPTY_FC); return; }
     const nowSec = Math.floor(Date.now() / 1000);
     src.setData(annotateAge(fc, nowSec));
-  }, [mapRef]);
+  }, [mapRef, mapTick]);
 
   // 拉資料
   useEffect(() => {
@@ -101,5 +105,5 @@ export function useA1AccidentRealtimeLayer(
     return () => {
       map.off("style.load", onStyleLoad);
     };
-  }, [mapRef, visible, feed]);
+  }, [mapRef, visible, feed, mapTick]);
 }

--- a/src/hooks/useAqiImageryLayer.ts
+++ b/src/hooks/useAqiImageryLayer.ts
@@ -23,6 +23,7 @@ import {
 import { timeStore } from "../state/timeStore";
 import { keepLoadingUntilMapIdle } from "../lib/loadingRegistry";
 import type { AqiProduct } from "../types";
+import { useMapReadyTick } from "./useMapReadyTick";
 
 const SINCE_HOURS = 24;
 const SOURCE_ID = "aqi-imagery-src";
@@ -75,6 +76,9 @@ export function useAqiImageryLayer({
   product,
   opacity,
 }: UseAqiImageryLayerOptions) {
+  /** map 就緒通知：mapRef 是 ref，.current 變動不觸發 re-render（見 useMapReadyTick） */
+  const mapTick = useMapReadyTick(mapRef);
+
   const stateRef = useRef<LayerState>(createEmptyState());
 
   // ── Loader：visible 開啟 / 產品切換時觸發 ──
@@ -188,7 +192,7 @@ export function useAqiImageryLayer({
     return () => {
       if (unsubTime) unsubTime();
     };
-  }, [mapRef, visible, product, opacity]);
+  }, [mapRef, visible, product, opacity, mapTick]);
 
   // ── Unmount 清理 ──
   useEffect(() => {

--- a/src/hooks/useAqiStationsLayer.ts
+++ b/src/hooks/useAqiStationsLayer.ts
@@ -17,6 +17,7 @@ import { buildAqiStepExpression } from "../map/aqiColorScale";
 import { timeStore } from "../state/timeStore";
 import { keepLoadingUntilMapIdle } from "../lib/loadingRegistry";
 import type { AqiStation } from "../types";
+import { useMapReadyTick } from "./useMapReadyTick";
 
 const SOURCE_ID = "aqi-stations-src";
 const LAYER_GLOW = "aqi-stations-glow";
@@ -78,6 +79,9 @@ export function useAqiStationsLayer(
   visible: boolean,
   isDark: boolean,
 ) {
+  /** map 就緒通知：mapRef 是 ref，.current 變動不觸發 re-render（見 useMapReadyTick） */
+  const mapTick = useMapReadyTick(mapRef, visible);
+
   const stationsRef = useRef<AqiStation[]>([]);
   const fetchingKeyRef = useRef<string>("");
   const lastKeyRef = useRef<string>("");
@@ -154,7 +158,7 @@ export function useAqiStationsLayer(
       cancelled = true;
       if (unsub) unsub();
     };
-  }, [mapRef, visible, isDark]);
+  }, [mapRef, visible, isDark, mapTick]);
 
   // ── 主題變更時刷新 paint ──
   useEffect(() => {
@@ -171,5 +175,5 @@ export function useAqiStationsLayer(
         isDark ? "rgba(255,255,255,0.8)" : "rgba(0,0,0,0.5)",
       );
     }
-  }, [mapRef, isDark, visible]);
+  }, [mapRef, isDark, visible, mapTick]);
 }

--- a/src/hooks/useAspectVectorLayer.ts
+++ b/src/hooks/useAspectVectorLayer.ts
@@ -2,6 +2,7 @@ import { useEffect } from "react";
 import type { Map as MapboxMap, ExpressionSpecification } from "mapbox-gl";
 import { registerPmtilesSourceTypeOnce } from "../map/pmtilesSourceType";
 import { PMTILES_SOURCE_TYPE } from "../map/pmtilesConstants";
+import { useMapReadyTick } from "./useMapReadyTick";
 
 /**
  * 坡向分級（8 方位 + 平地）靜態向量圖層 — aspect_vector.pmtiles polygon。
@@ -47,6 +48,9 @@ export function useAspectVectorLayer(
   opacity: number,
   styleId: string,
 ) {
+  /** map 就緒通知：mapRef 是 ref，.current 變動不觸發 re-render（見 useMapReadyTick） */
+  const mapTick = useMapReadyTick(mapRef, visible);
+
   useEffect(() => {
     let cancelled = false;
     let map: MapboxMap | null = null;
@@ -125,5 +129,5 @@ export function useAspectVectorLayer(
     };
     // styleId 進 deps：底圖 style 切換時 effect 重跑 → 重新 ensureLayer（走與手動 re-toggle
     // 相同的成功路徑）。diff setStyle 會移除自訂圖層且 event listener 重掛不可靠，改靠 React 重跑。
-  }, [mapRef, visible, opacity, styleId]);
+  }, [mapRef, visible, opacity, styleId, mapTick]);
 }

--- a/src/hooks/useAviationAirspaceLayer.ts
+++ b/src/hooks/useAviationAirspaceLayer.ts
@@ -3,6 +3,7 @@ import mapboxgl from "mapbox-gl";
 import type { Map as MapboxMap, FilterSpecification } from "mapbox-gl";
 // @ts-expect-error 套件未提供 ESM build 的型別宣告
 import { PmTilesSource } from "mapbox-pmtiles/dist/mapbox-pmtiles.js";
+import { useMapReadyTick } from "./useMapReadyTick";
 
 /**
  * 航空器空域 eAIP — 共用 1 份 PMTiles，filter 拆兩個 toggle：
@@ -95,6 +96,9 @@ export function useAviationAirspaceLayer(
   controlOpacity: number,
   restrictedOpacity: number,
 ) {
+  /** map 就緒通知：mapRef 是 ref，.current 變動不觸發 re-render（見 useMapReadyTick） */
+  const mapTick = useMapReadyTick(mapRef);
+
   useEffect(() => {
     const anyVisible = controlVisible || restrictedVisible;
     let cancelled = false;
@@ -244,5 +248,5 @@ export function useAviationAirspaceLayer(
         setVis(map, RESTRICTED_FILL, false); setVis(map, RESTRICTED_LINE, false);
       }
     };
-  }, [mapRef, controlVisible, restrictedVisible, controlOpacity, restrictedOpacity]);
+  }, [mapRef, controlVisible, restrictedVisible, controlOpacity, restrictedOpacity, mapTick]);
 }

--- a/src/hooks/useAviationRestrictedGlowLayer.ts
+++ b/src/hooks/useAviationRestrictedGlowLayer.ts
@@ -3,6 +3,7 @@ import mapboxgl from "mapbox-gl";
 import type { Map as MapboxMap, FilterSpecification } from "mapbox-gl";
 // @ts-expect-error 套件未提供 ESM build 的型別宣告
 import { PmTilesSource } from "mapbox-pmtiles/dist/mapbox-pmtiles.js";
+import { useMapReadyTick } from "./useMapReadyTick";
 
 /**
  * 機場管制/限航/危險 rim-glow 測試 —— 純 Mapbox 疊層版
@@ -75,6 +76,9 @@ export function useAviationRestrictedGlowLayer(
   visible: boolean,
   opacity: number,
 ) {
+  /** map 就緒通知：mapRef 是 ref，.current 變動不觸發 re-render（見 useMapReadyTick） */
+  const mapTick = useMapReadyTick(mapRef, visible);
+
   useEffect(() => {
     let cancelled = false;
     let map: MapboxMap | null = null;
@@ -183,5 +187,5 @@ export function useAviationRestrictedGlowLayer(
       map?.off("style.load", onStyleLoad);
       if (map) for (const id of LAYER_IDS) setVis(map, id, false);
     };
-  }, [mapRef, visible, opacity]);
+  }, [mapRef, visible, opacity, mapTick]);
 }

--- a/src/hooks/useBuildingsNightBloomLayer.ts
+++ b/src/hooks/useBuildingsNightBloomLayer.ts
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from "react";
 import type { Map as MapboxMap } from "mapbox-gl";
+import { useMapReadyTick } from "./useMapReadyTick";
 import {
   createBuildingsNightBloomLayer,
   BUILDINGS_NIGHT_BLOOM_LAYER_ID,
@@ -18,6 +19,9 @@ export function useBuildingsNightBloomLayer(
   opacity: number,
   minHeight: number,
 ) {
+  /** map 就緒通知：mapRef 是 ref，.current 變動不觸發 re-render（見 useMapReadyTick） */
+  const mapTick = useMapReadyTick(mapRef, visible);
+
   const visibleRef = useRef(visible);
   visibleRef.current = visible;
   const opacityRef = useRef(opacity);
@@ -51,5 +55,5 @@ export function useBuildingsNightBloomLayer(
     return () => {
       map.off("style.load", tryMount);
     };
-  }, [mapRef, visible]);
+  }, [mapRef, visible, mapTick]);
 }

--- a/src/hooks/useClimateParticleLineLayer.ts
+++ b/src/hooks/useClimateParticleLineLayer.ts
@@ -7,6 +7,7 @@ import {
 } from "../map/climateParticleLineLayer";
 import { timeStore } from "../state/timeStore";
 import { climateFrameStore, type ClimateFrameStatusKey } from "../state/climateFrameStore";
+import { useMapReadyTick } from "./useMapReadyTick";
 import {
   loadClimateManifest,
   fetchClimateBaseMeta,
@@ -47,6 +48,9 @@ export function useClimateParticleLineLayer(
   mapRef: React.RefObject<MapboxMap | null>,
   o: HookOptions,
 ) {
+  /** map 就緒通知：mapRef 是 ref，.current 變動不觸發 re-render（見 useMapReadyTick） */
+  const mapTick = useMapReadyTick(mapRef);
+
   const visibleRef = useRef(o.visible);
   const opacityRef = useRef(o.opacity);
   const speedRef = useRef(o.animationSpeed);
@@ -145,13 +149,13 @@ export function useClimateParticleLineLayer(
     };
     // rampColors 只在建立時消費；visible 放 deps 讓 toggle ON 時重試 mapRef.current。
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [mapRef, o.layerId, o.pngUrl, o.metaUrl, o.visible]);
+  }, [mapRef, o.layerId, o.pngUrl, o.metaUrl, o.visible, mapTick]);
 
   useEffect(() => {
     const map = mapRef.current;
     if (!map) return;
     map.triggerRepaint();
-  }, [mapRef, o.visible, o.opacity, o.animationSpeed, o.particleCount, o.lineWidth]);
+  }, [mapRef, o.visible, o.opacity, o.animationSpeed, o.particleCount, o.lineWidth, mapTick]);
 
   // ── Time-aware 換幀（timeStore 訂閱；遵守鐵則：currentTime 不進 React deps）──
   // 依 timeline 當前時間選最近幀，換 UV 場保留粒子。manifest 404 / 解析失敗 → 不動作，
@@ -226,5 +230,5 @@ export function useClimateParticleLineLayer(
       unsubThrottled?.();
       if (statusKey) climateFrameStore.clear(statusKey);
     };
-  }, [mapRef, o.visible, o.frameDataset, o.metaUrl, statusKey]);
+  }, [mapRef, o.visible, o.frameDataset, o.metaUrl, statusKey, mapTick]);
 }

--- a/src/hooks/useCwaImageryLayer.ts
+++ b/src/hooks/useCwaImageryLayer.ts
@@ -36,6 +36,7 @@ import {
 } from "../map/cwaImageryLayer";
 import { timeStore } from "../state/timeStore";
 import { keepLoadingUntilMapIdle } from "../lib/loadingRegistry";
+import { useMapReadyTick } from "./useMapReadyTick";
 
 const CLOUD_DATASET = "O-C0042-004";
 const RADAR_DATASET = "O-A0058-005";
@@ -139,6 +140,9 @@ export function useCwaImageryLayer({
   cloudOpacity,
   radarOpacity,
 }: UseCwaImageryLayerOptions) {
+  /** map 就緒通知：mapRef 是 ref，.current 變動不觸發 re-render（見 useMapReadyTick） */
+  const mapTick = useMapReadyTick(mapRef);
+
   const cloudRef = useRef<LayerState>(createEmptyState());
   const radarRef = useRef<LayerState>(createEmptyState());
   // 最新可見性（給 subscribeDate / 背景預載 callback 避免閉包過期）
@@ -362,7 +366,7 @@ export function useCwaImageryLayer({
       if (unsubTime) unsubTime();
       if (runRef.current === run) runRef.current = null;
     };
-  }, [mapRef, cloudVisible, radarVisible, cloudOpacity, radarOpacity]);
+  }, [mapRef, cloudVisible, radarVisible, cloudOpacity, radarOpacity, mapTick]);
 
   // 注：原本獨立的 preloadDays effect 已不需要 — window 變動會由 subscribeWindowDateKeys
   // 觸發 ensureFresh，evict 邏輯在那裡執行（保護視窗內所有日）。

--- a/src/hooks/useDisasterAlertLayer.ts
+++ b/src/hooks/useDisasterAlertLayer.ts
@@ -15,6 +15,7 @@ import {
 import { ALERT_GROUP_KEYS, type AlertGroupKey } from "../data/disasterAlertTypes";
 import { timeStore } from "../state/timeStore";
 import { keepLoadingUntilMapIdle } from "../lib/loadingRegistry";
+import { useMapReadyTick } from "./useMapReadyTick";
 
 /**
  * NCDR 災害示警 timeline 圖層（5 主題群組）
@@ -129,6 +130,9 @@ export function useDisasterAlertLayer(
   visibility: Record<AlertGroupKey, boolean>,
   opacity: number = 1,
 ) {
+  /** map 就緒通知：mapRef 是 ref，.current 變動不觸發 re-render（見 useMapReadyTick） */
+  const mapTick = useMapReadyTick(mapRef);
+
   const cacheRef = useRef<Map<string, CachedDay>>(new Map());
   const activeDayRef = useRef<DisasterAlert[] | null>(null);
   const activeDateRef = useRef<string>("");
@@ -272,7 +276,7 @@ export function useDisasterAlertLayer(
 
     tick(timeStore.getTime()); // 初始化
     return timeStore.subscribeThrottled(500, tick);
-  }, [anyVisible, visKey, ensureLayers, refreshSource, mapRef]);
+  }, [anyVisible, visKey, ensureLayers, refreshSource, mapRef, mapTick]);
 
   // 套用 opacity（乘以各 layer 的 base opacity，5 群組共用）
   useEffect(() => {
@@ -297,5 +301,5 @@ export function useDisasterAlertLayer(
         map.setPaintProperty(ids.point, "circle-stroke-opacity", o);
       }
     }
-  }, [opacity, visKey, mapRef]);
+  }, [opacity, visKey, mapRef, mapTick]);
 }

--- a/src/hooks/useDroneRestrictedZonesLayer.ts
+++ b/src/hooks/useDroneRestrictedZonesLayer.ts
@@ -3,6 +3,7 @@ import mapboxgl from "mapbox-gl";
 import type { Map as MapboxMap, FilterSpecification } from "mapbox-gl";
 // @ts-expect-error 套件未提供 ESM build 的型別宣告
 import { PmTilesSource } from "mapbox-pmtiles/dist/mapbox-pmtiles.js";
+import { useMapReadyTick } from "./useMapReadyTick";
 
 /**
  * 無人機禁/限航區（民航局 dronegis）— 5,741 polygon 共用 PMTiles，filter 拆兩 layer
@@ -74,6 +75,9 @@ export function useDroneZonesLayer(
   nfzOpacity: number,
   restrictedOpacity: number,
 ) {
+  /** map 就緒通知：mapRef 是 ref，.current 變動不觸發 re-render（見 useMapReadyTick） */
+  const mapTick = useMapReadyTick(mapRef);
+
   useEffect(() => {
     const anyVisible = nfzVisible || restrictedVisible;
     let cancelled = false;
@@ -188,5 +192,5 @@ export function useDroneZonesLayer(
         setVis(map, RESTRICTED_FILL, false); setVis(map, RESTRICTED_LINE, false);
       }
     };
-  }, [mapRef, nfzVisible, restrictedVisible, nfzOpacity, restrictedOpacity]);
+  }, [mapRef, nfzVisible, restrictedVisible, nfzOpacity, restrictedOpacity, mapTick]);
 }

--- a/src/hooks/useDustForecastLayer.ts
+++ b/src/hooks/useDustForecastLayer.ts
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from "react";
 import type { Map as MapboxMap } from "mapbox-gl";
+import { useMapReadyTick } from "./useMapReadyTick";
 
 interface DustMeta {
   width: number;
@@ -19,6 +20,9 @@ export function useDustForecastLayer(
   visible: boolean,
   opacity: number,
 ) {
+  /** map 就緒通知：mapRef 是 ref，.current 變動不觸發 re-render（見 useMapReadyTick） */
+  const mapTick = useMapReadyTick(mapRef, visible);
+
   const opacityRef = useRef(opacity);
   opacityRef.current = opacity;
 
@@ -87,7 +91,7 @@ export function useDustForecastLayer(
         if (map.getSource(SOURCE_ID)) map.removeSource(SOURCE_ID);
       } catch { /* style 已沒 */ }
     };
-  }, [mapRef, visible]);
+  }, [mapRef, visible, mapTick]);
 
   // visibility / opacity 即時切
   useEffect(() => {
@@ -101,5 +105,5 @@ export function useDustForecastLayer(
     apply();
     map.on("style.load", apply);
     return () => { map.off("style.load", apply); };
-  }, [mapRef, visible, opacity]);
+  }, [mapRef, visible, opacity, mapTick]);
 }

--- a/src/hooks/useEarthquakeLayer.ts
+++ b/src/hooks/useEarthquakeLayer.ts
@@ -2,6 +2,7 @@ import { useEffect, useRef, useCallback } from "react";
 import type { Map as MapboxMap, ExpressionSpecification, FilterSpecification, CircleLayer } from "mapbox-gl";
 import { fetchEarthquakes, earthquakesToGeoJSON, type EarthquakeEvent } from "../data/earthquakeLoader";
 import { timeStore } from "../state/timeStore";
+import { useMapReadyTick } from "./useMapReadyTick";
 
 /**
  * 地震事件 timeline 動態顯示
@@ -120,6 +121,9 @@ export function useEarthquakeLayer(
   opacity: number = 1,
   showHistory: boolean = false,
 ) {
+  /** map 就緒通知：mapRef 是 ref，.current 變動不觸發 re-render（見 useMapReadyTick） */
+  const mapTick = useMapReadyTick(mapRef, visible);
+
   const eventsRef = useRef<EarthquakeEvent[]>([]);
   const dataReadyRef = useRef(false);
   const layersReadyRef = useRef(false);
@@ -215,7 +219,7 @@ export function useEarthquakeLayer(
 
     applyFilter(timeStore.getTime()); // 初始化
     return timeStore.subscribeThrottled(500, applyFilter);
-  }, [visible, showHistory, ensureSource, mapRef]);
+  }, [visible, showHistory, ensureSource, mapRef, mapTick]);
 
   // 套用 opacity（乘以各 layer 的 base opacity）
   useEffect(() => {
@@ -230,7 +234,7 @@ export function useEarthquakeLayer(
     if (map.getLayer(LAYER_PRE)) {
       map.setPaintProperty(LAYER_PRE, "circle-stroke-opacity", 0.25 * o);
     }
-  }, [opacity, visible, mapRef]);
+  }, [opacity, visible, mapRef, mapTick]);
 
   // ripple 動畫
   useEffect(() => {
@@ -280,5 +284,5 @@ export function useEarthquakeLayer(
 
     rafRef.current = requestAnimationFrame(animate);
     return () => cancelAnimationFrame(rafRef.current);
-  }, [visible, ensureSource, mapRef]);
+  }, [visible, ensureSource, mapRef, mapTick]);
 }

--- a/src/hooks/useEarthquakeReplayLayer.ts
+++ b/src/hooks/useEarthquakeReplayLayer.ts
@@ -6,6 +6,7 @@ import {
   type EqReplayDetail,
 } from "../data/earthquakeReplayTypes";
 import { earthquakeReplayClock } from "../state/earthquakeReplayClock";
+import { useMapReadyTick } from "./useMapReadyTick";
 import {
   EQ_REPLAY_EPICENTER_LAYER,
   EQ_REPLAY_GRID_SOURCE,
@@ -127,6 +128,9 @@ export function useEarthquakeReplayLayer(
   playing: boolean,
   onEnded?: () => void,
 ) {
+  /** map 就緒通知：mapRef 是 ref，.current 變動不觸發 re-render（見 useMapReadyTick） */
+  const mapTick = useMapReadyTick(mapRef, visible);
+
   const [detail, setDetail] = useState<EqReplayDetail | null>(null);
   /** mapRef 還沒填時的重試 tick（production 首載 map "load" 可能晚於資料就緒） */
   const [mapRetry, setMapRetry] = useState(0);
@@ -334,7 +338,7 @@ export function useEarthquakeReplayLayer(
       beachballRef.current = null;
       if (map.getLayer(EQ_REPLAY_EPICENTER_LAYER)) setEarthquakeReplayVisible(map, false);
     };
-  }, [mapRef, visible, detail, mapRetry]);
+  }, [mapRef, visible, detail, mapRetry, mapTick]);
 
   // ── 圖層關閉：source / layer 一併拆掉，dispose 乾淨 ──
   useEffect(() => {
@@ -343,7 +347,7 @@ export function useEarthquakeReplayLayer(
     if (!map) return;
     removeEarthquakeReplayLayers(map);
     earthquakeReplayClock.clear();
-  }, [mapRef, visible]);
+  }, [mapRef, visible, mapTick]);
 
   // ── 透明度 slider ──
   useEffect(() => {
@@ -351,5 +355,5 @@ export function useEarthquakeReplayLayer(
     if (!map || !visible) return;
     setReplayStationOpacity(map, opacity);
     setReplayGridOpacity(map, opacity, 1 - 0.55 * clamp01(lastTownBucketRef.current / 40));
-  }, [mapRef, opacity, visible, detail]);
+  }, [mapRef, opacity, visible, detail, mapTick]);
 }

--- a/src/hooks/useEarthquakesGlobalLayer.ts
+++ b/src/hooks/useEarthquakesGlobalLayer.ts
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useCallback } from "react";
 import type { Map as MapboxMap, ExpressionSpecification, CircleLayer } from "mapbox-gl";
+import { useMapReadyTick } from "./useMapReadyTick";
 import {
   fetchEarthquakesGlobal,
   earthquakesGlobalToGeoJSON,
@@ -36,6 +37,9 @@ export function useEarthquakesGlobalLayer(
   visible: boolean,
   opacity: number = 0.9,
 ) {
+  /** map 就緒通知：mapRef 是 ref，.current 變動不觸發 re-render（見 useMapReadyTick） */
+  const mapTick = useMapReadyTick(mapRef, visible);
+
   const eventsRef = useRef<EarthquakeGlobalEvent[]>([]);
   const dataReadyRef = useRef(false);
   const layerReadyRef = useRef(false);
@@ -95,5 +99,5 @@ export function useEarthquakesGlobalLayer(
       map.setPaintProperty(LAYER_ID, "circle-opacity", 0.55 * o);
       map.setPaintProperty(LAYER_ID, "circle-stroke-opacity", 0.8 * o);
     }
-  }, [visible, opacity, ensureSource, mapRef]);
+  }, [visible, opacity, ensureSource, mapRef, mapTick]);
 }

--- a/src/hooks/useEnergyPoiLayer.ts
+++ b/src/hooks/useEnergyPoiLayer.ts
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useCallback } from "react";
 import type { Map as MapboxMap, GeoJSONSource } from "mapbox-gl";
+import { useMapReadyTick } from "./useMapReadyTick";
 import {
   fetchPowerPlants,
   invalidatePowerPlants,
@@ -317,13 +318,16 @@ function useSourceFeed(
   sourceId: string,
   fcRef: React.MutableRefObject<GeoJSON.FeatureCollection | null>,
 ) {
+  /** map 就緒通知：mapRef 是 ref，.current 變動不觸發 re-render（見 useMapReadyTick） */
+  const mapTick = useMapReadyTick(mapRef, visible);
+
   const feed = useCallback(() => {
     const map = mapRef.current;
     if (!map) return;
     const src = map.getSource(sourceId) as GeoJSONSource | undefined;
     if (!src) return;
     src.setData(fcRef.current ?? EMPTY_FC);
-  }, [mapRef, sourceId, fcRef]);
+  }, [mapRef, sourceId, fcRef, mapTick]);
 
   useEffect(() => {
     const map = mapRef.current;
@@ -334,7 +338,7 @@ function useSourceFeed(
     return () => {
       map.off("style.load", onStyleLoad);
     };
-  }, [mapRef, visible, feed]);
+  }, [mapRef, visible, feed, mapTick]);
 
   return feed;
 }

--- a/src/hooks/useErHospitalLayer.ts
+++ b/src/hooks/useErHospitalLayer.ts
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useCallback } from "react";
 import type { Map as MapboxMap, GeoJSONSource } from "mapbox-gl";
 import { fetchErHospitalFC, invalidateErHospitalLatest } from "../data/erHospitalLoader";
+import { useMapReadyTick } from "./useMapReadyTick";
 
 /**
  * 急診壅塞 er_hospital 圖層 — 當下快照（比照核安 LIVE，不接 timeStore）。
@@ -18,6 +19,9 @@ export function useErHospitalLayer(
   mapRef: React.RefObject<MapboxMap | null>,
   visible: boolean,
 ) {
+  /** map 就緒通知：mapRef 是 ref，.current 變動不觸發 re-render（見 useMapReadyTick） */
+  const mapTick = useMapReadyTick(mapRef, visible);
+
   const fcRef = useRef<GeoJSON.FeatureCollection | null>(null);
 
   const feed = useCallback(() => {
@@ -26,7 +30,7 @@ export function useErHospitalLayer(
     const src = map.getSource(SRC) as GeoJSONSource | undefined;
     if (!src) return;
     src.setData(fcRef.current ?? EMPTY_FC);
-  }, [mapRef]);
+  }, [mapRef, mapTick]);
 
   useEffect(() => {
     if (!visible) return;
@@ -57,5 +61,5 @@ export function useErHospitalLayer(
       map?.off("style.load", onStyleLoad);
       window.clearInterval(id);
     };
-  }, [visible, feed, mapRef]);
+  }, [visible, feed, mapRef, mapTick]);
 }

--- a/src/hooks/useFireEventsLayer.ts
+++ b/src/hooks/useFireEventsLayer.ts
@@ -2,6 +2,7 @@ import { useEffect, useRef } from "react";
 import type { Map as MapboxMap, GeoJSONSource } from "mapbox-gl";
 import { loadFireEventsByYear, type FireEvent } from "../data/fireLoader";
 import type { HistoricalGranularity } from "../components/HistoricalTimeline";
+import { useMapReadyTick } from "./useMapReadyTick";
 
 const SOURCE_ID = "fire-events-src";
 const LAYER_ID = "fire-events-layer";
@@ -115,6 +116,9 @@ export function useFireEventsLayer(
   isDarkTheme: boolean,
   opacity = 1,
 ) {
+  /** map 就緒通知：mapRef 是 ref，.current 變動不觸發 re-render（見 useMapReadyTick） */
+  const mapTick = useMapReadyTick(mapRef, visible);
+
   const lastYearRef = useRef<number | null>(null);
   const yearEventsRef = useRef<FireEvent[]>([]);
 
@@ -149,5 +153,5 @@ export function useFireEventsLayer(
     return () => {
       cancelled = true;
     };
-  }, [mapRef, visible, year, month, day, granularity, isDarkTheme, opacity]);
+  }, [mapRef, visible, year, month, day, granularity, isDarkTheme, opacity, mapTick]);
 }

--- a/src/hooks/useFireLatestLayer.ts
+++ b/src/hooks/useFireLatestLayer.ts
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from "react";
 import type { Map as MapboxMap, GeoJSONSource } from "mapbox-gl";
 import { loadFireEventsByYear, loadFireEventYears, type FireEvent } from "../data/fireLoader";
+import { useMapReadyTick } from "./useMapReadyTick";
 
 /**
  * 火災「最新年度」layer — 直接顯示資料庫最新一年（民國 113 / 2024）的火災點位，
@@ -75,6 +76,9 @@ export function useFireLatestLayer(
   isDarkTheme: boolean,
   opacity = 1,
 ) {
+  /** map 就緒通知：mapRef 是 ref，.current 變動不觸發 re-render（見 useMapReadyTick） */
+  const mapTick = useMapReadyTick(mapRef, visible);
+
   const loadedRef = useRef(false);
 
   useEffect(() => {
@@ -108,5 +112,5 @@ export function useFireLatestLayer(
     };
     run();
     return () => { cancelled = true; };
-  }, [mapRef, visible, isDarkTheme, opacity]);
+  }, [mapRef, visible, isDarkTheme, opacity, mapTick]);
 }

--- a/src/hooks/useFloodSensorIsochroneLayer.ts
+++ b/src/hooks/useFloodSensorIsochroneLayer.ts
@@ -4,6 +4,7 @@ import type { Map as MapboxMap, FilterSpecification } from "mapbox-gl";
 // @ts-expect-error 套件未提供 ESM build 的型別宣告
 import { PmTilesSource } from "mapbox-pmtiles/dist/mapbox-pmtiles.js";
 import { fetchFloodSensorLatest, type FloodSensorRow } from "../data/floodSensorLoader";
+import { useMapReadyTick } from "./useMapReadyTick";
 
 /**
  * 雙北 USWG 3-min 步行等時圈
@@ -77,6 +78,9 @@ export function useFloodSensorIsochroneLayer(
   visible: boolean,
   opacity: number,
 ) {
+  /** map 就緒通知：mapRef 是 ref，.current 變動不觸發 re-render（見 useMapReadyTick） */
+  const mapTick = useMapReadyTick(mapRef, visible);
+
   const latestRowsRef = useRef<FloodSensorRow[]>([]);
 
   useEffect(() => {
@@ -168,5 +172,5 @@ export function useFloodSensorIsochroneLayer(
       if (map.getLayer(FILL_ID)) map.setLayoutProperty(FILL_ID, "visibility", "none");
       if (map.getLayer(LINE_ID)) map.setLayoutProperty(LINE_ID, "visibility", "none");
     };
-  }, [mapRef, visible, opacity]);
+  }, [mapRef, visible, opacity, mapTick]);
 }

--- a/src/hooks/useFloodSensorLayer.ts
+++ b/src/hooks/useFloodSensorLayer.ts
@@ -11,6 +11,7 @@ import {
 } from "../data/floodSensorLoader";
 import { keepLoadingUntilMapIdle } from "../lib/loadingRegistry";
 import { timeStore } from "../state/timeStore";
+import { useMapReadyTick } from "./useMapReadyTick";
 
 /**
  * USWG 都市淹水感測器 — Timeline-driven 點圖層
@@ -263,6 +264,9 @@ export function useFloodSensorLayer(
   scale = 1,
   opacity = 1,
 ) {
+  /** map 就緒通知：mapRef 是 ref，.current 變動不觸發 re-render（見 useMapReadyTick） */
+  const mapTick = useMapReadyTick(mapRef, visible);
+
   const byStationRef = useRef<Map<string, StationSeries>>(new Map());
   const currentDateRef = useRef<string>("");
 
@@ -326,5 +330,5 @@ export function useFloodSensorLayer(
       unsubTime();
       if (map.getLayer(LAYER_DOT)) setLayerVisibility(map, false);
     };
-  }, [mapRef, visible, isDark, scale, opacity]);
+  }, [mapRef, visible, isDark, scale, opacity, mapTick]);
 }

--- a/src/hooks/useFreewayLayer.ts
+++ b/src/hooks/useFreewayLayer.ts
@@ -7,6 +7,7 @@ import {
 } from "../data/freewayLoader";
 import { timeStore } from "../state/timeStore";
 import { keepLoadingUntilMapIdle } from "../lib/loadingRegistry";
+import { useMapReadyTick } from "./useMapReadyTick";
 
 /**
  * 國道壅塞動態圖層
@@ -77,6 +78,9 @@ export function useFreewayLayer(
   width: number,
   isDark: boolean,
 ) {
+  /** map 就緒通知：mapRef 是 ref，.current 變動不觸發 re-render（見 useMapReadyTick） */
+  const mapTick = useMapReadyTick(mapRef, visible);
+
   const cacheRef = useRef<Map<string, CachedDay>>(new Map());
   const activeDayRef = useRef<FreewayDayData | null>(null);
   const activeDateRef = useRef<string>("");
@@ -228,7 +232,7 @@ export function useFreewayLayer(
     tick(timeStore.getTime()); // 初始化
     // 1s 節流足夠（資料本身 10min 粒度）
     return timeStore.subscribeThrottled(1000, tick);
-  }, [visible, ensureLayers, refreshSource, mapRef]);
+  }, [visible, ensureLayers, refreshSource, mapRef, mapTick]);
 
   // ── 寬度 / 主題變更時重建 paint ──
   useEffect(() => {
@@ -250,5 +254,5 @@ export function useFreewayLayer(
       ] as unknown as mapboxgl.ExpressionSpecification);
       map.setPaintProperty(LAYER_LINE, "line-opacity", isDark ? 0.75 : 0.65);
     }
-  }, [width, isDark, mapRef]);
+  }, [width, isDark, mapRef, mapTick]);
 }

--- a/src/hooks/useFuneralDensityLayer.ts
+++ b/src/hooks/useFuneralDensityLayer.ts
@@ -4,6 +4,7 @@ import { fetchFuneralDensity, type FuneralDensityData } from "../data/funeralDen
 import { funeralDensityColorExpr, FUNERAL_LAYER_COLORS } from "../data/funeralTypes";
 import { registerPmtilesSourceTypeOnce } from "../map/pmtilesSourceType";
 import { PMTILES_SOURCE_TYPE } from "../map/pmtilesConstants";
+import { useMapReadyTick } from "./useMapReadyTick";
 
 /**
  * 殯葬禮儀業者「區級密度」面量圖（funeralOperatorDensity）。
@@ -46,6 +47,9 @@ export function useFuneralDensityLayer(
   visible: boolean,
   opacity: number,
 ) {
+  /** map 就緒通知：mapRef 是 ref，.current 變動不觸發 re-render（見 useMapReadyTick） */
+  const mapTick = useMapReadyTick(mapRef, visible);
+
   const dataRef = useRef<FuneralDensityData | null>(null);
   const [dataTick, setDataTick] = useState(0);
   /** mapRef 還沒填時的重試 tick（production 首載 map "load" 可能晚於資料就緒） */
@@ -180,7 +184,7 @@ export function useFuneralDensityLayer(
       map.off("sourcedata", onSourceData);
       map.off("style.load", onStyleLoad);
     };
-  }, [mapRef, visible, dataTick, mapRetry]);
+  }, [mapRef, visible, dataTick, mapRetry, mapTick]);
 
   // ── 透明度 slider ──
   useEffect(() => {
@@ -188,5 +192,5 @@ export function useFuneralDensityLayer(
     if (!map || !visible) return;
     if (map.getLayer(LAYER_FILL)) map.setPaintProperty(LAYER_FILL, "fill-opacity", opacity);
     if (map.getLayer(LAYER_LINE)) map.setPaintProperty(LAYER_LINE, "line-opacity", opacity * 0.5);
-  }, [mapRef, visible, opacity]);
+  }, [mapRef, visible, opacity, mapTick]);
 }

--- a/src/hooks/useGroundwaterWellsLayer.ts
+++ b/src/hooks/useGroundwaterWellsLayer.ts
@@ -2,6 +2,7 @@ import { useEffect, useRef } from "react";
 import type { Map as MapboxMap, CircleLayer, GeoJSONSource } from "mapbox-gl";
 import { fetchGroundwaterLatest, type GroundwaterLatestRow } from "../data/groundwaterLoader";
 import { keepLoadingUntilMapIdle } from "../lib/loadingRegistry";
+import { useMapReadyTick } from "./useMapReadyTick";
 
 /**
  * 地下水井靜態點位層（backdrop，48h 內有讀值的 ~733 站）
@@ -81,6 +82,9 @@ export function useGroundwaterWellsLayer(
   scale = 1,
   opacity = 1,
 ) {
+  /** map 就緒通知：mapRef 是 ref，.current 變動不觸發 re-render（見 useMapReadyTick） */
+  const mapTick = useMapReadyTick(mapRef, visible);
+
   const dataLoadedRef = useRef(false);
 
   useEffect(() => {
@@ -126,5 +130,5 @@ export function useGroundwaterWellsLayer(
       if (pollTimer) clearInterval(pollTimer);
       if (map.getLayer(LAYER_CIRCLE)) setLayerVisibility(map, false);
     };
-  }, [mapRef, visible, isDark, scale, opacity]);
+  }, [mapRef, visible, isDark, scale, opacity, mapTick]);
 }

--- a/src/hooks/useHazardLayer.ts
+++ b/src/hooks/useHazardLayer.ts
@@ -12,6 +12,7 @@ import {
 } from "../data/nuclearLoader";
 import { timeStore } from "../state/timeStore";
 import { subscribePrefetchWindow } from "../lib/dayPrefetch";
+import { useMapReadyTick } from "./useMapReadyTick";
 
 /**
  * HAZARD（v2 Phase B++）— 落雷 + 核安，**day preload + scrub fade**
@@ -48,13 +49,16 @@ function useSourceFeed(
   sourceId: string,
   fcRef: React.MutableRefObject<GeoJSON.FeatureCollection | null>,
 ) {
+  /** map 就緒通知：mapRef 是 ref，.current 變動不觸發 re-render（見 useMapReadyTick） */
+  const mapTick = useMapReadyTick(mapRef, visible);
+
   const feed = useCallback(() => {
     const map = mapRef.current;
     if (!map) return;
     const src = map.getSource(sourceId) as GeoJSONSource | undefined;
     if (!src) return;
     src.setData(fcRef.current ?? EMPTY_FC);
-  }, [mapRef, sourceId, fcRef]);
+  }, [mapRef, sourceId, fcRef, mapTick]);
 
   useEffect(() => {
     const map = mapRef.current;
@@ -65,7 +69,7 @@ function useSourceFeed(
     return () => {
       map.off("style.load", onStyleLoad);
     };
-  }, [mapRef, visible, feed]);
+  }, [mapRef, visible, feed, mapTick]);
 
   return feed;
 }

--- a/src/hooks/useIotWraRiverLayer.ts
+++ b/src/hooks/useIotWraRiverLayer.ts
@@ -1,4 +1,5 @@
 import { useEffect } from "react";
+import { useMapReadyTick } from "./useMapReadyTick";
 import type {
   Map as MapboxMap,
   CircleLayer,
@@ -201,6 +202,9 @@ export function useIotWraRiverLayer(
   showMeasured = true,
   showForecast = true,
 ) {
+  /** map 就緒通知：mapRef 是 ref，.current 變動不觸發 re-render（見 useMapReadyTick） */
+  const mapTick = useMapReadyTick(mapRef, visible);
+
   // showMeasured / showForecast 會進 loadDay 的 filter（且在 deps 內觸發重載），
   // CONFIG 無法是純模組常數 → 在 effect 內組 config，編排仍走 factory controller
   useEffect(() => {
@@ -213,5 +217,5 @@ export function useIotWraRiverLayer(
         buildSeriesMap(await fetchIotWraRiverDay(dateKey), showMeasured, showForecast),
     };
     return startTimelineSliceController(map, config, isDark, scale, opacity);
-  }, [mapRef, visible, isDark, scale, opacity, showMeasured, showForecast]);
+  }, [mapRef, visible, isDark, scale, opacity, showMeasured, showForecast, mapTick]);
 }

--- a/src/hooks/useIotWraStructureLayer.ts
+++ b/src/hooks/useIotWraStructureLayer.ts
@@ -11,6 +11,7 @@ import {
 } from "../data/iotWraStructureLoader";
 import { keepLoadingUntilMapIdle } from "../lib/loadingRegistry";
 import { timeStore } from "../state/timeStore";
+import { useMapReadyTick } from "./useMapReadyTick";
 
 /**
  * IoT 水工結構/環境圖層（5 in 1）
@@ -163,6 +164,9 @@ export function useIotWraStructureLayer(
   showErosion = true,
   showDust = true,
 ) {
+  /** map 就緒通知：mapRef 是 ref，.current 變動不觸發 re-render（見 useMapReadyTick） */
+  const mapTick = useMapReadyTick(mapRef, visible);
+
   const rowsRef = useRef<IotWraLatestRow[]>([]);
 
   useEffect(() => {
@@ -233,5 +237,5 @@ export function useIotWraStructureLayer(
         setLayerVisibility(map, false);
       }
     };
-  }, [mapRef, visible, isDark, scale, opacity, showFlow, showGate, showDam, showErosion, showDust]);
+  }, [mapRef, visible, isDark, scale, opacity, showFlow, showGate, showDam, showErosion, showDust, mapTick]);
 }

--- a/src/hooks/useLibrarySeatsLayer.ts
+++ b/src/hooks/useLibrarySeatsLayer.ts
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useCallback } from "react";
 import type { Map as MapboxMap, GeoJSONSource } from "mapbox-gl";
 import { fetchLibrarySeatsFC, invalidateLibrarySeatsCurrent } from "../data/librarySeatsLoader";
+import { useMapReadyTick } from "./useMapReadyTick";
 
 /**
  * 北市圖即時座位 librarySeats 圖層 — 當下快照（比照 er-hospital，不接 timeStore）。
@@ -18,6 +19,9 @@ export function useLibrarySeatsLayer(
   mapRef: React.RefObject<MapboxMap | null>,
   visible: boolean,
 ) {
+  /** map 就緒通知：mapRef 是 ref，.current 變動不觸發 re-render（見 useMapReadyTick） */
+  const mapTick = useMapReadyTick(mapRef, visible);
+
   const fcRef = useRef<GeoJSON.FeatureCollection | null>(null);
 
   const feed = useCallback(() => {
@@ -26,7 +30,7 @@ export function useLibrarySeatsLayer(
     const src = map.getSource(SRC) as GeoJSONSource | undefined;
     if (!src) return;
     src.setData(fcRef.current ?? EMPTY_FC);
-  }, [mapRef]);
+  }, [mapRef, mapTick]);
 
   useEffect(() => {
     if (!visible) return;
@@ -57,5 +61,5 @@ export function useLibrarySeatsLayer(
       map?.off("style.load", onStyleLoad);
       window.clearInterval(id);
     };
-  }, [visible, feed, mapRef]);
+  }, [visible, feed, mapRef, mapTick]);
 }

--- a/src/hooks/useMapReadyTick.ts
+++ b/src/hooks/useMapReadyTick.ts
@@ -1,0 +1,63 @@
+import { useEffect, useState } from "react";
+import type { Map as MapboxMap } from "mapbox-gl";
+
+/**
+ * mapRef 就緒通知 —— 解 layer hook 的「建層 effect 早於 map load」競態。
+ *
+ * ## 為什麼需要這個
+ *
+ * App 的 `mapRef.current` 是在 MapView 的 `map.on("load")` 裡透過 `onMapReady`
+ * 回呼才填的，而**production 首載 load 事件可能晚達 ~30 秒**。在那之前：
+ *
+ * ```ts
+ * useEffect(() => {
+ *   const map = mapRef.current;
+ *   if (!map) return;        // ← 提早 return，什麼也沒建
+ *   ...建 source / layer...
+ * }, [mapRef, visible]);
+ * ```
+ *
+ * `mapRef` 是 ref，**`.current` 變動不觸發 re-render**，所以 effect 不會因為
+ * 「map 終於好了」而重跑。只要 `visible` 在那之後沒再變，這個圖層就**永遠不會被建出來**。
+ *
+ * 兩個實際會中招的情境：
+ * - **deep-link**（`?layers=`）：App 掛載時就把 visible 設成 true，遠早於 map load
+ * - **手動 toggle**：使用者在 load 完成前就點開圖層（首載 30 秒是很長的時間）
+ *
+ * `OVERLAY_REGISTRY` 那條路徑早就有補發機制（MapView 的 `map.on("load")` 裡會用
+ * ref 最新值重放一次），所以 registry 層不受影響 —— 缺的一直是 hook 這條路徑。
+ *
+ * ## 用法
+ *
+ * ```ts
+ * const mapTick = useMapReadyTick(mapRef, visible);
+ * useEffect(() => {
+ *   const map = mapRef.current;
+ *   if (!map) return;
+ *   ...
+ * }, [mapRef, visible, mapTick]);   // ← 把 tick 放進 deps
+ * ```
+ *
+ * @param enabled 通常傳 `visible` —— 圖層關著就不需要輪詢，省掉沒必要的 timer
+ * @returns map 就緒時 +1 的 tick（放進 deps 即可觸發 effect 重跑）
+ */
+export function useMapReadyTick(
+  mapRef: React.RefObject<MapboxMap | null>,
+  enabled = true,
+): number {
+  const [tick, setTick] = useState(0);
+
+  useEffect(() => {
+    // map 已就緒 → 不需要輪詢（絕大多數情況會走這條，成本為零）
+    if (!enabled || mapRef.current) return;
+
+    const timer = setInterval(() => {
+      if (!mapRef.current) return;
+      clearInterval(timer);
+      setTick((v) => v + 1);
+    }, 200);
+    return () => clearInterval(timer);
+  }, [mapRef, enabled]);
+
+  return tick;
+}

--- a/src/hooks/useMicroSensorsLayer.ts
+++ b/src/hooks/useMicroSensorsLayer.ts
@@ -28,6 +28,7 @@ import {
 import { microSensorColorExpr } from "../data/microSensorTypes";
 import { keepLoadingUntilMapIdle } from "../lib/loadingRegistry";
 import type { MicroSensor } from "../types";
+import { useMapReadyTick } from "./useMapReadyTick";
 
 const SOURCE_ID = "aqi-micro-src";
 const LAYER_CLUSTER = "aqi-micro-cluster";
@@ -113,6 +114,9 @@ export function useMicroSensorsLayer(
   cluster: boolean,
   modeIdx: number,
 ) {
+  /** map 就緒通知：mapRef 是 ref，.current 變動不觸發 re-render（見 useMapReadyTick） */
+  const mapTick = useMapReadyTick(mapRef, visible);
+
   const loadedRef = useRef(false);
   const dataRef = useRef<MicroSensor[]>([]);
   const loadingRef = useRef(false);
@@ -158,7 +162,7 @@ export function useMicroSensorsLayer(
       cancelled = true;
       if (intervalId !== null) window.clearInterval(intervalId);
     };
-  }, [visible, mapRef]);
+  }, [visible, mapRef, mapTick]);
 
   // ── Layer 生命週期（visible / cluster 模式變動都會重建 source） ──
   useEffect(() => {
@@ -189,7 +193,7 @@ export function useMicroSensorsLayer(
       };
     }
     apply();
-  }, [mapRef, visible, isDark, cluster]);
+  }, [mapRef, visible, isDark, cluster, mapTick]);
 
   // ── 顯示模式切換：只換 circle-color 欄位，不動 source / 不重建 layer ──
   useEffect(() => {
@@ -203,7 +207,7 @@ export function useMicroSensorsLayer(
       "circle-color",
       microSensorColorExpr(modeIdx) as unknown as mapboxgl.ExpressionSpecification,
     );
-  }, [mapRef, visible, modeIdx]);
+  }, [mapRef, visible, modeIdx, mapTick]);
 
   // ── Unmount 清理 ──
   useEffect(() => {
@@ -213,5 +217,5 @@ export function useMicroSensorsLayer(
         try { removeLayers(map); } catch { /* map 已銷毀 */ }
       }
     };
-  }, [mapRef]);
+  }, [mapRef, mapTick]);
 }

--- a/src/hooks/useNewsEventsLayer.ts
+++ b/src/hooks/useNewsEventsLayer.ts
@@ -3,6 +3,7 @@ import type { Map as MapboxMap, GeoJSONSource } from "mapbox-gl";
 import { fetchNewsEventsDay, DEFAULT_NEWS_FILTER, type NewsFilter } from "../data/newsEventsLoader";
 import { timeStore } from "../state/timeStore";
 import { keepLoadingUntilMapIdle } from "../lib/loadingRegistry";
+import { useMapReadyTick } from "./useMapReadyTick";
 
 /**
  * 新聞事件資料載入（Supabase 按日）
@@ -27,6 +28,9 @@ export function useNewsEventsLayer(
   visible: boolean,
   filter: NewsFilter = DEFAULT_NEWS_FILTER,
 ) {
+  /** map 就緒通知：mapRef 是 ref，.current 變動不觸發 re-render（見 useMapReadyTick） */
+  const mapTick = useMapReadyTick(mapRef, visible);
+
   const activeFcRef = useRef<GeoJSON.FeatureCollection | null>(null);
   const activeKeyRef = useRef<string>(""); // "date|gr|ev|sv" 組合 key
   const fetchingRef = useRef<string>("");
@@ -37,7 +41,7 @@ export function useNewsEventsLayer(
     const src = map.getSource(SOURCE_ID) as GeoJSONSource | undefined;
     if (!src) return;
     src.setData(activeFcRef.current ?? EMPTY_FC);
-  }, [mapRef]);
+  }, [mapRef, mapTick]);
 
   const loadDay = useCallback(
     (dateStr: string, f: NewsFilter) => {
@@ -89,5 +93,5 @@ export function useNewsEventsLayer(
     return () => {
       map.off("style.load", onStyleLoad);
     };
-  }, [visible, feed, mapRef]);
+  }, [visible, feed, mapRef, mapTick]);
 }

--- a/src/hooks/useOsmPowerLinesGlowLayer.ts
+++ b/src/hooks/useOsmPowerLinesGlowLayer.ts
@@ -6,6 +6,7 @@ import {
 } from "../map/osmPowerLinesGlowCustomLayer";
 import type { PowerLineFeature } from "../three/OsmPowerLinesGlowScene";
 import { fetchOsmPowerLines, powerLineTierKv } from "../data/energyLoader";
+import { useMapReadyTick } from "./useMapReadyTick";
 
 /**
  * Three.js bloom glow layer 取代 Mapbox 4-line stacking 的視覺方案。
@@ -17,6 +18,9 @@ export function useOsmPowerLinesGlowLayer(
   opacity: number,
   widthMul: number,
 ) {
+  /** map 就緒通知：mapRef 是 ref，.current 變動不觸發 re-render（見 useMapReadyTick） */
+  const mapTick = useMapReadyTick(mapRef, visible);
+
   const featuresRef = useRef<PowerLineFeature[] | null>(null);
   const visibleRef = useRef(visible);
   const opacityRef = useRef(opacity);
@@ -58,7 +62,7 @@ export function useOsmPowerLinesGlowLayer(
         map.removeLayer(OSM_POWER_LINES_GLOW_LAYER_ID);
       }
     };
-  }, [mapRef, visible]);
+  }, [mapRef, visible, mapTick]);
 
   // Lazy fetch lines when first visible
   useEffect(() => {
@@ -91,10 +95,10 @@ export function useOsmPowerLinesGlowLayer(
       })
       .catch((err) => console.warn("[osmPowerLinesGlow] fetch failed:", err));
     return () => { cancelled = true; };
-  }, [visible, mapRef]);
+  }, [visible, mapRef, mapTick]);
 
   // Param change → repaint
   useEffect(() => {
     mapRef.current?.triggerRepaint();
-  }, [visible, opacity, widthMul, mapRef]);
+  }, [visible, opacity, widthMul, mapRef, mapTick]);
 }

--- a/src/hooks/useParkingLayer.ts
+++ b/src/hooks/useParkingLayer.ts
@@ -7,6 +7,7 @@ import {
   parkingSlotIndexAt, rateFromChar, type ParkingDayData,
 } from "../data/parkingLoader";
 import { timeStore } from "../state/timeStore";
+import { useMapReadyTick } from "./useMapReadyTick";
 
 /**
  * 停車 parking 圖層 — Live（當下快照）+ Replay（15 分鐘 timeline 回放）雙模式。
@@ -38,6 +39,9 @@ function useParkingSource(
   sourceId: string,
   cfg: ParkingSourceCfg,
 ) {
+  /** map 就緒通知：mapRef 是 ref，.current 變動不觸發 re-render（見 useMapReadyTick） */
+  const mapTick = useMapReadyTick(mapRef, visible);
+
   // fcRef 永遠是「當前該貼到 source 的 FC」（live 快照 or replay 當前 slot 已染色的 day fc）
   const fcRef = useRef<GeoJSON.FeatureCollection | null>(null);
   const dayRef = useRef<ParkingDayData | null>(null);
@@ -48,7 +52,7 @@ function useParkingSource(
   const feed = useCallback(() => {
     const src = mapRef.current?.getSource(sourceId) as GeoJSONSource | undefined;
     src?.setData(fcRef.current ?? EMPTY_FC);
-  }, [mapRef, sourceId]);
+  }, [mapRef, sourceId, mapTick]);
 
   // ── Live：當下快照 poll ──
   useEffect(() => {
@@ -78,7 +82,7 @@ function useParkingSource(
       window.clearInterval(id);
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [visible, isLive, sourceId, feed, mapRef]);
+  }, [visible, isLive, sourceId, feed, mapRef, mapTick]);
 
   // ── Replay：day timeline scrub ──
   useEffect(() => {
@@ -135,7 +139,7 @@ function useParkingSource(
       unsubTick();
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [visible, isLive, sourceId, feed, mapRef]);
+  }, [visible, isLive, sourceId, feed, mapRef, mapTick]);
 }
 
 export function useParkingLayer(

--- a/src/hooks/usePlaActivityLayer.ts
+++ b/src/hooks/usePlaActivityLayer.ts
@@ -15,6 +15,7 @@ import {
 } from "../data/plaTracksLoader";
 import { timeStore } from "../state/timeStore";
 import { keepLoadingUntilMapIdle } from "../lib/loadingRegistry";
+import { useMapReadyTick } from "./useMapReadyTick";
 
 /**
  * 共機活動區 timeline 圖層（依日期回放 + 多日疊加）
@@ -164,6 +165,9 @@ export function usePlaActivityLayer(
    */
   dateOverride: string | null = null,
 ) {
+  /** map 就緒通知：mapRef 是 ref，.current 變動不觸發 re-render（見 useMapReadyTick） */
+  const mapTick = useMapReadyTick(mapRef, visible);
+
   const cacheRef = useRef<Map<string, CachedWindow>>(new Map());
   const activeRef = useRef<PlaTrack[] | null>(null);
   const activeKeyRef = useRef<string>("");
@@ -317,7 +321,7 @@ export function usePlaActivityLayer(
     return () => {
       map.off("style.load", onStyleLoad);
     };
-  }, [visible, ensureLayers, refreshSource, mapRef]);
+  }, [visible, ensureLayers, refreshSource, mapRef, mapTick]);
 
   // ── 累積回放：自己的 clock，只改 filter 不重打 RPC ──
   useEffect(() => {
@@ -349,7 +353,7 @@ export function usePlaActivityLayer(
       // 停止回放後不要留在半截狀態
       if (map.getLayer(FILL_ID)) applyThresh(map, 0);
     };
-  }, [visible, replay, trailDays, applyThresh, mapRef]);
+  }, [visible, replay, trailDays, applyThresh, mapRef, mapTick]);
 
   // ── 透明度 / 疊加天數（新舊淡化的斜率隨 trailDays 變）──
   useEffect(() => {
@@ -363,5 +367,5 @@ export function usePlaActivityLayer(
       map.setPaintProperty(LINE_ID, "line-opacity", lineOpacityExpr(o, trailDays));
       map.setPaintProperty(LINE_ID, "line-width", lineWidth(trailDays));
     }
-  }, [opacity, trailDays, visible, mapRef]);
+  }, [opacity, trailDays, visible, mapRef, mapTick]);
 }

--- a/src/hooks/usePowerGenerationBeamLayer.ts
+++ b/src/hooks/usePowerGenerationBeamLayer.ts
@@ -14,6 +14,7 @@ import {
   type PowerGenerationRow,
 } from "../data/energyLoader";
 import { timeStore } from "../state/timeStore";
+import { useMapReadyTick } from "./useMapReadyTick";
 
 /** 透明 hit-test source — 提供「點 beam 也會出 PowerPlantPanel」 */
 const HIT_SOURCE_ID = "energy-power-generation-hit";
@@ -56,6 +57,9 @@ export function usePowerGenerationBeamLayer(
   opacity: number,
   heightScale: number,
 ) {
+  /** map 就緒通知：mapRef 是 ref，.current 變動不觸發 re-render（見 useMapReadyTick） */
+  const mapTick = useMapReadyTick(mapRef, visible);
+
   const visibleRef = useRef(visible);
   visibleRef.current = visible;
   const opacityRef = useRef(opacity);
@@ -101,7 +105,7 @@ export function usePowerGenerationBeamLayer(
     return () => {
       map.off("style.load", tryMount);
     };
-  }, [mapRef, visible]);
+  }, [mapRef, visible, mapTick]);
 
   // 24h preload + 跟隨 timeStore（client binary search 解析）
   useEffect(() => {
@@ -152,5 +156,5 @@ export function usePowerGenerationBeamLayer(
       unsub();
       window.clearInterval(poll);
     };
-  }, [visible, mapRef]);
+  }, [visible, mapRef, mapTick]);
 }

--- a/src/hooks/usePowerLinesGlowTestLayer.ts
+++ b/src/hooks/usePowerLinesGlowTestLayer.ts
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from "react";
 import type { Map as MapboxMap, GeoJSONSource, ExpressionSpecification } from "mapbox-gl";
+import { useMapReadyTick } from "./useMapReadyTick";
 import {
   fetchOsmPowerLines,
   powerLineTierKv,
@@ -81,6 +82,9 @@ export function usePowerLinesGlowTestLayer(
   opacity: number,
   widthMul: number,
 ) {
+  /** map 就緒通知：mapRef 是 ref，.current 變動不觸發 re-render（見 useMapReadyTick） */
+  const mapTick = useMapReadyTick(mapRef, visible);
+
   const fcRef = useRef<GeoJSON.FeatureCollection | null>(null);
 
   // 拉一次資料
@@ -101,7 +105,7 @@ export function usePowerLinesGlowTestLayer(
       })
       .catch((err) => console.warn("[PowerLinesGlowTest] fetch failed:", err));
     return () => { cancelled = true; };
-  }, [visible, mapRef]);
+  }, [visible, mapRef, mapTick]);
 
   useEffect(() => {
     let cancelled = false;
@@ -190,5 +194,5 @@ export function usePowerLinesGlowTestLayer(
       map?.off("style.load", onStyleLoad);
       if (map) for (const id of LAYER_IDS) setVis(map, id, false);
     };
-  }, [mapRef, visible, opacity, widthMul]);
+  }, [mapRef, visible, opacity, widthMul, mapTick]);
 }

--- a/src/hooks/usePowerPlantGlowLayer.ts
+++ b/src/hooks/usePowerPlantGlowLayer.ts
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from "react";
 import type { Map as MapboxMap } from "mapbox-gl";
+import { useMapReadyTick } from "./useMapReadyTick";
 import {
   createPowerPlantGlowLayer,
   POWER_PLANT_GLOW_LAYER_ID,
@@ -24,6 +25,9 @@ export function usePowerPlantGlowLayer(
   opacity: number,
   sizeMul: number,
 ) {
+  /** map 就緒通知：mapRef 是 ref，.current 變動不觸發 re-render（見 useMapReadyTick） */
+  const mapTick = useMapReadyTick(mapRef, visible);
+
   const visibleRef = useRef(visible);
   visibleRef.current = visible;
   const opacityRef = useRef(opacity);
@@ -59,7 +63,7 @@ export function usePowerPlantGlowLayer(
     return () => {
       map.off("style.load", tryMount);
     };
-  }, [mapRef, visible]);
+  }, [mapRef, visible, mapTick]);
 
   // Fetch plants once when toggled on (5 min cache in loader)
   useEffect(() => {
@@ -79,5 +83,5 @@ export function usePowerPlantGlowLayer(
     return () => {
       cancelled = true;
     };
-  }, [visible, mapRef]);
+  }, [visible, mapRef, mapTick]);
 }

--- a/src/hooks/usePowerPolesLayer.ts
+++ b/src/hooks/usePowerPolesLayer.ts
@@ -3,6 +3,7 @@ import mapboxgl from "mapbox-gl";
 import type { Map as MapboxMap } from "mapbox-gl";
 // @ts-expect-error 套件未提供 ESM build 的型別宣告
 import { PmTilesSource } from "mapbox-pmtiles/dist/mapbox-pmtiles.js";
+import { useMapReadyTick } from "./useMapReadyTick";
 
 /**
  * 台電全國電桿 PMTiles 圖層 — 2,959,326 點
@@ -59,6 +60,9 @@ export function usePowerPolesLayer(
   heatStrength: number,
   z5Reveal: number,
 ) {
+  /** map 就緒通知：mapRef 是 ref，.current 變動不觸發 re-render（見 useMapReadyTick） */
+  const mapTick = useMapReadyTick(mapRef, visible);
+
   useEffect(() => {
     const map = mapRef.current;
     if (!map) return;
@@ -198,5 +202,5 @@ export function usePowerPolesLayer(
       if (map.getLayer(HEAT_ID)) map.setLayoutProperty(HEAT_ID, "visibility", "none");
       if (map.getLayer(CIRCLE_ID)) map.setLayoutProperty(CIRCLE_ID, "visibility", "none");
     };
-  }, [mapRef, visible, opacity, size, heatStrength, z5Reveal]);
+  }, [mapRef, visible, opacity, size, heatStrength, z5Reveal, mapTick]);
 }

--- a/src/hooks/usePowerRegionBarsLayer.ts
+++ b/src/hooks/usePowerRegionBarsLayer.ts
@@ -5,6 +5,7 @@ import {
   POWER_REGION_BARS_LAYER_ID,
 } from "../map/powerRegionBarsCustomLayer";
 import type { PowerDashboard } from "../data/energyLoader";
+import { useMapReadyTick } from "./useMapReadyTick";
 
 /**
  * Layer 3：區域用電 3D bars。掛 CustomLayer，資料源由
@@ -16,6 +17,9 @@ export function usePowerRegionBarsLayer(
   opacity: number,
   dashboardRef: React.RefObject<PowerDashboard | null>,
 ) {
+  /** map 就緒通知：mapRef 是 ref，.current 變動不觸發 re-render（見 useMapReadyTick） */
+  const mapTick = useMapReadyTick(mapRef, visible);
+
   const visibleRef = useRef(visible);
   visibleRef.current = visible;
   const opacityRef = useRef(opacity);
@@ -42,5 +46,5 @@ export function usePowerRegionBarsLayer(
       map.off("style.load", mount);
       // toggle 切 OFF 不 removeLayer，只靠 scene.setVisible 控制
     };
-  }, [mapRef, visible, dashboardRef]);
+  }, [mapRef, visible, dashboardRef, mapTick]);
 }

--- a/src/hooks/usePrecipRasterLayer.ts
+++ b/src/hooks/usePrecipRasterLayer.ts
@@ -3,6 +3,7 @@ import type { Map as MapboxMap } from "mapbox-gl";
 import { fetchPrecipRasterFrames, type PrecipRasterFrame } from "../data/precipRasterLoader";
 import { createCwaImageryLayer, type CwaImageryLayerHandle } from "../map/cwaImageryLayer";
 import { timeStore } from "../state/timeStore";
+import { useMapReadyTick } from "./useMapReadyTick";
 
 /**
  * 累積雨量柵格 — Mapbox image source + raster layer
@@ -47,6 +48,9 @@ export function usePrecipRasterLayer(
   cumulativeHours: 1 | 3 | 6 | 24,
   opacity: number,
 ) {
+  /** map 就緒通知：mapRef 是 ref，.current 變動不觸發 re-render（見 useMapReadyTick） */
+  const mapTick = useMapReadyTick(mapRef, visible);
+
   const handleRef = useRef<CwaImageryLayerHandle | null>(null);
   const framesRef = useRef<PrecipRasterFrame[]>([]);
   const currentIsoRef = useRef<string | null>(null);
@@ -160,7 +164,7 @@ export function usePrecipRasterLayer(
       if (refreshTimer) clearInterval(refreshTimer);
       handleRef.current?.setVisible(false);
     };
-  }, [mapRef, visible, cumulativeHours]);
+  }, [mapRef, visible, cumulativeHours, mapTick]);
 
   // cleanup object URLs on full unmount
   useEffect(() => () => {

--- a/src/hooks/useRealEstatePointsLayer.ts
+++ b/src/hooks/useRealEstatePointsLayer.ts
@@ -2,6 +2,7 @@ import { useEffect } from "react";
 import type { Map as MapboxMap } from "mapbox-gl";
 import { createRealEstatePointsLayer, RE_POINTS_LAYER_ID } from "../map/realEstatePointsCustomLayer";
 import { rePointsStore } from "../state/realEstatePointsStore";
+import { useMapReadyTick } from "./useMapReadyTick";
 
 /**
  * 掛載房地產「點」CustomLayer，並把控制欄位（show / excludeTaipei / baseOpacity）寫進 rePointsStore。
@@ -19,6 +20,9 @@ export function useRealEstatePointsLayer(
     baseOpacity: number;
   },
 ) {
+  /** map 就緒通知：mapRef 是 ref，.current 變動不觸發 re-render（見 useMapReadyTick） */
+  const mapTick = useMapReadyTick(mapRef);
+
   const { showRental, showSale, showPresale, excludeTaipei, baseOpacity } = opts;
   const anyShown = showRental || showSale || showPresale;
 
@@ -42,7 +46,7 @@ export function useRealEstatePointsLayer(
       map.off("style.load", tryMount);
       if (map.getLayer(RE_POINTS_LAYER_ID)) map.removeLayer(RE_POINTS_LAYER_ID);
     };
-  }, [mapRef, anyShown]);
+  }, [mapRef, anyShown, mapTick]);
 
   // 控制欄位 → store + 重繪（暫停/切換時的唯一重繪觸發；播放中由 timeline RAF 帶動）
   useEffect(() => {
@@ -50,5 +54,5 @@ export function useRealEstatePointsLayer(
     rePointsStore.excludeTaipei = excludeTaipei;
     rePointsStore.baseOpacity = baseOpacity;
     mapRef.current?.triggerRepaint();
-  }, [mapRef, showRental, showSale, showPresale, excludeTaipei, baseOpacity]);
+  }, [mapRef, showRental, showSale, showPresale, excludeTaipei, baseOpacity, mapTick]);
 }

--- a/src/hooks/useReservoirContextLayer.ts
+++ b/src/hooks/useReservoirContextLayer.ts
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { useMapReadyTick } from "./useMapReadyTick";
 import type {
   Map as MapboxMap,
   FillLayer,
@@ -240,6 +241,9 @@ export function useReservoirContextLayer(
   mapRef: React.RefObject<MapboxMap | null>,
   activeCompareId: number | null,
 ): ReservoirContext | null {
+  /** map 就緒通知：mapRef 是 ref，.current 變動不觸發 re-render（見 useMapReadyTick） */
+  const mapTick = useMapReadyTick(mapRef);
+
   const [context, setContext] = useState<ReservoirContext | null>(null);
 
   useEffect(() => {
@@ -254,7 +258,7 @@ export function useReservoirContextLayer(
     };
     if (map.isStyleLoaded()) init();
     else map.once("load", init);
-  }, [mapRef]);
+  }, [mapRef, mapTick]);
 
   useEffect(() => {
     const map = mapRef.current;
@@ -299,7 +303,7 @@ export function useReservoirContextLayer(
     return () => {
       stale = true;
     };
-  }, [activeCompareId, mapRef]);
+  }, [activeCompareId, mapRef, mapTick]);
 
   // ── 依 activeCompareId 調整其他水庫圖層 opacity（突顯當前、淡化其他） ──
   useEffect(() => {
@@ -307,7 +311,7 @@ export function useReservoirContextLayer(
     if (!map) return;
     // 若 layer 還沒建（overlayManager 還沒 load），下次 effect trigger 再試
     applyReservoirDim(map, activeCompareId);
-  }, [activeCompareId, mapRef]);
+  }, [activeCompareId, mapRef, mapTick]);
 
   return context;
 }

--- a/src/hooks/useReservoirStatusLayer.ts
+++ b/src/hooks/useReservoirStatusLayer.ts
@@ -11,6 +11,7 @@ import { ReservoirScene } from "../three/ReservoirScene";
 import { createReservoirLayer } from "../map/reservoirCustomLayer";
 import { keepLoadingUntilMapIdle } from "../lib/loadingRegistry";
 import { timeStore } from "../state/timeStore";
+import { useMapReadyTick } from "./useMapReadyTick";
 
 /**
  * 水庫 3D 水位計 hook — Timeline 驅動
@@ -126,6 +127,9 @@ export function useReservoirStatusLayer(
   statusesRef: React.RefObject<ReservoirStatus[]>,
   activeReservoirId: number | null,
 ) {
+  /** map 就緒通知：mapRef 是 ref，.current 變動不觸發 re-render（見 useMapReadyTick） */
+  const mapTick = useMapReadyTick(mapRef, visible);
+
   const visibleRef = useRef(visible);
   const isDarkRef = useRef(isDark);
   const heightScaleRef = useRef(heightScale);
@@ -199,7 +203,7 @@ export function useReservoirStatusLayer(
       cancelled = true;
       if (pollTimer) clearInterval(pollTimer);
     };
-  }, [mapRef, visible, sceneRef, statusesRef]);
+  }, [mapRef, visible, sceneRef, statusesRef, mapTick]);
 
   // ── visible=true：fetch day + 訂閱 date/time ──
   useEffect(() => {
@@ -257,14 +261,14 @@ export function useReservoirStatusLayer(
       unsubDate();
       unsubTime();
     };
-  }, [mapRef, sceneRef, statusesRef, visible]);
+  }, [mapRef, sceneRef, statusesRef, visible, mapTick]);
 
   // ── heightScale / isDark / visible 變化：觸發 repaint
   // （移除 per-frame triggerRepaint 後，需要確保 state 變動能反映到畫面）
   useEffect(() => {
     const map = mapRef.current;
     if (map) map.triggerRepaint();
-  }, [heightScale, isDark, visible, mapRef]);
+  }, [heightScale, isDark, visible, mapRef, mapTick]);
 
   // ── activeReservoirId：點選水庫後撈近 3 日進/出流量，推給 scene 畫雙柱 ──
   useEffect(() => {
@@ -313,5 +317,5 @@ export function useReservoirStatusLayer(
     return () => {
       cancelled = true;
     };
-  }, [activeReservoirId, sceneRef, statusesRef, mapRef]);
+  }, [activeReservoirId, sceneRef, statusesRef, mapRef, mapTick]);
 }

--- a/src/hooks/useRoadCongestionLayer.ts
+++ b/src/hooks/useRoadCongestionLayer.ts
@@ -9,6 +9,7 @@ import {
 import { timeStore } from "../state/timeStore";
 import { registerPmtilesSourceTypeOnce } from "../map/pmtilesSourceType";
 import { PMTILES_SOURCE_TYPE } from "../map/pmtilesConstants";
+import { useMapReadyTick } from "./useMapReadyTick";
 
 /**
  * 省道路況（TDX live_highway）動態圖層 — v1 highway only。
@@ -57,6 +58,9 @@ export function useRoadCongestionLayer(
   width: number,
   opacity: number,
 ) {
+  /** map 就緒通知：mapRef 是 ref，.current 變動不觸發 re-render（見 useMapReadyTick） */
+  const mapTick = useMapReadyTick(mapRef, visible);
+
   const dayRef = useRef<RoadCongestionDayData | null>(null);
   const activeDateRef = useRef<string>("");
   const fetchingRef = useRef<string>("");
@@ -212,7 +216,7 @@ export function useRoadCongestionLayer(
       map.off("sourcedata", onSourceData);
       unsub();
     };
-  }, [visible, ensureLayers, flush, mapRef]);
+  }, [visible, ensureLayers, flush, mapRef, mapTick]);
 
   // ── 寬度 / 透明度變更 ──
   useEffect(() => {
@@ -222,5 +226,5 @@ export function useRoadCongestionLayer(
       map.setPaintProperty(LAYER_LINE, "line-width", widthExpr(width));
       map.setPaintProperty(LAYER_LINE, "line-opacity", opacity);
     }
-  }, [width, opacity, mapRef]);
+  }, [width, opacity, mapRef, mapTick]);
 }

--- a/src/hooks/useRoadEventsLayer.ts
+++ b/src/hooks/useRoadEventsLayer.ts
@@ -14,6 +14,7 @@ import {
 } from "../data/roadEventsLoader";
 import { timeStore } from "../state/timeStore";
 import { keepLoadingUntilMapIdle } from "../lib/loadingRegistry";
+import { useMapReadyTick } from "./useMapReadyTick";
 
 /**
  * TDX 即時路況事件 timeline 圖層
@@ -110,6 +111,9 @@ export function useRoadEventsLayer(
   visible: boolean,
   opacity: number = 1,
 ) {
+  /** map 就緒通知：mapRef 是 ref，.current 變動不觸發 re-render（見 useMapReadyTick） */
+  const mapTick = useMapReadyTick(mapRef, visible);
+
   const cacheRef = useRef<Map<string, CachedDay>>(new Map());
   const activeDayRef = useRef<RoadEvent[] | null>(null);
   const activeDateRef = useRef<string>("");
@@ -240,7 +244,7 @@ export function useRoadEventsLayer(
 
     tick(timeStore.getTime());
     return timeStore.subscribeThrottled(500, tick);
-  }, [visible, ensureLayers, refreshSource, mapRef]);
+  }, [visible, ensureLayers, refreshSource, mapRef, mapTick]);
 
   // ── 套用 opacity ──
   useEffect(() => {
@@ -258,5 +262,5 @@ export function useRoadEventsLayer(
       map.setPaintProperty(LAYER_POINT, "circle-opacity", 0.9 * o);
       map.setPaintProperty(LAYER_POINT, "circle-stroke-opacity", o);
     }
-  }, [opacity, visible, mapRef]);
+  }, [opacity, visible, mapRef, mapTick]);
 }

--- a/src/hooks/useSatellitesLayer.ts
+++ b/src/hooks/useSatellitesLayer.ts
@@ -23,6 +23,7 @@ import {
 } from "../data/satelliteTypes";
 import { propagate, splitAtDateline } from "../data/satelliteSGP4";
 import { timeStore } from "../state/timeStore";
+import { useMapReadyTick } from "./useMapReadyTick";
 
 /**
  * 衛星圖層 — 三個 toggle（中國軍事 / 中國遙測 / 台灣），共用 SGP4 計算
@@ -126,6 +127,9 @@ export function useSatellitesLayer(
   mapRef: React.RefObject<MapboxMap | null>,
   opts: UseSatellitesLayerOpts,
 ) {
+  /** map 就緒通知：mapRef 是 ref，.current 變動不觸發 re-render（見 useMapReadyTick） */
+  const mapTick = useMapReadyTick(mapRef);
+
   const { visibility, opacity = 1, trackMinutes = DEFAULT_TRACK_MIN, consoleFilter = null } = opts;
   const consoleFilterRef = useRef(consoleFilter);
   consoleFilterRef.current = consoleFilter;
@@ -453,7 +457,7 @@ export function useSatellitesLayer(
       map.off("style.load", onSetupStyleLoad);
       map.off("idle", onSetupIdle);
     };
-  }, [dataReady, anyVisible, ensureLayers, recompute, recomputeLight, recomputeTrack, mapRef]);
+  }, [dataReady, anyVisible, ensureLayers, recompute, recomputeLight, recomputeTrack, mapRef, mapTick]);
 
   // ── toggle 變動即刻 force recompute ──
   // visibility 物件 identity 每 render 都新；用 JSON 字串穩定化 deps，
@@ -471,7 +475,7 @@ export function useSatellitesLayer(
     if (!map) return;
     if (!layersReadyRef.current && !ensureLayers(map)) return;
     recompute(map, timeStore.getTime());
-  }, [visKey, dataReady, ensureLayers, recompute, mapRef]);
+  }, [visKey, dataReady, ensureLayers, recompute, mapRef, mapTick]);
 
   // ── visibility toggle（用 layer visibility，避免 source 反覆重設） ──
   useEffect(() => {
@@ -487,7 +491,7 @@ export function useSatellitesLayer(
     ]) {
       if (map.getLayer(id)) map.setLayoutProperty(id, "visibility", v);
     }
-  }, [anyVisible, mapRef, dataReady]);
+  }, [anyVisible, mapRef, dataReady, mapTick]);
 
   // ── opacity ──
   useEffect(() => {
@@ -506,5 +510,5 @@ export function useSatellitesLayer(
     if (map.getLayer(SAT_LAYER_POINT)) {
       map.setPaintProperty(SAT_LAYER_POINT, "circle-opacity", 1 * o);
     }
-  }, [opacity, mapRef, dataReady]);
+  }, [opacity, mapRef, dataReady, mapTick]);
 }

--- a/src/hooks/useSlopeVectorLayer.ts
+++ b/src/hooks/useSlopeVectorLayer.ts
@@ -2,6 +2,7 @@ import { useEffect } from "react";
 import type { Map as MapboxMap, ExpressionSpecification } from "mapbox-gl";
 import { registerPmtilesSourceTypeOnce } from "../map/pmtilesSourceType";
 import { PMTILES_SOURCE_TYPE } from "../map/pmtilesConstants";
+import { useMapReadyTick } from "./useMapReadyTick";
 
 /**
  * 坡度分級（建管六級坡）靜態向量圖層 — slope_vector.pmtiles polygon。
@@ -44,6 +45,9 @@ export function useSlopeVectorLayer(
   opacity: number,
   styleId: string,
 ) {
+  /** map 就緒通知：mapRef 是 ref，.current 變動不觸發 re-render（見 useMapReadyTick） */
+  const mapTick = useMapReadyTick(mapRef, visible);
+
   useEffect(() => {
     let cancelled = false;
     let map: MapboxMap | null = null;
@@ -122,5 +126,5 @@ export function useSlopeVectorLayer(
     };
     // styleId 進 deps：底圖 style 切換時 effect 重跑 → 重新 ensureLayer（走與手動 re-toggle
     // 相同的成功路徑）。diff setStyle 會移除自訂圖層且 event listener 重掛不可靠，改靠 React 重跑。
-  }, [mapRef, visible, opacity, styleId]);
+  }, [mapRef, visible, opacity, styleId, mapTick]);
 }

--- a/src/hooks/useStaticRasterLayer.ts
+++ b/src/hooks/useStaticRasterLayer.ts
@@ -9,6 +9,7 @@
 
 import { useEffect, useRef } from "react";
 import type { Map as MapboxMap } from "mapbox-gl";
+import { useMapReadyTick } from "./useMapReadyTick";
 import {
   createCwaImageryLayer,
   type CwaImageryBBox,
@@ -37,6 +38,9 @@ export function useStaticRasterLayer({
   opacity,
   beforeId,
 }: UseStaticRasterLayerOptions) {
+  /** map 就緒通知：mapRef 是 ref，.current 變動不觸發 re-render（見 useMapReadyTick） */
+  const mapTick = useMapReadyTick(mapRef);
+
   const handleRef = useRef<CwaImageryLayerHandle | null>(null);
 
   useEffect(() => {
@@ -71,7 +75,7 @@ export function useStaticRasterLayer({
       };
     }
     ensure();
-  }, [mapRef, sourceId, layerId, url, bbox, visible, opacity, beforeId]);
+  }, [mapRef, sourceId, layerId, url, bbox, visible, opacity, beforeId, mapTick]);
 
   useEffect(() => {
     return () => {

--- a/src/hooks/useSubstationEhvGlowLayer.ts
+++ b/src/hooks/useSubstationEhvGlowLayer.ts
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from "react";
 import type { Map as MapboxMap } from "mapbox-gl";
+import { useMapReadyTick } from "./useMapReadyTick";
 import {
   createSubstationEhvGlowLayer,
   SUBSTATION_EHV_GLOW_LAYER_ID,
@@ -15,6 +16,9 @@ export function useSubstationEhvGlowLayer(
   opacity: number,
   sizeMul: number,
 ) {
+  /** map 就緒通知：mapRef 是 ref，.current 變動不觸發 re-render（見 useMapReadyTick） */
+  const mapTick = useMapReadyTick(mapRef, visible);
+
   const visibleRef = useRef(visible);
   visibleRef.current = visible;
   const opacityRef = useRef(opacity);
@@ -48,7 +52,7 @@ export function useSubstationEhvGlowLayer(
     return () => {
       map.off("style.load", tryMount);
     };
-  }, [mapRef, visible]);
+  }, [mapRef, visible, mapTick]);
 
   useEffect(() => {
     if (!visible) return;
@@ -63,5 +67,5 @@ export function useSubstationEhvGlowLayer(
     return () => {
       cancelled = true;
     };
-  }, [visible, mapRef]);
+  }, [visible, mapRef, mapTick]);
 }

--- a/src/hooks/useTaipeiEvacuateLayer.ts
+++ b/src/hooks/useTaipeiEvacuateLayer.ts
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from "react";
 import type { Map as MapboxMap, GeoJSONSource, ExpressionSpecification } from "mapbox-gl";
 import { fetchTaipeiEvacuateLatest, type EvacuateLatestRow } from "../data/wicTaipeiLoader";
+import { useMapReadyTick } from "./useMapReadyTick";
 
 /**
  * 北市疏散門 latest layer
@@ -105,6 +106,9 @@ export function useTaipeiEvacuateLayer(
   scale: number,
   opacity: number,
 ) {
+  /** map 就緒通知：mapRef 是 ref，.current 變動不觸發 re-render（見 useMapReadyTick） */
+  const mapTick = useMapReadyTick(mapRef, visible);
+
   const dataRef = useRef<EvacuateLatestRow[]>([]);
 
   useEffect(() => {
@@ -136,5 +140,5 @@ export function useTaipeiEvacuateLayer(
       return () => { cancelled = true; window.clearInterval(t); };
     }
     return () => { cancelled = true; };
-  }, [mapRef, visible, scale, opacity]);
+  }, [mapRef, visible, scale, opacity, mapTick]);
 }

--- a/src/hooks/useTaipeiPumbLayer.ts
+++ b/src/hooks/useTaipeiPumbLayer.ts
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from "react";
 import type { Map as MapboxMap, GeoJSONSource, ExpressionSpecification } from "mapbox-gl";
 import { fetchTaipeiPumbLatest, type PumbLatestRow } from "../data/wicTaipeiLoader";
+import { useMapReadyTick } from "./useMapReadyTick";
 
 /**
  * 北市抽水站 latest layer — 即時運轉狀態 + 內池警戒比
@@ -124,6 +125,9 @@ export function useTaipeiPumbLayer(
   scale: number,
   opacity: number,
 ) {
+  /** map 就緒通知：mapRef 是 ref，.current 變動不觸發 re-render（見 useMapReadyTick） */
+  const mapTick = useMapReadyTick(mapRef, visible);
+
   const dataRef = useRef<PumbLatestRow[]>([]);
 
   useEffect(() => {
@@ -155,5 +159,5 @@ export function useTaipeiPumbLayer(
       return () => { cancelled = true; window.clearInterval(t); };
     }
     return () => { cancelled = true; };
-  }, [mapRef, visible, scale, opacity]);
+  }, [mapRef, visible, scale, opacity, mapTick]);
 }

--- a/src/hooks/useTaipeiSewerLayer.ts
+++ b/src/hooks/useTaipeiSewerLayer.ts
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from "react";
 import type { Map as MapboxMap, GeoJSONSource, ExpressionSpecification } from "mapbox-gl";
 import { fetchTaipeiSewerLatest, type SewerLatestRow } from "../data/wicTaipeiLoader";
+import { useMapReadyTick } from "./useMapReadyTick";
 
 /**
  * 北市雨水下水道水位 latest layer
@@ -98,6 +99,9 @@ export function useTaipeiSewerLayer(
   scale: number,
   opacity: number,
 ) {
+  /** map 就緒通知：mapRef 是 ref，.current 變動不觸發 re-render（見 useMapReadyTick） */
+  const mapTick = useMapReadyTick(mapRef, visible);
+
   const dataRef = useRef<SewerLatestRow[]>([]);
 
   useEffect(() => {
@@ -129,5 +133,5 @@ export function useTaipeiSewerLayer(
       return () => { cancelled = true; window.clearInterval(t); };
     }
     return () => { cancelled = true; };
-  }, [mapRef, visible, scale, opacity]);
+  }, [mapRef, visible, scale, opacity, mapTick]);
 }

--- a/src/hooks/useTemperatureGridLayer.ts
+++ b/src/hooks/useTemperatureGridLayer.ts
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from "react";
 import type { Map as MapboxMap, MapSourceDataEvent } from "mapbox-gl";
 import type { TemperatureGridData } from "../data/temperatureLoader";
 import { timeStore } from "../state/timeStore";
+import { useMapReadyTick } from "./useMapReadyTick";
 import {
   TEMPERATURE_GRID_SOURCE_ID,
   TEMPERATURE_GRID_FILL_LAYER_ID,
@@ -51,6 +52,9 @@ export function useTemperatureGridLayer(
   visible: boolean,
   opacity: number,
 ) {
+  /** map 就緒通知：mapRef 是 ref，.current 變動不觸發 re-render（見 useMapReadyTick） */
+  const mapTick = useMapReadyTick(mapRef, visible);
+
   const opacityRef = useRef(opacity);
   opacityRef.current = opacity;
 
@@ -196,12 +200,12 @@ export function useTemperatureGridLayer(
       unsubscribe();
       if (map.getLayer(TEMPERATURE_GRID_FILL_LAYER_ID)) setTemperatureGridVisible(map, false);
     };
-  }, [mapRef, data, visible, mapRetry]);
+  }, [mapRef, data, visible, mapRetry, mapTick]);
 
   // ── 透明度 slider ──
   useEffect(() => {
     const map = mapRef.current;
     if (!map || !visible) return;
     setTemperatureGridOpacity(map, opacity);
-  }, [mapRef, opacity, visible]);
+  }, [mapRef, opacity, visible, mapTick]);
 }

--- a/src/hooks/useTyphoonTracksLayer.ts
+++ b/src/hooks/useTyphoonTracksLayer.ts
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useCallback } from "react";
 import type { Map as MapboxMap, LineLayer, CircleLayer, ExpressionSpecification } from "mapbox-gl";
+import { useMapReadyTick } from "./useMapReadyTick";
 import {
   fetchTyphoonPoints,
   typhoonPointsToGeoJSON,
@@ -31,6 +32,9 @@ export function useTyphoonTracksLayer(
   opacity: number = 0.9,
   sourceFilter: TyphoonSource = "all",
 ) {
+  /** map 就緒通知：mapRef 是 ref，.current 變動不觸發 re-render（見 useMapReadyTick） */
+  const mapTick = useMapReadyTick(mapRef, visible);
+
   const dataRef = useRef<TyphoonPoint[]>([]);
   const dataReadyRef = useRef(false);
   const layersReadyRef = useRef(false);
@@ -178,5 +182,5 @@ export function useTyphoonTracksLayer(
     if (map.getLayer(LAYER_CURRENT_HALO)) map.setPaintProperty(LAYER_CURRENT_HALO, "circle-opacity", 0.16 * o);
     if (map.getLayer(LAYER_CURRENT_RING)) map.setPaintProperty(LAYER_CURRENT_RING, "circle-stroke-opacity", 0.95 * o);
     if (map.getLayer(LAYER_CURRENT_DOT)) map.setPaintProperty(LAYER_CURRENT_DOT, "circle-opacity", 1 * o);
-  }, [visible, opacity, sourceFilter, ensureSource, mapRef]);
+  }, [visible, opacity, sourceFilter, ensureSource, mapRef, mapTick]);
 }

--- a/src/hooks/useWasteCleaningSquadLayer.ts
+++ b/src/hooks/useWasteCleaningSquadLayer.ts
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from "react";
 import type { Map as MapboxMap, GeoJSONSource } from "mapbox-gl";
 import { fetchWasteCleaningSquads, type WasteCleaningSquadRow } from "../data/wasteLoader";
+import { useMapReadyTick } from "./useMapReadyTick";
 
 /**
  * 全國 清潔隊辦公點 layer — spatial.waste_cleaning_squads（359 / 23 縣市）。
@@ -87,6 +88,9 @@ export function useWasteCleaningSquadLayer(
   visible: boolean,
   isDarkTheme: boolean,
 ) {
+  /** map 就緒通知：mapRef 是 ref，.current 變動不觸發 re-render（見 useMapReadyTick） */
+  const mapTick = useMapReadyTick(mapRef, visible);
+
   const loadedRef = useRef(false);
 
   useEffect(() => {
@@ -117,5 +121,5 @@ export function useWasteCleaningSquadLayer(
     else map.once("style.load", run);
 
     return () => { cancelled = true; };
-  }, [mapRef, visible, isDarkTheme]);
+  }, [mapRef, visible, isDarkTheme, mapTick]);
 }

--- a/src/hooks/useWorldTrashDebrisLayer.ts
+++ b/src/hooks/useWorldTrashDebrisLayer.ts
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useCallback } from "react";
 import type { Map as MapboxMap, ExpressionSpecification, CircleLayer } from "mapbox-gl";
 import { fetchWorldTrashDebris } from "../data/worldTrashDebrisLoader";
+import { useMapReadyTick } from "./useMapReadyTick";
 
 // 全球垃圾殘骸（Outerview，CC-BY-4.0）— 靜態載一次，Mapbox 原生 circle。
 // 單色小點，radius 依 zoom 內插；不接 timeline（比照 useEarthquakesGlobalLayer）。
@@ -23,6 +24,9 @@ export function useWorldTrashDebrisLayer(
   visible: boolean,
   opacity: number = 0.85,
 ) {
+  /** map 就緒通知：mapRef 是 ref，.current 變動不觸發 re-render（見 useMapReadyTick） */
+  const mapTick = useMapReadyTick(mapRef, visible);
+
   const fcRef = useRef<GeoJSON.FeatureCollection | null>(null);
   const dataReadyRef = useRef(false);
 
@@ -75,5 +79,5 @@ export function useWorldTrashDebrisLayer(
       const o = Math.max(0, Math.min(1, opacity));
       map.setPaintProperty(LAYER_ID, "circle-opacity", o);
     }
-  }, [visible, opacity, ensureSource, mapRef]);
+  }, [visible, opacity, ensureSource, mapRef, mapTick]);
 }


### PR DESCRIPTION
## 症狀

分享連結 `?layers=fireEvents,parking` 打開後那些圖層**不出現**，但自己手動點側欄 toggle 完全正常。沒有任何錯誤訊息。

## 根因

App 的 `mapRef.current` 是在 `MapView` 的 `map.on("load")` 裡透過 `onMapReady` 回呼才填的，而 **production 首載 load 可能晚達 ~30 秒**（MapView 既有註解已寫明）。在那之前，layer hook 的建層 effect 是：

```ts
const map = mapRef.current;
if (!map) return;        // ← 什麼也沒建
```

`mapRef` 是 ref，**`.current` 變動不觸發 re-render**，effect 不會因為「map 終於好了」而重跑。只要 `visible` 之後沒再變，該圖層就**永遠不會被建出來**。

兩種會中招的情境：

1. **deep-link**（`?layers=`）— `App.tsx` 的 EM-03 effect 在掛載時就 `setVisible(true)`，遠早於 map load
2. **首載期間手動 toggle** — 30 秒是很長的時間，使用者早就點下去了

`OVERLAY_REGISTRY` 那條路徑不受影響 —— MapView 的 `map.on("load")` 裡本來就有補發機制（用 ref 最新值重放一次）。**缺的一直是 hook 這條路徑。**

## 修法

抽出 `useMapReadyTick(mapRef, enabled)`：map 未就緒時每 200ms 輪詢，一就緒就 `clearInterval` 並遞增 tick；**已就緒則完全不建 timer**（絕大多數情況成本為零）。把 tick 放進建層 effect 的 deps 即可。

原本只有 3 個檔案各自複製這個 `setInterval` 寫法（`useEarthquakeReplayLayer` / `useFuneralDensityLayer` / `useTemperatureGridLayer`），本 PR 讓 **55 個 layer hook 全部套上**，並在 `factories/timelineSliceLayer` 補一次（`rainGauge` / `riverLevel` / `groundwater` 三個薄包裝共用）。

有 3 個檔案的 tick 宣告要放在**檔內私有 hook**（`useSourceFeed` / `useParkingSource`）而非 export function —— 真正持有建層 effect 的是私有 hook。

## 守門

新增 `mapReadyTickCoverage` 測試，走 `layerConsistency` / `overlayParamsDeps` 既有的靜態比對風格：**deps 陣列含 `mapRef` 就必須含 `mapTick`**。新增 layer hook 漏接時會紅。

實測拆掉 `useFreewayLayer` 的 tick，測試立刻紅並指出：

```
useFreewayLayer.ts → [visible, ensureLayers, refreshSource, mapRef]
```

## 驗證

- `npx tsc -b` 綠
- `pnpm test` **30 檔 318 tests 全過**（新增 2 個）
- ratchet 反向驗證如上

🤖 Generated with [Claude Code](https://claude.com/claude-code)