### PR TITLE
feat(ui): 圖層預設全關 + Layers 入口紅點導引

### DIFF
--- a/src/components/IconRailSidebar.tsx
+++ b/src/components/IconRailSidebar.tsx
@@ -570,7 +570,11 @@ export function IconRailSidebar({
     onWidthChange?.(RAIL_WIDTH);
   }, [onWidthChange]);
 
+  // Layers 入口紅點：每次進站顯示，第一次點開 Layers 後本 session 消失（引導訪客發現圖層）
+  const [layersBadgeSeen, setLayersBadgeSeen] = useState(false);
+
   const togglePanel = (panel: PanelId) => {
+    if (panel === "layers") setLayersBadgeSeen(true);
     // 是否為「開啟」動作（切到別的 panel 或開啟目前關閉的）。activePanel === panel 才是關閉。
     const willOpen = activePanel !== panel;
     // 開啟 Layers/Locations 時，關掉 Intel / Satellite（左側 panel 互斥）。
@@ -663,6 +667,7 @@ export function IconRailSidebar({
           active={activePanel === "layers"}
           onClick={() => togglePanel("layers")}
           tooltip="Layers"
+          badge={!layersBadgeSeen}
         />
 
         {/* Locations */}
@@ -863,9 +868,11 @@ function WorldGlyph({ size = 20 }: { size?: number }) {
 }
 
 function RailIcon({
-  icon: Icon, active, onClick, tooltip,
+  icon: Icon, active, onClick, tooltip, badge,
 }: {
   icon: ComponentType<{ size?: number }>; active: boolean; onClick: () => void; tooltip: string;
+  /** 右上角紅底白字「!」提示圓點（引導點擊；點開後由呼叫端關閉） */
+  badge?: boolean;
 }) {
   const { ACCENT, DIM, RAIL_ICON_ACTIVE } = useRailTheme();
   return (
@@ -873,6 +880,7 @@ function RailIcon({
       onClick={onClick}
       title={tooltip}
       style={{
+        position: "relative",
         width: 40,
         height: 40,
         borderRadius: RADIUS.xl,
@@ -889,6 +897,27 @@ function RailIcon({
       }}
     >
       <Icon size={20} />
+      {badge && (
+        <span
+          style={{
+            position: "absolute",
+            top: 2,
+            right: 2,
+            width: 14,
+            height: 14,
+            borderRadius: "50%",
+            background: "#dc2626",
+            color: "#fff",
+            fontSize: 10,
+            fontWeight: 700,
+            lineHeight: "14px",
+            textAlign: "center",
+            pointerEvents: "none",
+          }}
+        >
+          !
+        </span>
+      )}
     </button>
   );
 }

--- a/src/hooks/useLayerVisibility.ts
+++ b/src/hooks/useLayerVisibility.ts
@@ -7,10 +7,8 @@ import { LAYER_COLORS } from "../components/sidebar/layerCatalog";
  * key 全集從 layerCatalog 的 LAYER_COLORS 派生（型別強制完整）—
  * 新增 layer 不用再改本檔，除非要預設開啟。
  */
-// 預設幾乎全關：訪客一進站不打任何 RPC；唯行道樹（靜態 PMTiles，經 Cloudflare 邊緣快取）預設開啟。
-const DEFAULT_ON: ReadonlySet<keyof LayerVisibility> = new Set<keyof LayerVisibility>([
-  "streetTreesTaipeiDiff",
-]);
+// 預設全關：訪客一進站不打任何 RPC、不載任何圖層（2026-08-10 移除行道樹預設開啟）。
+const DEFAULT_ON: ReadonlySet<keyof LayerVisibility> = new Set<keyof LayerVisibility>([]);
 
 function buildDefaults(): LayerVisibility {
   const keys = Object.keys(LAYER_COLORS) as (keyof LayerVisibility)[];


### PR DESCRIPTION
## Summary
訪客進站不再預設開啟行道樹圖層（零圖層零請求），改以 Layers 入口的紅底白字「!」圓點引導自行探索圖層。

## Changes
- `useLayerVisibility.ts`：DEFAULT_ON 清空
- `IconRailSidebar.tsx`：RailIcon 加 badge prop；Layers 入口紅點，點開後本 session 消失

## Test
- [x] `npx tsc -b` 通過
- [x] `pnpm test` 通過（含 layerConsistency）
- [x] Browser 驗收：badge 顯示/點開消失、地圖預設乾淨（agent-browser 截圖）

## Risk / Rollback
- 影響：首頁預設視覺（少一層）；revert 本 PR 即回復

## Related
- 2026-08-10 稽核波次（docs/research/architecture-audit-2026-08-10.md）

🤖 Generated with [Claude Code](https://claude.com/claude-code)