### PR TITLE
feat(embed): rsys= 擴充到營運者級 + 線路級（機場捷運／新北捷運／各捷運線可單選）

### DIFF
--- a/demo-embed.html
+++ b/demo-embed.html
@@ -93,14 +93,29 @@
   </div>
 
   <div class="card">
-    <h2>🚇 台北捷運・早上 8:00<span class="badge">rsys=trtc · 180x</span></h2>
+    <h2>🚇 台北捷運本體・早上 8:00<span class="badge">rsys=trtc · 180x</span></h2>
     <div class="desc">
-      <strong>只顯示台北捷運</strong>一個系統——加上 <strong>rsys=trtc</strong> 之後，台鐵的灰色軌道與高鐵都不會進場
-      （過濾發生在組裝階段，沒被選到的系統連時刻表都不解析）。從 08:00 通勤尖峰起播，
-      放慢到每秒約 3 分鐘，六條線的班距疏密才看得出來。
+      <strong>只顯示台北捷運本體五線</strong>（文湖／淡水信義／松山新店／中和新蘆／板南）——加上
+      <strong>rsys=trtc</strong> 之後，台鐵的灰色軌道與高鐵都不會進場（過濾發生在組裝階段，
+      沒被選到的線連時刻表都不解析）。<strong>2026-08 起 trtc 不再包含機場捷運與新北各線</strong>——
+      那些改用 <strong>rsys=tymc</strong> / <strong>rsys=ntm</strong>，要三家一起看就寫 <strong>rsys=trtc,tymc,ntm</strong>。
+      從 08:00 通勤尖峰起播，放慢到每秒約 3 分鐘，五條線的班距疏密才看得出來。
     </div>
     <iframe loading="lazy" src="/embed.html?v=1&layers=rail&date=2026-08-06&h=8&rsys=trtc&p.speed=180&lng=121.52&lat=25.06&z=10.3"></iframe>
     <div class="url">/embed.html?v=1&amp;layers=rail&amp;date=2026-08-06&amp;h=8&amp;rsys=trtc&amp;p.speed=180&amp;lng=121.52&amp;lat=25.06&amp;z=10.3</div>
+  </div>
+
+  <div class="card">
+    <h2>🔵 板南線一條線・早上 8:00<span class="badge">rsys=trtc-bl · 180x</span></h2>
+    <div class="desc">
+      同一個參數再往下切一級：<strong>rsys=trtc-bl</strong> 只留<strong>板南線</strong>一條——
+      頂埔／南港展覽館之間，全天 596 班次、15 條軌道。線路代碼一律帶營運者前綴
+      （北捷與高捷都有 R 與 O，<strong>krtc-r</strong> 是高雄紅線、<strong>trtc-r</strong> 才是淡水信義線），
+      混用也可以：<strong>rsys=trtc-bl,tymc</strong> ＝ 板南線 + 機場捷運。圖例跟著收斂到線路級，
+      只列板南線那一格官方藍。
+    </div>
+    <iframe loading="lazy" src="/embed.html?v=1&layers=rail&date=2026-08-06&h=8&rsys=trtc-bl&p.speed=180&lng=121.522&lat=25.036&z=11.2"></iframe>
+    <div class="url">/embed.html?v=1&amp;layers=rail&amp;date=2026-08-06&amp;h=8&amp;rsys=trtc-bl&amp;p.speed=180&amp;lng=121.522&amp;lat=25.036&amp;z=11.2</div>
   </div>
 
   <div class="card">

--- a/docs/features/embeddable-map/README.md
+++ b/docs/features/embeddable-map/README.md
@@ -54,9 +54,83 @@
 | `date` / `h` | 凍結日期（YYYY-MM-DD）+ 小時 0–23 | ✅ | ✅（需有快照） |
 | `p.<key>` | overlayParams 覆寫 | ❌ | ✅ |
 | `theme` | `dark`\|`light`（style 未給時的回退） | — | ✅ |
+| `rsys` | 鐵路只顯示哪幾個營運者／線路（見下節代碼表） | — | ✅ |
 
 **主站不支援 `p.*` 是刻意的**：主站有 sidebar，URL override 會與使用者拉 slider 打架
 （`useTransportParams` 3028 行、數百個 hardcode `useState`，無法注入初始值）。
+
+## `rsys=` 鐵路代碼表（營運者級 + 線路級）
+
+一個參數吃三種粒度，可混用取聯集（`rsys=trtc-bl,tymc`）。代碼一律小寫、線路碼**必帶
+營運者前綴**（北捷與高捷都有 `R`／`O`，裸碼會撞名）。未知代碼逐一 drop、全 drop 後
+＝ 未指定 ＝ 顯示全部（不會白畫面）。SSOT：[`src/constants/railLines.ts`](../../../src/constants/railLines.ts)。
+
+### ⚠️ Breaking change（2026-08-09，owner 拍板）
+
+`trtc` 在資料裡是「台北都會區軌道」的大雜燴，不只北捷：
+
+| | 舊語意（PR #118） | 新語意 |
+|---|---|---|
+| `rsys=trtc` | 整個 trtc 系統 = 北捷 5 線 **+ 機場捷運 + 新北 4 線**（94 軌道／4,516 班次） | **只有北捷本體 5 線**（76 軌道／3,017 班次） |
+| 要回到舊範圍 | — | 寫 `rsys=trtc,tymc,ntm` |
+
+**沒有升 `URL_STATE_VERSION`**：升版會讓所有舊嵌入碼（含與 rail 無關的）整組作廢，
+代價遠大於這欄的語意修正；而且解析結果本身沒變（仍是 `["trtc"]`），變的是下游詮釋。
+理由與例外紀錄同時寫在 `src/lib/urlState.ts` 檔頭第 3 點。
+
+### 營運者／系統級
+
+| 代碼 | 中文名 | 涵蓋 line_id | 軌道數 | 班次（2026-08-06） |
+|---|---|---|---|---|
+| `tra` | 台鐵 | —（無線路概念） | 267 O-D（畫 37 golden） | 907 |
+| `thsr` | 高鐵 | — | 2 | 160 |
+| `trtc` | 台北捷運 | BR / R / G / O / BL | 76 | 3,017 |
+| `tymc` | 桃園捷運（機場線） | A | 8 | 329 |
+| `ntm` | 新北捷運 | Y / V / K / LB | 10 | 1,170 |
+| `krtc` | 高雄捷運 | 整個系統 | 4 | 620 |
+| `klrt` | 高雄輕軌 | 整個系統 | 2 | 154 |
+| `tmrt` | 台中捷運 | 整個系統 | 2 | 306 |
+
+> `tymc` 與 `ntm` 的線路在資料裡都住在 `trtc` **系統**底下（快照與幾何 bundle 的 key），
+> 代碼是營運者視角、系統是引擎視角，兩者刻意分開。
+
+### 線路級
+
+| 代碼 | 中文名 | line_id | 軌道數 | 班次 | 官方線色 |
+|---|---|---|---|---|---|
+| `trtc-br` | 文湖線 | BR | 2 | 402 | `#c48c31` |
+| `trtc-r` | 淡水信義線 | R | 19 | 768 | `#d90023` |
+| `trtc-g` | 松山新店線 | G | 15 | 689 | `#008659` |
+| `trtc-o` | 中和新蘆線 | O | 25 | 562 | `#f8b61c` |
+| `trtc-bl` | 板南線 | BL | 15 | 596 | `#0070c0` |
+| `tymc-a` | 機場捷運 | A | 8 | 329 | `#8246af` |
+| `ntm-y` | 環狀線 | Y | 2 | 332 | `#fedb00` |
+| `ntm-v` | 淡海輕軌 | V | 4 | 494 | `#a4ce4e` |
+| `ntm-k` | 安坑輕軌 | K | 2 | 177 | `#8cc540` |
+| `ntm-lb` | 三鶯線 | LB | 2 | 167 | `#6db7d0` |
+| `krtc-r` | 高雄紅線 | R | 2 | 319 | `#e2211c` |
+| `krtc-o` | 高雄橘線 | O | 2 | 301 | `#f8981d` |
+| `tmrt-g` | 台中捷運綠線 | G | 2 | 306 | `#0cab2c` |
+
+**沒有線路碼的三個系統**：`tra` / `thsr` / `klrt` —— 資料裡的軌道沒有 `line_id`
+（klrt 只有一條環狀線），系統級即最細粒度，刻意不發明 `klrt-c` 這種「查得到卻沒東西」的代碼。
+
+**貓空纜車（`MK-*`）刻意沒有代碼**：它掛在 trtc 底下但不是軌道運輸，主站與嵌入版都排除，
+所以 `rsys=trtc` 是 94→76 而不是 96→76。打 `rsys=trtc-mk` 會被當未知代碼 drop。
+
+### ⚠️ 資料的坑：`line_id` 並非每條軌道都有
+
+`rail_slim.json.gz` 裡 trtc 的 96 條軌道中，**13 條淡水信義線變體**（`R-4-*`～`R-15-*`，
+如「大安 → 象山」「北投 → 淡水」）只有 `track_id` / `route_id` / `name` / `color`，
+**沒有 `line_id`**；時刻表快照更是整份都沒有 `line_id`（只有 `track_id`）。
+所以線路歸屬是 `properties.line_id` 優先、缺了才退回 **trtc 專用**的 `track_id` 前綴解析
+（`railLineIdOf()`）。上游 `build-rail-slim-bundle.py` 補齊後可刪掉這個 fallback。
+
+### 圖例
+
+`RailLegend` 跟著代碼收斂到同一粒度：`rsys=trtc` 列五線、`rsys=trtc-bl` 只列板南線
+（用上表的官方線色，與地圖上那條線同色）；未指定（主站）維持泛稱一行「捷運依各路線官方線色」，
+輸出逐字不變。
 
 ## 嵌入版可用的圖層（三層白名單）
 
@@ -69,8 +143,10 @@
 🔒 **35 個 owner-gated 圖層一律排除**，且不只是「不顯示」——實測 URL 硬塞 gated key 時，
 對應的資料檔**連一個 byte 都不會下載**（source 根本不建立）。
 
-**不支援**：Three.js CustomLayer（`ships` / `flights` / `rail` / `busLive`），
-embed 刻意不掛 Three.js。詳見 [`embed-dynamic-layers.md`](../../proposal/embed-dynamic-layers.md) §2。
+**回放層（EM-16，2026-08-09 上線）**：`ships` / `flights` / `rail` 三層 Three.js 回放，
+只在網址真的帶了這些 key + `date=` 時才 `import()` three（純靜態嵌入完全不下載）。
+`busLive` 仍不支援（EM-24）。原「Three.js 圖層不做」的結論已翻案，詳見
+[`embed-dynamic-layers.md`](../../proposal/embed-dynamic-layers.md) §2 與 [`changelog.md`](./changelog.md)。
 
 ## 檔案地圖
 

--- a/docs/features/embeddable-map/changelog.md
+++ b/docs/features/embeddable-map/changelog.md
@@ -1,5 +1,19 @@
 # Embeddable Map — Changelog
 
+## 2026-08-09 — `rsys=` 擴充到營運者級 + 線路級（`feat/rail-line-codes`）
+
+- 一個參數吃三種粒度：`trtc`（營運者）／`trtc-bl`（線路，必帶前綴避免北捷高捷 R/O 撞名）／
+  `tra`（系統即最細）。混用取聯集，代碼表 SSOT = `src/constants/railLines.ts`
+- ⚠️ **breaking**：`rsys=trtc` 從「整個 trtc 系統」（含機捷 + 新北四線，94 軌道／4,516 班次）
+  縮成「北捷本體五線」（76／3,017）。舊範圍寫 `rsys=trtc,tymc,ntm`。
+  **不升 `URL_STATE_VERSION`**（升版會讓所有舊嵌入碼作廢，代價遠大於此；解析結果本身沒變）
+- 過濾仍在**組裝階段**（`railReplayData`），沒選到的線連時刻表都不進 Map；
+  時刻表沒有 `line_id` → 留不下軌道的班表一起丟，避免 departureCounts 與軌道數對不上
+- 圖例跟著收斂到線路級（`rsys=trtc-bl` 只列板南線，用資料裡的官方線色）
+- 🕳 **資料坑**：trtc 96 條軌道有 13 條（淡水信義線變體 `R-4-*`～`R-15-*`）**沒有 `line_id`**，
+  快照時刻表更是整份都沒有 → `railLineIdOf()` 以 properties 優先、缺了才退回 trtc 專用的
+  `track_id` 前綴解析。follow-up：上游 bundle 補齊後刪掉 fallback
+
 ## 2026-08-05 — Cloudflare 邊緣快取（EM-13）
 
 - 建 Cache Rule `Static map data`（設定內容記於 [`handoff.md`](./handoff.md) §0b）——

--- a/src/components/LegendPanel.tsx
+++ b/src/components/LegendPanel.tsx
@@ -14,6 +14,7 @@ import { PLA_KIND_COLORS, PLA_KIND_LABELS } from "../data/plaTracksLoader";
 import { SHIP_TYPE_LEGEND, SHIP_TYPE_COLORS_DARK } from "../data/shipTrails";
 import { LAYER_COLORS } from "./sidebar/layerCatalog";
 import { TRA_TRAIN_TYPES } from "../constants/traTrainTypes";
+import { railLegendLines, railMetroOperatorNames, resolveRailCodes } from "../constants/railLines";
 import { ECO_NETWORK_ZONE_TYPES } from "../data/ecoNetworkZoneTypes";
 import { TEMPERATURE_GRID_BANDS } from "../data/temperatureGridTypes";
 import { CWA_INTENSITY_BANDS } from "../data/earthquakeReplayTypes";
@@ -602,44 +603,39 @@ const TRA_TRAIN_TYPE_ROWS = (() => {
   return [...byColor].map(([color, names]) => ({ color, label: names.join(" / ") }));
 })();
 
-/** 走 RailEngine 的四座捷運／輕軌（label 同 `railLoader.RAIL_SYSTEMS`）。 */
-const METRO_SYSTEMS = [
-  { id: "trtc", label: "台北捷運" },
-  { id: "krtc", label: "高雄捷運" },
-  { id: "klrt", label: "高雄輕軌" },
-  { id: "tmrt", label: "台中捷運" },
-] as const;
-
 /**
  * 鐵路 —— 分色維度是**車種（台鐵）與路線（高鐵／捷運）**，不是「系統」。
  *
  * 台鐵佔畫面上絕大多數的車，且引擎確實照車種上色（`getTrainColor`），所以那是主圖例。
  * 高鐵全線同色（時刻表無 `train_color`、軌道無 `color` → 落到系統預設 #ee6c00）。
- * 捷運則是**每條路線各自的官方線色**（北捷 96 條路線各有 color），數量太多不逐條列，
- * 也不硬編一個「捷運＝某色」的假分類 —— 用一行說明帶過（同 FlightsLegend 的原則）。
+ * 捷運則是**每條路線各自的官方線色**。
  *
- * `railSystems`（`/embed` 的 `rsys=`）指定單一系統時**整段收斂**：沒被選到的系統
+ * `railSystems`（`/embed` 的 `rsys=`）指定時**整段收斂**：沒被選到的系統／線路
  * 連軌道都沒進場（過濾在 `railReplayData` 的組裝階段），圖例還列著就是誤導。
+ * 收斂粒度跟著代碼走 —— `rsys=trtc` 列北捷五線、`rsys=trtc-bl` 只列板南線，
+ * 用的是 `constants/railLines.ts` 抄自資料的官方線色（與地圖上那條線同色）。
  * 特別是「灰線為軌道」——灰色是台鐵 golden track 專屬，沒選台鐵時畫面上根本沒有灰線。
- * 未傳（主站）＝ undefined ＝ 全部顯示，輸出與加這個參數之前逐字相同。
+ *
+ * 未傳（主站）＝ undefined ＝ 全部顯示：**不逐條列**（六系統上百條路線列不完），
+ * 用一行「捷運依各路線官方線色」帶過，輸出與加這個參數之前逐字相同。
  */
 function RailLegend({ railSystems }: { railSystems?: readonly string[] }) {
   const t = useLegendTheme();
-  const has = (id: string) => railSystems == null || railSystems.includes(id);
-
-  const showTra = has("tra");
-  const showThsr = has("thsr");
-  const metros = METRO_SYSTEMS.filter((m) => has(m.id));
-  // 全選時用泛稱「捷運」（同原本的措辭）；部分選取才逐一點名
-  const metroLabel =
-    metros.length === METRO_SYSTEMS.length ? "捷運" : metros.map((m) => m.label).join("／");
+  // null ＝ 未指定 ＝ 全部（主站恆走這條）
+  const selection = resolveRailCodes(railSystems);
+  const showTra = selection == null || selection.has("tra");
+  const showThsr = selection == null || selection.has("thsr");
+  const lineRows = selection ? railLegendLines(selection) : [];
+  const metroNames = selection ? railMetroOperatorNames(railSystems ?? []) : ["捷運"];
+  const hasMetro = selection ? lineRows.length > 0 : true;
 
   const heading = { fontSize: FONT_SIZE.xs, color: t.textDim, letterSpacing: 1 };
-  const secondTitle = [showThsr ? "高鐵" : null, metros.length ? metroLabel : null]
+  const secondTitle = [showThsr ? "高鐵" : null, hasMetro ? metroNames.join("／") : null]
     .filter(Boolean)
     .join("・");
   const note = [
-    metros.length ? "捷運依各路線官方線色" : null,
+    // 有逐條列出線色時這句就多餘了，只在「未指定＝不逐條列」時保留
+    hasMetro && selection == null ? "捷運依各路線官方線色" : null,
     showTra ? "灰線為軌道" : null,
   ].filter(Boolean).join("｜");
 
@@ -657,6 +653,9 @@ function RailLegend({ railSystems }: { railSystems?: readonly string[] }) {
             {showTra ? secondTitle : `鐵路 RAIL・${secondTitle}`}
           </div>
           {showThsr && <FireCatRows cats={[{ color: LAYER_COLORS.rail, label: "高鐵 THSR" }]} />}
+          {lineRows.length > 0 && (
+            <FireCatRows cats={lineRows.map((l) => ({ color: l.color, label: l.name }))} />
+          )}
         </>
       )}
       {note && (

--- a/src/constants/railLines.ts
+++ b/src/constants/railLines.ts
@@ -1,0 +1,243 @@
+/**
+ * `rsys=` 的鐵路代碼表（營運者級 + 線路級）—— **純資料模組，零相依**。
+ *
+ * 為什麼要有這張表：`rsys=trtc` 字面是「台北捷運」，但資料裡的 `trtc` 系統其實是
+ * 「台北都會區軌道」的大雜燴 —— 除北捷本體五線外，還掛著桃捷機場線（A）、
+ * 新北捷運的環狀／淡海／安坑／三鶯（Y/V/K/LB）與貓空纜車（MK）。
+ * 讀者寫 `rsys=trtc` 想要的是北捷，不是連桃園中壢都入鏡，所以把代碼拆成三種粒度：
+ *
+ *   系統／營運者級   `trtc` `tymc` `ntm` `krtc` `klrt` `tmrt` `tra` `thsr`
+ *   線路級           `trtc-bl` `trtc-r` `krtc-r` `tmrt-g` …（**必帶營運者前綴**）
+ *
+ * 前綴不是裝飾：北捷與高捷都有 `R`（淡水信義線 vs 高雄紅線）與 `O`（中和新蘆 vs 高雄橘線），
+ * 裸的 `r` 無法分辨。代碼一律小寫（同 `style=` 的網址契約）。
+ *
+ * ⚠️ **`trtc-mk`（貓空纜車）刻意不在表內**：它掛在 trtc 底下但不是軌道運輸，
+ * 主站 `railLoader.postProcess` 與 `railReplayData` 都排除，故也不給它代碼 ——
+ * 打 `rsys=trtc-mk` 會被當未知代碼 drop（全 drop → 顯示全部，不白畫面）。
+ *
+ * 三個消費端共用本表，任何一端都不准自己重寫這套聯集邏輯：
+ *   `lib/urlState.ts`（白名單）／`embed/railReplayData.ts`（組裝過濾）／
+ *   `components/LegendPanel.tsx`（圖例收斂）
+ */
+
+/** 走 `RailEngine` / `TraTrainEngine` 的底層系統 id（＝快照列與幾何 bundle 的 key）。 */
+export type RailSystemId = "tra" | "thsr" | "trtc" | "krtc" | "klrt" | "tmrt";
+
+export interface RailLineInfo {
+  /** `rsys=` 代碼（小寫，恆為 `<operator>-<line>`） */
+  code: string;
+  /** 所屬營運者代碼（＝ code 的前綴，明列出來免得消費端去 split 字串） */
+  operator: string;
+  /** 底層系統 id —— 注意 `tymc` / `ntm` 的線路都住在 `trtc` 系統裡 */
+  system: RailSystemId;
+  /** 資料裡的 `line_id`（見 railLineIdOf 的取得方式） */
+  lineId: string;
+  name: string;
+  /**
+   * 官方線色 —— 抄自 `public/embed-rail/rail_slim.json.gz` 各線 **direction 0 主軌道**
+   * 的 `properties.color`（例：`BL-1-0` → #0070c0）。
+   * 為什麼不是從 bundle 現讀：圖例是靜態元件、手上沒有那份幾何資料；
+   * 且同一條線的反向／區間車軌道帶的是變體色（`R-1-1` 是 #ff6b6b、`R-2-0` 是 #e63946），
+   * 逐條讀反而拿不到「這條線的顏色」。改動時對齊 bundle。
+   */
+  color: string;
+}
+
+export interface RailOperatorInfo {
+  /** `rsys=` 代碼 */
+  id: string;
+  name: string;
+  system: RailSystemId;
+  /**
+   * 限定收哪幾個 `line_id`；`undefined` ＝ 整個系統全收
+   * （krtc/klrt/tmrt/tra/thsr 的系統與營運者一對一，不必逐線列，日後上新線也自動涵蓋）。
+   */
+  lineIds?: readonly string[];
+  /** 沒有線路級代碼的系統（klrt）在圖例上用的色，同 railLoader 的系統預設色 */
+  color?: string;
+}
+
+/**
+ * 線路級代碼表。**只收資料裡真的有 `line_id` 的線** ——
+ * klrt（高雄輕軌環狀線）與 thsr、tra 的軌道沒有 `line_id`，系統級即最細粒度，
+ * 故意不給 `klrt-c` 之類的代碼，避免出現「查不到東西的合法代碼」。
+ */
+export const RAIL_LINES: readonly RailLineInfo[] = [
+  // ── 台北捷運本體 5 線 ──
+  { code: "trtc-br", operator: "trtc", system: "trtc", lineId: "BR", name: "文湖線", color: "#c48c31" },
+  { code: "trtc-r", operator: "trtc", system: "trtc", lineId: "R", name: "淡水信義線", color: "#d90023" },
+  { code: "trtc-g", operator: "trtc", system: "trtc", lineId: "G", name: "松山新店線", color: "#008659" },
+  { code: "trtc-o", operator: "trtc", system: "trtc", lineId: "O", name: "中和新蘆線", color: "#f8b61c" },
+  { code: "trtc-bl", operator: "trtc", system: "trtc", lineId: "BL", name: "板南線", color: "#0070c0" },
+  // ── 桃園捷運（機場線）── 資料掛在 trtc 系統底下
+  { code: "tymc-a", operator: "tymc", system: "trtc", lineId: "A", name: "機場捷運", color: "#8246af" },
+  // ── 新北捷運 4 線 ── 同樣掛在 trtc 系統底下
+  { code: "ntm-y", operator: "ntm", system: "trtc", lineId: "Y", name: "環狀線", color: "#fedb00" },
+  { code: "ntm-v", operator: "ntm", system: "trtc", lineId: "V", name: "淡海輕軌", color: "#a4ce4e" },
+  { code: "ntm-k", operator: "ntm", system: "trtc", lineId: "K", name: "安坑輕軌", color: "#8cc540" },
+  { code: "ntm-lb", operator: "ntm", system: "trtc", lineId: "LB", name: "三鶯線", color: "#6db7d0" },
+  // ── 高雄捷運 ──
+  { code: "krtc-r", operator: "krtc", system: "krtc", lineId: "R", name: "高雄紅線", color: "#e2211c" },
+  { code: "krtc-o", operator: "krtc", system: "krtc", lineId: "O", name: "高雄橘線", color: "#f8981d" },
+  // ── 台中捷運 ──
+  { code: "tmrt-g", operator: "tmrt", system: "tmrt", lineId: "G", name: "台中捷運綠線", color: "#0cab2c" },
+];
+
+/**
+ * 營運者／系統級代碼表。
+ *
+ * ⚠️ `trtc` 的語意在 2026-08 **刻意縮小**（breaking change，owner 拍板）：
+ * 舊版 `rsys=trtc` ＝ 整個 trtc 系統（含機場捷運與新北四線，94 條軌道）；
+ * 新版 ＝ 台北捷運本體五線（76 條）。要回到舊範圍請寫 `rsys=trtc,tymc,ntm`。
+ */
+export const RAIL_OPERATORS: readonly RailOperatorInfo[] = [
+  { id: "tra", name: "台鐵", system: "tra" },
+  { id: "thsr", name: "高鐵", system: "thsr" },
+  { id: "trtc", name: "台北捷運", system: "trtc", lineIds: ["BR", "R", "G", "O", "BL"] },
+  { id: "tymc", name: "桃園捷運", system: "trtc", lineIds: ["A"] },
+  { id: "ntm", name: "新北捷運", system: "trtc", lineIds: ["Y", "V", "K", "LB"] },
+  { id: "krtc", name: "高雄捷運", system: "krtc" },
+  { id: "klrt", name: "高雄輕軌", system: "klrt", color: "#43aa8b" },
+  { id: "tmrt", name: "台中捷運", system: "tmrt" },
+];
+
+const OPERATOR_BY_ID = new Map(RAIL_OPERATORS.map((o) => [o.id, o]));
+const LINE_BY_CODE = new Map(RAIL_LINES.map((l) => [l.code, l]));
+
+/** `rsys=` 收得下的全部代碼（營運者級 + 線路級）。urlState 的白名單就是這一份。 */
+export const RAIL_CODES: readonly string[] = [
+  ...RAIL_OPERATORS.map((o) => o.id),
+  ...RAIL_LINES.map((l) => l.code),
+];
+const RAIL_CODE_SET = new Set<string>(RAIL_CODES);
+
+/** 代碼是否合法（大小寫敏感，網址契約一律小寫）。 */
+export function isRailCode(code: string): boolean {
+  return RAIL_CODE_SET.has(code);
+}
+
+/** 單一系統要收哪些線。`all` ＝ 不做線路過濾（該系統整包收）。 */
+export interface RailSelection {
+  all: boolean;
+  /** `all === false` 時才有意義：要收的 `line_id` 集合 */
+  lineIds: Set<string>;
+}
+
+/**
+ * `rsys=` 代碼陣列 → 「哪個系統收哪些線」。
+ *
+ * - 回傳 `null` ＝ 未指定 ＝ 全部都要（呼叫端不得把它當成空集合）。
+ * - **同系統的多個代碼取聯集**：`rsys=trtc,trtc-bl` ＝ trtc 五線（`trtc-bl` 已被涵蓋）；
+ *   `rsys=trtc-bl,tymc` ＝ 板南線 + 機場捷運。混用不是錯誤，就是加法。
+ * - 只要有任一代碼是「整個系統」（如 `krtc`），該系統就變 `all`，後續線路級代碼不再收斂它。
+ *
+ * @param codes urlState 已濾過未知代碼；空陣列與 undefined 一律當「未指定」。
+ */
+export function resolveRailCodes(
+  codes: readonly string[] | undefined,
+): Map<RailSystemId, RailSelection> | null {
+  if (!codes || codes.length === 0) return null;
+
+  const out = new Map<RailSystemId, RailSelection>();
+  const pick = (system: RailSystemId): RailSelection => {
+    let sel = out.get(system);
+    if (!sel) {
+      sel = { all: false, lineIds: new Set<string>() };
+      out.set(system, sel);
+    }
+    return sel;
+  };
+
+  for (const code of codes) {
+    const op = OPERATOR_BY_ID.get(code);
+    if (op) {
+      const sel = pick(op.system);
+      if (!op.lineIds) sel.all = true;
+      else for (const id of op.lineIds) sel.lineIds.add(id);
+      continue;
+    }
+    const line = LINE_BY_CODE.get(code);
+    if (line) pick(line.system).lineIds.add(line.lineId);
+  }
+
+  // 全部都是未知代碼時（理論上 urlState 已擋掉）比照「未指定」，不要回空 Map 造成白畫面
+  return out.size > 0 ? out : null;
+}
+
+/** 這個系統的這條線要不要收。`sel` 為 undefined ＝ 該系統整個不收。 */
+export function isLineWanted(sel: RailSelection | undefined, lineId: string | null): boolean {
+  if (!sel) return false;
+  if (sel.all) return true;
+  return lineId != null && sel.lineIds.has(lineId);
+}
+
+/**
+ * 取得一條軌道的 `line_id`。
+ *
+ * ⚠️ **`properties.line_id` 不是每條都有**：`rail_slim.json.gz` 裡 trtc 的 96 條軌道中，
+ * 13 條淡水信義線的變體（`R-4-*` ~ `R-15-*`，如「大安 → 象山」「北投 → 淡水」）
+ * 只有 `track_id` / `route_id` / `name` / `color`，**沒有 `line_id`**；
+ * 時刻表快照（`departures` 那份）更是整份都沒有 `line_id`，只有 `track_id`。
+ * 因此純靠 properties 過濾會讓 `rsys=trtc` 少掉 13 條淡水信義線軌道。
+ *
+ * 取法：`properties.line_id` 優先，缺了才退回 **trtc 專用**的 `track_id` 前綴解析
+ * （trtc 的 id 格式恆為 `<LINE>-<route>-<direction>`；krtc/klrt/tmrt 是
+ * `KRTC-R-0` 這種帶系統前綴的格式，前綴解析會得到系統名而不是線路，
+ * 但那幾個系統的 `line_id` 都齊全，用不到 fallback）。
+ *
+ * follow-up：上游 `build-rail-slim-bundle.py` 補齊全部軌道的 `line_id` 後，可刪掉 fallback。
+ */
+export function railLineIdOf(
+  system: RailSystemId,
+  trackId: string,
+  properties: Record<string, unknown> | null | undefined,
+): string | null {
+  const raw = properties?.line_id;
+  if (typeof raw === "string" && raw) return raw;
+  if (system === "trtc") {
+    const prefix = trackId.split("-")[0];
+    return prefix || null;
+  }
+  return null;
+}
+
+/**
+ * 圖例要列的項目：被選到的線路（線路級）＋ 沒有線路概念的系統（如高雄輕軌整條）。
+ * TRA 車種與高鐵不在此列（各有自己的圖例區塊）。
+ */
+export function railLegendLines(
+  selection: Map<RailSystemId, RailSelection>,
+): { color: string; name: string }[] {
+  const rows: { color: string; name: string }[] = [];
+  for (const line of RAIL_LINES) {
+    const sel = selection.get(line.system);
+    if (isLineWanted(sel, line.lineId)) rows.push({ color: line.color, name: line.name });
+  }
+  // klrt 這種「整個系統只有一條線、資料又沒有 line_id」的，用營運者名 + 系統色補一列
+  for (const op of RAIL_OPERATORS) {
+    if (!op.color || !selection.has(op.system)) continue;
+    rows.push({ color: op.color, name: op.name });
+  }
+  return rows;
+}
+
+/**
+ * 代碼 → 捷運／輕軌**營運者**中文名（去重、依代碼順序）。台鐵與高鐵不在內
+ * （圖例各有自己的區塊）。用於圖例標題「鐵路 RAIL・台北捷運／桃園捷運」。
+ */
+export function railMetroOperatorNames(codes: readonly string[]): string[] {
+  const names: string[] = [];
+  const seen = new Set<string>();
+  const push = (id: string) => {
+    const op = OPERATOR_BY_ID.get(id);
+    if (!op || op.system === "tra" || op.system === "thsr" || seen.has(id)) return;
+    seen.add(id);
+    names.push(op.name);
+  };
+  for (const code of codes) {
+    const line = LINE_BY_CODE.get(code);
+    push(line ? line.operator : code);
+  }
+  return names;
+}

--- a/src/embed/railReplayData.ts
+++ b/src/embed/railReplayData.ts
@@ -35,6 +35,9 @@
 import type {
   RailData, RailSchedule, RailStationTime, RailSystem, TraData, TraDeparture, TraSchedule,
 } from "../types";
+import {
+  isLineWanted, railLineIdOf, resolveRailCodes, type RailSystemId,
+} from "../constants/railLines";
 import { fetchMaybeGzipJson, fetchReplaySnapshot } from "./replayLayers";
 
 /** 幾何 bundle：日期無關，整站共用一個 URL（見檔頭）。 */
@@ -57,7 +60,9 @@ const SYSTEM_COLORS: Record<string, string> = {
 const TRA_TRACK_COLOR = "#7B7B7B";
 
 /** 走 RailEngine 的 5 系統（TRA 由 TraTrainEngine 獨立處理）。 */
-const RAIL_ENGINE_SYSTEMS = ["thsr", "trtc", "krtc", "klrt", "tmrt"] as const;
+const RAIL_ENGINE_SYSTEMS = [
+  "thsr", "trtc", "krtc", "klrt", "tmrt",
+] as const satisfies readonly RailSystemId[];
 
 /** 快照列 → 系統 id 的對照（`tra_daily` / `trtc_fixed` 都要還原成 `tra` / `trtc`）。 */
 function systemIdOf(rowSystem: string): string {
@@ -180,21 +185,22 @@ export interface RailReplayData extends RailData {
  * 讀時刻表快照 + 幾何 bundle，組成引擎輸入。
  * 任一塊缺失（404 / 壞檔 / 沒有 TRA 也沒有任何系統）一律回 null，呼叫端靜默略過該層。
  *
- * @param wantedSystems `rsys=` 指定只組哪幾個系統（urlState 已濾過未知 id，且保證非空陣列）；
- *   `undefined` ＝ 未指定 ＝ 六系統全上。
+ * @param wantedCodes `rsys=` 代碼（urlState 已濾過未知代碼，且保證非空陣列）：
+ *   營運者級 `trtc` / 線路級 `trtc-bl` 混用皆可，語意由 `resolveRailCodes` 收斂成
+ *   「哪個系統收哪些 line_id」；`undefined` ＝ 未指定 ＝ 全上。
  *
- *   過濾發生在**組裝階段**而非渲染階段：沒被選到的系統連時刻表都不解析、軌道也不進
- *   `allTracks`，所以單選捷運時畫面上不會殘留台鐵的灰色軌道，載入也更快
- *   （TRA 是最大宗 —— 900+ 班車 × 每班數十站的時刻表）。
+ *   過濾發生在**組裝階段**而非渲染階段：沒被選到的系統／線路連時刻表都不進 Map、
+ *   軌道也不進 `allTracks`，所以單選板南線時畫面上不會殘留台鐵的灰色軌道或其他線，
+ *   載入也更快（TRA 是最大宗 —— 900+ 班車 × 每班數十站的時刻表）。
  */
 export async function loadRailReplayData(
   date: string,
-  wantedSystems?: readonly string[],
+  wantedCodes?: readonly string[],
 ): Promise<RailReplayData | null> {
-  // 空陣列不該出現（urlState 全 drop 時給的是 undefined），但真的來了就當作未指定 ——
-  // 「一個系統都不顯示」的空白畫面永遠不是讀者想要的結果。
-  const wanted = wantedSystems && wantedSystems.length > 0 ? new Set(wantedSystems) : null;
-  const isWanted = (id: string) => wanted == null || wanted.has(id);
+  // 空陣列不該出現（urlState 全 drop 時給的是 undefined），但真的來了 resolveRailCodes
+  // 也會回 null 當「未指定」——「一條線都不顯示」的空白畫面永遠不是讀者想要的結果。
+  const selection = resolveRailCodes(wantedCodes);
+  const isWanted = (id: RailSystemId) => selection == null || selection.has(id);
   // 兩塊平行抓：幾何是共用資產（多半已在快取），不該被時刻表卡住。
   const [rows, bundle] = await Promise.all([
     fetchReplaySnapshot<RailScheduleRow>("rail", date),
@@ -250,15 +256,22 @@ export async function loadRailReplayData(
     const schedules = parseRailSchedules(row.data);
     const tracks = new Map<string, GeoJSON.Feature>();
     const defaultColor = SYSTEM_COLORS[id] ?? "#ffffff";
+    // `all` 的系統（krtc/klrt/tmrt，或未指定 rsys）不必逐條看 line_id
+    const sel = selection?.get(id);
+    const byLine = sel != null && !sel.all;
     for (const [trackId, track] of Object.entries(sysBundle.tracks)) {
-      // 貓空纜車（MK-*）掛在 trtc 底下但不是捷運，主站 postProcess 也剔除。
+      // 貓空纜車（MK-*）掛在 trtc 底下但不是軌道運輸，主站 postProcess 也剔除。
+      // 它沒有任何 rsys 代碼（見 constants/railLines.ts），故線路過濾時本來就不會中，
+      // 但「未指定 rsys ＝ 全上」那條路徑要靠這行才排得掉。
       if (id === "trtc" && trackId.startsWith("MK-")) continue;
+      if (byLine && !isLineWanted(sel, railLineIdOf(id, trackId, track.properties))) continue;
       tracks.set(trackId, toFeature(track, defaultColor));
     }
-    if (id === "trtc") {
-      for (const key of [...schedules.keys()]) {
-        if (key.startsWith("MK-")) schedules.delete(key);
-      }
+    // 時刻表整份沒有 line_id（只有 track_id），所以線路歸屬一律以軌道那邊算好的為準：
+    // 留不下軌道的班表也一起丟掉 —— 引擎本來就會跳過孤兒班表，但 departureCounts
+    // 是從班表數出來的，不丟會報出「有 329 班卻只有 8 條軌道」這種對不上的數字。
+    for (const key of [...schedules.keys()]) {
+      if (!tracks.has(key)) schedules.delete(key);
     }
     if (schedules.size === 0 || tracks.size === 0) continue;
 

--- a/src/embed/replayRuntime.ts
+++ b/src/embed/replayRuntime.ts
@@ -56,7 +56,10 @@ export interface StartReplayOptions {
   speedParam?: number;
   /** `h=` 起始時刻 0–23（台北時區） */
   hour?: number;
-  /** `rsys=` 鐵路只顯示這幾個系統；未指定 = 全部（只對 rail 層有意義） */
+  /**
+   * `rsys=` 鐵路只顯示這幾個**代碼**（營運者級 `trtc` 或線路級 `trtc-bl`，可混用）；
+   * 未指定 = 全部（只對 rail 層有意義）。代碼表見 `constants/railLines.ts`
+   */
   railSystems?: readonly string[];
   /** effect 已被 cleanup（StrictMode 會掛兩次）—— 每個 await 後都要再查一次 */
   isCancelled: () => boolean;

--- a/src/lib/__tests__/urlState.test.ts
+++ b/src/lib/__tests__/urlState.test.ts
@@ -5,7 +5,8 @@
  * 圖層改名/下架/上鎖之後，舊網址必須安靜降級而不是炸掉整個 iframe。
  */
 import { describe, it, expect } from "vitest";
-import { parseUrlState, buildUrl, URL_STATE_VERSION, RAIL_SYSTEM_IDS } from "../urlState";
+import { parseUrlState, buildUrl, URL_STATE_VERSION } from "../urlState";
+import { RAIL_CODES, resolveRailCodes } from "../../constants/railLines";
 import { LAYER_COLORS, GATED_LAYERS } from "../../components/sidebar/layerCatalog";
 import type { LayerVisibility } from "../../types";
 
@@ -179,34 +180,45 @@ describe("parseUrlState — style / hour（分享主站畫面用）", () => {
   });
 });
 
-describe("parseUrlState — rsys（鐵路系統過濾）", () => {
-  it("單一系統", () => {
+describe("parseUrlState — rsys（鐵路營運者／線路過濾）", () => {
+  it("單一營運者", () => {
     expect(parseUrlState(`?${V}&rsys=trtc`).railSystems).toEqual(["trtc"]);
   });
 
-  it("多系統以逗號分隔，保留書寫順序", () => {
+  it("多代碼以逗號分隔，保留書寫順序", () => {
     expect(parseUrlState(`?${V}&rsys=trtc,tmrt`).railSystems).toEqual(["trtc", "tmrt"]);
     expect(parseUrlState(`?${V}&rsys=tmrt,trtc`).railSystems).toEqual(["tmrt", "trtc"]);
   });
 
-  it("六個系統 id 都收得下", () => {
-    for (const id of RAIL_SYSTEM_IDS) {
+  it("代碼表裡每個代碼都收得下（營運者級 + 線路級）", () => {
+    for (const id of RAIL_CODES) {
       expect(parseUrlState(`?${V}&rsys=${id}`).railSystems).toEqual([id]);
     }
+  });
+
+  it("線路級代碼（帶營運者前綴）", () => {
+    expect(parseUrlState(`?${V}&rsys=trtc-bl`).railSystems).toEqual(["trtc-bl"]);
+    expect(parseUrlState(`?${V}&rsys=trtc-bl,tymc`).railSystems).toEqual(["trtc-bl", "tymc"]);
   });
 
   it("空白與重複值不影響結果", () => {
     expect(parseUrlState(`?${V}&rsys= trtc , trtc ,tmrt`).railSystems).toEqual(["trtc", "tmrt"]);
   });
 
-  it("未知 id 只 drop 該項，合法的留著（不是整包作廢）", () => {
+  it("未知代碼只 drop 該項，合法的留著（不是整包作廢）", () => {
     expect(parseUrlState(`?${V}&rsys=trtc,nonsense`).railSystems).toEqual(["trtc"]);
+    // 未知**線路**同理（trtc-zz 不存在，但 trtc-bl 要活下來）
+    expect(parseUrlState(`?${V}&rsys=trtc-zz,trtc-bl`).railSystems).toEqual(["trtc-bl"]);
   });
 
   it.each([
     ["全部未知", "rsys=nonsense"],
     ["多個未知", "rsys=foo,bar"],
+    ["未知線路", "rsys=trtc-zz"],
+    ["裸線路碼（沒帶營運者前綴，會撞名故不收）", "rsys=bl"],
+    ["貓空纜車（刻意不給代碼）", "rsys=trtc-mk"],
     ["大寫（網址契約一律小寫）", "rsys=TRTC"],
+    ["線路碼大寫", "rsys=trtc-BL"],
     ["只有分隔符", "rsys=,,,"],
     ["空值", "rsys="],
   ])("%s → undefined（＝未指定＝顯示全部，不是空白畫面）", (_label, qs) => {
@@ -225,6 +237,67 @@ describe("parseUrlState — rsys（鐵路系統過濾）", () => {
       date: "2026-08-06",
       hour: 8,
     });
+  });
+
+  it("向後相容：升級成營運者／線路代碼後，`rsys=trtc` 的**解析結果**仍是 ['trtc']", () => {
+    // 語意（涵蓋範圍）縮小了，但 parse 層沒變 —— 所以不升 URL_STATE_VERSION，
+    // 舊嵌入碼不會整組作廢。範圍差異由 resolveRailCodes 表達，見下方 describe。
+    expect(parseUrlState(`?${V}&rsys=trtc`)).toEqual({ railSystems: ["trtc"] });
+    expect(URL_STATE_VERSION).toBe(1);
+  });
+});
+
+/** 代碼的**語意**（parse 只管合不合法，收斂成「哪個系統收哪些線」是這裡） */
+describe("resolveRailCodes — rsys 代碼語意", () => {
+  const lines = (codes: string[], system: string) => {
+    const sel = resolveRailCodes(codes)?.get(system as never);
+    return sel ? { all: sel.all, lines: [...sel.lineIds].sort() } : null;
+  };
+
+  it("未指定 / 空陣列 → null（＝全部，消費端不得當空集合）", () => {
+    expect(resolveRailCodes(undefined)).toBeNull();
+    expect(resolveRailCodes([])).toBeNull();
+  });
+
+  it("撞名：krtc-r（高雄紅線）與 trtc-r（淡水信義線）是不同東西", () => {
+    const kr = resolveRailCodes(["krtc-r"])!;
+    const tr = resolveRailCodes(["trtc-r"])!;
+    expect([...kr.keys()]).toEqual(["krtc"]);
+    expect([...tr.keys()]).toEqual(["trtc"]);
+    // 兩者的 line_id 都叫 "R"，靠系統前綴才分得開 —— 前綴不是裝飾
+    expect(kr.get("krtc")!.lineIds.has("R")).toBe(true);
+    expect(tr.get("trtc")!.lineIds.has("R")).toBe(true);
+    expect(kr.has("trtc")).toBe(false);
+    expect(tr.has("krtc")).toBe(false);
+  });
+
+  it("trtc 只剩北捷本體五線（breaking change：不再含機捷與新北四線）", () => {
+    expect(lines(["trtc"], "trtc")).toEqual({ all: false, lines: ["BL", "BR", "G", "O", "R"] });
+  });
+
+  it("tymc = 機場捷運 A、ntm = 新北四線（都住在 trtc 系統裡）", () => {
+    expect(lines(["tymc"], "trtc")).toEqual({ all: false, lines: ["A"] });
+    expect(lines(["ntm"], "trtc")).toEqual({ all: false, lines: ["K", "LB", "V", "Y"] });
+  });
+
+  it("trtc,tymc,ntm 的聯集 ＝ 舊版 rsys=trtc 的涵蓋範圍（貓空纜車除外）", () => {
+    expect(lines(["trtc", "tymc", "ntm"], "trtc")).toEqual({
+      all: false,
+      lines: ["A", "BL", "BR", "G", "K", "LB", "O", "R", "V", "Y"],
+    });
+  });
+
+  it("營運者與其線路混用取聯集（trtc,trtc-bl ＝ trtc）", () => {
+    expect(lines(["trtc", "trtc-bl"], "trtc")).toEqual(lines(["trtc"], "trtc"));
+    expect(lines(["trtc-bl", "tymc"], "trtc")).toEqual({ all: false, lines: ["A", "BL"] });
+  });
+
+  it("系統即最細粒度者（tra / thsr / klrt / krtc / tmrt）是 all，不做線路過濾", () => {
+    for (const id of ["tra", "thsr", "klrt", "krtc", "tmrt"]) {
+      expect(lines([id], id)).toEqual({ all: true, lines: [] });
+    }
+    // 系統級與其線路混用時，系統級勝出（all 不會被線路收斂回去）
+    expect(lines(["krtc-r", "krtc"], "krtc")!.all).toBe(true);
   });
 });
 
@@ -266,6 +339,12 @@ describe("buildUrl", () => {
   it("railSystems 對稱輸出成 rsys=（空陣列不寫入）", () => {
     expect(buildUrl({ railSystems: ["trtc"] }, "https://e.com")).toContain("rsys=trtc");
     expect(buildUrl({ railSystems: [] }, "https://e.com")).not.toContain("rsys");
+  });
+
+  it("線路級代碼 round-trip（連字號不被編碼成 %2D）", () => {
+    const url = buildUrl({ railSystems: ["trtc-bl", "krtc-r"] }, "https://e.com");
+    expect(url).toContain("rsys=trtc-bl%2Ckrtc-r");
+    expect(parseUrlState(new URL(url).search).railSystems).toEqual(["trtc-bl", "krtc-r"]);
   });
 
   it("round-trip 座標精度：4 位小數（~11m）足夠且不放大浮點雜訊", () => {

--- a/src/lib/urlState.ts
+++ b/src/lib/urlState.ts
@@ -10,11 +10,19 @@
  * 3. **版本化**：`v=1`。缺版本或版本不符一律回空物件，避免舊嵌入碼被新解析器誤讀。
  *    新增**可選**欄位（如 `rsys=`）不升版 —— 舊網址少那一欄，解析結果與升版前完全相同；
  *    要升版的是「同一個 key 的語意改了」或「必要欄位變了」。
+ *
+ *    ⚠️ **2026-08 的例外（owner 拍板）**：`rsys=trtc` 的**涵蓋範圍縮小**了
+ *    （原本連機場捷運與新北四線一起收，現在只有北捷本體五線），照上面那條規則本該升版，
+ *    但沒有升 —— 理由是升版會讓**所有**舊嵌入碼（含與 rail 無關的）整組作廢、變成預設畫面，
+ *    代價遠大於這一欄的語意修正；且舊網址的**解析結果**其實沒變（仍是 `["trtc"]`），
+ *    變的是下游怎麼詮釋它。差異記錄在 `docs/features/embeddable-map/README.md`
+ *    「rsys= 代碼表」，要回到舊範圍寫 `rsys=trtc,tymc,ntm`。
  * 4. **靜默降級**：未知 key／越界數值／上鎖圖層一律 drop，絕不 throw ——
  *    別人的文章裡出現白屏是最糟的失敗模式，寧可少一層。
  */
 import type { LayerVisibility } from "../types";
 import { LAYER_COLORS, GATED_LAYERS } from "../components/sidebar/layerCatalog";
+import { isRailCode } from "../constants/railLines";
 
 export const URL_STATE_VERSION = 1;
 
@@ -46,12 +54,18 @@ export interface UrlState {
   /** UI 元件白名單（attribution 永遠存在、不可移除） */
   ui?: string[];
   /**
-   * 鐵路只顯示哪幾個系統（`rsys=trtc` / `rsys=trtc,tmrt`）。
-   * **未指定 = 全部六系統**（不是空集合）—— 全部 id 都不合法時本欄位為 undefined，
+   * 鐵路只顯示哪幾個**代碼**（`rsys=trtc` / `rsys=trtc-bl,tymc`）。
+   *
+   * 一個參數吃三種粒度（代碼表 = `src/constants/railLines.ts`）：
+   * 營運者級 `trtc` `tymc` `ntm` `krtc` `klrt` `tmrt`、系統級 `tra` `thsr`、
+   * 線路級 `trtc-bl` `krtc-r` …（線路碼**必帶營運者前綴**，因為北捷與高捷都有 R/O）。
+   * 欄位名沿用 `railSystems`（歷史名，也仍是 `rsys=` 的對稱欄位），值已不只是系統。
+   *
+   * **未指定 = 全部**（不是空集合）—— 全部代碼都不合法時本欄位為 undefined，
    * 消費端因此自動回到「顯示全部」，而不是變成空白畫面。
    *
    * 為什麼不是 `p.railSystems`：`p.*` 的契約只收數字（見 parseParams），
-   * 系統 id 是字串塞不進去，故立為一等公民欄位（比照 `h=` / `style=`）。
+   * 代碼是字串塞不進去，故立為一等公民欄位（比照 `h=` / `style=`）。
    */
   railSystems?: string[];
 }
@@ -68,19 +82,14 @@ const ALL_LAYER_KEYS = new Set(Object.keys(LAYER_COLORS));
 const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
 
 /**
- * `rsys=` 收得下的鐵路系統 id（tra=台鐵、thsr=高鐵，其餘四座捷運／輕軌）。
- *
- * **刻意在此重列而非 import**：canonical 的組裝端是 `src/embed/railReplayData.ts`
- * （`RAIL_ENGINE_SYSTEMS` + tra），但那是回放 chunk 的東西，urlState 在 embed
- * 基礎 bundle 裡、也給主站用，不該為了一張字串表把它拉進來
- * （同 railReplayData 的 `SYSTEM_COLORS` 對 railLoader 的處理）。改動時兩邊要一起改。
- *
- * 白名單擺在 parse 而非消費端，是因為「未知 id → 顯示全部」這條降級規則必須
+ * `rsys=` 白名單擺在 parse 而非消費端，是因為「未知代碼 → 顯示全部」這條降級規則必須
  * 在同一處收斂：全部 drop 後 `railSystems` 為 undefined，下游看到的永遠是
- * 「未指定」或「至少一個合法 id」，不會出現空陣列導致的空白畫面。
+ * 「未指定」或「至少一個合法代碼」，不會出現空陣列導致的空白畫面。
+ *
+ * 代碼表本身住在 `src/constants/railLines.ts`（純資料模組、零相依，主站與 embed
+ * 基礎 bundle 都吃得下），組裝端 `embed/railReplayData.ts` 與圖例 `LegendPanel`
+ * 共用同一份 —— 三處都不准自己重寫一套。
  */
-export const RAIL_SYSTEM_IDS = ["tra", "thsr", "trtc", "krtc", "klrt", "tmrt"] as const;
-const RAIL_SYSTEM_ID_SET = new Set<string>(RAIL_SYSTEM_IDS);
 /** 底圖 id 格式（不查表，見 UrlState.style 註解） */
 const STYLE_ID_RE = /^[a-z0-9-]{1,32}$/;
 
@@ -136,9 +145,13 @@ function parseLayers(q: URLSearchParams, opts: ParseOptions): (keyof LayerVisibi
 }
 
 /**
- * `rsys=trtc,tmrt` → `["trtc","tmrt"]`。未知 id 逐一 drop（不整包作廢），
+ * `rsys=trtc,tmrt` → `["trtc","tmrt"]`。未知代碼逐一 drop（不整包作廢），
  * 全部 drop 後回 undefined ＝ 視同未指定 ＝ 顯示全部（同 parseLayers 的收尾）。
  * 大小寫敏感（同 `style=` 的格式契約，網址一律小寫）。
+ *
+ * 三種粒度同吃一個參數（見 constants/railLines.ts）：`trtc`（營運者）、
+ * `trtc-bl`（線路）、`tra`（系統即最細）。混用取聯集，解析階段不做收斂 ——
+ * 這裡只負責「這串代碼合不合法」，語意交給 resolveRailCodes。
  */
 function parseRailSystems(q: URLSearchParams): string[] | undefined {
   const raw = q.get("rsys");
@@ -148,7 +161,7 @@ function parseRailSystems(q: URLSearchParams): string[] | undefined {
     .split(",")
     .map((s) => s.trim())
     .filter((id) => {
-      if (!id || seen.has(id) || !RAIL_SYSTEM_ID_SET.has(id)) return false;
+      if (!id || seen.has(id) || !isRailCode(id)) return false;
       seen.add(id);
       return true;
     });


### PR DESCRIPTION
## 這個 PR 做了什麼

`rsys=` 從**系統級**擴充到**營運者級 + 線路級**。起因：owner 發現 `rsys=trtc` 的範圍比字面大——除台北捷運本線外，還包含機場捷運、淡海輕軌等，是上游把它們歸在同一包的結果。

## 代碼表

**營運者／系統級**：`tra`(907 班) `thsr`(160) `trtc`(3,017／76 軌道) `tymc`(329／8) `ntm`(1,170／10) `krtc`(620／4) `klrt`(154／2) `tmrt`(306／2)

**線路級**（一律帶營運者前綴——北捷與高捷都有 R/O，裸碼會撞名）：
`trtc-br` 文湖線 · `trtc-r` 淡水信義線 · `trtc-g` 松山新店線 · `trtc-o` 中和新蘆線 · `trtc-bl` 板南線 · `tymc-a` 機場捷運 · `ntm-y` 環狀線 · `ntm-v` 淡海輕軌 · `ntm-k` 安坑輕軌 · `ntm-lb` 三鶯線 · `krtc-r` 高雄紅線 · `krtc-o` 高雄橘線 · `tmrt-g` 台中捷運綠線

`tra`／`thsr`／`klrt` **不給線路碼**——資料沒有線路概念，系統級即最細，不發明「查得到卻沒東西」的代碼。`trtc-mk`（貓空纜車）刻意不在白名單，維持與主站一致的排除。

## ⚠️ Breaking change

`rsys=trtc`：94 軌道／4,516 班次 → **76／3,017**。舊範圍等價寫法 `rsys=trtc,tymc,ntm`。

**刻意不升 `URL_STATE_VERSION`**：升版會讓所有舊嵌入碼（含與 rail 無關的）整組作廢，代價遠大於這一欄的語意修正；且 parse 結果本身沒變（仍是 `["trtc"]`）。已記錄於 `urlState.ts` 檔頭、`docs/features/embeddable-map/README.md`（新舊對照 + 完整代碼表）、`changelog.md`，並有測試守著「舊網址逐欄解析結果不變 + 版本仍是 1」。

## 實作要點

- 代碼表 SSOT = `src/constants/railLines.ts`（純資料模組）；urlState／railReplayData／LegendPanel 三處共用同一個 `resolveRailCodes`，不各寫一套
- 過濾仍在**組裝階段**（沒選到的線連時刻表都不解析），軌道也不進 `allTracks`
- 混用取**聯集**：`rsys=trtc,trtc-bl` ＝ `rsys=trtc`
- 圖例收斂到線路級，用資料裡的官方線色
- 沿用降級原則：未知代碼逐一 drop、全 drop 回顯示全部、絕不 throw、不白畫面

## ⚠️ 資料層發現：`line_id` 並非每條軌道都有

`rail_slim.json.gz` 裡 trtc 的 96 條軌道**有 13 條缺 `line_id`**（全是淡水信義線變體 `R-4-*`～`R-15-*`），且**時刻表整份沒有 `line_id`**。純靠 properties 過濾會少掉那 13 條。

處理：`railLineIdOf()` 以 properties 優先、缺了才退回 track_id 前綴解析；時刻表側改成「留不下軌道的班表一起丟」，否則班次數會與軌道數對不上。

**Follow-up**：上游 `build-rail-slim-bundle.py` 補齊全部軌道的 `line_id` 後即可刪掉 fallback。

## 驗證

- `npx tsc -b` ✅　`npx vitest run` ✅ **414 passed / 0 failed**
- agent-browser 實測：`rsys=trtc`（76 軌道，機捷紫線與淡海輕軌確實消失）／`tymc`（8）／`ntm`（10，四線都在跑）／`trtc-bl`（15，圖例只列板南線）／`krtc-r`（撞名驗證，解析成高雄紅線）／`klrt`（154，與改版前數字相同）
- 邊界：`rsys=trtc-zz` → 降級顯示全部且**圖例輸出與改版前逐字相同**；`rsys=trtc,trtc-bl` → 取聯集
- 幾何過濾獨立複驗：`trtc-bl` 留下的 15 條軌道經度範圍 121.4187~121.6169（頂埔↔南港走廊），三鶯線確認排除

## 示範頁

北捷卡語意更新，新增板南線單線卡（`rsys=trtc-bl`，08:00 尖峰）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DwLrRRPzsEjnxuYgBiH7t9
