### PR TITLE
fix(test): deployContract 認得 location ^~ 前綴修飾符（修 master 紅燈）

### DIFF
--- a/src/map/__tests__/deployContract.test.ts
+++ b/src/map/__tests__/deployContract.test.ts
@@ -57,7 +57,11 @@ const referencedDirs = new Set<string>([
 ]);
 
 function nginxCovers(dir: string): boolean {
-  return nginxConf.includes(`location /${dir}/`);
+  // `^~` 也是前綴 location（語意相同，只是命中後不再比對正則、優先序更高）
+  return (
+    nginxConf.includes(`location /${dir}/`) ||
+    nginxConf.includes(`location ^~ /${dir}/`)
+  );
 }
 
 function pullCovers(dir: string): boolean {
@@ -113,18 +117,25 @@ interface NginxLoc {
 
 /**
  * ⚠️ **脆弱點（刻意的簡化，改 nginx.conf 時請一起看這裡）**：
- *   1. 只解析「前綴 location」（`location /<dir>/ {`），**不解析** `location = `
- *      精確匹配與 `location ~ ` 正則匹配。真實 nginx 的正則 location 優先序**高於**
- *      前綴，例如檔尾那條 `~* \.(js|css|png|…)$` 其實會截走 `/base_map/hillshade.png`
- *      並從 dist 供檔。本模型刻意不含它 —— 那條只設快取 header 不換 root 的意圖，
- *      靠它來供大檔是意外行為不是契約（且 hillshade 的修法已由 overnight-log 拍板
- *      為「PNG 補進 upload 清單」）。要改這個判斷請連同拍板一起改。
+ *   1. 只解析「前綴 location」——`location /<dir>/ {` 與 `location ^~ /<dir>/ {` 兩種寫法
+ *      （`^~` 語意同前綴，差別在命中後不再比對正則、優先序更高）。
+ *      **不解析** `location = ` 精確匹配與 `location ~ ` 正則匹配。
+ *      真實 nginx 的正則 location 優先序**高於**無修飾符的前綴，例如檔尾那條
+ *      `~* \.(js|css|png|…)$` 會截走 `/base_map/hillshade.png` 並從 dist 供檔。
+ *      本模型刻意不含它 —— 那條只設快取 header 不換 root 的意圖，靠它來供大檔
+ *      是意外行為不是契約。
+ *      📌 2026-08-14 實例：`/climate/*.png` 就是這樣被截走的，dist 的 build 快照
+ *      遮蔽了 `/data` 的 S3 新版，`refresh-climate.sh` 每輪更新使用者永遠拿不到
+ *      （實測 dust_latest.png 線上 17,649B vs S3 18,027B），還被加上 7 天 immutable。
+ *      修法是把該 location 改成 `^~`（治本，不必依賴「PNG 補進 upload 清單」）。
+ *      `base_map/hillshade.png` 同樣被截，但 dist 與 S3 逐位元相同且為不變的靜態
+ *      底圖，保留 dist fallback 較穩健，故維持無修飾符。
  *   2. location body 假設**沒有巢狀大括號**（現況成立）。
  *   3. 沒有任何前綴命中 → 落到 SPA root `location /`（`try_files $uri …`），
  *      等同 dist 供檔。
  */
 const NGINX_LOCS: NginxLoc[] = [
-  ...nginxConf.matchAll(/location\s+(\/[A-Za-z0-9_.-]+\/)\s*\{([^}]*)\}/g),
+  ...nginxConf.matchAll(/location\s+(?:\^~\s*)?(\/[A-Za-z0-9_.-]+\/)\s*\{([^}]*)\}/g),
 ].map((m) => ({
   prefix: m[1] as string,
   readsData: /root\s+\/data\s*;/.test(m[2] as string),


### PR DESCRIPTION
## 問題

PR #135 把 `/climate/` 改成 `location ^~ /climate/` 之後，`deployContract.test.ts` 轉紅：

```
deploy 管線把檔案推進 /data/<dir>/ 但 nginx 沒有讀得到它的 location
⇒ 那條 S3 路徑整條死掉：climate
```

**誤判**。該測試用字串／正則解析 `nginx.conf` 找 `location /<dir>/`，不認得 `^~` 修飾符。

這是我 merge #135 時的疏失 —— 當時想「只改設定檔不影響測試」就沒跑全套，但**這支測試正是在讀 nginx.conf**。

## 修法

`nginxCovers()` 與 `NGINX_LOCS` 的正則都接受可選的 `^~`。它語意同前綴匹配，差別只在命中後不再比對正則、優先序更高 —— 本來就該被當成前綴 location 解析。

順帶把檔頭的「脆弱點」註解補上這次的實例。**那段註解早就記錄了** `~* \.(png|…)$` 會截走 `/base_map/hillshade.png`，climate 是同一個坑的第二次發作；這次選擇治本（`^~`）而不是當初拍板的「PNG 補進 upload 清單」。

## 驗證

- 全套 **43 檔 588 passed**、`tsc -b` **0 error**
- **紅燈演練**：整段移除 `/climate/` 的 location block → 測試如預期轉紅（證明它仍在守該守的東西）；還原後 `nginx.conf` 零 diff
- 註：拔掉 `^~` 但保留 location 時測試維持綠，這是**正確行為** —— 它守的是「有沒有 location」，不是「有沒有 ^~」

🤖 Generated with [Claude Code](https://claude.com/claude-code)