### PR TITLE
fix(global-layers): 風場/海流/沙塵/地震/颱風 時間軸修復 + 地震回溯 toggle 與擴散圈

### DIFF
--- a/docs/features/global-climate/changelog.md
+++ b/docs/features/global-climate/changelog.md
@@ -1,5 +1,38 @@
 # Global Climate Changelog
 
+## 2026-08-14 — fix/global-layers-timeline（五圖層時間軸修復）
+
+三個獨立根因，一次收掉。上游 data-collectors PR #48 同批。
+
+**颱風軌跡（TY-3）**：loader `ascending:true` + `limit(5000)` 在表長到 23,541 筆後，
+升冪取前 5000 = 取最舊那批 → 窗凍結在 06-14~07-06，畫面永遠是 7 月的 Bavi/Maysak。
+改近 14 天下界 + `now+7d` 上界（擋 8/31 JTWC 壞列）；`ACTIVE_WINDOW_SEC` 基準從
+「資料內最大觀測時間」改成每點帶 `[valid_ts, valid_until)` 區間，t=now 自動退化成牆鐘。
+接 timeStore 只 `setFilter` 不 `setData`。新增 `dataTick`（map 先就緒、資料後到是常態路徑）。
+
+**全球地震（新增 select）**：原本註解自陳「不接 timeline filter」，裸 `limit(2000)` 只露 11.6 天
+（DB 有 46 天，丟掉 76%）。改日期窗查詢（錨點是 timeline 選定日非掛鐘 now）+ `keyedThunkCache`；
+照抄 `useEarthquakeLayer` 的 post/pre/ripple 三窗 + RAF 擴散圈（data-driven expression，
+一次 `setPaintProperty` 服務全部震央）。新增「回溯」select：僅當日/3/7/14(預設)/30 天。
+修 `setData` 被 `isStyleLoaded()` 擋掉且無重試（切大天數時約一半地震靜默消失）→ 150ms 有界重試。
+
+**幀選取容差（GC-8 相關）**：`pickNearestFrame` 原本無距離上限，本機幀停在 7/24 時
+時間軸拉到 8 月任何一天都 clamp 到同一張 —— 這是「換日期不會變」的直接成因。
+加 `FRAME_PICK_TOLERANCE_MS = 18h`（daily 幀最壞合法距離 12h + 50% 緩衝），超窗回 `null`
+並清 `climateFrameStore` + 重置 `currentKey`。沙塵接 timeStore 換幀（三態 fallback：
+無 frames 維持單張常駐，絕不隱藏）。
+
+**上游同批（PR #48）**：`global_climate_grids` 三支源改 `do_update` —— 唯一鍵
+`(dataset_id, observed_at)` 配 `DO NOTHING` 讓舊 cycle 的 f120 佔位、新 cycle 的 f000
+被靜默拒絕（近 14 天 lt=0 零筆），GC-2 修過的「預報冒充實況」因此回歸。
+另 USGS feed 改 `all_day`（修 8 個 1.1~1.32h 漏抓空洞）、沙塵烤固定 sqrt 色階 + 時間序列幀。
+
+驗證：`tsc -b` exit 0、`npm test` 43 files / 594 tests 全綠、browser 四圖層端到端過
+（Nangka 光圈位置正確、地震 ripple 半徑 18.3→49.8→65.9、風場換日期實抓對應幀、沙塵 fallback 完好）。
+
+⚠️ 未做：歷史回填（`data-collectors/scripts/backfill_climate_f000.py` 已入庫，dry-run 過，
+41 筆待 upsert，user 決定先不執行）→ 過去 14 天窗口需等 collector 逐日累積。
+
 ## 2026-07-02 — feat/global-climate-ux（GC-3/4/5/6）
 
 - 風場改速度色階（`climateRamps.ts` 色階 SSOT，App 渲染與圖例共用）

--- a/src/components/LegendPanel.tsx
+++ b/src/components/LegendPanel.tsx
@@ -3100,7 +3100,9 @@ function DustForecastLegend() {
         DUST AOD 550NM · CAMS
       </div>
       <div style={{ fontSize: FONT_SIZE.xs, color: t.textMuted, marginBottom: 2 }}>
-        沙塵光學厚度（相對色階，透明 = 無沙塵）
+        {/* 上游 climate_bake 已從 per-file normalize 改為固定 sqrt 色階（t = √(AOD/1.0)），
+            跨幀可比 —— 文案須與上游同時上線，否則會描述錯誤的色階語意。 */}
+        沙塵光學厚度 AOD 0–1 固定色階（跨時間可比，透明 = 無沙塵）
       </div>
       <ClimateGradientBar
         gradient={`linear-gradient(to right, ${DUST_BAKE_STOPS.map((s) => `${s.color} ${(s.t * 100).toFixed(0)}%`).join(", ")})`}

--- a/src/data/__tests__/__fixtures__/layer-golden.json
+++ b/src/data/__tests__/__fixtures__/layer-golden.json
@@ -43855,6 +43855,33 @@
     ],
     "earthquakesGlobal": [
       {
+        "label": "回溯",
+        "options": [
+          {
+            "label": "僅當日",
+            "value": "1"
+          },
+          {
+            "label": "3 天",
+            "value": "3"
+          },
+          {
+            "label": "7 天",
+            "value": "7"
+          },
+          {
+            "label": "14 天",
+            "value": "14"
+          },
+          {
+            "label": "30 天",
+            "value": "30"
+          }
+        ],
+        "type": "select",
+        "value": "14"
+      },
+      {
         "label": "透明度 0.90",
         "max": 1,
         "min": 0,

--- a/src/data/__tests__/climateFrames.test.ts
+++ b/src/data/__tests__/climateFrames.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { pickNearestFrame, type ClimateFrame } from "../climateFrames";
+import { pickNearestFrame, FRAME_PICK_TOLERANCE_MS, type ClimateFrame } from "../climateFrames";
 
 function frame(t: string, kind: "analysis" | "forecast" = "analysis"): ClimateFrame {
   return {
@@ -56,5 +56,39 @@ describe("pickNearestFrame", () => {
     // 07-19 12:00 距 07-19 00:00 與 07-20 00:00 皆 12h → 取較早
     const got = pickNearestFrame(frames, Date.parse("2026-07-19T12:00:00Z"));
     expect(got?.t).toBe("2026-07-19T00:00:00Z");
+  });
+});
+
+describe("pickNearestFrame 容差上限", () => {
+  const HOUR = 3600_000;
+
+  it("不傳容差 → 維持舊行為（多遠都給）", () => {
+    const got = pickNearestFrame(frames, Date.parse("2026-08-14T00:00:00Z"));
+    expect(got?.t).toBe("2026-07-20T12:00:00Z");
+  });
+
+  it("窗口過期（幀停在 7/20、目標 8/14）→ null", () => {
+    const got = pickNearestFrame(frames, Date.parse("2026-08-14T00:00:00Z"), FRAME_PICK_TOLERANCE_MS);
+    expect(got).toBeNull();
+  });
+
+  it("daily 幀最壞合法距離 12h 仍在 18h 容差內", () => {
+    const got = pickNearestFrame(frames, Date.parse("2026-07-19T12:00:00Z"), FRAME_PICK_TOLERANCE_MS);
+    expect(got?.t).toBe("2026-07-19T00:00:00Z");
+  });
+
+  it("距離剛好等於容差 → 給（不是嚴格小於）", () => {
+    // 目標 07-18 00:00 減 18h＝07-17 06:00，距首幀恰 18h
+    const got = pickNearestFrame(frames, Date.parse("2026-07-17T06:00:00Z"), 18 * HOUR);
+    expect(got?.t).toBe("2026-07-18T00:00:00Z");
+  });
+
+  it("距離超過容差 1ms → null", () => {
+    const got = pickNearestFrame(frames, Date.parse("2026-07-17T06:00:00Z") - 1, 18 * HOUR);
+    expect(got).toBeNull();
+  });
+
+  it("空清單 + 容差 → null", () => {
+    expect(pickNearestFrame([], Date.now(), FRAME_PICK_TOLERANCE_MS)).toBeNull();
   });
 });

--- a/src/data/climateFrames.ts
+++ b/src/data/climateFrames.ts
@@ -26,6 +26,18 @@ const MANIFEST_URL = `${FRAMES_BASE}manifest.json`;
 const MANIFEST_TTL_MS = 30 * 60 * 1000;
 const LRU_MAX = 8;
 
+/**
+ * pickNearestFrame 的建議容差上限（18 小時）。
+ *
+ * 為什麼是 18h：各 dataset 過去段一律是 **daily 00Z**（wind10m / currents 皆然，
+ * dust 的 CAMS leadtime 只有 0/24/48/72/96/120 也是 daily），daily 幀的「最壞合法距離」
+ * ＝半個間隔＝ 12h（例如 timeline 停在 12:00，前後兩張 00Z 各差 12h）。
+ * 取 18h ＝ 12h + 50% 緩衝（吸收 init cycle 偏移、缺 1 張 6h 幀之類的抖動），
+ * 同時仍嚴格擋掉「差一天以上」的過期幀 —— 也就是幀窗口停在 7/24、timeline 拉到 8/14
+ * 卻硬給 7/24 那張的病灶。
+ */
+export const FRAME_PICK_TOLERANCE_MS = 18 * 60 * 60 * 1000;
+
 export type FrameKind = "analysis" | "forecast";
 
 export interface ClimateFrame {
@@ -35,6 +47,7 @@ export interface ClimateFrame {
   tMs: number;
   /** PNG 路徑（相對 /climate/frames/） */
   png: string;
+  /** 向量場值域；scalar dataset（如 dust，PNG 已預烤色階）四者皆 0。 */
   u_min: number;
   u_max: number;
   v_min: number;
@@ -82,15 +95,21 @@ function normalizeManifest(raw: unknown): ClimateFramesManifest | null {
       const png = typeof fr.png === "string" ? fr.png : null;
       const tMs = t ? Date.parse(t) : NaN;
       if (!t || !png || !Number.isFinite(tMs)) continue;
-      if (![fr.u_min, fr.u_max, fr.v_min, fr.v_max].every((n) => typeof n === "number" && Number.isFinite(n))) continue;
+      // 向量場（wind10m / currents）四件套必須齊全且 finite；
+      // scalar dataset（dust：PNG 已預烤色階，前端不解 UV）整組缺席 → 視為 0。
+      // 「部分缺」仍視為壞資料丟棄，保住向量場的品質檢查。
+      const uv = [fr.u_min, fr.u_max, fr.v_min, fr.v_max];
+      const uvPresent = uv.filter((n) => n !== undefined && n !== null).length;
+      if (uvPresent !== 0 && uvPresent !== 4) continue;
+      if (uvPresent === 4 && !uv.every((n) => typeof n === "number" && Number.isFinite(n))) continue;
       frames.push({
         t,
         tMs,
         png,
-        u_min: fr.u_min as number,
-        u_max: fr.u_max as number,
-        v_min: fr.v_min as number,
-        v_max: fr.v_max as number,
+        u_min: (fr.u_min as number) ?? 0,
+        u_max: (fr.u_max as number) ?? 0,
+        v_min: (fr.v_min as number) ?? 0,
+        v_max: (fr.v_max as number) ?? 0,
         kind: fr.kind === "forecast" ? "forecast" : "analysis",
         init_at: typeof fr.init_at === "string" ? fr.init_at : undefined,
       });
@@ -199,8 +218,16 @@ export async function loadFrameRaster(frame: ClimateFrame, baseMeta: ClimateMeta
 /**
  * 選最接近 targetMs 的幀（兩幀之間取較近者；相等取較早）。
  * frames 假設已依 tMs 升冪；純函式，方便單元測試。
+ *
+ * @param maxGapMs 容差上限：最近幀距 targetMs 超過此值 → 回 null（「這段沒資料」），
+ *   避免幀窗口早已過期還默默給一張幾週前的圖。預設 Infinity ＝ 舊行為（永遠給最近的），
+ *   呼叫端請明確傳 {@link FRAME_PICK_TOLERANCE_MS} 或自家 dataset 的合適值。
  */
-export function pickNearestFrame(frames: ClimateFrame[], targetMs: number): ClimateFrame | null {
+export function pickNearestFrame(
+  frames: ClimateFrame[],
+  targetMs: number,
+  maxGapMs: number = Infinity,
+): ClimateFrame | null {
   if (frames.length === 0) return null;
   let best = frames[0]!;
   let bestDist = Math.abs(best.tMs - targetMs);
@@ -211,7 +238,12 @@ export function pickNearestFrame(frames: ClimateFrame[], targetMs: number): Clim
       bestDist = d;
     }
   }
-  return best;
+  return bestDist > maxGapMs ? null : best;
+}
+
+/** 幀 PNG 的可載入 URL（含 BASE_URL 前綴）；raster overlay 類圖層直接餵 mapbox image source。 */
+export function frameImageUrl(frame: ClimateFrame): string {
+  return resolvePublicAssetUrl(`${FRAMES_BASE}${frame.png}`);
 }
 
 /** per-dataset LRU raster cache（key = frame.png，Map 插入序即 LRU）。 */

--- a/src/data/earthquakesGlobalLoader.ts
+++ b/src/data/earthquakesGlobalLoader.ts
@@ -1,7 +1,42 @@
 // USGS 全球地震 loader（from public.earthquakes_global view，migration 261）
 import { supabase } from "../lib/supabase";
 import { withLoading } from "../lib/loadingRegistry";
-import { cachedOnce } from "../lib/loaderCache";
+import { keyedThunkCache } from "../lib/loaderCache";
+
+/**
+ * 「回溯天數」選項（SSOT）—— 圖層參數 select 與本 loader 的查詢窗共用同一份。
+ * 1 = 僅顯示當日（台北日界）；其餘為 timeline 游標往前的滾動視窗。
+ * DB 現有 46 天（日均 ~180 筆），30 天撐得住。
+ */
+export const EARTHQUAKE_GLOBAL_DAY_OPTIONS = [1, 3, 7, 14, 30] as const;
+export const EARTHQUAKE_GLOBAL_DAYS_DEFAULT = 14;
+
+/**
+ * 查詢窗比顯示窗多抓的天數。
+ *
+ * 查詢窗錨在 **timeline 選定日**（不是掛鐘現在）—— 往回拉日期時顯示窗整段跟著往前移，
+ * 錨在掛鐘就會讓最舊那幾天靜默空掉（使用者看到「越往回拉地震越少」，比報錯更糟）。
+ *
+ * 錨定後仍留 7 天緩衝的理由：日期通知走 debounce（`dateNotifier` quietMs 300，
+ * 見 timeStore），連續 scrub 跨多日時錨點會短暫落後於游標；緩衝讓那段過渡期
+ * 仍有資料可畫。7 天 = 全域 timeline 視窗上限（`timeStore.setRangeDays`）。
+ */
+const FETCH_SLACK_DAYS = 7;
+
+/**
+ * 安全上限。錨定日 + 30 天 + 7 天緩衝約 6.6k 筆，此值純粹防呆。
+ *
+ * ⚠️ 觸頂時 `order desc` 丟掉的是**最舊的**（正是往回拉時要看的那段）。查詢**不設上界**
+ * （抓到比錨定日更新的資料無害，filter 本來就會擋），所以 DB 保留天數若日後遠超過
+ * 60 天，這裡要補 `.lt("observed_at", 錨定日+緩衝)` 把查詢窗兩端都夾住。
+ */
+const MAX_ROWS = 12000;
+
+/** 台北日 key（YYYY-MM-DD）→ 該日 00:00 的 unix 秒。與 timeStore.getDateKey() 同一套日界 */
+function taipeiDayKeyToUnix(dateKey: string): number | null {
+  const ms = Date.parse(`${dateKey}T00:00:00+08:00`);
+  return Number.isFinite(ms) ? Math.floor(ms / 1000) : null;
+}
 
 export interface EarthquakeGlobalEvent {
   event_id: string;
@@ -37,20 +72,31 @@ function extractLngLat(geom: GeomLike): [number, number] | null {
   return null;
 }
 
-async function fetchEarthquakesGlobalUncached(): Promise<EarthquakeGlobalEvent[]> {
+async function fetchEarthquakesGlobalUncached(
+  days: number,
+  dateKey: string,
+): Promise<EarthquakeGlobalEvent[]> {
   const t0 = performance.now();
+  // 顯示窗下界 = 游標 - N 天，而游標最早落在錨定日 00:00 → 查詢下界從錨定日 00:00 起算
+  const anchorStart = taipeiDayKeyToUnix(dateKey) ?? Math.floor(Date.now() / 1000);
+  const sinceIso = new Date((anchorStart - (days + FETCH_SLACK_DAYS) * 86400) * 1000).toISOString();
   const { data, error } = await withLoading(
-    "earthquakes-global",
+    // id 帶天數 + 日期：快速切換選項／日期時，前一發 fetch 的 end() 不會把後一發的 loading 提早關掉
+    `earthquakes-global-d${days}-${dateKey}`,
     "全球地震 USGS",
     supabase
       .from("earthquakes_global")
       .select("event_id,mag,place,observed_at,depth_km,geom")
+      .gte("observed_at", sinceIso)
       .order("observed_at", { ascending: false })
-      .limit(2000),
+      .limit(MAX_ROWS),
   );
   if (error) throw new Error(`Supabase earthquakes_global: ${error.message}`);
 
   const rows = (data ?? []) as RawRow[];
+  if (rows.length >= MAX_ROWS) {
+    console.warn(`[EarthquakesGlobal] 觸頂 ${MAX_ROWS} 筆（錨定 ${dateKey} 回溯 ${days} 天），最舊的資料已被截斷`);
+  }
   const events: EarthquakeGlobalEvent[] = [];
   let skipped = 0;
   for (const r of rows) {
@@ -67,14 +113,24 @@ async function fetchEarthquakesGlobalUncached(): Promise<EarthquakeGlobalEvent[]
       observed_ts: Math.floor(new Date(r.observed_at).getTime() / 1000),
     });
   }
-  console.log(`[EarthquakesGlobal] Loaded ${events.length} events (skipped ${skipped}) in ${(performance.now() - t0).toFixed(0)}ms`);
+  console.log(`[EarthquakesGlobal] Loaded ${events.length} events (skipped ${skipped}, ${days}d @${dateKey}) in ${(performance.now() - t0).toFixed(0)}ms`);
   return events;
 }
 
-const fetchEarthquakesGlobalCached = cachedOnce(fetchEarthquakesGlobalUncached, 10 * 60_000);
+// 查詢有參數了 → keyedThunkCache（key = 回溯天數 + 錨定日）；
+// 切回抓過的組合不重打 DB。16 筆 LRU ≈ 一次 session 內 scrub 幾天 × 幾種天數。
+const earthquakesGlobalCache = keyedThunkCache<EarthquakeGlobalEvent[]>(10 * 60_000, 16);
 
-export function fetchEarthquakesGlobal(): Promise<EarthquakeGlobalEvent[]> {
-  return fetchEarthquakesGlobalCached();
+/**
+ * @param days    回溯天數（顯示窗長度；查詢窗 = days + 緩衝）
+ * @param dateKey 錨定日（YYYY-MM-DD，台北時區）—— 傳 `timeStore.getDateKey()`
+ */
+export function fetchEarthquakesGlobal(
+  days: number = EARTHQUAKE_GLOBAL_DAYS_DEFAULT,
+  dateKey: string,
+): Promise<EarthquakeGlobalEvent[]> {
+  const d = Number.isFinite(days) ? Math.max(1, Math.min(90, Math.round(days))) : EARTHQUAKE_GLOBAL_DAYS_DEFAULT;
+  return earthquakesGlobalCache(`d${d}_${dateKey}`, () => fetchEarthquakesGlobalUncached(d, dateKey));
 }
 
 export function earthquakesGlobalToGeoJSON(events: EarthquakeGlobalEvent[]): GeoJSON.FeatureCollection {

--- a/src/data/layerManifest.ts
+++ b/src/data/layerManifest.ts
@@ -3917,12 +3917,12 @@ export const LAYER_MANIFEST = {
     dataClass: "D",
     source: {
       kind: "custom",
-      note: "hook 自建 source/layer（earthquakes-global / earthquakes-global-circle），資料走 earthquakesGlobalLoader 打 USGS feed —— 非 OVERLAY_REGISTRY",
+      note: "hook 自建 source + 四層（earthquakes-global-circle 主層 / -pre 預示 / -ripple-0..1 擴散圈），資料走 earthquakesGlobalLoader 打 Supabase public.earthquakes_global（USGS feed 由上游 collector 抓，前端不直接打）—— 非 OVERLAY_REGISTRY。ripple/pre 為裝飾層，刻意不進 gisClickRegistry 免搶點擊",
     },
     legend: "earthquakesGlobal",
     popup: "earthquakeGlobal",
-    params: { count: 1, kinds: ["slider"] },
-    description: "USGS 全球地震（規模分大小、深度分色，最近 2000 筆）",
+    params: { count: 2, kinds: ["select", "slider"] },
+    description: "USGS 全球地震（規模分大小、深度分色，回溯天數可選，跟時間軸播放並跑震波擴散圈）",
     topics: ["全球氣候", "地震", "即時"],
   },
 

--- a/src/data/layerParamsSpec.ts
+++ b/src/data/layerParamsSpec.ts
@@ -1061,6 +1061,20 @@ export const LAYER_PARAMS_SPEC = {
 
   // ══════════ 天災・水利・農業・運動生態 ══════════
   earthquakesGlobal: [
+    // 回溯天數決定 loader 的「查詢窗」（非 filter）—— 全域時間軸最多 7 天視窗，
+    // 表達不了 14/30 天的回看。hook 端 `Number(value)` 還原成數字。
+    // 「僅當日」走台北日界，與 timeline 日期選擇器顯示的一致。
+    {
+      kind: "select", name: "earthquakesGlobalDays", label: "回溯", default: "14",
+      options: [
+        { label: "僅當日", value: "1" },
+        { label: "3 天", value: "3" },
+        { label: "7 天", value: "7" },
+        { label: "14 天", value: "14" },
+        { label: "30 天", value: "30" },
+      ],
+      out: null,
+    },
     { kind: "slider", name: "earthquakesGlobalOpacity", labelPrefix: "透明度", digits: 2, default: 0.9, min: 0, max: 1, step: 0.05 },
   ],
   worldTrashDebris: [

--- a/src/data/typhoonTracksLoader.ts
+++ b/src/data/typhoonTracksLoader.ts
@@ -34,8 +34,37 @@ interface RawRow {
   max_wind_kt: number | null;
 }
 
+/**
+ * observed 列的「未來容忍度」。上游 JTWC 實測有 `point_type='observed'` 卻 `valid_at`
+ * 落在三週後的壞列（2026-08 觀察到 valid_at=2026-08-31 的 wp1226 Dolphin /
+ * ep0726 Genevieve 殘列）。**兩處共用同一套判準**：
+ *   ① 軌跡 loader 解析階段（見 fetchTyphoonPointsUncached）
+ *   ② Monitor 卡的 `public.typhoons_active`（view 只濾了下界 now-24h、沒有上界，
+ *      這種列每天都滿足「近 24h」→ 變成永遠不消失的幽靈來源，見 pickActiveTyphoon）
+ * forecast 列不受此限 —— 其 valid_at 本來就是未來（實測最遠 +5 天，合法），
+ * 由查詢上界 FORECAST_HORIZON_SEC 把關。
+ */
+const FUTURE_TOLERANCE_SEC = 6 * 3600;
+
+// ── 查詢窗 ────────────────────────────────────────────────────────────
+// `live.typhoon_positions` 無 retention（2026-08 已累積 2.3 萬筆），裸 `limit` 一定
+// 撈錯批：升冪 = 撈到**最舊**那批（實測窗 2026-06-14 ~ 07-06，8 月資料 0 筆，
+// 於是「現在位置」光圈凍在 5 週前）。改成明確時間窗：
+//   · 下界 now-14d —— 與地震預設一致；observed 軌跡尺度也就這個量級
+//   · 上界 now+7d  —— 放行合法預報（最遠 +5 天），擋掉 8/31 那種離譜壞列
+// order 改**降冪**是**在有上界的前提下**才安全：沒有上界的降冪會先撈到 8/31 幽靈，
+// 把真實的 Nangka 擠出 limit（畫面只剩兩個假光圈）。有上界後，降冪的好處是萬一
+// 真的截斷，掉的是窗內**最舊**的一段，最新軌跡一定留得住。
+// limit 12000：實測 14 天窗約 8.3k 列（JMA 同一 valid_at 會寫多列，dedupe 後僅 ~960 點）。
+const LOOKBACK_SEC = 14 * 24 * 3600;
+const FORECAST_HORIZON_SEC = 7 * 24 * 3600;
+const MAX_ROWS = 12000;
+
 async function fetchTyphoonPointsUncached(): Promise<TyphoonPoint[]> {
   const t0 = performance.now();
+  const nowSec = Math.floor(Date.now() / 1000);
+  const sinceIso = new Date((nowSec - LOOKBACK_SEC) * 1000).toISOString();
+  const untilIso = new Date((nowSec + FORECAST_HORIZON_SEC) * 1000).toISOString();
   const { data, error } = await withLoading(
     "typhoon-positions",
     "颱風軌跡 JMA/JTWC",
@@ -44,21 +73,32 @@ async function fetchTyphoonPointsUncached(): Promise<TyphoonPoint[]> {
       .select(
         "storm_id,source,valid_at,point_type,advisory_number,name_local,name_en,center_lat,center_lon,center_pressure_hpa,max_wind_kt",
       )
-      .order("valid_at", { ascending: true })
-      .limit(5000),
+      .gte("valid_at", sinceIso)
+      .lte("valid_at", untilIso)
+      .order("valid_at", { ascending: false })
+      .limit(MAX_ROWS),
   );
   if (error) throw new Error(`Supabase typhoon_positions: ${error.message}`);
 
   const rows = (data ?? []) as RawRow[];
   const pts: TyphoonPoint[] = [];
+  let dropped = 0;
   for (const r of rows) {
     if (r.center_lat == null || r.center_lon == null) continue;
+    const pointType = r.point_type === "forecast" ? "forecast" : "observed";
+    const validTs = Math.floor(new Date(r.valid_at).getTime() / 1000);
+    // 第二道防線：SQL 上界之外，observed 再用 Monitor 卡同一判準擋一次
+    // （上界放寬到 +7d 是為了讓 forecast 過，壞列剛好也是 observed）
+    if (pointType === "observed" && validTs > nowSec + FUTURE_TOLERANCE_SEC) {
+      dropped += 1;
+      continue;
+    }
     pts.push({
       storm_id: r.storm_id,
       source: r.source,
-      point_type: r.point_type === "forecast" ? "forecast" : "observed",
+      point_type: pointType,
       advisory_number: r.advisory_number,
-      valid_ts: Math.floor(new Date(r.valid_at).getTime() / 1000),
+      valid_ts: validTs,
       name_en: r.name_en ?? "",
       name_local: r.name_local ?? "",
       center_lat: Number(r.center_lat),
@@ -67,7 +107,10 @@ async function fetchTyphoonPointsUncached(): Promise<TyphoonPoint[]> {
       max_wind_kt: r.max_wind_kt == null ? null : Number(r.max_wind_kt),
     });
   }
-  console.log(`[TyphoonTracks] Loaded ${pts.length} points in ${(performance.now() - t0).toFixed(0)}ms`);
+  console.log(
+    `[TyphoonTracks] Loaded ${pts.length} points in ${(performance.now() - t0).toFixed(0)}ms` +
+      (dropped ? ` (dropped ${dropped} future-observed rows)` : ""),
+  );
   return pts;
 }
 
@@ -78,11 +121,28 @@ export function fetchTyphoonPoints(): Promise<TyphoonPoint[]> {
 }
 
 /**
- * 把 point 陣列轉成兩種 feature：
- * - LineString per (storm_id, source, point_type) — 觀測 / 預報各一條
- * - Point per row — 給 hover popup
+ * 把 point 陣列轉成三種 feature（全部帶時間欄位，讓圖層用 setFilter 跟著時間軸走）：
+ * - LineString：**相鄰兩點一段**，帶 `seg_start_ts` / `seg_end_ts`
+ *   （不是整條軌跡一個 feature —— Mapbox filter 是 per-feature 全有全無，
+ *     切成段才能「已過去的畫、還沒到的不畫」）
+ * - Point per row — 給 hover popup，帶 `valid_ts`
+ * - Current：每個觀測點帶 `[valid_ts, valid_until)` 有效區間，由 filter 挑出
+ *   「區間包住 currentTime」的那一點當現在位置光圈
  */
-/** 活躍門檻：storm 最新觀測點若落後「全體最新觀測」超過此秒數，視為已消散，不標現在位置。 */
+
+/**
+ * 「現在位置」光圈的滯留秒數：某 storm×source 的觀測點往後撐這麼久仍算「現在在這」
+ * （相鄰點間隔更短時以下一點為準，見 typhoonPointsToGeoJSON）。
+ *
+ * 判準基準已從「抓到的資料內最大觀測時間」(globalMaxObs) 改成**時間軸 currentTime**：
+ *   ① 拉時間軸 → 光圈沿軌跡移動到當時位置
+ *   ② currentTime = now（Live）時自動退化成**牆鐘** —— 5 週前消散的颱風區間早就
+ *      結束，不會再畫光圈（舊版 globalMaxObs 會跟著舊資料一起漂，於是光圈凍在
+ *      5 週前還照畫）
+ *
+ * 與 Monitor 卡的 `typhoons_active`（下界 now-24h）刻意不同門檻：那張卡只回報
+ * 「此刻最靠近台灣的活躍颱風」，寧可嚴一點；軌跡圖層則要容忍觀測間隔的空窗。
+ */
 const ACTIVE_WINDOW_SEC = 48 * 3600;
 
 // 颱風前進最快約 120 km/h；相鄰點距離超過「120×時距 + 緩衝」視為資料異常（JMA preTyphoon
@@ -100,25 +160,35 @@ function haversineKm(a: [number, number], b: [number, number]): number {
   return 2 * R * Math.asin(Math.min(1, Math.sqrt(h)));
 }
 
-/** 把時序點陣列切成多段（相鄰點跳躍不合理處斷開），每段回傳座標陣列。 */
-function splitOnJumps(arr: TyphoonPoint[]): number[][][] {
-  const segments: number[][][] = [];
-  let cur: number[][] = [];
-  for (let i = 0; i < arr.length; i++) {
+interface TrackSegment {
+  coords: number[][];
+  /** 段起點時刻（unix 秒） */
+  t0: number;
+  /** 段終點時刻（unix 秒） */
+  t1: number;
+}
+
+/**
+ * 把時序點陣列切成「相鄰兩點一段」。跳躍不合理的那一對直接略過 ＝ 在該處斷線
+ * （原 splitOnJumps 的效果；改成逐段是為了讓時間軸能逐段揭露）。
+ */
+function pairSegments(arr: TyphoonPoint[]): TrackSegment[] {
+  const segments: TrackSegment[] = [];
+  for (let i = 1; i < arr.length; i++) {
+    const prev = arr[i - 1]!;
     const p = arr[i]!;
-    const coord = [p.center_lon, p.center_lat];
-    if (cur.length > 0) {
-      const prev = arr[i - 1]!;
-      const dtHr = Math.max(0.5, (p.valid_ts - prev.valid_ts) / 3600);
-      const maxKm = MAX_STORM_KMH * dtHr + JUMP_BUFFER_KM;
-      if (haversineKm([prev.center_lon, prev.center_lat], [p.center_lon, p.center_lat]) > maxKm) {
-        if (cur.length >= 2) segments.push(cur);
-        cur = [];
-      }
-    }
-    cur.push(coord);
+    const dtHr = Math.max(0.5, (p.valid_ts - prev.valid_ts) / 3600);
+    const maxKm = MAX_STORM_KMH * dtHr + JUMP_BUFFER_KM;
+    if (haversineKm([prev.center_lon, prev.center_lat], [p.center_lon, p.center_lat]) > maxKm) continue;
+    segments.push({
+      coords: [
+        [prev.center_lon, prev.center_lat],
+        [p.center_lon, p.center_lat],
+      ],
+      t0: prev.valid_ts,
+      t1: p.valid_ts,
+    });
   }
-  if (cur.length >= 2) segments.push(cur);
   return segments;
 }
 
@@ -160,23 +230,54 @@ export function typhoonPointsToGeoJSON(
     if (arr) arr.push(p);
     else groups.set(key, [p]);
   }
+  for (const arr of groups.values()) arr.sort((a, b) => a.valid_ts - b.valid_ts);
+
   const lineFeatures: GeoJSON.Feature[] = [];
+  // 現在位置：每個觀測點帶有效區間 [valid_ts, valid_until)，由圖層 filter 挑
+  // 「區間包住 currentTime」的那一點（見 ACTIVE_WINDOW_SEC）
+  const currentFeatures: GeoJSON.Feature[] = [];
   for (const [key, arr] of groups) {
-    if (arr.length < 2) continue;
-    arr.sort((a, b) => a.valid_ts - b.valid_ts);
     const [stormId, source, pointType] = key.split("::");
     const head = arr[0]!;
-    // 在不合理跳點處斷開成多段（避免 JMA preTyphoon 時間戳交錯畫出穿越假線）
-    for (const coords of splitOnJumps(arr)) {
+    // 在不合理跳點處斷開（避免 JMA preTyphoon 時間戳交錯畫出穿越假線）
+    for (const seg of pairSegments(arr)) {
       lineFeatures.push({
         type: "Feature",
-        geometry: { type: "LineString", coordinates: coords },
+        geometry: { type: "LineString", coordinates: seg.coords },
         properties: {
           storm_id: stormId,
           source,
           point_type: pointType,
           name_en: head.name_en,
           name_local: head.name_local,
+          seg_start_ts: seg.t0,
+          seg_end_ts: seg.t1,
+        },
+      });
+    }
+
+    if (pointType !== "observed") continue;
+    for (let i = 0; i < arr.length; i++) {
+      const p = arr[i]!;
+      const next = arr[i + 1];
+      // 觀測空窗過大時不硬撐（撐滿 ACTIVE_WINDOW_SEC 就斷），避免光圈長時間凍住
+      const validUntil = Math.min(
+        next ? next.valid_ts : Infinity,
+        p.valid_ts + ACTIVE_WINDOW_SEC,
+      );
+      currentFeatures.push({
+        type: "Feature",
+        geometry: { type: "Point", coordinates: [p.center_lon, p.center_lat] },
+        properties: {
+          storm_id: p.storm_id,
+          source: p.source,
+          point_type: p.point_type,
+          valid_ts: p.valid_ts,
+          valid_until: validUntil,
+          name_en: p.name_en,
+          name_local: p.name_local,
+          center_pressure: p.center_pressure,
+          max_wind_kt: p.max_wind_kt,
         },
       });
     }
@@ -196,35 +297,6 @@ export function typhoonPointsToGeoJSON(
       max_wind_kt: p.max_wind_kt,
     },
   }));
-  // 現在位置：每個「活躍」storm×source 的最新觀測點（畫成醒目圈圈）
-  const latestByStorm = new Map<string, TyphoonPoint>();
-  let globalMaxObs = 0;
-  for (const p of pts) {
-    if (p.point_type !== "observed") continue;
-    globalMaxObs = Math.max(globalMaxObs, p.valid_ts);
-    const key = `${p.storm_id}::${p.source}`;
-    const cur = latestByStorm.get(key);
-    if (!cur || p.valid_ts > cur.valid_ts) latestByStorm.set(key, p);
-  }
-  const currentFeatures: GeoJSON.Feature[] = [];
-  for (const p of latestByStorm.values()) {
-    if (globalMaxObs - p.valid_ts > ACTIVE_WINDOW_SEC) continue; // 已消散
-    currentFeatures.push({
-      type: "Feature",
-      geometry: { type: "Point", coordinates: [p.center_lon, p.center_lat] },
-      properties: {
-        storm_id: p.storm_id,
-        source: p.source,
-        point_type: p.point_type,
-        valid_ts: p.valid_ts,
-        name_en: p.name_en,
-        name_local: p.name_local,
-        center_pressure: p.center_pressure,
-        max_wind_kt: p.max_wind_kt,
-      },
-    });
-  }
-
   return {
     lines: { type: "FeatureCollection", features: lineFeatures },
     points: { type: "FeatureCollection", features: pointFeatures },
@@ -288,12 +360,8 @@ function distToTaiwanKm(lon: number, lat: number): number {
   return min;
 }
 
-/**
- * view 只濾了 valid_at 的**下界**（now-24h），沒有上界 —— 上游 JTWC 實測有 valid_at
- * 落在三週後的壞列（2026-08 觀察到 valid_at=2026-08-31 的殘列）。這種列每天都滿足
- * 「近 24h」，會變成永遠不消失的幽靈來源，故在前端補上界。
- */
-const FUTURE_TOLERANCE_SEC = 6 * 3600;
+// view 只濾了 valid_at 的**下界**（now-24h），沒有上界 → 用檔頭的 FUTURE_TOLERANCE_SEC
+// 在前端補上界（與軌跡 loader 共用同一判準，見該常數註解）。
 
 /**
  * 跨來源補值（氣壓 / 風速 / 名稱 / 來源徽章）只吃「離代表點夠近」的列。

--- a/src/hooks/useClimateParticleLineLayer.ts
+++ b/src/hooks/useClimateParticleLineLayer.ts
@@ -13,6 +13,7 @@ import {
   fetchClimateBaseMeta,
   pickNearestFrame,
   FrameRasterCache,
+  FRAME_PICK_TOLERANCE_MS,
   type ClimateFrame,
 } from "../data/climateFrames";
 
@@ -191,8 +192,17 @@ export function useClimateParticleLineLayer(
 
     const selectForTime = (tSec: number) => {
       if (cancelled || !cache || frames.length === 0) return;
-      const frame = pickNearestFrame(frames, tSec * 1000);
-      if (!frame || frame.png === currentKey) return;
+      const frame = pickNearestFrame(frames, tSec * 1000, FRAME_PICK_TOLERANCE_MS);
+      // 超出資料窗口：清圖例（否則 legend 卡在過期 validAt，畫面沒資料卻標著舊時刻），
+      // 並重置 currentKey —— 只 clear 不重置的話，拉出窗口再拉回同一張幀時
+      // frame.png === currentKey 會提早 return，legend 永遠空但畫面仍顯示該幀。
+      // 重置後重套只是 LRU cache hit，成本近零。粒子場本身不清（保留 *_latest fallback 底圖）。
+      if (!frame) {
+        currentKey = null;
+        if (statusKey) climateFrameStore.clear(statusKey);
+        return;
+      }
+      if (frame.png === currentKey) return;
       currentKey = frame.png;
       cache
         .get(frame)

--- a/src/hooks/useDustForecastLayer.ts
+++ b/src/hooks/useDustForecastLayer.ts
@@ -1,6 +1,15 @@
-import { useEffect, useRef } from "react";
-import type { Map as MapboxMap } from "mapbox-gl";
+import { useCallback, useEffect, useRef } from "react";
+import type { Map as MapboxMap, ImageSource } from "mapbox-gl";
 import { useMapReadyTick } from "./useMapReadyTick";
+import { timeStore } from "../state/timeStore";
+import { withLoading, keepLoadingUntilMapIdle } from "../lib/loadingRegistry";
+import {
+  loadClimateManifest,
+  pickNearestFrame,
+  frameImageUrl,
+  FRAME_PICK_TOLERANCE_MS,
+  type ClimateFrame,
+} from "../data/climateFrames";
 
 interface DustMeta {
   width: number;
@@ -15,6 +24,21 @@ interface DustMeta {
 const SOURCE_ID = "dust-forecast-img";
 const LAYER_ID = "dust-forecast-raster";
 
+/** manifest.datasets 的 key（上游 climate_bake 尚未產出時 → 走 dust_latest fallback）。 */
+const FRAME_DATASET = "dust";
+/** 換幀節流：同 useClimateParticleLineLayer，400ms 已足夠平滑。 */
+const FRAME_THROTTLE_MS = 400;
+
+/**
+ * 沙塵預報 raster overlay（CAMS duaod550，PNG 已預烤棕色色階 + alpha mask）。
+ *
+ * 時間軸：manifest 有 `datasets.dust` → 依 timeline 時間換 image source 的 URL；
+ * 沒有（目前 S3 只烤 dust_latest）→ 維持 dust_latest.png 一次性行為（graceful fallback）。
+ * 有 frames 但 timeline 落在窗口外（超過 {@link FRAME_PICK_TOLERANCE_MS}）→ 隱藏圖層
+ * 表示「這段沒資料」，而不是默默留著一張過期的圖。
+ *
+ * 鐵則：currentTime 不進 React deps，一律走 timeStore 訂閱（見 docs/TIMELINE_ARCHITECTURE.md）。
+ */
 export function useDustForecastLayer(
   mapRef: React.RefObject<MapboxMap | null>,
   visible: boolean,
@@ -23,10 +47,23 @@ export function useDustForecastLayer(
   /** map 就緒通知：mapRef 是 ref，.current 變動不觸發 re-render（見 useMapReadyTick） */
   const mapTick = useMapReadyTick(mapRef, visible);
 
+  const visibleRef = useRef(visible);
   const opacityRef = useRef(opacity);
+  /** 有 frames 但當前時間無可用幀 → 隱藏（與 visible 一起決定實際 visibility）。 */
+  const noDataRef = useRef(false);
+  visibleRef.current = visible;
   opacityRef.current = opacity;
 
-  // 載 meta + 加 image source（PNG 已預烤棕色色階 + alpha mask，mapbox 直接 raster 顯示）
+  const applyStyle = useCallback(() => {
+    const map = mapRef.current;
+    if (!map || !map.getLayer(LAYER_ID)) return;
+    const show = visibleRef.current && !noDataRef.current;
+    map.setLayoutProperty(LAYER_ID, "visibility", show ? "visible" : "none");
+    map.setPaintProperty(LAYER_ID, "raster-opacity", opacityRef.current);
+    // mapTick：map 首載較晚就緒時換一份新 callback，讓下面兩個 effect 一起重跑
+  }, [mapRef, mapTick]);
+
+  // 載 meta + 加 image source；有 frames 就訂閱 timeline 換幀
   useEffect(() => {
     const map = mapRef.current;
     if (!map) {
@@ -38,13 +75,60 @@ export function useDustForecastLayer(
       return;
     }
     let cancelled = false;
+    let frames: ClimateFrame[] = [];
+    /** 已套用的幀 png（null = 目前顯示 dust_latest 或尚未套幀）。 */
+    let currentKey: string | null = null;
+    let unsubDate: (() => void) | null = null;
+    let unsubThrottled: (() => void) | null = null;
+
+    /** 換 image source 的 URL；source 尚未就緒回 false（由 ensureLayer 完成後補套）。 */
+    const applyFrame = (frame: ClimateFrame): boolean => {
+      const src = map.getSource(SOURCE_ID) as ImageSource | undefined;
+      if (!src || typeof src.updateImage !== "function") return false;
+      src.updateImage({ url: frameImageUrl(frame) });
+      keepLoadingUntilMapIdle(map, "dust-forecast-frame", "沙塵預報幀", SOURCE_ID);
+      return true;
+    };
+
+    const setNoData = (next: boolean) => {
+      if (noDataRef.current === next) return;
+      noDataRef.current = next;
+      applyStyle();
+    };
+
+    const selectForTime = (tSec: number) => {
+      if (cancelled || frames.length === 0) return;
+      const frame = pickNearestFrame(frames, tSec * 1000, FRAME_PICK_TOLERANCE_MS);
+      if (!frame) {
+        // 窗口外 → 誠實顯示「無資料」（隱藏），並清 currentKey 讓回到窗口內時必定重套
+        currentKey = null;
+        setNoData(true);
+        return;
+      }
+      if (frame.png === currentKey) {
+        setNoData(false);
+        return;
+      }
+      if (!applyFrame(frame)) return; // source 未就緒 → 不記 currentKey，稍後由 ensureLayer 補
+      currentKey = frame.png;
+      setNoData(false);
+      // 預載相鄰 ±1 幀（只暖瀏覽器快取）
+      const idx = frames.indexOf(frame);
+      for (const j of [idx - 1, idx + 1]) {
+        if (j >= 0 && j < frames.length) new Image().src = frameImageUrl(frames[j]!);
+      }
+    };
 
     const ensureLayer = async () => {
       if (cancelled) return;
       // 已存在 → 不重複加
       if (map.getLayer(LAYER_ID)) return;
       try {
-        const meta: DustMeta = await fetch("./climate/dust_latest.json", { cache: "no-cache" }).then((r) => r.json());
+        const meta: DustMeta = await withLoading(
+          "dust-forecast-meta",
+          "沙塵預報中繼資料",
+          fetch("./climate/dust_latest.json", { cache: "no-cache" }).then((r) => r.json()),
+        );
         if (cancelled) return;
         const [lonMin, latMin, lonMax, latMax] = meta.bbox;
         // valid_at 帶進 PNG URL 破快取（S3 每日重烤 → 前端追得上）
@@ -74,36 +158,55 @@ export function useDustForecastLayer(
           });
         }
         console.log(`[DustForecast] ready: ${meta.width}×${meta.height} bbox=[${meta.bbox.join(", ")}] AOD∈[${meta.dust_min.toFixed(3)}, ${meta.dust_max.toFixed(3)}]`);
+        // source 重建（首次 / style.load 重掛）後畫的是 latest → 重置 currentKey 再補套當前幀
+        currentKey = null;
+        applyStyle();
+        selectForTime(timeStore.getTime());
       } catch (e) {
         console.warn("[DustForecast] load failed:", e);
       }
     };
 
-    if (map.isStyleLoaded()) ensureLayer();
+    if (map.isStyleLoaded()) void ensureLayer();
     else map.once("load", ensureLayer);
     map.on("style.load", ensureLayer);
 
+    // ── Time-aware 換幀（timeStore 訂閱；鐵則：currentTime 不進 React deps）──
+    void (async () => {
+      const manifest = await loadClimateManifest();
+      if (cancelled || !manifest) return; // 無 manifest → fallback（dust_latest 已顯示）
+      const ds = manifest.datasets[FRAME_DATASET];
+      if (!ds || ds.frames.length === 0) {
+        console.log("[DustForecast] manifest 無 dust frames → 維持 dust_latest");
+        return;
+      }
+      frames = ds.frames;
+      console.log(`[DustForecast] frames=${frames.length} ${frames[0]!.t} → ${frames[frames.length - 1]!.t}`);
+      selectForTime(timeStore.getTime()); // 初始套用
+      // 跨日 + 同日 scrub：兩種訂閱都掛（selectForTime idempotent，key 沒變不動作）
+      unsubDate = timeStore.subscribeDate(() => selectForTime(timeStore.getTime()));
+      unsubThrottled = timeStore.subscribeThrottled(FRAME_THROTTLE_MS, (t) => selectForTime(t));
+    })();
+
     return () => {
       cancelled = true;
+      unsubDate?.();
+      unsubThrottled?.();
+      noDataRef.current = false;
       map.off("style.load", ensureLayer);
       try {
         if (map.getLayer(LAYER_ID)) map.removeLayer(LAYER_ID);
         if (map.getSource(SOURCE_ID)) map.removeSource(SOURCE_ID);
       } catch { /* style 已沒 */ }
     };
-  }, [mapRef, visible, mapTick]);
+  }, [mapRef, visible, mapTick, applyStyle]);
 
   // visibility / opacity 即時切
   useEffect(() => {
     const map = mapRef.current;
     if (!map) return;
-    const apply = () => {
-      if (!map.getLayer(LAYER_ID)) return;
-      map.setLayoutProperty(LAYER_ID, "visibility", visible ? "visible" : "none");
-      map.setPaintProperty(LAYER_ID, "raster-opacity", opacity);
-    };
-    apply();
-    map.on("style.load", apply);
-    return () => { map.off("style.load", apply); };
-  }, [mapRef, visible, opacity, mapTick]);
+    applyStyle();
+    map.on("style.load", applyStyle);
+    return () => { map.off("style.load", applyStyle); };
+  }, [mapRef, visible, opacity, mapTick, applyStyle]);
 }

--- a/src/hooks/useEarthquakesGlobalLayer.ts
+++ b/src/hooks/useEarthquakesGlobalLayer.ts
@@ -1,17 +1,62 @@
-import { useEffect, useRef, useCallback } from "react";
-import type { Map as MapboxMap, ExpressionSpecification, CircleLayer } from "mapbox-gl";
+import { useEffect, useRef, useState, useCallback } from "react";
+import type {
+  Map as MapboxMap, ExpressionSpecification, FilterSpecification, CircleLayer, GeoJSONSource,
+} from "mapbox-gl";
+import { timeStore } from "../state/timeStore";
 import { useMapReadyTick } from "./useMapReadyTick";
 import {
   fetchEarthquakesGlobal,
   earthquakesGlobalToGeoJSON,
+  EARTHQUAKE_GLOBAL_DAYS_DEFAULT,
   type EarthquakeGlobalEvent,
 } from "../data/earthquakesGlobalLoader";
 
-// USGS 全球地震 — 累積展示，依規模分大小、依深度分色（同 CWA earthquake 配色邏輯）。
-// 不接 timeline filter（先做最簡：全部顯示最近 2000 筆）。
+/**
+ * USGS 全球地震 — timeline 連動 + 擴散圈動畫。
+ *
+ * 三窗共用同一份 geojson source（結構照抄 `useEarthquakeLayer`（CWA 國內），
+ * 欄位對應 `occurred_ts → observed_ts`、`magnitude → mag`；配色沿用全球版原色）：
+ *
+ * - post   : 已發生（observed <= current）→ 淡標記持續顯示，**popup 掛在這層**
+ * - pre    : 即將發生（current < observed <= current + PRE_WINDOW）→ 空心預示
+ * - ripple : 剛發生（current - FRESH_WINDOW < observed <= current）→ 擴散圈動畫
+ *
+ * 「回溯天數」（lookbackDays）同時決定 loader 查詢窗與顯示窗下界：
+ *   - 1  → 僅顯示當日（台北日界；timeline 日期選擇器也是台北日，兩者對齊）
+ *   - >1 → timeline 游標往前 N 天的滾動視窗
+ *
+ * 兩個窗都錨在 **timeline 選定日**（`subscribeDate` 換日重抓），所以把日期往回拉時
+ * 整段窗一起往前移；錨在掛鐘現在的話最舊那幾天會靜默空掉。
+ *
+ * ⚠️ currentTime **不在** deps（專案鐵則 §6）—— filter 走 timeStore 訂閱，
+ * 擴散圈走 RAF；React 只負責 visible / opacity / lookbackDays 這類真依賴。
+ */
 
 const SOURCE_ID = "earthquakes-global";
-const LAYER_ID = "earthquakes-global-circle";
+/** ⚠️ 主層 id 不可改名：`gisClickRegistry` 的 popup 綁在這個字串上 */
+const LAYER_POST = "earthquakes-global-circle";
+const LAYER_PRE = "earthquakes-global-pre";
+const RIPPLE_COUNT = 2;
+const RIPPLE_IDS = Array.from({ length: RIPPLE_COUNT }, (_, i) => `earthquakes-global-ripple-${i}`);
+
+/** 預示視窗：發生前多久就出現淡標記（秒） */
+const PRE_WINDOW = 1800; // 30 分鐘
+/** 剛發生視窗：擴散動畫持續多久（秒，timeline 時間） */
+const FRESH_WINDOW = 1200; // 20 分鐘
+const RIPPLE_CYCLE_MS = 2400;
+const FRAME_INTERVAL = 33;
+
+const SEC_PER_DAY = 86400;
+const POST_OPACITY = 0.55;
+const POST_STROKE_OPACITY = 0.8;
+const PRE_STROKE_OPACITY = 0.25;
+
+/** 給定 unix 秒，回傳「該時間在台灣時區所屬日」的 [00:00, 隔日 00:00) unix 秒區間 */
+function taipeiDayBounds(ts: number): { dayStart: number; dayEnd: number } {
+  const tzOffset = 8 * 3600;
+  const dayStart = Math.floor((ts + tzOffset) / SEC_PER_DAY) * SEC_PER_DAY - tzOffset;
+  return { dayStart, dayEnd: dayStart + SEC_PER_DAY };
+}
 
 const RADIUS_EXPR = [
   "interpolate", ["linear"], ["get", "mag"],
@@ -32,34 +77,84 @@ const COLOR_EXPR = [
   300, "#3949ab",
 ] as unknown as ExpressionSpecification;
 
+function buildLayers(map: MapboxMap) {
+  if (!map.getSource(SOURCE_ID)) return false;
+
+  // post：已發生的持續標記（popup 目標層）
+  if (!map.getLayer(LAYER_POST)) {
+    map.addLayer({
+      id: LAYER_POST,
+      type: "circle",
+      source: SOURCE_ID,
+      filter: ["literal", false] as unknown as FilterSpecification,
+      paint: {
+        "circle-radius": RADIUS_EXPR,
+        "circle-color": COLOR_EXPR,
+        "circle-opacity": POST_OPACITY,
+        "circle-stroke-color": COLOR_EXPR,
+        "circle-stroke-width": 1,
+        "circle-stroke-opacity": POST_STROKE_OPACITY,
+      },
+    } as CircleLayer);
+  }
+
+  // pre：即將發生的預示（空心）
+  if (!map.getLayer(LAYER_PRE)) {
+    map.addLayer({
+      id: LAYER_PRE,
+      type: "circle",
+      source: SOURCE_ID,
+      filter: ["literal", false] as unknown as FilterSpecification,
+      paint: {
+        "circle-radius": RADIUS_EXPR,
+        "circle-color": "transparent",
+        "circle-stroke-color": COLOR_EXPR,
+        "circle-stroke-width": 1,
+        "circle-stroke-opacity": PRE_STROKE_OPACITY,
+      },
+    } as CircleLayer);
+  }
+
+  // ripple：半徑／透明度由 RAF 每幀改寫（見下方動畫 effect）
+  for (const id of RIPPLE_IDS) {
+    if (map.getLayer(id)) continue;
+    map.addLayer({
+      id,
+      type: "circle",
+      source: SOURCE_ID,
+      filter: ["literal", false] as unknown as FilterSpecification,
+      paint: {
+        "circle-radius": 8,
+        "circle-color": "transparent",
+        "circle-stroke-color": COLOR_EXPR,
+        "circle-stroke-width": 2,
+        "circle-stroke-opacity": 0,
+      },
+    } as CircleLayer);
+  }
+
+  return true;
+}
+
 export function useEarthquakesGlobalLayer(
   mapRef: React.RefObject<MapboxMap | null>,
   visible: boolean,
   opacity: number = 0.9,
+  lookbackDays: number = EARTHQUAKE_GLOBAL_DAYS_DEFAULT,
 ) {
   /** map 就緒通知：mapRef 是 ref，.current 變動不觸發 re-render（見 useMapReadyTick） */
   const mapTick = useMapReadyTick(mapRef, visible);
 
   const eventsRef = useRef<EarthquakeGlobalEvent[]>([]);
   const dataReadyRef = useRef(false);
-  const layerReadyRef = useRef(false);
-
-  // 載入一次（lazy）
-  useEffect(() => {
-    if (!visible || dataReadyRef.current) return;
-    let cancelled = false;
-    fetchEarthquakesGlobal()
-      .then((evs) => {
-        if (cancelled) return;
-        eventsRef.current = evs;
-        dataReadyRef.current = true;
-        const map = mapRef.current;
-        if (map && map.isStyleLoaded()) ensureSource(map);
-      })
-      .catch((err) => console.warn("[EarthquakesGlobal] load failed:", err));
-    return () => { cancelled = true; };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [visible]);
+  const layersReadyRef = useRef(false);
+  const rafRef = useRef(0);
+  const lastFrameRef = useRef(0);
+  /**
+   * 資料到位／換天數重抓後 +1。filter effect 必須靠它重跑 ——
+   * mapTick 只在「map 從 null 變 ready」時跳，抓到資料本身不會通知 React。
+   */
+  const [dataTick, setDataTick] = useState(0);
 
   const ensureSource = useCallback((map: MapboxMap) => {
     if (!dataReadyRef.current) return false;
@@ -69,35 +164,189 @@ export function useEarthquakesGlobalLayer(
         data: earthquakesGlobalToGeoJSON(eventsRef.current),
       });
     }
-    if (!map.getLayer(LAYER_ID)) {
-      map.addLayer({
-        id: LAYER_ID,
-        type: "circle",
-        source: SOURCE_ID,
-        paint: {
-          "circle-radius": RADIUS_EXPR,
-          "circle-color": COLOR_EXPR,
-          "circle-opacity": 0.55,
-          "circle-stroke-color": COLOR_EXPR,
-          "circle-stroke-width": 1,
-          "circle-stroke-opacity": 0.8,
-        },
-      } as CircleLayer);
+    if (!layersReadyRef.current || !map.getLayer(LAYER_POST)) {
+      layersReadyRef.current = buildLayers(map);
     }
-    layerReadyRef.current = true;
-    return true;
+    return layersReadyRef.current;
   }, []);
 
-  // visibility + opacity
+  // 載入（lazy：visible 才抓）。查詢窗錨在 **timeline 選定日**，所以換日要重抓 ——
+  // 訂閱 `subscribeDate`（日粒度）而非 subscribeThrottled：同一天內移動游標只改 filter，
+  // 不該打 DB。currentTime 一樣不進 deps（鐵則 §6）。換回溯天數則靠 effect 重跑。
+  useEffect(() => {
+    if (!visible) return;
+    let cancelled = false;
+    let inflightKey: string | null = null;
+    let applyTimer: number | null = null;
+
+    // 世界視野下幾千顆點時 map.isStyleLoaded() 可能長時間為 false（實測連續 9 秒不動）；
+    // 當下沒套上就靜默放棄的話，source 資料會卡在舊的一份不再更新。改成有界重試：
+    // 每 150ms 檢查一次，直到 style 就緒、或本次載入已過期／effect 被清理才停止
+    // （照抄 useClimateParticleLineLayer.ts applyRaster 的重試精神）。
+    const applyData = (evs: EarthquakeGlobalEvent[], dateKey: string) => {
+      if (cancelled || inflightKey !== dateKey) return; // 期間又換日／換天數 → 這批已過期
+      const map = mapRef.current;
+      if (!map || !map.isStyleLoaded()) {
+        if (applyTimer === null) {
+          applyTimer = window.setTimeout(() => {
+            applyTimer = null;
+            applyData(evs, dateKey);
+          }, 150);
+        }
+        return;
+      }
+      const src = map.getSource(SOURCE_ID) as GeoJSONSource | undefined;
+      if (src) src.setData(earthquakesGlobalToGeoJSON(evs));
+      else ensureSource(map);
+    };
+
+    const load = (dateKey: string) => {
+      if (cancelled || dateKey === inflightKey) return; // 同日重複通知 → 不動作
+      inflightKey = dateKey;
+      fetchEarthquakesGlobal(lookbackDays, dateKey)
+        .then((evs) => {
+          // 期間又換日／換天數 → 丟掉這批過期結果
+          if (cancelled || inflightKey !== dateKey) return;
+          eventsRef.current = evs;
+          dataReadyRef.current = true;
+          applyData(evs, dateKey);
+          setDataTick((v) => v + 1);
+        })
+        .catch((err) => {
+          if (inflightKey === dateKey) inflightKey = null; // 允許同日重試
+          console.warn("[EarthquakesGlobal] load failed:", err);
+        });
+    };
+
+    load(timeStore.getDateKey()); // 初始
+    const unsubDate = timeStore.subscribeDate(load);
+    return () => {
+      cancelled = true;
+      unsubDate();
+      if (applyTimer !== null) window.clearTimeout(applyTimer);
+    };
+    // mapTick 必須在（ratchet mapReadyTickCoverage）：資料先到、map 後就緒時，
+    // 上面那段 `mapRef.current` 分支會整個跳過 —— 靠 mapTick 重跑補建 source。
+    // 重跑走 keyedThunkCache 命中，不會多打一次 DB。
+    // dataTick 則**不**在此（它由本 effect 自己遞增，放進來會無限迴圈）。
+  }, [visible, lookbackDays, ensureSource, mapRef, mapTick]);
+
+  // 更新 filter（訂閱 timeStore 節流 500ms，不走 React re-render）
   useEffect(() => {
     const map = mapRef.current;
     if (!map) return;
     if (!ensureSource(map)) return;
-    if (map.getLayer(LAYER_ID)) {
-      map.setLayoutProperty(LAYER_ID, "visibility", visible ? "visible" : "none");
-      const o = Math.max(0, Math.min(1, opacity));
-      map.setPaintProperty(LAYER_ID, "circle-opacity", 0.55 * o);
-      map.setPaintProperty(LAYER_ID, "circle-stroke-opacity", 0.8 * o);
+
+    const allIds = [LAYER_POST, LAYER_PRE, ...RIPPLE_IDS];
+    const v = visible ? "visible" : "none";
+    for (const id of allIds) {
+      if (map.getLayer(id)) map.setLayoutProperty(id, "visibility", v);
     }
-  }, [visible, opacity, ensureSource, mapRef, mapTick]);
+    if (!visible) return;
+
+    const applyFilter = (currentTime: number) => {
+      // 顯示窗下界：僅當日 → 台北日界 00:00；其餘 → 游標往前 N 天
+      const onlyToday = lookbackDays <= 1;
+      const { dayStart, dayEnd } = taipeiDayBounds(currentTime);
+      const lowerBound = onlyToday ? dayStart : currentTime - lookbackDays * SEC_PER_DAY;
+      // 僅當日時，預示視窗不得越過日界（否則會露出明天的地震）
+      const preUpper = onlyToday
+        ? Math.min(currentTime + PRE_WINDOW, dayEnd)
+        : currentTime + PRE_WINDOW;
+
+      const postFilter = [
+        "all",
+        [">=", ["get", "observed_ts"], lowerBound],
+        ["<=", ["get", "observed_ts"], currentTime],
+      ];
+      const preFilter = [
+        "all",
+        [">", ["get", "observed_ts"], currentTime],
+        ["<=", ["get", "observed_ts"], preUpper],
+      ];
+      const rippleFilter = [
+        "all",
+        [">=", ["get", "observed_ts"], lowerBound],
+        [">", ["get", "observed_ts"], currentTime - FRESH_WINDOW],
+        ["<=", ["get", "observed_ts"], currentTime],
+      ];
+
+      if (map.getLayer(LAYER_POST))
+        map.setFilter(LAYER_POST, postFilter as unknown as FilterSpecification);
+      if (map.getLayer(LAYER_PRE))
+        map.setFilter(LAYER_PRE, preFilter as unknown as FilterSpecification);
+      for (const id of RIPPLE_IDS) {
+        if (map.getLayer(id))
+          map.setFilter(id, rippleFilter as unknown as FilterSpecification);
+      }
+    };
+
+    applyFilter(timeStore.getTime()); // 初始化
+    return timeStore.subscribeThrottled(500, applyFilter);
+  }, [visible, lookbackDays, ensureSource, mapRef, mapTick, dataTick]);
+
+  // 套用 opacity（乘以各 layer 的 base opacity；ripple 由 RAF 全權改寫，不在此列）
+  useEffect(() => {
+    const map = mapRef.current;
+    if (!map) return;
+    if (!layersReadyRef.current) return;
+    const o = Math.max(0, Math.min(1, opacity));
+    if (map.getLayer(LAYER_POST)) {
+      map.setPaintProperty(LAYER_POST, "circle-opacity", POST_OPACITY * o);
+      map.setPaintProperty(LAYER_POST, "circle-stroke-opacity", POST_STROKE_OPACITY * o);
+    }
+    if (map.getLayer(LAYER_PRE)) {
+      map.setPaintProperty(LAYER_PRE, "circle-stroke-opacity", PRE_STROKE_OPACITY * o);
+    }
+  }, [opacity, visible, mapRef, mapTick, dataTick]);
+
+  // ripple 動畫：半徑用 data-driven expression，一次 setPaintProperty 服務全部震央
+  useEffect(() => {
+    if (!visible) return;
+
+    const animate = () => {
+      const map = mapRef.current;
+      if (!map) {
+        rafRef.current = requestAnimationFrame(animate);
+        return;
+      }
+      const now = performance.now();
+      if (now - lastFrameRef.current < FRAME_INTERVAL) {
+        rafRef.current = requestAnimationFrame(animate);
+        return;
+      }
+      lastFrameRef.current = now;
+
+      // style 切換後 layers 可能消失 → 自癒重建
+      if (layersReadyRef.current && !map.getLayer(RIPPLE_IDS[0]!)) {
+        layersReadyRef.current = false;
+      }
+      if (!layersReadyRef.current) ensureSource(map);
+
+      if (layersReadyRef.current) {
+        for (let i = 0; i < RIPPLE_COUNT; i++) {
+          const id = RIPPLE_IDS[i]!;
+          if (!map.getLayer(id)) continue;
+          const phase =
+            ((now + i * (RIPPLE_CYCLE_MS / RIPPLE_COUNT)) % RIPPLE_CYCLE_MS) / RIPPLE_CYCLE_MS;
+          const eased = 1 - Math.pow(1 - phase, 2);
+          // 規模越大，擴散範圍越大
+          const baseR = 6;
+          const maxAdd = 60;
+          map.setPaintProperty(id, "circle-radius", [
+            "+",
+            ["*", ["get", "mag"], 2],
+            baseR + maxAdd * eased,
+          ] as unknown as ExpressionSpecification);
+          map.setPaintProperty(id, "circle-stroke-opacity", 0.7 * (1 - eased));
+          map.setPaintProperty(id, "circle-stroke-width", 2.5 * (1 - eased * 0.5));
+        }
+      }
+
+      rafRef.current = requestAnimationFrame(animate);
+    };
+
+    rafRef.current = requestAnimationFrame(animate);
+    return () => cancelAnimationFrame(rafRef.current);
+  }, [visible, ensureSource, mapRef, mapTick]);
 }

--- a/src/hooks/useTyphoonTracksLayer.ts
+++ b/src/hooks/useTyphoonTracksLayer.ts
@@ -1,14 +1,27 @@
-import { useEffect, useRef, useCallback } from "react";
-import type { Map as MapboxMap, LineLayer, CircleLayer, ExpressionSpecification } from "mapbox-gl";
+import { useEffect, useRef, useCallback, useState } from "react";
+import type {
+  Map as MapboxMap,
+  LineLayer,
+  CircleLayer,
+  ExpressionSpecification,
+  FilterSpecification,
+} from "mapbox-gl";
 import { useMapReadyTick } from "./useMapReadyTick";
+import { timeStore } from "../state/timeStore";
 import {
   fetchTyphoonPoints,
   typhoonPointsToGeoJSON,
   type TyphoonPoint,
 } from "../data/typhoonTracksLoader";
 
-// 颱風軌跡 — observed 實線 + forecast 虛線 + 軌跡點。
-// 先做最簡：載入所有點 → 兩條 source（line / point）→ filter by point_type。
+// 颱風軌跡 — observed 實線 + forecast 虛線 + 軌跡點 + 現在位置光圈。
+//
+// 跟著時間軸走（鐵則：currentTime 禁止進 effect deps，一律 timeStore 訂閱）：
+//   · observed 線段：整段落在 currentTime 之前才畫（軌跡逐段長出來）
+//   · forecast 線段：整段在 currentTime 之後才畫（還沒到的預報虛線）
+//   · 軌跡點：observed 取 ≤ currentTime、forecast 取 > currentTime
+//   · 現在位置光圈：挑 [valid_ts, valid_until) 包住 currentTime 的觀測點 → 沿軌跡移動
+// 三個 source 的 feature 都在 loader 端就帶好時間欄位，這裡只 setFilter，不 setData。
 
 const SRC_LINES = "typhoon-tracks-lines";
 const SRC_POINTS = "typhoon-tracks-points";
@@ -19,6 +32,8 @@ const LAYER_POINTS = "typhoon-tracks-points";
 const LAYER_CURRENT_HALO = "typhoon-tracks-current-halo";
 const LAYER_CURRENT_RING = "typhoon-tracks-current-ring";
 const LAYER_CURRENT_DOT = "typhoon-tracks-current-dot";
+const CURRENT_LAYER_IDS = [LAYER_CURRENT_HALO, LAYER_CURRENT_RING, LAYER_CURRENT_DOT];
+const ALL_LAYER_IDS = [LAYER_LINE_OBS, LAYER_LINE_FCST, LAYER_POINTS, ...CURRENT_LAYER_IDS];
 
 // 實際=紫 #a855f7（粗實線 / 實心點）；預測=藍 #38bdf8（細疏虛線 / 空心點）— 拉開差異
 const OBS_COLOR = "#a855f7";
@@ -38,6 +53,9 @@ export function useTyphoonTracksLayer(
   const dataRef = useRef<TyphoonPoint[]>([]);
   const dataReadyRef = useRef(false);
   const layersReadyRef = useRef(false);
+  // 資料到齊通知：map 先就緒、資料後到是常態路徑，沒有這個 tick，下方的
+  // timeStore 訂閱 effect 只會在資料未到時跑一次就早退，時間軸永遠接不上。
+  const [dataTick, setDataTick] = useState(0);
 
   useEffect(() => {
     if (!visible || dataReadyRef.current) return;
@@ -49,6 +67,7 @@ export function useTyphoonTracksLayer(
         dataReadyRef.current = true;
         const map = mapRef.current;
         if (map && map.isStyleLoaded()) ensureSource(map);
+        setDataTick((v) => v + 1);
       })
       .catch((err) => console.warn("[TyphoonTracks] load failed:", err));
     return () => { cancelled = true; };
@@ -156,25 +175,63 @@ export function useTyphoonTracksLayer(
     return true;
   }, []);
 
+  // 可見性 + 時間過濾（訂閱 timeStore 節流 500ms，不走 React re-render）
   useEffect(() => {
     const map = mapRef.current;
     if (!map) return;
     if (!ensureSource(map)) return;
     const v = visible ? "visible" : "none";
-    for (const id of [LAYER_LINE_OBS, LAYER_LINE_FCST, LAYER_POINTS, LAYER_CURRENT_HALO, LAYER_CURRENT_RING, LAYER_CURRENT_DOT]) {
+    for (const id of ALL_LAYER_IDS) {
       if (map.getLayer(id)) map.setLayoutProperty(id, "visibility", v);
     }
-    // 資料源篩選（全部 / JMA / JTWC）：組合 point_type 與 source 條件套到各 layer
-    const srcCond: unknown[] | null = sourceFilter === "all" ? null : ["==", ["get", "source"], sourceFilter];
-    const withSrc = (base: unknown[] | null): unknown => {
-      if (base && srcCond) return ["all", base, srcCond];
-      return (base ?? srcCond ?? true) as unknown;
+    if (!visible) return;
+
+    // 資料源篩選（全部 / JMA / JTWC）：與時間條件一起併進同一個 ["all", ...]
+    const srcCond: unknown[] | null =
+      sourceFilter === "all" ? null : ["==", ["get", "source"], sourceFilter];
+    const compose = (...conds: (unknown[] | null)[]): FilterSpecification =>
+      ["all", ...conds.filter(Boolean), ...(srcCond ? [srcCond] : [])] as unknown as FilterSpecification;
+    const setF = (id: string, ...conds: (unknown[] | null)[]) => {
+      if (map.getLayer(id)) map.setFilter(id, compose(...conds));
     };
-    if (map.getLayer(LAYER_LINE_OBS)) map.setFilter(LAYER_LINE_OBS, withSrc(["==", ["get", "point_type"], "observed"]) as ExpressionSpecification);
-    if (map.getLayer(LAYER_LINE_FCST)) map.setFilter(LAYER_LINE_FCST, withSrc(["==", ["get", "point_type"], "forecast"]) as ExpressionSpecification);
-    for (const id of [LAYER_POINTS, LAYER_CURRENT_HALO, LAYER_CURRENT_RING, LAYER_CURRENT_DOT]) {
-      if (map.getLayer(id)) map.setFilter(id, withSrc(null) as ExpressionSpecification);
-    }
+
+    const applyFilter = (currentTime: number) => {
+      // 線段逐段揭露：observed 段整段走完才畫；forecast 段整段還沒到才畫
+      setF(
+        LAYER_LINE_OBS,
+        ["==", ["get", "point_type"], "observed"],
+        ["<=", ["get", "seg_end_ts"], currentTime],
+      );
+      setF(
+        LAYER_LINE_FCST,
+        ["==", ["get", "point_type"], "forecast"],
+        [">=", ["get", "seg_start_ts"], currentTime],
+      );
+      setF(LAYER_POINTS, [
+        "any",
+        ["all", ["==", ["get", "point_type"], "observed"], ["<=", ["get", "valid_ts"], currentTime]],
+        ["all", ["==", ["get", "point_type"], "forecast"], [">", ["get", "valid_ts"], currentTime]],
+      ]);
+      // 現在位置光圈：有效區間包住 currentTime 的那一個觀測點（每個 storm×source 至多一點）
+      // → 拉時間軸時沿軌跡移動；currentTime = now 時等價於「最後觀測還夠新」的牆鐘判活躍
+      for (const id of CURRENT_LAYER_IDS) {
+        setF(
+          id,
+          ["<=", ["get", "valid_ts"], currentTime],
+          [">", ["get", "valid_until"], currentTime],
+        );
+      }
+    };
+
+    applyFilter(timeStore.getTime()); // 初始化
+    return timeStore.subscribeThrottled(500, applyFilter);
+  }, [visible, sourceFilter, ensureSource, mapRef, mapTick, dataTick]);
+
+  // 套用 opacity（乘以各 layer 的 base opacity）
+  useEffect(() => {
+    const map = mapRef.current;
+    if (!map) return;
+    if (!layersReadyRef.current) return;
     const o = Math.max(0, Math.min(1, opacity));
     if (map.getLayer(LAYER_LINE_OBS)) map.setPaintProperty(LAYER_LINE_OBS, "line-opacity", 0.9 * o);
     if (map.getLayer(LAYER_LINE_FCST)) map.setPaintProperty(LAYER_LINE_FCST, "line-opacity", 0.7 * o);
@@ -182,5 +239,5 @@ export function useTyphoonTracksLayer(
     if (map.getLayer(LAYER_CURRENT_HALO)) map.setPaintProperty(LAYER_CURRENT_HALO, "circle-opacity", 0.16 * o);
     if (map.getLayer(LAYER_CURRENT_RING)) map.setPaintProperty(LAYER_CURRENT_RING, "circle-stroke-opacity", 0.95 * o);
     if (map.getLayer(LAYER_CURRENT_DOT)) map.setPaintProperty(LAYER_CURRENT_DOT, "circle-opacity", 1 * o);
-  }, [visible, opacity, sourceFilter, ensureSource, mapRef, mapTick]);
+  }, [opacity, visible, mapRef, mapTick, dataTick]);
 }

--- a/src/layers/hosts/climateHosts.tsx
+++ b/src/layers/hosts/climateHosts.tsx
@@ -20,11 +20,15 @@ import { paramBool, paramNum, useKeyOverlayParams, useLayerParams } from "../lay
 /** 全球地震（USGS） */
 export const EarthquakesGlobalHost: LayerHostComponent = ({ deps }) => {
   bumpHostRender("useEarthquakesGlobalLayer");
+  // 兩種取值路徑並存：opacity 是既有的 overlayParams 參數（無 out:null，維持原行為不動），
+  // 回溯天數是 out:null 的 select（值只回 hook 不進 overlay）→ 走 useLayerParams + paramNum。
   const p = useKeyOverlayParams("earthquakesGlobal");
+  const values = useLayerParams("earthquakesGlobal");
   useEarthquakesGlobalLayer(
     deps.mapRef,
     deps.layerVisibility.earthquakesGlobal,
     p.earthquakesGlobalOpacity ?? 0.9,
+    paramNum(values, "earthquakesGlobal", "earthquakesGlobalDays"),
   );
   return null;
 };


### PR DESCRIPTION
## Summary

全球五圖層「換日期不會變／顯示舊資料」一次收掉：三個獨立根因（颱風查詢取到最舊那批、
幀選取無容差上限、三層從沒接時間軸），並依 user 需求新增地震回溯天數 toggle 與震波擴散圈。
上游同批 data-collectors PR #48（已 merged）。

## Changes

- **`typhoonTracksLoader.ts` / `useTyphoonTracksLayer.ts`** — 查詢改 `now-14d` 下界 + `now+7d` 上界
  取代裸 `limit(5000)`（表已 23,541 筆，升冪取前 5000 = 取最舊那批，窗凍結在 06-14~07-06）；
  `ACTIVE_WINDOW_SEC` 基準改成每點帶 `[valid_ts, valid_until)` 區間，t=now 自動退化成牆鐘；
  接 timeStore 只 `setFilter` 不 `setData`；`FUTURE_TOLERANCE_SEC` 與 Monitor 卡共用同一常數
- **`earthquakesGlobalLoader.ts` / `useEarthquakesGlobalLayer.ts`** — 日期窗查詢（錨點是 timeline
  選定日，非掛鐘 now）+ `keyedThunkCache`；post/pre/ripple 三窗 + RAF 擴散圈；
  修 `setData` 被 `isStyleLoaded()` 擋掉且無重試（切大天數時約一半地震靜默消失）
- **`climateFrames.ts`** — `pickNearestFrame` 加 `FRAME_PICK_TOLERANCE_MS = 18h`（簽名第三參數
  預設 `Infinity`，既有呼叫端零變動）；`normalizeManifest` 放寬讓 scalar 幀（dust）通過
- **`useClimateParticleLineLayer.ts`** — 超窗清 `climateFrameStore` + 重置 `currentKey`
  （只清不重置會讓拉回窗口時因 key 未變而不重套）
- **`useDustForecastLayer.ts`** — 接 timeStore 換幀，三態 fallback（無 frames → 維持單張常駐）
- **接線** — `layerParamsSpec` 新增 `earthquakesGlobalDays` select、`layerManifest` params 1→2
  + 修正錯誤註解（原寫「打 USGS feed」，實際打 Supabase view）、`climateHosts` 混用兩種取值路徑、
  golden fixture 重生、`LegendPanel` 沙塵文案改固定色階

## Test

- [x] `npx tsc -b` 通過（exit 0）
- [x] `npm test` 通過（**43 files / 594 tests**，含 `layerConsistency` 9 條）
- [x] Browser 驗收（All Off 單測）— 四圖層端到端：
  - 颱風：t=now 出現 4 個光圈（TC2620/wp1626 Nangka、TC2618/wp1326 Peilou），
    兩個 8/31 幽靈未出現；拉到 8/12 Nangka 退到 (139.4,21.4)、8/9 尚未生成
  - 地震：14d=3830 / 7d=2525 / 30d=6896，source 筆數全程跟上 loader；
    ripple 半徑 18.3→49.8→65.9 連續變化、兩圈相位錯開
  - 風場/海流：換日期實抓 `frames/wind10m/20260813T1200Z.png`，圖例時刻 08:00→20:00；
    拉到 8/1 時海流顯示「01/08 08:00」而風場時刻清空（兩者窗口不同，容差逐 dataset 生效）
  - 沙塵：`manifest 無 dust frames → 維持 dust_latest`，圖層照常顯示，fallback 未破
- [ ] 不涉 Supabase RPC（PostgREST 直查 view）

## Risk / Rollback

**影響範圍**：僅 `全球氣候 Global Climate` 分類下五個圖層。共用檔改動限於
`layerParamsSpec` / `layerManifest` 的 `earthquakesGlobal` 一筆條目 + golden fixture 同步。

**已知行為變化**：
1. 沙塵在上游烤圖部署後會時間軸化 → **超出資料窗口 ±18h 會隱藏圖層**。歷史回填未執行，
   拉到更早的日期沙塵會消失（誠實但看起來像壞掉），直到 collector 逐日累積滿 14 天窗口
2. 颱風 `-points` 現在有時間過濾（舊版永遠全顯示）；跨越播放頭那一段兩邊都不畫，
   觀測線尾與預報線頭之間有一小段空隙（逐段顯示的必然結果）

**Rollback**：`git revert` 本 PR 即可，無資料庫變更、無資料遷移。上游 PR #48 亦僅改
upsert 策略值（`do_nothing` → `do_update`），revert 後行為立即復原。

## Related

- Feature: `docs/features/global-climate/`（changelog 已加本 PR 段落）
- Upstream: data-collectors PR #48（已 merged）— grids `do_update` / USGS `all_day` / 沙塵烤圖
- Backlog: GC-8（時間序列）本 PR 前端半邊完成；GC-2b / TY-2 仍 open
- 未執行：`data-collectors/scripts/backfill_climate_f000.py`（dry-run 過，41 筆待 upsert）

## Checklist

- [x] Branch 名符合 `fix/<slug>`
- [x] Commit prefix 走 Conventional Commits
- [x] 動既有 layer（非新增）— 四鐵則維持：透明度 slider / 圖例 / popup / select 皆在
- [x] 未動資料契約（欄位與 view 不變，僅查詢條件與 upsert 策略）
- [x] `docs/features/global-climate/changelog.md` 已加本 PR 段落

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WD3foxTyYwJBpeZ8a3VBg2