### PR TITLE
perf(state): AR-21 layerVisibilityStore 試點（store + bridge + 2 consumer）

### DIFF
--- a/docs/proposal/architecture-overhaul-plan.md
+++ b/docs/proposal/architecture-overhaul-plan.md
@@ -106,7 +106,7 @@ P0 止血 ──────────────┐
 
 | # | 內容 | Branch | 驗證 | 狀態 |
 |---|---|---|---|---|
-| AR-21 | `layerVisibilityStore`：照 `timeStore.ts` 模式建細粒度訂閱 store（`getVisibility(key)` / `subscribeKey(key, cb)` / `useLayerVisible(key)`）。過渡期與現有 App state 雙向 bridge，元件逐步改訂閱 | `perf/visibility-store` | React Profiler：toggle 單層 commit 不含無關元件；行為零變化（All Off → 逐層開抽查） | ☐ |
+| AR-21 | `layerVisibilityStore`：照 `timeStore.ts` 模式建細粒度訂閱 store（`getVisibility(key)` / `subscribeKey(key, cb)` / `useLayerVisible(key)`）。過渡期與現有 App state 雙向 bridge，元件逐步改訂閱 | `perf/visibility-store` | React Profiler：toggle 單層 commit 不含無關元件；行為零變化（All Off → 逐層開抽查） | 🔃 試點分支 `perf/visibility-store`（store + bridge + 2 consumer），全量遷移待 AR-22/23 |
 | AR-22 | Layer Manifest schema 定義（key/section/color/dataClass/source/polling/legend/popup/params/description/topics）+ 試點 5 層（挑近期熟悉的：real-estate、fire、bloom 系） | `feat/layer-manifest-pilot` | 試點層全部行為不變；layerConsistency 測試新增 manifest 完整性檢查 | ☐ |
 | AR-23 | 全量遷移（按 sidebar section 分批，每批一 PR）：App.tsx 55 個手寫 hook 呼叫改 manifest 驅動迴圈；LAYER_COLORS / SECTIONS 從 manifest 派生，消滅三處平行清單 | `feat/layer-manifest-s1..sN` | 每批：tsc + test + browser 抽查；批間可暫停 | ☐ |
 | AR-24 | params 遷移：per-layer param spec 進 manifest，`useTransportParams` 退役為 generic param store + renderer（同 AR-21 訂閱模式） | `perf/params-store` | slider 拖動只 render 該層控件 + 地圖 diff；2104 行檔刪除 | ☐ |

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1961,6 +1961,7 @@ export default function App() {
           </div>
         </div>
       )}
+      {/* AR-21：layerVisibility 不再經由 prop —— MapView 直接訂閱 layerVisibilityStore */}
       <MapView
         preset={preset}
         styleUrl={styleUrl}
@@ -1969,7 +1970,6 @@ export default function App() {
         renderMode={renderMode}
         isDarkTheme={isDarkTheme}
         showTrails={showTrails}
-        layerVisibility={layerVisibility}
         overlayParams={transportParams.overlayParams}
         onMapReady={handleMapReady}
       />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3117,7 +3117,9 @@ export default function App() {
           </div>
         )}
         <div style={{ pointerEvents: "auto" }}>
-          <LegendPanel visibility={layerVisibility} overlayParams={transportParams.overlayParams} isDarkTheme={isDarkTheme} />
+          {/* AR-21：不再傳 visibility —— LegendPanel 自己訂閱 layerVisibilityStore，
+              App 因無關狀態重繪時 memo 可整個跳過本面板 */}
+          <LegendPanel overlayParams={transportParams.overlayParams} isDarkTheme={isDarkTheme} />
         </div>
       </div>
 

--- a/src/components/LegendPanel.tsx
+++ b/src/components/LegendPanel.tsx
@@ -1,9 +1,10 @@
-import { Fragment, useState, createContext, useContext } from "react";
+import { Fragment, memo, useState, createContext, useContext } from "react";
 import { ChevronDown, ChevronRight } from "lucide-react";
 import { COLORS, SURFACE, FONT_DATA, RADIUS, FONT_SIZE } from "../styles/designTokens";
 import { ROAD_CONGESTION_COLORS } from "../data/roadCongestionLoader";
 import { CONGESTION_COLORS, CONGESTION_LABELS } from "../data/freewayLoader";
 import type { LayerVisibility } from "../types";
+import { useLayerVisibilityAll } from "../state/layerVisibilityStore";
 import { CROP_SUITABILITY_CROPS } from "../data/cropSuitabilityCrops";
 import { AGRI_POI_TYPES } from "../data/agriPOITypes";
 import { MEDICAL_POI_TYPES } from "../data/medicalPOITypes";
@@ -210,7 +211,14 @@ const CROP_KIND_ITEMS = [
 ];
 
 interface LegendPanelProps {
-  visibility: LayerVisibility;
+  /**
+   * 圖層開關。**主站不傳** —— 改由本元件自己訂閱 `layerVisibilityStore`
+   * （AR-21 試點），這樣 App 因無關狀態重繪時 memo 能整個跳過本面板。
+   *
+   * `/embed` 仍要傳：embed 的 visibility 是 mount 時從網址參數凍結的 ref，
+   * 完全不進 store（embed 從不寫 store）。有 prop 就以 prop 為準。
+   */
+  visibility?: LayerVisibility;
   overlayParams: Record<string, number>;
   /** 淺色底圖時傳 false 讓面板外殼切成淺色 chrome（色票資料兩主題共用，不受影響）*/
   isDarkTheme?: boolean;
@@ -441,10 +449,15 @@ export const LEGEND_REGISTRY: LegendEntry[] = [
   },
 ];
 
-export function LegendPanel({
-  visibility, overlayParams, isDarkTheme = true, railSystems,
+export const LegendPanel = memo(function LegendPanel({
+  visibility: visibilityProp, overlayParams, isDarkTheme = true, railSystems,
 }: LegendPanelProps) {
   const [expanded, setExpanded] = useState(false);
+
+  // AR-21：主站走 store 訂閱、embed 走 prop。hook 無條件呼叫（embed 情境下
+  // 這份訂閱是惰性的 —— embed 從不寫 store，永遠拿到預設全關的快照）。
+  const storeVisibility = useLayerVisibilityAll();
+  const visibility = visibilityProp ?? storeVisibility;
 
   // 面板外殼 chrome（僅容器與標題文字，色票資料兩主題共用）
   const c = isDarkTheme
@@ -520,7 +533,7 @@ export function LegendPanel({
     </div>
     </LegendThemeCtx.Provider>
   );
-}
+});
 
 // ── 環境污染：嚴重度（設施 + 場址共用）──
 function PollutionSeverityLegend({ visibility }: { visibility: LayerVisibility }) {

--- a/src/hooks/useLayerVisibility.ts
+++ b/src/hooks/useLayerVisibility.ts
@@ -1,29 +1,60 @@
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useRef } from "react";
+import type { Dispatch, SetStateAction } from "react";
 import type { LayerVisibility } from "../types";
-import { LAYER_COLORS } from "../components/sidebar/layerCatalog";
+import {
+  layerVisibilityStore,
+  useLayerVisibilityAll,
+} from "../state/layerVisibilityStore";
 
 /**
- * 預設開啟的圖層；其餘一律 false。
- * key 全集從 layerCatalog 的 LAYER_COLORS 派生（型別強制完整）—
- * 新增 layer 不用再改本檔，除非要預設開啟。
+ * AR-21 過渡期 bridge —— App state 與 `layerVisibilityStore` 的雙向橋。
+ *
+ * 介面與改造前一模一樣（`layerVisibility` / `layerVisibilityRef` /
+ * `setLayerVisibility` / `toggleVisibility`），所以 App.tsx 既有的 71 處呼叫
+ * **一行都不用改**。差別只在底下：狀態的家從 `useState` 搬到了 store。
+ *
+ * 雙向怎麼成立的（**沒有兩份 state，所以不需要防迴圈旗標**）：
+ *   - App → store：`setLayerVisibility` / `toggleVisibility` 直接寫 store，
+ *     不再持有自己的 useState。
+ *   - store → App：`useLayerVisibilityAll()` 是 `useSyncExternalStore`，
+ *     store 被**任何人**（未來直接訂閱的元件、chat bridge、深連結）改動都會
+ *     讓 App 重繪拿到新值。
+ *
+ * 防迴圈的根本手段是 store 端的「同值不通知」（見 layerVisibilityStore
+ * `applyChanges`）：值沒變就不換 snapshot identity、不通知任何 listener，
+ * 於是 store→App→store 這條路走不到第二圈。StrictMode 雙跑同理安全 ——
+ * 重複的 subscribe/unsubscribe 與重複渲染都只是讀同一份 snapshot。
+ *
+ * ⚠️ `layerVisibilityRef` 刻意維持「render 時賦值」的舊語意，**不要**改成直接
+ * 讀 store。App.tsx 多處在 setState 之後立刻
+ * `sessionTracker.logWithSnapshot(..., layerVisibilityRef.current)`，靠的就是
+ * 這個 ref 此刻仍是**變更前**的快照；改成讀 store 會把那些分析事件悄悄
+ * 換成變更後的值。
+ *
+ * AR-23 全量遷移完成後本 hook 即可退場。
  */
-// 預設全關：訪客一進站不打任何 RPC、不載任何圖層（2026-08-10 移除行道樹預設開啟）。
-const DEFAULT_ON: ReadonlySet<keyof LayerVisibility> = new Set<keyof LayerVisibility>([]);
-
-function buildDefaults(): LayerVisibility {
-  const keys = Object.keys(LAYER_COLORS) as (keyof LayerVisibility)[];
-  return Object.fromEntries(
-    keys.map((k) => [k, DEFAULT_ON.has(k)]),
-  ) as unknown as LayerVisibility;
-}
-
 export function useLayerVisibility() {
-  const [layerVisibility, setLayerVisibility] = useState<LayerVisibility>(buildDefaults);
+  const layerVisibility = useLayerVisibilityAll();
   const layerVisibilityRef = useRef(layerVisibility);
   layerVisibilityRef.current = layerVisibility;
 
+  const setLayerVisibility = useCallback<Dispatch<SetStateAction<LayerVisibility>>>(
+    (action) => {
+      // updater 形式讀 store 當前值（而非 render 時的值）——與 useState 的
+      // 「同批多次 updater 依序疊加」語意一致，因為 store 寫入是同步生效的。
+      const next =
+        typeof action === "function"
+          ? (action as (prev: LayerVisibility) => LayerVisibility)(
+              layerVisibilityStore.getAll(),
+            )
+          : action;
+      layerVisibilityStore.setAll(next);
+    },
+    [],
+  );
+
   const toggleVisibility = useCallback((layer: keyof LayerVisibility) => {
-    setLayerVisibility((prev) => ({ ...prev, [layer]: !prev[layer] }));
+    layerVisibilityStore.toggle(layer);
   }, []);
 
   return { layerVisibility, layerVisibilityRef, setLayerVisibility, toggleVisibility };

--- a/src/map/MapView.tsx
+++ b/src/map/MapView.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef } from "react";
 import mapboxgl from "mapbox-gl";
 import "mapbox-gl/dist/mapbox-gl.css";
 import type { CameraPreset, Flight, RenderMode, LayerVisibility } from "../types";
+import { layerVisibilityStore } from "../state/layerVisibilityStore";
 import { updateStaticTrails, setStaticTrailsOpacity, setStaticTrailsVisible } from "./staticTrails";
 import { OVERLAY_REGISTRY } from "./overlayRegistry";
 import { addAllOverlays, updateAllOverlayThemes, setOverlayVisible, hydrateOverlayIfNeeded, resetOverlayHydration, isOverlayVisible } from "./overlayManager";
@@ -92,7 +93,10 @@ interface MapViewProps {
   renderMode: RenderMode;
   isDarkTheme?: boolean;
   showTrails?: boolean;
-  layerVisibility: LayerVisibility;
+  /**
+   * ⚠️ AR-21：`layerVisibility` 已不是 prop —— 改直接讀 `layerVisibilityStore`。
+   * overlay 的顯示/隱藏是純命令式的地圖操作，不需要先經過一次 React re-render。
+   */
   overlayParams: Record<string, number>;
   onMapReady?: (map: mapboxgl.Map) => void;
 }
@@ -163,7 +167,7 @@ function applyPureBlackTheme(map: mapboxgl.Map): void {
   }
 }
 
-export function MapView({ preset, styleUrl, pureBlack = false, flights, renderMode, isDarkTheme = true, showTrails = true, layerVisibility, overlayParams, onMapReady }: MapViewProps) {
+export function MapView({ preset, styleUrl, pureBlack = false, flights, renderMode, isDarkTheme = true, showTrails = true, overlayParams, onMapReady }: MapViewProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const mapRef = useRef<mapboxgl.Map | null>(null);
   const readyRef = useRef(false);
@@ -175,7 +179,6 @@ export function MapView({ preset, styleUrl, pureBlack = false, flights, renderMo
   const isDarkThemeRef = useRef(isDarkTheme);
   const pureBlackRef = useRef(pureBlack);
   const showTrailsRef = useRef(showTrails);
-  const layerVisibilityRef = useRef(layerVisibility);
   const overlayParamsRef = useRef(overlayParams);
 
   onMapReadyRef.current = onMapReady;
@@ -185,7 +188,6 @@ export function MapView({ preset, styleUrl, pureBlack = false, flights, renderMo
   isDarkThemeRef.current = isDarkTheme;
   pureBlackRef.current = pureBlack;
   showTrailsRef.current = showTrails;
-  layerVisibilityRef.current = layerVisibility;
   overlayParamsRef.current = overlayParams;
 
   useEffect(() => {
@@ -216,18 +218,22 @@ export function MapView({ preset, styleUrl, pureBlack = false, flights, renderMo
       // 否則 hydratedSources 殘留會讓下方 re-hydrate 被跳過 → 靜態 GeoJSON 圖層切底圖後變空白。
       resetOverlayHydration();
 
+      // AR-21：visibility 讀 store（原本讀 layerVisibilityRef.current，語意相同 ——
+      // 都是「此刻的最新值」，只是家從 prop 搬到了 store）
+      const vis = layerVisibilityStore.getAll();
+
       // 批量新增所有 overlays + 設定初始可見性
       addAllOverlays(
         map,
         OVERLAY_REGISTRY,
         isDarkThemeRef.current,
-        layerVisibilityRef.current,
+        vis,
         overlayParamsRef.current,
       );
 
       // 重建後：把目前可見的靜態 GeoJSON 圖層重新 fetch + setData（切底圖不再消失）
       for (const config of OVERLAY_REGISTRY) {
-        if (isOverlayVisible(config, layerVisibilityRef.current, overlayParamsRef.current)) {
+        if (isOverlayVisible(config, vis, overlayParamsRef.current)) {
           void hydrateOverlayIfNeeded(map, config);
         }
       }
@@ -251,13 +257,13 @@ export function MapView({ preset, styleUrl, pureBlack = false, flights, renderMo
       ensureIndicatorsLayers(map);
       ensureYoubikeLayers(map);
       ensureAllAgricultureLayers(map);
-      updateAllAgricultureLayers(map, layerVisibilityRef.current, overlayParamsRef.current);
+      updateAllAgricultureLayers(map, vis, overlayParamsRef.current);
       // 等時圈 PMTiles 層（須排在 agriculture 之後 → 共用 PMTiles SourceType 已註冊）
       ensureFireIsochroneLayer(map);
-      updateFireIsochroneLayer(map, layerVisibilityRef.current.fireIsochrone, fireIsochroneParamsOf(overlayParamsRef.current));
+      updateFireIsochroneLayer(map, vis.fireIsochrone, fireIsochroneParamsOf(overlayParamsRef.current));
       // 醫療等時圈 + 醫療沙漠（PMTiles fill，共用 SourceType）
       ensureMedicalIsochroneLayers(map);
-      updateMedicalIsochroneLayers(map, layerVisibilityRef.current, overlayParamsRef.current);
+      updateMedicalIsochroneLayers(map, vis, overlayParamsRef.current);
 
       // 初次載入後，每次樣式切換都重建 flight layer
       if (readyRef.current) {
@@ -278,19 +284,21 @@ export function MapView({ preset, styleUrl, pureBlack = false, flights, renderMo
       ensureIndicatorsLayers(map);
       ensureYoubikeLayers(map);
       ensureAllAgricultureLayers(map);
-      updateAllAgricultureLayers(map, layerVisibilityRef.current, overlayParamsRef.current);
+      // AR-21：同 style.load —— visibility 讀 store 的最新值
+      const vis = layerVisibilityStore.getAll();
+      updateAllAgricultureLayers(map, vis, overlayParamsRef.current);
       ensureFireIsochroneLayer(map);
-      updateFireIsochroneLayer(map, layerVisibilityRef.current.fireIsochrone, fireIsochroneParamsOf(overlayParamsRef.current));
+      updateFireIsochroneLayer(map, vis.fireIsochrone, fireIsochroneParamsOf(overlayParamsRef.current));
       ensureMedicalIsochroneLayers(map);
-      updateMedicalIsochroneLayers(map, layerVisibilityRef.current, overlayParamsRef.current);
+      updateMedicalIsochroneLayers(map, vis, overlayParamsRef.current);
       // 補發 load 之前用戶已切的 toggle / slider：
       // mapRef 在 load 才設定，而 production 首載 load 事件可能晚達 ~30s，
       // 期間 visibility / params effect 全部 no-op（mapRef null）。
-      // 這裡用 ref 的最新值重放一次，避免「toggle 開了但圖層沒出現」。
+      // 這裡用 store 的最新值重放一次，避免「toggle 開了但圖層沒出現」。
       for (const config of OVERLAY_REGISTRY) {
-        const vis = isOverlayVisible(config, layerVisibilityRef.current, overlayParamsRef.current);
-        if (vis) void hydrateOverlayIfNeeded(map, config);
-        setOverlayVisible(map, config, vis);
+        const v = isOverlayVisible(config, vis, overlayParamsRef.current);
+        if (v) void hydrateOverlayIfNeeded(map, config);
+        setOverlayVisible(map, config, v);
       }
       updateAllOverlayThemes(map, OVERLAY_REGISTRY, isDarkThemeRef.current, overlayParamsRef.current);
       onMapReadyRef.current?.(map);
@@ -383,44 +391,49 @@ export function MapView({ preset, styleUrl, pureBlack = false, flights, renderMo
   useEffect(() => {
     const map = mapRef.current;
     if (!map || !readyRef.current) return;
+    const vis = layerVisibilityStore.getAll();
     updateAllOverlayThemes(map, OVERLAY_REGISTRY, isDarkTheme, overlayParams);
     // OVERLAY_REGISTRY 之外的專屬圖層：params 變動也要 re-apply
-    updateAllAgricultureLayers(map, layerVisibility, overlayParams);
+    updateAllAgricultureLayers(map, vis, overlayParams);
     // 等時圈：透明度 / 縣市下拉變動 → 更新
-    updateFireIsochroneLayer(map, layerVisibility.fireIsochrone, fireIsochroneParamsOf(overlayParams));
+    updateFireIsochroneLayer(map, vis.fireIsochrone, fireIsochroneParamsOf(overlayParams));
     // 醫療等時圈 + 醫療沙漠
-    updateMedicalIsochroneLayers(map, layerVisibility, overlayParams);
-  }, [
-    isDarkTheme, overlayParams,
-    layerVisibility.agriculture,
-    layerVisibility.agriSoil,
-    layerVisibility.agriSoilFertility,
-    layerVisibility.agriLeisureFarmZones,
-    layerVisibility.agriRuralRegen,
-    layerVisibility.agriCropSuitability,
-    layerVisibility.agriPOI,
-  ]);
+    updateMedicalIsochroneLayers(map, vis, overlayParams);
+    // ⚠️ AR-21：這裡原本還掛著 7 個 agriculture 的 visibility key 當 deps。
+    //    visibility 改由下方 store 訂閱驅動後那些 dep 是多餘的 —— 訂閱路徑
+    //    (applyOverlayVisibility) 會呼叫同樣這三個 update 函式，故 agriculture
+    //    的開/關依舊會即時反映；此處只保留主題 / params 這兩個觸發源。
+  }, [isDarkTheme, overlayParams]);
 
   // Overlay 可見性（一個 useEffect 取代原本 7 個）
+  // AR-21：visibility 不再是 prop，改訂閱 layerVisibilityStore —— toggle 直接跑
+  // 這段命令式更新，不必先等 MapView re-render（也讓 MapView 之後可被 memo）。
   // guard 不加 isStyleLoaded()，理由同上 — busy 期間 toggle 會被丟棄
   useEffect(() => {
-    const map = mapRef.current;
-    if (!map || !readyRef.current) return;
-    for (const config of OVERLAY_REGISTRY) {
-      const vis = isOverlayVisible(config, layerVisibility, overlayParamsRef.current);
-      if (vis) void hydrateOverlayIfNeeded(map, config);
-      setOverlayVisible(map, config, vis);
-    }
-    // OVERLAY_REGISTRY 之外的專屬圖層
-    updateAllAgricultureLayers(map, layerVisibility, overlayParamsRef.current);
-    // 等時圈開/關層
-    updateFireIsochroneLayer(map, layerVisibility.fireIsochrone, fireIsochroneParamsOf(overlayParamsRef.current));
-    // 醫療等時圈 + 醫療沙漠開/關
-    updateMedicalIsochroneLayers(map, layerVisibility, overlayParamsRef.current);
-    // ⚠️ deps 除了 layerVisibility 還要收 propertyValueGridScaleIdx：
+    const applyOverlayVisibility = () => {
+      const map = mapRef.current;
+      if (!map || !readyRef.current) return;
+      const vis = layerVisibilityStore.getAll();
+      for (const config of OVERLAY_REGISTRY) {
+        const v = isOverlayVisible(config, vis, overlayParamsRef.current);
+        if (v) void hydrateOverlayIfNeeded(map, config);
+        setOverlayVisible(map, config, v);
+      }
+      // OVERLAY_REGISTRY 之外的專屬圖層
+      updateAllAgricultureLayers(map, vis, overlayParamsRef.current);
+      // 等時圈開/關層
+      updateFireIsochroneLayer(map, vis.fireIsochrone, fireIsochroneParamsOf(overlayParamsRef.current));
+      // 醫療等時圈 + 醫療沙漠開/關
+      updateMedicalIsochroneLayers(map, vis, overlayParamsRef.current);
+    };
+    // mount / scaleIdx 變動時跑一次（等同原本 effect 的 mount + dep 觸發），
+    // 之後任何 visibility 變動由 store 訂閱驅動。
+    applyOverlayVisibility();
+    return layerVisibilityStore.subscribe(applyOverlayVisibility);
+    // ⚠️ deps 除了 visibility（已改訂閱）還要收 propertyValueGridScaleIdx：
     //    總市值網格的三個尺度共用同一個 layer key，切尺度是 param 變動而非 toggle 變動，
     //    不收這個 dep 會「選了 450m 但畫面還是 150m」（見 overlayManager.isOverlayVisible）。
-  }, [layerVisibility, overlayParams.propertyValueGridScaleIdx]);
+  }, [overlayParams.propertyValueGridScaleIdx]);
 
   return (
     <div

--- a/src/state/__tests__/layerVisibilityStore.test.ts
+++ b/src/state/__tests__/layerVisibilityStore.test.ts
@@ -1,0 +1,260 @@
+/**
+ * layerVisibilityStore（AR-21）等價性 / 訂閱語意測試。
+ *
+ * 測試環境是 `environment: "node"`（見 vitest.config.ts），沒有 DOM 也沒有
+ * @testing-library/react，所以這裡驗的是 **store 層語意**，不是 React hook 行為。
+ * bridge（hooks/useLayerVisibility.ts）是 useSyncExternalStore 的薄殼，它的正確性
+ * 取決於下面這幾條：
+ *   1. getAll() 的 snapshot identity 只在真的有值變動時才換 —— uSES 的硬需求，
+ *      也是「setLayerVisibility 同值寫入不觸發 re-render」的保證。
+ *   2. 同值寫入完全不通知 —— bridge 是雙向的，若同值也通知就會 store→App→store 互推。
+ *   3. per-key 訂閱只在該 key 變動時觸發。
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import {
+  layerVisibilityStore,
+  buildDefaultVisibility,
+} from "../layerVisibilityStore";
+import type { LayerVisibility } from "../../types";
+
+const store = layerVisibilityStore;
+
+beforeEach(() => {
+  store.reset();
+});
+
+describe("buildDefaultVisibility", () => {
+  it("預設全關（訪客一進站不打任何 RPC）", () => {
+    const defaults = buildDefaultVisibility();
+    const keys = Object.keys(defaults) as (keyof LayerVisibility)[];
+    expect(keys.length).toBeGreaterThan(0);
+    expect(keys.every((k) => defaults[k] === false)).toBe(true);
+  });
+
+  it("每次呼叫回傳新物件（不共享 mutable 預設值）", () => {
+    expect(buildDefaultVisibility()).not.toBe(buildDefaultVisibility());
+  });
+});
+
+describe("基本讀寫", () => {
+  it("setVisibility / getVisibility 往返", () => {
+    expect(store.getVisibility("earthquakes")).toBe(false);
+    store.setVisibility("earthquakes", true);
+    expect(store.getVisibility("earthquakes")).toBe(true);
+    expect(store.getAll().earthquakes).toBe(true);
+  });
+
+  it("toggle 反轉單一 key，不動其他 key", () => {
+    store.setVisibility("earthquakes", true);
+    store.toggle("earthquakes");
+    expect(store.getVisibility("earthquakes")).toBe(false);
+    store.toggle("earthquakes");
+    expect(store.getVisibility("earthquakes")).toBe(true);
+    expect(store.getVisibility("popCount")).toBe(false);
+  });
+
+  it("setBulk 只寫入 partial 提到的 key", () => {
+    store.setVisibility("popCount", true);
+    store.setBulk({ earthquakes: true, typhoonTracks: true });
+    expect(store.getVisibility("earthquakes")).toBe(true);
+    expect(store.getVisibility("typhoonTracks")).toBe(true);
+    // 沒被 partial 提到的維持原值
+    expect(store.getVisibility("popCount")).toBe(true);
+  });
+
+  it("setAll 整包取代（App 端 setLayerVisibility(obj) 的落點）", () => {
+    store.setVisibility("earthquakes", true);
+    const next = { ...buildDefaultVisibility(), popCount: true };
+    store.setAll(next);
+    expect(store.getVisibility("earthquakes")).toBe(false);
+    expect(store.getVisibility("popCount")).toBe(true);
+  });
+});
+
+describe("snapshot identity（useSyncExternalStore 契約）", () => {
+  it("有變動才換 identity", () => {
+    const before = store.getAll();
+    store.setVisibility("earthquakes", true);
+    expect(store.getAll()).not.toBe(before);
+  });
+
+  it("同值 setVisibility 不換 identity", () => {
+    store.setVisibility("earthquakes", true);
+    const before = store.getAll();
+    store.setVisibility("earthquakes", true);
+    expect(store.getAll()).toBe(before);
+  });
+
+  it("值全同的 setAll 不換 identity（bridge 防迴圈的關鍵）", () => {
+    store.setVisibility("earthquakes", true);
+    const before = store.getAll();
+    // 模擬 App 端 `setLayerVisibility({ ...prev })`：新物件、值全同
+    store.setAll({ ...before });
+    expect(store.getAll()).toBe(before);
+  });
+
+  it("沒有實際變動的 setBulk 不換 identity", () => {
+    const before = store.getAll();
+    store.setBulk({ earthquakes: false, popCount: false });
+    expect(store.getAll()).toBe(before);
+  });
+
+  it("getAll() 連續呼叫回傳同一個物件（getSnapshot 穩定，否則 uSES 無限迴圈）", () => {
+    expect(store.getAll()).toBe(store.getAll());
+  });
+});
+
+describe("全域訂閱 subscribe", () => {
+  it("任何 key 變動都通知，且每次寫入只通知一次", () => {
+    const cb = vi.fn();
+    const unsub = store.subscribe(cb);
+
+    store.setVisibility("earthquakes", true);
+    expect(cb).toHaveBeenCalledTimes(1);
+
+    store.setVisibility("popCount", true);
+    expect(cb).toHaveBeenCalledTimes(2);
+
+    // setBulk 改了 2 個 key，全域仍只通知一次
+    store.setBulk({ typhoonTracks: true, windField: true });
+    expect(cb).toHaveBeenCalledTimes(3);
+
+    unsub();
+    store.setVisibility("earthquakes", false);
+    expect(cb).toHaveBeenCalledTimes(3);
+  });
+
+  it("同值寫入完全不通知（bridge 不會 store→App→store 互推）", () => {
+    store.setVisibility("earthquakes", true);
+    const cb = vi.fn();
+    store.subscribe(cb);
+
+    store.setVisibility("earthquakes", true);
+    store.setAll({ ...store.getAll() });
+    store.setBulk({ earthquakes: true });
+    expect(cb).not.toHaveBeenCalled();
+  });
+
+  it("listener 觸發時讀到的已經是新狀態（先換 snapshot 再通知）", () => {
+    let seen: boolean | null = null;
+    store.subscribe(() => {
+      seen = store.getVisibility("earthquakes");
+    });
+    store.setVisibility("earthquakes", true);
+    expect(seen).toBe(true);
+  });
+});
+
+describe("per-key 訂閱 subscribeKey", () => {
+  it("只在該 key 變動時觸發", () => {
+    const onEq = vi.fn();
+    const onPop = vi.fn();
+    store.subscribeKey("earthquakes", onEq);
+    store.subscribeKey("popCount", onPop);
+
+    store.setVisibility("earthquakes", true);
+    expect(onEq).toHaveBeenCalledTimes(1);
+    expect(onPop).not.toHaveBeenCalled();
+
+    store.setVisibility("popCount", true);
+    expect(onEq).toHaveBeenCalledTimes(1);
+    expect(onPop).toHaveBeenCalledTimes(1);
+  });
+
+  it("setBulk 只通知真的變動的 key", () => {
+    store.setVisibility("earthquakes", true);
+    const onEq = vi.fn();
+    const onPop = vi.fn();
+    store.subscribeKey("earthquakes", onEq);
+    store.subscribeKey("popCount", onPop);
+
+    // earthquakes 已是 true → 同值不通知；popCount 由 false→true → 通知
+    store.setBulk({ earthquakes: true, popCount: true });
+    expect(onEq).not.toHaveBeenCalled();
+    expect(onPop).toHaveBeenCalledTimes(1);
+  });
+
+  it("setAll 只通知有 diff 的 key", () => {
+    const onEq = vi.fn();
+    const onPop = vi.fn();
+    store.subscribeKey("earthquakes", onEq);
+    store.subscribeKey("popCount", onPop);
+
+    store.setAll({ ...buildDefaultVisibility(), popCount: true });
+    expect(onEq).not.toHaveBeenCalled();
+    expect(onPop).toHaveBeenCalledTimes(1);
+  });
+
+  it("unsubscribe 後不再觸發，且同 key 多訂閱者互不影響", () => {
+    const a = vi.fn();
+    const b = vi.fn();
+    const unsubA = store.subscribeKey("earthquakes", a);
+    store.subscribeKey("earthquakes", b);
+
+    store.toggle("earthquakes");
+    expect(a).toHaveBeenCalledTimes(1);
+    expect(b).toHaveBeenCalledTimes(1);
+
+    unsubA();
+    store.toggle("earthquakes");
+    expect(a).toHaveBeenCalledTimes(1);
+    expect(b).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("bridge 等價性（模擬 App 端既有寫入路徑）", () => {
+  /** App.tsx handleAllOff 的寫法：`{ ...prev }` 後全刷 false */
+  function allOff() {
+    const next = { ...store.getAll() };
+    for (const k in next) next[k as keyof LayerVisibility] = false;
+    store.setAll(next);
+  }
+
+  it("All Off 後全部關閉；再按一次 All Off 完全沒有通知（空轉不 re-render）", () => {
+    store.setBulk({ earthquakes: true, popCount: true });
+    allOff();
+    const all = store.getAll();
+    expect((Object.keys(all) as (keyof LayerVisibility)[]).every((k) => !all[k])).toBe(true);
+
+    const cb = vi.fn();
+    store.subscribe(cb);
+    allOff();
+    expect(cb).not.toHaveBeenCalled();
+    expect(store.getAll()).toBe(all);
+  });
+
+  /** App.tsx 歷史模式：snapshot → 全關 → 還原 */
+  it("歷史模式 snapshot / 還原往返後狀態一致", () => {
+    store.setBulk({ earthquakes: true, typhoonTracks: true });
+    const snapshotBefore = store.getAll();
+
+    const allOffObj = { ...snapshotBefore };
+    for (const k in allOffObj) allOffObj[k as keyof LayerVisibility] = false;
+    store.setAll({ ...allOffObj, popCount: true });
+    expect(store.getVisibility("earthquakes")).toBe(false);
+    expect(store.getVisibility("popCount")).toBe(true);
+
+    store.setAll(snapshotBefore);
+    expect(store.getVisibility("earthquakes")).toBe(true);
+    expect(store.getVisibility("typhoonTracks")).toBe(true);
+    expect(store.getVisibility("popCount")).toBe(false);
+  });
+
+  /** App.tsx 常見的 updater 寫法：`setLayerVisibility(prev => ({ ...prev, [k]: true }))` */
+  it("updater 形式的整包寫入等價於 setVisibility", () => {
+    const viaUpdater = { ...store.getAll(), earthquakes: true };
+    store.setAll(viaUpdater);
+    const afterUpdater = store.getAll();
+
+    store.reset();
+    store.setVisibility("earthquakes", true);
+    expect(store.getAll()).toEqual(afterUpdater);
+  });
+
+  it("reset 回到預設全關", () => {
+    store.setBulk({ earthquakes: true, popCount: true });
+    store.reset();
+    expect(store.getAll()).toEqual(buildDefaultVisibility());
+  });
+});

--- a/src/state/layerVisibilityStore.ts
+++ b/src/state/layerVisibilityStore.ts
@@ -1,0 +1,181 @@
+/**
+ * Layer Visibility Store（AR-21 試點）
+ *
+ * 圖層開關的 SSOT。目的與 `timeStore.ts` 相同：讓「誰關心哪個 key」變成細粒度
+ * 訂閱，而不是「一包大物件進 App state → 任何 toggle 都讓整棵樹 reconcile」。
+ *
+ * 模式完全比照 timeStore（本專案已驗證的自家寫法，不引入 zustand/jotai）：
+ *   - 模組級 state + getter/setter + subscribe，寫入時同值不通知（消除 identity churn）
+ *   - React 端一律走 `useSyncExternalStore`，不再維護第二份 useState 副本
+ *
+ * 過渡期（AR-21 → AR-23）：
+ *   `hooks/useLayerVisibility.ts` 是本 store 的 React 門面（bridge）。App.tsx 既有的
+ *   71 處 `layerVisibility` / `setLayerVisibility` 呼叫一行不改仍可運作 —— 因為那個
+ *   hook 現在讀寫的就是本 store。元件可逐步改成直接訂閱（`useLayerVisible(key)`），
+ *   全部改完後 bridge 即可退場（AR-23）。
+ *
+ * 寫入者：useLayerVisibility 的 setter（App 端所有既有路徑）。
+ * 未來直接呼叫本 store 的 setter 也可以 —— bridge 是雙向的，App state 會跟著動。
+ */
+
+import { useCallback, useSyncExternalStore } from "react";
+import type { LayerVisibility } from "../types";
+import { LAYER_COLORS } from "../components/sidebar/layerCatalog";
+
+type Listener = () => void;
+type VisKey = keyof LayerVisibility;
+
+/**
+ * 預設開啟的圖層；其餘一律 false。
+ * key 全集從 layerCatalog 的 LAYER_COLORS 派生（型別強制完整）—
+ * 新增 layer 不用再改本檔，除非要預設開啟。
+ *
+ * 預設全關：訪客一進站不打任何 RPC、不載任何圖層（2026-08-10 移除行道樹預設開啟）。
+ */
+const DEFAULT_ON: ReadonlySet<VisKey> = new Set<VisKey>([]);
+
+export function buildDefaultVisibility(): LayerVisibility {
+  const keys = Object.keys(LAYER_COLORS) as VisKey[];
+  return Object.fromEntries(
+    keys.map((k) => [k, DEFAULT_ON.has(k)]),
+  ) as unknown as LayerVisibility;
+}
+
+/**
+ * 當前快照。**identity 只在真的有 key 變動時才換新** —— 這是
+ * `useSyncExternalStore` 的硬性要求（getSnapshot 每次回傳新物件會無限迴圈），
+ * 同時也順手消滅了「setLayerVisibility({...prev}) 但值沒變」造成的空轉 re-render。
+ */
+let snapshot: LayerVisibility = buildDefaultVisibility();
+
+const globalListeners = new Set<Listener>();
+/** per-key 訂閱者；只有該 key 真的變動時才通知。 */
+const keyListeners = new Map<VisKey, Set<Listener>>();
+
+/**
+ * 套用一批變更。
+ * 回傳是否真的有變動 —— 沒變動就完全不換 snapshot identity、不通知任何人。
+ *
+ * 通知順序刻意固定：**先把 snapshot 換掉，再通知**（所有 listener 讀到的都是
+ * 已完成的新狀態）；先 per-key 後 global，且 global 只發一次。
+ */
+function applyChanges(changed: VisKey[], next: LayerVisibility): boolean {
+  if (changed.length === 0) return false;
+  snapshot = next;
+  for (const k of changed) {
+    const set = keyListeners.get(k);
+    if (set) for (const cb of set) cb();
+  }
+  for (const cb of globalListeners) cb();
+  return true;
+}
+
+export const layerVisibilityStore = {
+  /** 單一 key 的開關狀態。純讀，不觸發 React。 */
+  getVisibility(key: VisKey): boolean {
+    return snapshot[key];
+  },
+
+  /**
+   * 整包快照。**回傳的物件請視為 immutable**（不要 mutate）——
+   * 它就是 useSyncExternalStore 的 snapshot，identity 是判斷變動的依據。
+   */
+  getAll(): LayerVisibility {
+    return snapshot;
+  },
+
+  /** 設定單一 key。同值 no-op。 */
+  setVisibility(key: VisKey, value: boolean): void {
+    if (snapshot[key] === value) return;
+    applyChanges([key], { ...snapshot, [key]: value });
+  },
+
+  /** 反轉單一 key。 */
+  toggle(key: VisKey): void {
+    applyChanges([key], { ...snapshot, [key]: !snapshot[key] });
+  },
+
+  /** 批次設定（只寫入 partial 提到的 key）。同值的 key 不會觸發其 per-key listener。 */
+  setBulk(partial: Partial<LayerVisibility>): void {
+    const next = { ...snapshot };
+    const changed: VisKey[] = [];
+    for (const k of Object.keys(partial) as VisKey[]) {
+      const v = partial[k];
+      if (v === undefined || snapshot[k] === v) continue;
+      next[k] = v;
+      changed.push(k);
+    }
+    applyChanges(changed, next);
+  },
+
+  /**
+   * 整包取代（bridge 用：App 端 `setLayerVisibility(obj)` 的落點）。
+   * 逐 key 比對，值全同 → 完全 no-op（snapshot identity 不變）。
+   */
+  setAll(next: LayerVisibility): void {
+    if (next === snapshot) return;
+    const changed: VisKey[] = [];
+    for (const k of Object.keys(snapshot) as VisKey[]) {
+      if (snapshot[k] !== next[k]) changed.push(k);
+    }
+    applyChanges(changed, next);
+  },
+
+  /** 訂閱任何 key 的變動（整包消費者用，例如 MapView 的 overlay hydrate）。 */
+  subscribe(cb: Listener): () => void {
+    globalListeners.add(cb);
+    return () => globalListeners.delete(cb);
+  },
+
+  /** 訂閱單一 key —— 只有該 key 變動才觸發（AR-21 的核心賣點）。 */
+  subscribeKey(key: VisKey, cb: Listener): () => void {
+    let set = keyListeners.get(key);
+    if (!set) {
+      set = new Set();
+      keyListeners.set(key, set);
+    }
+    const s = set;
+    s.add(cb);
+    return () => {
+      s.delete(cb);
+      if (s.size === 0) keyListeners.delete(key);
+    };
+  },
+
+  /** 測試 / 重置用：回到 buildDefaultVisibility()。 */
+  reset(): void {
+    layerVisibilityStore.setAll(buildDefaultVisibility());
+  },
+};
+
+export type LayerVisibilityStore = typeof layerVisibilityStore;
+
+// ── React 門面 ──────────────────────────────────────────────────────────
+
+/**
+ * 訂閱單一圖層的開關。**只有這個 key 變動時才 re-render** ——
+ * 元件從「吃整包 visibility prop」改吃這個 hook，就不會被無關圖層的 toggle 波及。
+ */
+export function useLayerVisible(key: VisKey): boolean {
+  const subscribe = useCallback(
+    (cb: Listener) => layerVisibilityStore.subscribeKey(key, cb),
+    [key],
+  );
+  return useSyncExternalStore(
+    subscribe,
+    () => layerVisibilityStore.getVisibility(key),
+    () => layerVisibilityStore.getVisibility(key),
+  );
+}
+
+/**
+ * 訂閱整包（給真的需要全 key 的消費者：LegendPanel 要掃 LEGEND_REGISTRY、
+ * IconRailSidebar 要畫全清單）。任何 key 變動都會 re-render。
+ */
+export function useLayerVisibilityAll(): LayerVisibility {
+  return useSyncExternalStore(
+    layerVisibilityStore.subscribe,
+    layerVisibilityStore.getAll,
+    layerVisibilityStore.getAll,
+  );
+}


### PR DESCRIPTION
## Summary
架構改造計畫 AR-21 第一步：照 timeStore 模式建細粒度訂閱 store，useLayerVisibility 改為單一 state 來源的 bridge（App.tsx 71 處呼叫零改動），試點遷移 LegendPanel＋MapView overlay hydrate。行為零變化。

## Changes
- `src/state/layerVisibilityStore.ts`：get/set/toggle/setBulk/subscribe/subscribeKey + useLayerVisible/useLayerVisibilityAll hooks＋22 條測試
- `useLayerVisibility.ts`：useSyncExternalStore bridge（identity 穩定防迴圈，非雙 state 互推）
- `LegendPanel`：自訂閱＋memo（App 不再傳 visibility；embed prop 優先相容）
- `MapView`：overlay hydrate 三處改讀 store，layerVisibilityRef 移除

## Test
- [x] `npx tsc -b` 通過；`pnpm test` 473/473（+22 新測試）
- [x] Browser 行為抽查：toggle 經 store 生效、圖例正常、All Off 連按兩次無誤

## Risk / Rollback
- 純重構、行為零變化已驗證；**re-render 收益未量測**（per-key 路徑零生產呼叫點，兌現於 AR-23）
- 一個時序變化：overlay 顯示/隱藏改在事件處理器內同步套用（視覺相同、略早）
- revert 整支 PR 即回滾

## Related
- docs/proposal/architecture-overhaul-plan.md AR-21；docs/research/architecture-audit-2026-08-10.md §C-1

🤖 Generated with [Claude Code](https://claude.com/claude-code)