### PR TITLE
fix(embed): gas 加油站 5 層接進 EMBED_CDN_LAYERS＋per-layer filter（EM-17/EM-07）

### DIFF
--- a/src/embed/EmbedApp.tsx
+++ b/src/embed/EmbedApp.tsx
@@ -19,7 +19,7 @@ import "maplibre-gl/dist/maplibre-gl.css";
 import { parseUrlState } from "../lib/urlState";
 import { EMBED_ALLOWED, buildEmbedVisibility, configsFor } from "./embedWhitelist";
 import { registerPmtilesProtocolOnce, maplibrePmtilesSource } from "./maplibreAdapters";
-import { EMBED_CDN_LAYERS, fetchCdnLayer } from "./dynamicCdnLayers";
+import { EMBED_CDN_LAYERS, EMBED_CDN_LAYER_FILTER, fetchCdnLayer } from "./dynamicCdnLayers";
 import { SNAPSHOT_LAYERS, fetchSnapshot } from "./snapshotLayers";
 import { isReplayLayer } from "./replayLayers";
 import { replayClock, formatReplayClock } from "./replayClock";
@@ -151,7 +151,7 @@ export function EmbedApp() {
       for (const config of configs) {
         const rpcName = EMBED_CDN_LAYERS[config.id];
         if (!rpcName) continue;
-        void fetchCdnLayer(rpcName).then((fc) => {
+        void fetchCdnLayer(rpcName, EMBED_CDN_LAYER_FILTER[config.id]).then((fc) => {
           if (!fc || !mapRef.current) return;      // 快照缺失 → 該層靜默留空，不 fallback 打 DB
           const src = map.getSource(config.sourceId);
           if (src && "setData" in src) (src as maplibregl.GeoJSONSource).setData(fc);

--- a/src/embed/dynamicCdnLayers.ts
+++ b/src/embed/dynamicCdnLayers.ts
@@ -21,11 +21,28 @@ export const EMBED_CDN_LAYERS: Readonly<Partial<Record<keyof LayerVisibility, st
   evChargingStations: "get_ev_charging_stations",
   islandPowerGrid: "get_island_power_grid",
   renewablePermitsTaipei: "get_renewable_permits_taipei",
-  // gasStation* 5 層待補：loader 已用 staticRpc("get_gas_station_layers")，
-  // 但 public/static-rpc/ 尚無該檔（一直靜默 fallback 打 RPC）。補產快照後再加進來。
+  // EM-17：加油站 5 層共用同一支 RPC（get_gas_station_layers），靠 row 的 `layer`
+  // 欄位區分品牌 —— 見下方 EMBED_CDN_LAYER_FILTER，否則 5 層會各自畫出全部 6,210 點。
+  gasStationCpc: "get_gas_station_layers",
+  gasStationFpcc: "get_gas_station_layers",
+  gasStationTaisugar: "get_gas_station_layers",
+  gasStationOther: "get_gas_station_layers",
+  gasStationCanonical: "get_gas_station_layers",
 };
 
 export const EMBED_CDN_KEYS = Object.keys(EMBED_CDN_LAYERS) as (keyof LayerVisibility)[];
+
+/**
+ * layer key → 快照 row 的 `layer` 欄位期望值。只有「一支 RPC 混多層」的 key 需要進來
+ * （目前只有加油站）；沒進來的 key 維持預設行為：整份快照本來就只有那一層。
+ */
+export const EMBED_CDN_LAYER_FILTER: Readonly<Partial<Record<keyof LayerVisibility, string>>> = {
+  gasStationCpc: "gas_station_cpc",
+  gasStationFpcc: "gas_station_fpcc",
+  gasStationTaisugar: "gas_station_taisugar",
+  gasStationOther: "gas_station_other",
+  gasStationCanonical: "gas_station_canonical",
+};
 
 type Row = Record<string, unknown>;
 
@@ -73,12 +90,22 @@ export function rowsToGeoJSON(rows: unknown): GeoJSON.FeatureCollection {
  * 載入一層的 CDN 快照。**只讀靜態檔，任何情況都不 fallback 到 Supabase**
  * —— 主站的 `staticRpc()` 會 fallback（rollout 安全網），但 embed 不行：
  * 那會讓別人文章的流量變成你的 DB egress。快照不存在就視同該層不可用。
+ *
+ * `layerFilter`：一支 RPC 混多層時（見 EMBED_CDN_LAYER_FILTER），只留下
+ * `row.layer === layerFilter` 的列再轉 GeoJSON；不帶則整份快照照原樣轉換。
  */
-export async function fetchCdnLayer(rpcName: string): Promise<GeoJSON.FeatureCollection | null> {
+export async function fetchCdnLayer(
+  rpcName: string,
+  layerFilter?: string,
+): Promise<GeoJSON.FeatureCollection | null> {
   try {
     const res = await fetch(`/static-rpc/${rpcName}.json`);
     if (!res.ok) return null;
-    return rowsToGeoJSON(await res.json());
+    const rows: unknown = await res.json();
+    const filtered = layerFilter && Array.isArray(rows)
+      ? (rows as Row[]).filter((r) => r && typeof r === "object" && r.layer === layerFilter)
+      : rows;
+    return rowsToGeoJSON(filtered);
   } catch {
     return null;
   }


### PR DESCRIPTION
## Summary
gas 快照檔已產出並上 S3（6,210 筆，與線上 RPC 逐位元一致）；本 PR 補 embed 端 5 品牌拆層接線（一支 RPC 混 5 層需 row.layer 過濾）。

## Changes
- `dynamicCdnLayers.ts`：EMBED_CDN_LAYERS 補 5 個 gasStation key＋EMBED_CDN_LAYER_FILTER 對照表＋fetchCdnLayer layerFilter 參數
- `EmbedApp.tsx`：呼叫端帶 filter

## Test
- [x] `npx tsc -b` 通過
- [x] `pnpm test` 通過（含 embedWhitelist 29 項）
- [x] 快照與 anon RPC 逐位元比對一致

## Risk / Rollback
- S3 已先行上傳（2026-08-10 22:40），部署後主站停止 fallback egress；快照缺檔時 embed 該 5 層靜默留空（設計如此，不打 DB）

## Related
- `docs/features/embeddable-map/` EM-17/EM-07

🤖 Generated with [Claude Code](https://claude.com/claude-code)