### PR TITLE
fix(nginx): /climate/ 改 ^~ 前綴優先，修正氣候貼圖被 dist 舊版遮蔽

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -225,7 +225,16 @@ server {
     }
 
     # 全球氣候 PMTiles（CMEMS 海流 / CAMS 沙塵 / NOAA GFS 風場 衍生切片）在 /data/climate/
-    location /climate/ {
+    #
+    # ⚠️ 必須用 `^~`：本檔末尾有 `location ~* \.(js|css|png|...)$` 的**正則** location，
+    #    而 nginx 的正則優先序高於普通前綴匹配。該正則 block 沒有自己的 root，
+    #    會落回 server 層的 `root /usr/share/nginx/html`（dist）——
+    #    結果 /climate/*.png 供的是 **build 當下的 dist 快照**，
+    #    `refresh-climate.sh` 每輪更新到 S3 的新貼圖使用者永遠拿不到，
+    #    還被那條正則加上 7 天 immutable 快取。
+    #    2026-08-14 實測：線上 dust_latest.png 17,649B vs S3 18,027B（currents/wind10m 同樣落後）。
+    #    `^~` 讓前綴匹配勝出、不再進正則比對，/climate/ 一律走 /data。
+    location ^~ /climate/ {
         root /data;
         expires 1d;
         add_header Cache-Control "public";


### PR DESCRIPTION
## 問題

`nginx.conf` 的 `location /climate/`（普通前綴）被檔案末尾的 `location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff2?)$`（**正則**）搶走 —— nginx 的正則優先序高於普通前綴匹配。

該正則 block 沒有自己的 `root`，於是落回 server 層的 `root /usr/share/nginx/html`（dist）。結果：

- `/climate/*.png` 供的是 **build 當下的 dist 快照**，而不是 `/data`（S3 同步）的最新版
- `refresh-climate.sh` 每輪更新到 S3 的貼圖，**使用者永遠拿不到**
- 更糟：還被那條正則加上 `expires 7d` + `immutable`

### 實測證據（2026-08-14）
| 檔案 | 線上 | S3 |
|---|---|---|
| `dust_latest.png` | 17,649 B | 18,027 B |
| `currents_latest.png` | 606,406 B | 609,523 B |
| `wind10m_latest.png` | 落後 | — |

## 修法

`location /climate/` → `location ^~ /climate/`。`^~` 讓前綴匹配勝出後**不再進入正則比對**，`/climate/` 一律走 `/data`。

## 為什麼不一併改 `/base_map/`

`base_map/hillshade.png` 同樣被遮蔽，但 dist 那份與 S3 那份**逐位元相同**（8,709,161 B），且它是不會變的靜態底圖 —— 保留 dist 當 fallback 反而更穩健（`/data` 尚未同步時仍有圖）。改動範圍限縮在真正有問題的 `/climate/`。

## 影響範圍確認

比對 **git 追蹤的 `public/` 圖片**（＝會進 build context 的）與 **S3 上的圖片**，交集只有 4 個檔：`base_map/hillshade.png`（無害，同上）＋ `climate/{currents,dust,wind10m}_latest.png`（有害，本 PR 修）。
`climate/frames/` 底下的大量歷史貼圖不在 git 中，本來就正確走 `/data`，不受影響。

## 驗證

- nginx 1.27.4 `nginx -t` — **syntax is ok**
- 純設定檔改動，不影響前端程式碼與測試

## 附帶：本次一併處理的兩件線上問題（不在本 PR，已直接修）

1. **領海界線圖層畫不出來** — `base_map/maritime_boundary.pmtiles` 漏傳 S3（忘跑 `upload-deploy-assets.sh`）。已上傳（363,404 B），**本 PR merge 觸發的重新部署會讓 `pull-deploy-assets.sh` 把它拉進 `/data`**
2. **氣象雲圖被 CORS 擋** — R2 bucket `mini-tw-pulse` 完全沒有 CORS 設定。已比照同帳號 `terrain-tiles` 的既有設定套用（`GET`/`HEAD`、`AllowedOrigins: *`，另補 `ExposeHeaders` 供 Range 請求）。實測 preflight 由 403 → **204**，`access-control-allow-origin` 已回傳

🤖 Generated with [Claude Code](https://claude.com/claude-code)
