### PR TITLE
feat(monitor): 供電卡 30 天趨勢圖 + 颱風卡空狀態修復

### DIFF
--- a/.claude/memory/DATA_SCOPE.md
+++ b/.claude/memory/DATA_SCOPE.md
@@ -337,9 +337,14 @@ satellitesChinaOther / satellitesTaiwan（全預設關，視效能與用戶習�
 | 光電月發電（站時序）| `analytics.solar_daily_generation` | 3,992 | 沒接（E-F 月趨勢）|
 | 落雷即時 | `live.lightning_events` | **雙源**（mig 338 加 `source`）| **已接 2 個圖層**：`lightning`（台電，橘/青）+ `lightningCwa`（氣象署，紫/綠）。⚠️ **台電源自 2026-07-10 起端點 200 但永遠回空檔**，氣象署源 2026-08-07 上線接手 |
 | 落雷日聚合 | `analytics.lightning_daily_summary` | 動態 | 沒接（E-F KPI）。mig 338 加 `source` 分組 —— 兩源混算會把同一場雷雨計兩次 |
-| **三本柱燈號** | `realtime.power_system_status` | 1,843 (10min × 約 13 天) | ✅ HUD（v1.1 留 hooks 給 monitor E-A）|
-| **區域用電** | `realtime.power_region_demand` | 7,352 | ✅ region bars（v1.1 留 hooks 給 monitor E-A）|
-| **機組即時** | `realtime.power_generation_unit` | 376,790 (7 天 retention) | ✅ 3D beam layer 4 |
+| **三本柱燈號** | `live.power_system_status` | 10,368（10min × 2026-06-05 起全量）| ✅ HUD + PowerCard + 30 天趨勢（RPC 351）|
+| **區域用電** | `live.power_region_demand` | 41,444（同上，全量）| ✅ region bars（v1.1 留 hooks 給 monitor E-A）|
+| **機組即時** | `live.power_generation_unit` | 2,119,163（同上，全量）| ✅ 3D beam layer 4 |
+
+> ⚠️ 三張 power 表 2026-08-17 實測：schema 已由 `realtime.*` 搬到 `live.*`（migration 312），
+> 且**全部自 2026-06-05 起全量留存、無任何 retention**（`cron.job` 中 `%power%` 查無 job）。
+> migration 217 註解與本檔舊版寫的「`power_generation_unit` 7 天 retention」**從未實作**，勿再引用。
+> RPC 351（30 天趨勢）直接讀 live 表、依賴此現況；日後若要加 retention，須先建 analytics 日彙總表。
 | 核安站當下 | `realtime.nuclear_radiation_stations` | 51 | **已接** v2 Phase B（feat/energy-v2-A b7d6154，5 階分級含 stale）|
 | 核安站歷史 | `realtime.nuclear_radiation_measurements` | 動態 | 沒接（E-B per-station sparkline）|
 | 核安日聚合 | `analytics.nuclear_radiation_daily` | 動態 | 沒接（E-F）|
@@ -355,7 +360,8 @@ satellitesChinaOther / satellitesTaiwan（全預設關，視效能與用戶習�
 | 216 | `get_osm_substations()` + `get_ev_charging_stations()` | 兩 slim POI |
 | 217 | `get_power_plants_at(ts)` + `get_power_plant_output_24h(name)` | timeline + popup sparkline |
 | 218 | `get_power_generation_at(ts)` | beam slim 14 廠 ~3 KB |
-| 219 | `get_power_generation_24h()` | 24h 全部 14 廠 × ~144 ts ~45 KB |
+| 219 | `get_power_generation_24h()` | 24h 全部 14 廠 × ~144 ts ~45 KB。⚠️ **PowerCard 實際呼叫的不是這支**，而是 `get_ssot_facility_output_24h()`（~23 廠 = 14 台電 + 6 離岸風場 + 3 離島，**owner-gated**，匿名使用者看不到 UNIT OUTPUT）|
+| **351** | `get_power_daily_trend(p_days)` | **30 天每日趨勢**：尖峰負載 / 最高供電能力 / 台電定稿備轉率。anon 可讀、10.6ms。備轉率取「隔日最後一筆的 `yday_peak_resv_rate`」——不可用同表 `fore_peak_resv_rate`（盤中預測，日內可從 36% 跳到 11%），也不可用 `MAX(yday_...)`（每日 03:00 才更新，凌晨殘留前天值）|
 
 ### 核電廠現況（2026-06）
 

--- a/docs/proposal/pulse-gis-mcp-plan.md
+++ b/docs/proposal/pulse-gis-mcp-plan.md
@@ -1,0 +1,581 @@
+# Pulse GIS MCP — 架構與實作規劃
+
+> 建立：2026-08-16
+>
+> 狀態：方向已拍板、待開工
+>
+> 決策：建立獨立 sibling repo `mini-pulse-gis-mcp`，並在既有 `mini-taiwan-pulse` 加入受控的本機 Agent Bridge；不建立第二套地圖網站。
+
+---
+
+## 0. 一句話結論
+
+**Mini Taiwan Pulse 繼續負責顯示與互動；新建 `mini-pulse-gis-mcp` 當 Claude Code 的翻譯／協調層；正式空間計算留在 `gis-platform` PostGIS。**
+
+```text
+Claude Code
+  → mini-pulse-gis-mcp（MCP tools + localhost bridge）
+      ├→ mini-taiwan-pulse（開圖層、移動鏡頭、呈現分析結果）
+      └→ gis-platform / PostGIS（距離、疊合、排名、路網分析）
+```
+
+MCP 不直接操作 Mapbox instance、不畫地圖，也不保存另一份圖層邏輯。
+
+---
+
+## 與既有文件的關係
+
+| 文件 | 本計畫如何沿用 |
+|---|---|
+| [`member-byok-chat-plan.md`](./member-byok-chat-plan.md) | 沿用白名單 tools、LLM 不生 SQL、輸出截斷與既有 MapBridge 經驗 |
+| [`architecture-overhaul-plan.md`](./architecture-overhaul-plan.md) | 接續 AR-43 對話介面與 Layer Manifest 架構，不另造圖層目錄 |
+| [`worldmonitor-deep-dive-2026-07.md`](../research/worldmonitor-deep-dive-2026-07.md) | 延續既有 MCP／discovery／freshness 研究 |
+| [`docs/features/byok-chat/README.md`](../features/byok-chat/README.md) | 外部 MCP 與已上線 BYOK chat 共用 controller，不取代內建 chat |
+| [`docs/features/layer-manifest/README.md`](../features/layer-manifest/README.md) | `LAYER_MANIFEST` 與 `LAYER_PARAMS_SPEC` 繼續作為圖層能力 SSOT |
+
+本檔是尚待執行的 architecture／implementation SSOT；功能正式開工後，再建立 `docs/features/mini-pulse-gis-mcp/` 四檔追蹤交付狀態。
+
+---
+
+## 1. 目標與非目標
+
+### 1.1 目標
+
+讓使用者可在 Claude Code 直接輸入：
+
+- 「打開魚塭圖層，移動到高雄沿海。」
+- 「找出污染源一公里內魚塭最密集的地區。」
+- 「把污染源、距離帶與命中的農地疊在一起，調整成看得清楚的畫面。」
+- 「把目前結果整理成可重現、可分享的資料故事場景。」
+
+系統必須能：
+
+1. 查詢圖層目錄與 metadata。
+2. 控制已開啟的本機地圖頁面。
+3. 回讀實際狀態，確認指令真的成功。
+4. 執行具型別、白名單的 GIS 分析。
+5. 自動找出值得觀察的區域並調整鏡頭。
+6. 保存分析參數、資料版本、場景與限制，讓結果可重現。
+
+### 1.2 非目標
+
+- 不建立第二套地圖前端。
+- 不讓 LLM 直接生成並執行任意 SQL。
+- 不提供 `execute_js`、任意 shell、任意 URL fetch。
+- 不以 Computer Use／滑鼠點擊作為主要控制方式。
+- 第一版不處理多使用者遠端 MCP 服務。
+- 第一版不宣稱「距離接近」等於污染因果。
+
+---
+
+## 2. 為什麼是獨立 MCP repo
+
+建議的 workspace：
+
+```text
+GIS/
+├─ mini-taiwan-pulse/   # 現有地圖 runtime
+├─ mini-pulse-gis-mcp/  # 新 repo：本計畫主體
+└─ gis-platform/        # Supabase / PostGIS / RPC
+```
+
+獨立 repo 的理由：
+
+| 理由 | 說明 |
+|---|---|
+| 執行生命週期不同 | Vite 網站由瀏覽器執行；MCP 是 Claude Code 啟動的本機 subprocess |
+| 安全邊界不同 | MCP 接觸本機 port、credential 與工具權限，不應混入前端 bundle |
+| 可獨立測試 | 可用 MCP Inspector 測 tools，不必啟動完整前端 build |
+| 可服務其他 client | 未來可供 Claude Desktop、Codex 或其他 MCP host 使用 |
+| 避免前端膨脹 | MCP SDK、WebSocket server、analysis client 不進 Vite bundle |
+
+代價是跨 repo contract 可能漂移，因此 Phase 0 必須先決定共用 schema 的 SSOT 與版本策略，不能各自手寫一份。
+
+---
+
+## 3. 現有地基
+
+Mini Taiwan Pulse 已有可重用能力：
+
+| 能力 | 現有位置 | MCP 化方向 |
+|---|---|---|
+| 瀏覽器內 agent loop | `src/chat/agent.ts` | 保留 BYOK chat；與外部 MCP 共用 controller |
+| 地圖控制 facade | `src/chat/types.ts` 的 `MapBridge` | 擴成有回執的 `MapController` |
+| 地圖工具 | `src/chat/tools/mapTools.ts` | tool 語意可沿用，執行改走共用 controller |
+| 圖層查詢 | `src/chat/tools/catalogTools.ts` | 改由 manifest 產生 schema/catalog |
+| 資料查詢 | `src/chat/tools/dataTools.ts`、`rpcTools.ts` | 保留白名單原則，逐步搬到 MCP adapter |
+| 圖層 metadata | `src/data/layerManifest.ts` | 作為圖層目錄 SSOT |
+| 圖層參數 | `src/data/layerParamsSpec.ts` | 產生 `set_layer_params` input schema |
+| visibility / params / time SSOT | `src/state/*Store.ts` | controller 直接讀寫 store |
+| 可重現 URL | `src/lib/urlState.ts`、`src/embed/EmbedApp.tsx` | 第一版優先產生 deterministic embed URL |
+
+目前主要缺口：
+
+1. `MapBridge` 多數方法回傳 `void`，Agent 無法確認實際套用結果。
+2. permission gate 可能擋下圖層，但 tool 仍回報成功。
+3. camera、selection、popup 與部分 UI state 尚未形成完整外部狀態契約。
+4. 缺 `set_layer_params`、完整 time control、`fit_bounds`、`apply_scene`、screenshot。
+5. 缺跨圖層 proximity／overlap／accessibility 分析 API。
+6. URL 能重現單一畫面，但尚無多步 Story schema。
+
+---
+
+## 4. 目標架構
+
+```text
+┌──────────────── Claude Code / MCP Host ────────────────┐
+│ 使用者自然語言                                         │
+│ GIS Skills：分析 SOP、限制、故事流程                    │
+└──────────────────────┬─────────────────────────────────┘
+                       │ stdio / JSON-RPC
+┌──────────────────────▼─────────────────────────────────┐
+│ mini-pulse-gis-mcp                                      │
+│                                                        │
+│ MCP tools                                               │
+│  ├─ Catalog tools                                       │
+│  ├─ Map control tools                                   │
+│  └─ Analysis tools                                      │
+│                                                        │
+│ BrowserBridge                 AnalysisClient            │
+│  └─ 127.0.0.1 WebSocket       └─ public allowlisted RPC │
+└───────────────┬──────────────────────────┬──────────────┘
+                │                          │
+┌───────────────▼──────────────┐  ┌────────▼──────────────┐
+│ mini-taiwan-pulse            │  │ gis-platform         │
+│ AgentBridge                  │  │ PostGIS / pgRouting  │
+│ MapController                │  │ pre-aggregate RPC    │
+│ MapScene / result overlay    │  │ spatial indexes      │
+│ Mapbox / MapLibre renderer   │  └───────────────────────┘
+└──────────────────────────────┘
+```
+
+### 4.1 控制迴圈
+
+每次操作一律遵守：
+
+```text
+observe → bounded action → acknowledge → read back → verify
+```
+
+例如：
+
+1. MCP 先讀目前 map revision。
+2. 呼叫 `pulse_apply_scene(scene, expectedRevision)`。
+3. 網站以共用 controller 套用狀態。
+4. 網站回傳 `{ applied, denied, actualState, newRevision }`。
+5. Agent 再讀狀態或 screenshot 驗證。
+
+不得只回「command received」就當作成功。
+
+---
+
+## 5. 責任邊界
+
+| 系統 | 負責 | 不負責 |
+|---|---|---|
+| `mini-pulse-gis-mcp` | MCP tools、schema validation、browser bridge、RPC client、context 截斷、錯誤訊息、audit | Mapbox rendering、React state、任意 SQL |
+| `mini-taiwan-pulse` | 真實地圖狀態、圖層、相機、時間、selection、popup、分析結果呈現 | LLM orchestration、PostGIS 全量 join |
+| `gis-platform` | 權威空間運算、索引、聚合、資料版本、read-only RPC | UI、自然語言理解 |
+| Skills | Tool 使用 SOP、領域限制、驗證步驟、敘事格式 | 執行程式或保存即時資料 |
+
+### 5.1 Client / Server GIS 分工
+
+| 工作 | 執行處 |
+|---|---|
+| hover、click、popup、camera、feature highlight | Browser / Mapbox |
+| viewport 內少量臨時 geometry | Browser / Turf.js（可選） |
+| 全臺 spatial join、正式統計、排名 | PostGIS |
+| 路網服務圈與最短路 | pgRouting |
+| 大型結果呈現 | server-side simplify / vector tiles；browser 只 render |
+
+`queryRenderedFeatures` 只可作 UI picking／視覺驗證，不可當正式統計母體。
+
+---
+
+## 6. 共用控制契約
+
+### 6.1 MapScene
+
+所有內建 chat、MCP、分享 URL 與未來 Story 都應使用同一個 declarative scene：
+
+```ts
+type MapScene = {
+  camera?: {
+    center?: [number, number]
+    zoom?: number
+    pitch?: number
+    bearing?: number
+    bounds?: [number, number, number, number]
+    padding?: number
+  }
+  layers: Array<{
+    id: string
+    visible: boolean
+    opacity?: number
+    params?: Record<string, string | number | boolean>
+    filter?: unknown
+  }>
+  time?: {
+    at?: string
+    from?: string
+    to?: string
+    playing?: boolean
+    speed?: number
+  }
+  selection?: {
+    layerId: string
+    featureIds: string[]
+  }
+  resultOverlay?: {
+    analysisId: string
+    stylePreset: string
+  }
+  narration?: string
+  citations?: DatasetReference[]
+}
+```
+
+### 6.2 Command Result
+
+所有 mutation 必須回傳結構化結果：
+
+```ts
+type MapCommandResult = {
+  commandId: string
+  success: boolean
+  previousRevision: number
+  newRevision: number
+  applied: string[]
+  denied: Array<{ target: string; reason: string }>
+  warnings: string[]
+  actualState: MapStateSummary
+}
+```
+
+### 6.3 版本與相容性
+
+- command envelope 必帶 `protocolVersion`。
+- 新增 optional field 不升 major version。
+- 刪除／改義既有 field 才升 major version。
+- 未知 command／field 必須回 actionable error，不可靜默成功。
+- `expectedRevision` 不一致時拒絕寫入，避免 Agent 覆蓋使用者剛做的操作。
+
+---
+
+## 7. MCP Server 設計
+
+### 7.1 技術選型
+
+| 項目 | 決策 |
+|---|---|
+| 語言 | TypeScript |
+| MCP SDK | 官方 TypeScript SDK |
+| Claude Code transport | stdio |
+| Browser bridge | `127.0.0.1` WebSocket |
+| Schema | Zod + structured output schema |
+| Remote transport | 第一版不做；未來再評估 Streamable HTTP + OAuth |
+
+### 7.2 v0 Tools
+
+命名一律以 `pulse_` 開頭，避免與其他 MCP server 衝突。
+
+| Tool | 性質 | 用途 |
+|---|---|---|
+| `pulse_search_layers` | read-only | 依文字、主題、data class 搜尋圖層 |
+| `pulse_get_layer_details` | read-only | 讀 metadata、來源、參數、資料日期與限制 |
+| `pulse_get_map_state` | read-only | 讀目前 camera、layers、params、time、selection、revision |
+| `pulse_apply_scene` | reversible mutation | 原子套用完整 MapScene |
+| `pulse_focus_results` | reversible mutation | 依分析 bbox／feature refs 調整鏡頭 |
+| `pulse_capture_view` | read-only | 取得 screenshot 與 render summary |
+
+### 7.3 v1 Analysis Tools
+
+| Tool | 用途 |
+|---|---|
+| `pulse_analyze_proximity` | 距離帶、最近距離、count／area aggregation |
+| `pulse_analyze_overlap` | Polygon 衝突／覆蓋面積 |
+| `pulse_analyze_accessibility` | 路網服務圈與可達性 |
+| `pulse_get_analysis_result` | 取得非同步 job 的統計、bbox 與結果圖層 reference |
+| `pulse_render_analysis` | 把分析結果轉成 MapScene 並呈現在網站 |
+
+### 7.4 MCP Resources
+
+```text
+pulse://catalog/layers
+pulse://layer/{id}/schema
+pulse://dataset/{id}/metadata
+pulse://map/{sessionId}/state
+pulse://analysis/{analysisId}/result
+```
+
+列表與 feature query 必須支援 `limit`／cursor、bbox 與欄位投影；禁止把全量 GeoJSON 放進 LLM context。
+
+### 7.5 Tool annotations
+
+- Catalog／query／capture：`readOnlyHint: true`。
+- `pulse_apply_scene`：`destructiveHint: false`、`idempotentHint: true`。
+- 外部下載、檔案輸出或未來資料寫入：必須要求人工確認。
+- annotations 只作提示；server 仍必須自行驗證 permission。
+
+---
+
+## 8. Mini Taiwan Pulse 修改範圍
+
+### 8.1 共用 MapController
+
+將現有 `chatBridge` 收斂成可被兩條入口共用的 controller：
+
+```text
+內建 BYOK Chat ─┐
+                ├→ MapController → stores / Mapbox
+外部 AgentBridge ┘
+```
+
+第一版最低能力：
+
+- `getMapState()`
+- `searchLayers()`
+- `applyScene()`
+- `setLayerParams()`
+- `setTimeState()`
+- `fitBounds()`
+- `selectFeatures()`
+- `showAnalysisResult()`
+- `captureView()`
+
+### 8.2 AgentBridge
+
+網站主動連線本機 bridge；MCP 不可直接注入 DOM 或呼叫任意 JS。
+
+最低要求：
+
+- session ID 與隨機 token。
+- Origin allowlist。
+- command ID、timeout、cancel。
+- protocol version handshake。
+- reconnect 與「目前沒有網頁連線」的明確錯誤。
+- 一次只控制使用者明確選定的 tab/session。
+
+### 8.3 Result Overlay
+
+分析結果不得混回來源 layer；使用獨立暫存 overlay，至少支援：
+
+- source features。
+- distance bands／service areas。
+- matched targets。
+- hotspot highlight。
+- legend、method、data timestamp。
+- clear／replace previous analysis。
+
+---
+
+## 9. 第一條垂直案例：污染源 × 農地／魚塭
+
+### 9.1 使用者問題
+
+> 顯示污染源和一公里內的魚塭，找出最明顯的地區。
+
+### 9.2 執行流程
+
+1. `pulse_search_layers` 找污染源與魚塭 layer ID。
+2. `pulse_get_layer_details` 驗證資料日期、geometry、欄位與可用範圍。
+3. `pulse_analyze_proximity` 使用 500／1,000／3,000 公尺距離帶。
+4. PostGIS 用 `ST_DWithin` + GiST index 找候選；需要面積時再算 intersection area。
+5. 依命中數、魚塭面積或風險分數排名 hotspot。
+6. 分析 API 回傳 aggregate、top N、bbox、simplified result reference、method 與 warnings。
+7. `pulse_render_analysis` 建立 MapScene。
+8. 網站開啟來源／目標／結果 overlay，自動 fit bounds。
+9. `pulse_capture_view` 驗證圖層、legend 與畫面清晰度。
+10. Agent 回答數字、資料時間、方法與限制。
+
+### 9.3 語意限制
+
+- 距離分析只代表 proximity／exposure screening。
+- 不得直接推論污染因果。
+- 若要討論傳播，必須另納入污染物種類、時間、風向、水系、地形或地下水。
+- count 應使用穩定實體 ID 去重，不可直接數 vector tile fragment。
+
+---
+
+## 10. 分階段實作
+
+### Phase 0 — Repo 與契約（MCP-00～04）
+
+| ID | 工作 | Repo | 驗收 |
+|---|---|---|---|
+| MCP-00 | 建立 `mini-pulse-gis-mcp` repo、TypeScript、lint/test/build | 新 repo | clean install + build 綠 |
+| MCP-01 | 定義 command envelope、MapScene、MapCommandResult、版本策略 | 新 repo + pulse | 兩端 contract tests 綠 |
+| MCP-02 | 建立 stdio MCP server 與 health tool | 新 repo | MCP Inspector 可連線 |
+| MCP-03 | 建立 localhost WebSocket server、token、Origin、timeout | 新 repo | unauthorized connection 被拒絕 |
+| MCP-04 | Claude Code 專案設定與開發 runbook | 新 repo | 新環境照文件可啟動 |
+
+Phase 0 完成定義：MCP Inspector 能連 server；瀏覽器尚未控制地圖也可以正確回報「無 active session」。
+
+### Phase 1 — 地圖控制 MVP（MCP-10～16）
+
+| ID | 工作 | Repo | 驗收 |
+|---|---|---|---|
+| MCP-10 | 現有 MapBridge 收斂成有回執的 MapController | pulse | BYOK chat 行為零退化 |
+| MCP-11 | AgentBridge handshake / reconnect / session selector | pulse | reload 後自動重連 |
+| MCP-12 | `pulse_search_layers`、`pulse_get_layer_details` | 兩端 | 結果由 manifest 產生 |
+| MCP-13 | `pulse_get_map_state` | 兩端 | 回傳 actual state + revision |
+| MCP-14 | `pulse_apply_scene` | 兩端 | atomic、冪等、gate denial 可見 |
+| MCP-15 | `pulse_capture_view` | 兩端 | screenshot + render summary |
+| MCP-16 | deterministic embed URL fallback | 兩端 | 無 active tab 時仍可產生 URL |
+
+Phase 1 成功情境：
+
+> 「打開魚塭圖層，移動到高雄沿海。」
+
+Claude Code 必須能完成操作、讀回狀態，且使用者在已開啟的頁面看到同步結果。
+
+### Phase 2 — Proximity 分析（MCP-20～26）
+
+| ID | 工作 | Repo | 驗收 |
+|---|---|---|---|
+| MCP-20 | 定義 proximity RPC contract 與資料語意 | analytics / platform | handoff 完整 |
+| MCP-21 | PostGIS RPC、GiST index、timeout／row limit | gis-platform | EXPLAIN + 固定 fixture 正確 |
+| MCP-22 | `pulse_analyze_proximity` tool | MCP | structured output + warnings |
+| MCP-23 | analysis result overlay | pulse | 可清除、可替換、不污染 source |
+| MCP-24 | hotspot ranking + recommended camera | platform / MCP | fixture 排名穩定 |
+| MCP-25 | `pulse_render_analysis` closed loop | 兩端 | render 後 read-back 成功 |
+| MCP-26 | Pollution × agriculture Skill | MCP repo | 真實題目走查通過 |
+
+跨 repo 順序遵守既有規則：上游資料／handoff → `gis-platform` RPC → `mini-pulse-gis-mcp` tool → `mini-taiwan-pulse` 呈現。
+
+### Phase 3 — Storytelling 與擴充分析（MCP-30～35）
+
+| ID | 工作 |
+|---|---|
+| MCP-30 | `MapStory = MapScene[]` schema、step narration、citations |
+| MCP-31 | proximity／overlap／accessibility workflow tools |
+| MCP-32 | Story preview、save、share／embed URL |
+| MCP-33 | OSM 固定日期 PBF → PostGIS／pgRouting |
+| MCP-34 | progress、cancel、long-running analysis job |
+| MCP-35 | 10 題以上 MCP evaluation suite |
+
+---
+
+## 11. 安全要求
+
+### 11.1 Local bridge
+
+- 只 bind `127.0.0.1`，禁止預設監聽 `0.0.0.0`。
+- 每次啟動產生高 entropy session token。
+- 驗證 WebSocket Origin。
+- 使用者明確選定 active tab；不可廣播控制所有開啟頁面。
+- MCP stdio stdout 只輸出 protocol，log 一律寫 stderr。
+
+### 11.2 Tool／資料
+
+- 不暴露任意 SQL、JS、shell、filesystem path 或任意 URL fetch。
+- 所有 layer ID、RPC、filter field、aggregation 都走 allowlist。
+- DB 使用 read-only／anon 可用的薄 RPC；加 statement timeout 與結果上限。
+- feature query 強制 bbox、limit/cursor、欄位投影。
+- 大 geometry 只回 simplified feature 或 tile reference。
+- 敏感／owner-gated layer 由網站做最終 permission check，MCP 不得繞過。
+
+### 11.3 Audit
+
+每次 tool call 至少記錄：
+
+- correlation ID／command ID。
+- tool name 與 validated params。
+- map state revision before／after。
+- applied／denied／warnings。
+- dataset IDs、版本／時間、分析參數。
+- RPC 名稱、latency、result count；不得記 credential。
+
+---
+
+## 12. 測試與驗收
+
+### 12.1 測試層級
+
+| 層級 | 內容 |
+|---|---|
+| Contract | command／result schema、protocol version、unknown field |
+| MCP unit | tool input validation、pagination、error message、annotations |
+| Bridge integration | auth、reconnect、timeout、wrong revision、no active session |
+| Frontend | MapController 對 visibility／params／time store 的真實 read-back |
+| Spatial truth | 已知 point/polygon fixture 的距離、intersection、去重 |
+| E2E | Claude／Inspector → MCP → browser → screenshot closed loop |
+| Evaluation | 10 個獨立、唯讀、可驗證、穩定的真實問題 |
+
+### 12.2 Phase 1 Definition of Done
+
+- Claude Code 能發現 v0 tools。
+- 能搜尋圖層、套用 scene、讀回實際狀態。
+- locked layer 會回 `denied`，不會假成功。
+- 沒有開網頁時回明確錯誤或 deterministic embed URL。
+- 頁面 reload 能重連，不需要重啟 Claude Code。
+- 既有 BYOK chat、URL state、embed 行為零退化。
+- TypeScript build、現有 tests、MCP Inspector 與 browser E2E 全綠。
+
+### 12.3 Phase 2 Definition of Done
+
+- 污染源 × 魚塭／農地的固定 fixture 有可驗證答案。
+- 正式統計不依賴 `queryRenderedFeatures`。
+- 結果包含資料時間、距離模型、參數、count／area、warnings。
+- 地圖能呈現來源、距離帶、命中目標與 hotspot。
+- Agent 能自動 fit 到清楚的區域並以 screenshot 驗證。
+- 回答明確區分 proximity 與 causality。
+
+---
+
+## 13. 主要風險
+
+| 風險 | 對策 |
+|---|---|
+| MCP 與 frontend schema 漂移 | 單一 contract SSOT + generated schema + CI compatibility test |
+| Tool 說成功但 UI 沒改 | mutation 必須 read-back actual state |
+| 使用者操作與 Agent 互相覆蓋 | map revision + optimistic concurrency |
+| 巨量 GeoJSON 灌爆 context／browser | aggregate、top N、simplify、vector tile |
+| 任意 code execution | 完全不提供 `execute_js`／任意 SQL，typed allowlisted tools |
+| 多個 tab 控錯畫面 | session picker + explicit active session |
+| 分析被誤解為因果 | Skill、tool output 與 UI 固定加入方法／限制 |
+| 公共 Overpass 被大量查詢 | 正式環境改用固定日期本地 OSM PBF |
+
+---
+
+## 14. 待拍板決策
+
+| ID | 問題 | 建議 |
+|---|---|---|
+| D1 | 新 repo 名稱 | `mini-pulse-gis-mcp`（已拍板） |
+| D2 | 跨 repo contract SSOT | MCP repo 保存 Zod/JSON Schema；pulse 使用 generated artifact 或版本化 package，開工前定案 |
+| D3 | localhost WebSocket port | 支援 config／自動探測，不硬寫單一 port |
+| D4 | screenshot 實作 | 優先使用既有 browser runtime capture；若受 Mapbox canvas 限制再加瀏覽器自動化 fallback |
+| D5 | 第一個污染源 dataset | 開工前依授權、時間、geometry、欄位完整性選定 |
+| D6 | 第一個目標層 | 建議魚塭 + 農地各一，先做一個、第二個驗證泛化性 |
+
+---
+
+## 15. 建議下一步
+
+先開一個只做地基的小 PR／session，不碰空間分析：
+
+1. 建立 sibling repo `mini-pulse-gis-mcp`。
+2. 定案 D2 contract SSOT。
+3. 完成 MCP-00～04。
+4. 在 Mini Taiwan Pulse 將 `MapBridge` 改成有 structured acknowledgement 的 `MapController`。
+5. 只做 `pulse_get_map_state` 與 `pulse_apply_scene` 的端到端閉環。
+6. 確認「開魚塭圖層並移動鏡頭」穩定後，再進 Phase 2 SQL／PostGIS。
+
+這個順序先證明控制鏈可靠，避免同時 debug MCP、WebSocket、React state 與空間 SQL。
+
+---
+
+## 16. 參考資料
+
+- [MCP Architecture](https://modelcontextprotocol.io/specification/2026-07-28/architecture)
+- [MCP stdio transport](https://modelcontextprotocol.io/specification/2026-07-28/basic/transports/stdio)
+- [MCP Tools](https://modelcontextprotocol.io/specification/2026-07-28/server/tools)
+- [Build with Agent Skills](https://modelcontextprotocol.io/docs/2026-07-28/develop/build-with-agent-skills)
+- [Blender MCP](https://github.com/ahujasid/blender-mcp)
+- [Anthropic Computer Use](https://platform.claude.com/docs/en/agents-and-tools/tool-use/computer-use-tool)
+- [Mapbox queryRenderedFeatures example](https://docs.mapbox.com/mapbox-gl-js/example/queryrenderedfeatures-around-point/)
+- [PostGIS ST_DWithin](https://postgis.net/docs/ST_DWithin.html)
+- [PostGIS proximity query guidance](https://postgis.net/documentation/tips/st-dwithin/)
+- [OpenStreetMap Overpass API](https://wiki.openstreetmap.org/wiki/Overpass_API)
+- [osm2pgsql manual](https://osm2pgsql.org/doc/manual.html)

--- a/src/components/TimeseriesSparkline.tsx
+++ b/src/components/TimeseriesSparkline.tsx
@@ -1,5 +1,5 @@
-import { useLayoutEffect, useMemo, useRef, useState } from "react";
-import { COLORS, FONT_SIZE } from "../styles/designTokens";
+import { useLayoutEffect, useMemo, useRef, useState, type MouseEvent as ReactMouseEvent } from "react";
+import { COLORS, FONT_SIZE, SURFACE, BORDER, RADIUS, WHITE_ALPHA } from "../styles/designTokens";
 
 /**
  * 24h SVG sparkline — Y 軸刻度 + 警戒線 + X 軸 6/12/18h tick
@@ -34,6 +34,84 @@ export interface TimeseriesSparklineProps {
    * 避免把「缺快照」讀成真實低谷。不傳 = 原行為（一路連線）。
    */
   gapSec?: number;
+  /**
+   * 第二條線（opt-in，與主線共用同一個 Y 軸）。Y 軸值域會把兩條線一起納入計算，
+   * gapSec 斷線邏輯同樣套用在這條線上。不傳 = 行為與現在完全相同。
+   */
+  extraSeries?: { data: SparklinePoint[]; color: string; label?: string };
+  /** 主線在 tooltip 中的標籤（搭配 extraSeries 使用時用來區分兩條線）；不傳則 tooltip 只顯示色點 + 數值 */
+  seriesLabel?: string;
+  /**
+   * 是否開啟 hover tooltip（opt-in，預設 false）：滑鼠移動時依 X 座標找最近資料點，
+   * 畫垂直指示線 + 資料點圓點 + tooltip（日期 + 數值，有 extraSeries 時兩條線都列出）。
+   */
+  showTooltip?: boolean;
+  /** tooltip 日期格式："datetime"（預設，月/日 時:分）或 "date"（只顯示月/日，適合每日一點的資料） */
+  tooltipDateFormat?: "date" | "datetime";
+  /** Y 軸刻度是否強制縮寫成 50k 這種格式（五位數以上數值避免擠爆）；預設 false = 沿用原本依 step 判斷的縮寫規則 */
+  compactYAxis?: boolean;
+}
+
+/**
+ * 主線 + extraSeries（如有）的 Y 值域合併計算（純函式，可獨立單元測試）。
+ * 抽出以確保「不傳 extraSeries」時與過去逐位元等價 —— data-only 分支完全複製舊有算法。
+ */
+export function computeCombinedYRange(
+  data: SparklinePoint[],
+  extraData?: SparklinePoint[],
+  warningValue?: number | null,
+): { vMin: number; vMax: number } | null {
+  if (data.length === 0) return null;
+  const vals = data.map((d) => d.v);
+  if (extraData && extraData.length > 0) vals.push(...extraData.map((d) => d.v));
+  let vMin = Math.min(...vals);
+  let vMax = Math.max(...vals);
+  if (warningValue != null) {
+    vMin = Math.min(vMin, warningValue);
+    vMax = Math.max(vMax, warningValue);
+  }
+  return { vMin, vMax };
+}
+
+/** 缺口分段（沿用主線舊邏輯，抽出後主線與 extraSeries 共用） */
+function buildSegments(points: SparklinePoint[], gapSec?: number): SparklinePoint[][] {
+  if (points.length === 0) return [];
+  const segments: SparklinePoint[][] = [];
+  let cur: SparklinePoint[] = [];
+  for (const d of points) {
+    if (cur.length > 0 && gapSec != null && d.t - cur[cur.length - 1]!.t > gapSec) {
+      segments.push(cur);
+      cur = [];
+    }
+    cur.push(d);
+  }
+  segments.push(cur);
+  return segments;
+}
+
+/** 單一 segment → polyline points / area path（baseY 不傳則不算 areaPath，供 extraSeries 用） */
+function buildSegView(
+  seg: SparklinePoint[],
+  xScale: (t: number) => number,
+  yScale: (v: number) => number,
+  baseY?: string,
+) {
+  const pts = seg.map((d) => `${xScale(d.t).toFixed(1)},${yScale(d.v).toFixed(1)}`).join(" ");
+  const areaPath =
+    baseY != null
+      ? `M${xScale(seg[0]!.t).toFixed(1)},${baseY} ` +
+        `L${pts.split(" ").join(" L")} ` +
+        `L${xScale(seg[seg.length - 1]!.t).toFixed(1)},${baseY} Z`
+      : undefined;
+  return { pts, areaPath, single: seg.length === 1, first: seg[0]! };
+}
+
+/** tooltip 日期格式化："date" 只顯示月/日（例 8/16）；"datetime" 另加時:分 */
+function fmtTooltipDate(t: number, format: "date" | "datetime"): string {
+  const d = new Date(t * 1000);
+  const md = `${d.getMonth() + 1}/${d.getDate()}`;
+  if (format === "date") return md;
+  return `${md} ${d.getHours().toString().padStart(2, "0")}:${d.getMinutes().toString().padStart(2, "0")}`;
 }
 
 const DEFAULT_W = 256;  // fallback 寬（量到容器實際寬度前使用），原配 popup 280 寬扣 padding
@@ -65,8 +143,8 @@ function niceTicks(min: number, max: number, count = 3): number[] {
  * Y 軸刻度格式：依刻度步距決定精度（step ≥ 1 → 整數；千級 → k 縮寫），
  * 修掉人數類量出現「0.00」的違和小數。
  */
-function fmtTick(v: number, step: number): string {
-  if (Math.abs(v) >= 1000 && step >= 1000) {
+function fmtTick(v: number, step: number, forceCompact = false): string {
+  if (Math.abs(v) >= 1000 && (forceCompact || step >= 1000)) {
     const kv = v / 1000;
     return `${Number.isInteger(kv) ? kv : +kv.toFixed(1)}k`;
   }
@@ -82,6 +160,16 @@ function fmtValue(v: number): string {
   return v.toFixed(2);
 }
 
+/**
+ * tooltip 數值格式：四位數以上補千分位、單位前留空格（% 除外），
+ * 對齊卡片其他數字的既有呈現（例：供電能力 49,496 MW / 備轉 22.2%）。
+ */
+function fmtTooltipValue(v: number, unit: string): string {
+  const num = Math.abs(v) >= 1000 ? Math.round(v).toLocaleString("en-US") : fmtValue(v);
+  if (!unit) return num;
+  return unit === "%" ? `${num}${unit}` : `${num} ${unit}`;
+}
+
 export function TimeseriesSparkline({
   data,
   unit = "",
@@ -92,9 +180,15 @@ export function TimeseriesSparkline({
   height = 120,
   fillArea = true,
   gapSec,
+  extraSeries,
+  seriesLabel,
+  showTooltip = false,
+  tooltipDateFormat = "datetime",
+  compactYAxis = false,
 }: TimeseriesSparklineProps) {
   const wrapRef = useRef<HTMLDivElement>(null);
   const [w, setW] = useState(DEFAULT_W);
+  const [hoverIdx, setHoverIdx] = useState<number | null>(null);
 
   useLayoutEffect(() => {
     const el = wrapRef.current;
@@ -116,14 +210,8 @@ export function TimeseriesSparkline({
     if (data.length === 0) return null;
     const tMin = data[0]!.t;
     const tMax = data[data.length - 1]!.t;
-    const vals = data.map((d) => d.v);
-    let vMin = Math.min(...vals);
-    let vMax = Math.max(...vals);
-    // 把警戒線也納入 y 範圍，否則警戒線可能跑出畫面
-    if (warningValue != null) {
-      vMin = Math.min(vMin, warningValue);
-      vMax = Math.max(vMax, warningValue);
-    }
+    // Y 值域把 extraSeries（如有）與警戒線一起納入，否則第二條線／警戒線可能跑出畫面
+    const { vMin, vMax } = computeCombinedYRange(data, extraSeries?.data, warningValue)!;
     // 給 vMax 留 10% 空間，避免最高點貼頂
     const pad = (vMax - vMin) * 0.1 || Math.max(Math.abs(vMax), 1) * 0.1;
     // 資料全非負（人數/雨量/水深…）→ y 下界 clamp 到 0，不長出負值刻度
@@ -136,27 +224,13 @@ export function TimeseriesSparkline({
     const yScale = (v: number) =>
       yHi === yLo ? PAD_T : PAD_T + (1 - (v - yLo) / (yHi - yLo)) * (height - PAD_T - PAD_B);
 
-    // 缺口分段：相鄰點時距 > gapSec → 斷線（不跨接），避免缺快照被讀成低谷
-    const segments: SparklinePoint[][] = [];
-    let cur: SparklinePoint[] = [];
-    for (const d of data) {
-      if (cur.length > 0 && gapSec != null && d.t - cur[cur.length - 1]!.t > gapSec) {
-        segments.push(cur);
-        cur = [];
-      }
-      cur.push(d);
-    }
-    segments.push(cur);
-
+    // 缺口分段：相鄰點時距 > gapSec → 斷線（不跨接），避免缺快照被讀成低谷（extraSeries 套同一條規則）
     const baseY = (height - PAD_B).toFixed(1);
-    const segViews = segments.map((seg) => {
-      const pts = seg.map((d) => `${xScale(d.t).toFixed(1)},${yScale(d.v).toFixed(1)}`).join(" ");
-      const areaPath =
-        `M${xScale(seg[0]!.t).toFixed(1)},${baseY} ` +
-        `L${pts.split(" ").join(" L")} ` +
-        `L${xScale(seg[seg.length - 1]!.t).toFixed(1)},${baseY} Z`;
-      return { pts, areaPath, single: seg.length === 1, first: seg[0]! };
-    });
+    const segViews = buildSegments(data, gapSec).map((seg) => buildSegView(seg, xScale, yScale, baseY));
+    const extraSegViews = extraSeries
+      ? buildSegments(extraSeries.data, gapSec).map((seg) => buildSegView(seg, xScale, yScale))
+      : [];
+    const extraByT = extraSeries ? new Map(extraSeries.data.map((d) => [d.t, d.v])) : undefined;
 
     // X 軸時間 tick：≤48h 取整點（local）、步距 1/2/4/8h；>48h 取日界 00:00、
     // 步距 1/2/4/7 天、標籤 M/D（8h 步距在多日範圍會生出數十個 tick 疊成字牆）
@@ -194,8 +268,29 @@ export function TimeseriesSparkline({
       }
     }
 
-    return { tMin, tMax, yLo, yHi, ticks, tickStep, xScale, yScale, segViews, timeTicks };
-  }, [data, warningValue, height, w, gapSec]);
+    return { tMin, tMax, yLo, yHi, ticks, tickStep, xScale, yScale, segViews, extraSegViews, extraByT, timeTicks };
+  }, [data, warningValue, height, w, gapSec, extraSeries]);
+
+  function handleMouseMove(e: ReactMouseEvent<SVGSVGElement>) {
+    if (!showTooltip || !view || data.length === 0) return;
+    const rect = e.currentTarget.getBoundingClientRect();
+    if (rect.width === 0) return;
+    const xViewBox = ((e.clientX - rect.left) / rect.width) * w;
+    let bestI = 0;
+    let bestD = Infinity;
+    for (let i = 0; i < data.length; i++) {
+      const d = Math.abs(view.xScale(data[i]!.t) - xViewBox);
+      if (d < bestD) {
+        bestD = d;
+        bestI = i;
+      }
+    }
+    setHoverIdx(bestI);
+  }
+
+  function handleMouseLeave() {
+    setHoverIdx(null);
+  }
 
   if (data.length === 0 || !view) {
     return (
@@ -219,6 +314,8 @@ export function TimeseriesSparkline({
         height={height}
         viewBox={`0 0 ${w} ${height}`}
         style={{ display: "block", marginTop: 4 }}
+        onMouseMove={showTooltip ? handleMouseMove : undefined}
+        onMouseLeave={showTooltip ? handleMouseLeave : undefined}
       >
         {/* Y 軸 grid + tick label */}
         {view.ticks.map((tv) => {
@@ -241,7 +338,7 @@ export function TimeseriesSparkline({
                 fill="rgba(255,255,255,0.5)"
                 fontFamily="monospace"
               >
-                {fmtTick(tv, view.tickStep)}
+                {fmtTick(tv, view.tickStep, compactYAxis)}
               </text>
             </g>
           );
@@ -311,6 +408,39 @@ export function TimeseriesSparkline({
           fill={lineColor}
         />
 
+        {/* 第二條線（extraSeries，opt-in；依缺口分段，同主線邏輯但不填色） */}
+        {extraSeries &&
+          view.extraSegViews.map((sv, i) =>
+            sv.single ? (
+              <circle
+                key={`es-${i}`}
+                cx={view.xScale(sv.first.t)}
+                cy={view.yScale(sv.first.v)}
+                r={1.6}
+                fill={extraSeries.color}
+              />
+            ) : (
+              <polyline
+                key={`es-${i}`}
+                data-testid="sparkline-extra-line"
+                points={sv.pts}
+                fill="none"
+                stroke={extraSeries.color}
+                strokeWidth={1.4}
+                strokeLinejoin="round"
+                strokeLinecap="round"
+              />
+            ),
+          )}
+        {extraSeries && extraSeries.data.length > 0 && (
+          <circle
+            cx={view.xScale(extraSeries.data[extraSeries.data.length - 1]!.t)}
+            cy={view.yScale(extraSeries.data[extraSeries.data.length - 1]!.v)}
+            r={2.2}
+            fill={extraSeries.color}
+          />
+        )}
+
         {/* X 軸時間 tick（貼邊者換錨點避免裁切） */}
         {view.timeTicks.map((tk, i) => (
           <text
@@ -339,6 +469,79 @@ export function TimeseriesSparkline({
             {unit}
           </text>
         )}
+
+        {/* Hover tooltip（opt-in）：指示線 + 資料點圓點 + 日期/數值 box，靠邊翻轉避免被裁掉 */}
+        {showTooltip &&
+          view &&
+          hoverIdx != null &&
+          hoverIdx < data.length &&
+          (() => {
+            const hp = data[hoverIdx]!;
+            const x = view.xScale(hp.t);
+            const yMain = view.yScale(hp.v);
+            const extraV = view.extraByT?.get(hp.t);
+            const yExtra = extraV != null ? view.yScale(extraV) : null;
+
+            const lines: { text: string; dot?: string }[] = [
+              { text: fmtTooltipDate(hp.t, tooltipDateFormat) },
+              { text: `${seriesLabel ? seriesLabel + " " : ""}${fmtTooltipValue(hp.v, unit)}`, dot: lineColor },
+            ];
+            if (extraSeries && extraV != null) {
+              lines.push({
+                text: `${extraSeries.label ? extraSeries.label + " " : ""}${fmtTooltipValue(extraV, unit)}`,
+                dot: extraSeries.color,
+              });
+            }
+
+            const charW = 5;
+            const boxW = Math.max(...lines.map((l) => l.text.length)) * charW + 18;
+            const lineH = 11;
+            const boxH = lines.length * lineH + 8;
+            const gap = 6;
+
+            let boxX = x + gap;
+            if (boxX + boxW > w - PAD_R) boxX = x - gap - boxW;
+            boxX = Math.max(PAD_L, Math.min(boxX, w - PAD_R - boxW));
+
+            const topY = yExtra != null ? Math.min(yMain, yExtra) : yMain;
+            const bottomY = yExtra != null ? Math.max(yMain, yExtra) : yMain;
+            let boxY = topY - gap - boxH;
+            if (boxY < PAD_T) boxY = bottomY + gap;
+            boxY = Math.max(PAD_T, Math.min(boxY, height - PAD_B - boxH));
+
+            return (
+              <g data-testid="sparkline-tooltip" pointerEvents="none">
+                <line
+                  x1={x} x2={x} y1={PAD_T} y2={height - PAD_B}
+                  stroke={WHITE_ALPHA[20]} strokeWidth={1} strokeDasharray="2 2"
+                />
+                <circle cx={x} cy={yMain} r={2.6} fill={lineColor} stroke={SURFACE.solid} strokeWidth={1} />
+                {yExtra != null && (
+                  <circle cx={x} cy={yExtra} r={2.6} fill={extraSeries!.color} stroke={SURFACE.solid} strokeWidth={1} />
+                )}
+                <rect
+                  x={boxX} y={boxY} width={boxW} height={boxH}
+                  rx={RADIUS.md} fill={SURFACE.solid} stroke={BORDER.panel} strokeWidth={1}
+                />
+                {lines.map((l, i) => (
+                  <g key={i}>
+                    {l.dot && (
+                      <circle cx={boxX + 8} cy={boxY + 4 + i * lineH + lineH / 2} r={2} fill={l.dot} />
+                    )}
+                    <text
+                      x={boxX + (l.dot ? 14 : 6)}
+                      y={boxY + 4 + i * lineH + lineH / 2 + 3}
+                      fontSize={8}
+                      fill={i === 0 ? COLORS.textStrong : COLORS.textDefault}
+                      fontFamily="monospace"
+                    >
+                      {l.text}
+                    </text>
+                  </g>
+                ))}
+              </g>
+            );
+          })()}
       </svg>
     </div>
   );

--- a/src/components/__tests__/TimeseriesSparkline.test.ts
+++ b/src/components/__tests__/TimeseriesSparkline.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from "vitest";
+import { computeCombinedYRange, type SparklinePoint } from "../TimeseriesSparkline";
+
+/**
+ * TimeseriesSparkline 的 Y 值域計算是 view useMemo 內唯一被抽成純函式的部分
+ * （其餘為 SVG geometry / hover 狀態，需要 DOM 才能渲染，此專案 vitest 環境是
+ * `environment: "node"` 且只 include `*.test.ts`，不接 jsdom/testing-library，
+ * 沿用 `src/data/__tests__/layerGoldenExtract.ts` 的既有做法：測純函式而非 SSR 渲染）。
+ *
+ * 驗兩件事：
+ * 1. 不傳 extraSeries 時，計算結果與過去「只用 data 算 min/max」逐位元等價
+ *    （PowerCard 既有的備轉率圖、AirportPaxCard、ERCard 都是這個分支，不可變動）。
+ * 2. 傳 extraSeries 時，值域必須涵蓋兩條線（否則第二條線會超出畫布，正是本次驗收要求）。
+ */
+describe("computeCombinedYRange", () => {
+  const data: SparklinePoint[] = [
+    { t: 1, v: 10 },
+    { t: 2, v: 30 },
+    { t: 3, v: 20 },
+  ];
+
+  it("no extraSeries: 與過去「只用 data 算 min/max」的算法逐位元等價", () => {
+    const result = computeCombinedYRange(data);
+    expect(result).toEqual({ vMin: 10, vMax: 30 });
+  });
+
+  it("no extraSeries + warningValue: 警戒線一起納入值域（既有行為）", () => {
+    const result = computeCombinedYRange(data, undefined, 5);
+    expect(result).toEqual({ vMin: 5, vMax: 30 });
+    const result2 = computeCombinedYRange(data, undefined, 999);
+    expect(result2).toEqual({ vMin: 10, vMax: 999 });
+  });
+
+  it("empty data: 回傳 null（既有行為，元件據此顯示「無讀值」）", () => {
+    expect(computeCombinedYRange([])).toBeNull();
+  });
+
+  it("extraSeries 值超出主線範圍時，值域必須涵蓋兩條線", () => {
+    const extra: SparklinePoint[] = [
+      { t: 1, v: -5 },   // 低於主線 min (10)
+      { t: 2, v: 100 },  // 高於主線 max (30)
+      { t: 3, v: 40 },
+    ];
+    const result = computeCombinedYRange(data, extra);
+    expect(result).toEqual({ vMin: -5, vMax: 100 });
+  });
+
+  it("extraSeries 全落在主線範圍內：值域仍等於主線 min/max（不會因為併入計算而變寬）", () => {
+    const extra: SparklinePoint[] = [
+      { t: 1, v: 15 },
+      { t: 2, v: 25 },
+    ];
+    const result = computeCombinedYRange(data, extra);
+    expect(result).toEqual({ vMin: 10, vMax: 30 });
+  });
+
+  it("extraSeries 為空陣列：等同不傳（不應污染值域，例如變成 0 起跳）", () => {
+    const result = computeCombinedYRange(data, []);
+    expect(result).toEqual({ vMin: 10, vMax: 30 });
+  });
+
+  it("extraSeries + warningValue 同時作用：三者一起納入值域", () => {
+    const extra: SparklinePoint[] = [{ t: 1, v: 200 }];
+    const result = computeCombinedYRange(data, extra, -50);
+    expect(result).toEqual({ vMin: -50, vMax: 200 });
+  });
+});

--- a/src/components/intel/monitor/HazardCards.tsx
+++ b/src/components/intel/monitor/HazardCards.tsx
@@ -20,7 +20,7 @@ import { SectionLabel } from "./PressureRing";
 import { HazardTrendBars, type HazardBar } from "./HazardTrendBars";
 import {
   fetchTyphoonProximityDaily, fetchTyphoonSummary, invalidateTyphoonSummary,
-  type TyphoonSummary,
+  type TyphoonProximityDay, type TyphoonSummary,
 } from "../../../data/typhoonTracksLoader";
 import {
   fetchEarthquakeDaily, fetchEarthquakeSummary, invalidateEarthquakeSummary,
@@ -237,6 +237,89 @@ function proximityHeight(km: number | null): number | null {
   return Math.max(0, PROXIMITY_CEIL_KM - km);
 }
 
+/**
+ * 45 天接近程度趨勢柱（兩排）＋ 點柱展開明細 —— 有活躍颱風／無活躍颱風兩條路徑
+ * 共用同一份 render。RPC 349 的設計初衷就是回答「這段期間有沒有颱風靠近」，
+ * 無颱風時才是最該看它的時候，因此兩條路徑都要能畫、都要能點展開（見檔頭 bug 說明）。
+ */
+function TyphoonTrendSection({
+  days, pickedDate, onSelectBar,
+}: {
+  days: TyphoonProximityDay[];
+  pickedDate: string | null;
+  onSelectBar: (b: HazardBar) => void;
+}) {
+  const distBars: HazardBar[] = days.map((d) => ({
+    key: d.dateKey,
+    label: d.dateKey.slice(5).replace("-", "/"),
+    value: proximityHeight(d.nearestKm),
+    level: proximityLevel(d.nearestKm),
+    note: d.nearestKm == null
+      ? "無觀測"
+      : `${d.name ?? d.stormId ?? "—"} ${Math.round(d.nearestKm).toLocaleString("zh-TW")} km`
+        + (d.windKt != null ? ` · ${d.windKt} kt` : ""),
+  }));
+  const nearbyBars: HazardBar[] = days.map((d) => ({
+    key: d.dateKey,
+    label: d.dateKey.slice(5).replace("-", "/"),
+    value: d.stormsNearby,
+    level: Math.min(d.stormsNearby, 2),
+    note: `${d.stormsNearby} 顆在 1000km 內`,
+  }));
+  const picked = pickedDate != null ? days.find((d) => d.dateKey === pickedDate) ?? null : null;
+  const closestKm = days.reduce<number | null>(
+    (m, d) => (d.nearestKm != null && (m == null || d.nearestKm < m) ? d.nearestKm : m), null,
+  );
+  return (
+    <>
+      {/* 上排：接近程度。柱高刻意反轉（越近越高）—— 直接用距離當柱高的話，
+          颱風在地球另一邊時柱子最高，與「該不該緊張」完全相反 */}
+      <HazardTrendBars
+        bars={distBars}
+        levelColors={PROXIMITY_COLORS}
+        caption={`${TYPHOON_TREND_DAYS}D · 接近程度（柱越高越近）／距離（色）· 可點`}
+        footer={closestKm != null ? `最近 ${Math.round(closestKm).toLocaleString("zh-TW")} km` : undefined}
+        height={34}
+        unit=" km（距 1500 圈）"
+        onSelectBar={onSelectBar}
+        selectedKey={pickedDate}
+      />
+      {/* 下排：顆數。JMA/JTWC 同一顆有兩套編號，RPC 349 已跨來源去重 */}
+      <HazardTrendBars
+        bars={nearbyBars}
+        levelColors={NEARBY_COLORS}
+        caption={`${TYPHOON_TREND_DAYS}D · 1000km 內颱風數`}
+        height={26}
+        unit=" 顆"
+        onSelectBar={onSelectBar}
+        selectedKey={pickedDate}
+      />
+      {/* 點某一天展開那天是哪顆 —— 兩排圖只看得出「有沒有／幾顆」，看不出是誰 */}
+      {picked && (
+        <div style={{ display: "flex", flexDirection: "column", gap: 2 }}>
+          <Note color={COLORS.textDefault}>
+            {picked.dateKey.slice(5).replace("-", "/")} ·{" "}
+            {picked.stormsNearby > 0
+              ? `${picked.stormsNearby} 顆在 1000km 內`
+              : picked.nearestKm == null
+                ? "當天無颱風觀測"
+                : `無颱風在 1000km 內（最近 ${picked.name ?? "—"} `
+                  + `${Math.round(picked.nearestKm).toLocaleString("zh-TW")} km）`}
+          </Note>
+          {/* 一顆一行 —— 說「2 顆」卻只列得出最近那顆，另一顆是誰看不到 */}
+          {picked.nearby.map((n) => (
+            <MetaRow
+              key={n.stormId}
+              left={`· ${n.name}`}
+              right={`${Math.round(n.km).toLocaleString("zh-TW")} km${n.kt != null ? ` · ${n.kt} kt` : ""}`}
+            />
+          ))}
+        </div>
+      )}
+    </>
+  );
+}
+
 export function TyphoonCard({ open, nowTs }: Props) {
   const { data, phase } = usePolledSummary<TyphoonSummary | null>(
     open, fetchTyphoonSummary, invalidateTyphoonSummary, 30 * 60_000, "[TyphoonCard]",
@@ -269,11 +352,19 @@ export function TyphoonCard({ open, nowTs }: Props) {
         dot={COLORS.textDim} title="活躍颱風（載入中）" footer={footer} />
     );
   }
+  const days = proximity ?? [];
+
   if (!data) {
+    // 無活躍颱風時，45 天趨勢柱照常畫（見檔頭 bug 說明：RPC 349 的設計初衷就是回答
+    // 「這段期間有沒有颱風靠近」，無颱風時才是最該看它的時候）。只有 45 天內完全
+    // 沒資料（RPC 失敗或窗內真的零觀測）才退回純一句話的空狀態。
     return (
       <HazardShell label={label} labelColor={COLORS.accent} tint={tint}
         dot={COLORS.statusLive} title="目前無活躍颱風" footer={footer}>
         <Note>JMA / JTWC 近 24 小時無颱風觀測回報。</Note>
+        {days.length > 0 && (
+          <TyphoonTrendSection days={days} pickedDate={pickedDate} onSelectBar={pickBar} />
+        )}
       </HazardShell>
     );
   }
@@ -281,31 +372,9 @@ export function TyphoonCard({ open, nowTs }: Props) {
   const tone = typhoonTone(data);
   const name = data.name_en || data.name_local || data.storm_id;
   const windMs = data.max_wind_kt != null ? Math.round(data.max_wind_kt * 0.514) : null;
-  const days = proximity ?? [];
   // 「活躍」只看近 24h 有觀測，東太平洋 10,000km 外的颱風也算活躍 —— 對台灣是零威脅，
   // 標題直說沒颱風接近，主數字仍留著（知道最近的一顆在哪還是有意義）
   const remote = data.distance_km > PROXIMITY_CEIL_KM;
-  const distBars: HazardBar[] = days.map((d) => ({
-    key: d.dateKey,
-    label: d.dateKey.slice(5).replace("-", "/"),
-    value: proximityHeight(d.nearestKm),
-    level: proximityLevel(d.nearestKm),
-    note: d.nearestKm == null
-      ? "無觀測"
-      : `${d.name ?? d.stormId ?? "—"} ${Math.round(d.nearestKm).toLocaleString("zh-TW")} km`
-        + (d.windKt != null ? ` · ${d.windKt} kt` : ""),
-  }));
-  const nearbyBars: HazardBar[] = days.map((d) => ({
-    key: d.dateKey,
-    label: d.dateKey.slice(5).replace("-", "/"),
-    value: d.stormsNearby,
-    level: Math.min(d.stormsNearby, 2),
-    note: `${d.stormsNearby} 顆在 1000km 內`,
-  }));
-  const picked = pickedDate != null ? days.find((d) => d.dateKey === pickedDate) ?? null : null;
-  const closestKm = days.reduce<number | null>(
-    (m, d) => (d.nearestKm != null && (m == null || d.nearestKm < m) ? d.nearestKm : m), null,
-  );
   return (
     <HazardShell
       label={label} labelColor={COLORS.accent} tint={tint}
@@ -320,50 +389,7 @@ export function TyphoonCard({ open, nowTs }: Props) {
           color={remote ? COLORS.textStrong : tone.distColor}
         />
       </MetricRow>
-      {/* 上排：接近程度。柱高刻意反轉（越近越高）—— 直接用距離當柱高的話，
-          颱風在地球另一邊時柱子最高，與「該不該緊張」完全相反 */}
-      <HazardTrendBars
-        bars={distBars}
-        levelColors={PROXIMITY_COLORS}
-        caption={`${TYPHOON_TREND_DAYS}D · 接近程度（柱越高越近）／距離（色）· 可點`}
-        footer={closestKm != null ? `最近 ${Math.round(closestKm).toLocaleString("zh-TW")} km` : undefined}
-        height={34}
-        unit=" km（距 1500 圈）"
-        onSelectBar={pickBar}
-        selectedKey={pickedDate}
-      />
-      {/* 下排：顆數。JMA/JTWC 同一顆有兩套編號，RPC 349 已跨來源去重 */}
-      <HazardTrendBars
-        bars={nearbyBars}
-        levelColors={NEARBY_COLORS}
-        caption={`${TYPHOON_TREND_DAYS}D · 1000km 內颱風數`}
-        height={26}
-        unit=" 顆"
-        onSelectBar={pickBar}
-        selectedKey={pickedDate}
-      />
-      {/* 點某一天展開那天是哪顆 —— 兩排圖只看得出「有沒有／幾顆」，看不出是誰 */}
-      {picked && (
-        <div style={{ display: "flex", flexDirection: "column", gap: 2 }}>
-          <Note color={COLORS.textDefault}>
-            {picked.dateKey.slice(5).replace("-", "/")} ·{" "}
-            {picked.stormsNearby > 0
-              ? `${picked.stormsNearby} 顆在 1000km 內`
-              : picked.nearestKm == null
-                ? "當天無颱風觀測"
-                : `無颱風在 1000km 內（最近 ${picked.name ?? "—"} `
-                  + `${Math.round(picked.nearestKm).toLocaleString("zh-TW")} km）`}
-          </Note>
-          {/* 一顆一行 —— 說「2 顆」卻只列得出最近那顆，另一顆是誰看不到 */}
-          {picked.nearby.map((n) => (
-            <MetaRow
-              key={n.stormId}
-              left={`· ${n.name}`}
-              right={`${Math.round(n.km).toLocaleString("zh-TW")} km${n.kt != null ? ` · ${n.kt} kt` : ""}`}
-            />
-          ))}
-        </div>
-      )}
+      <TyphoonTrendSection days={days} pickedDate={pickedDate} onSelectBar={pickBar} />
       {/* 右側刻意放 storm_id 而非 name_local —— JMA 的 name_local 是日文片假名
           （實測「ドルフィン」），單獨擺在小字列上像亂碼；storm_id 還能對照地圖層 */}
       <MetaRow

--- a/src/components/intel/monitor/MonitorPanel.tsx
+++ b/src/components/intel/monitor/MonitorPanel.tsx
@@ -58,7 +58,8 @@ import { useNewsFilter } from "../../../hooks/useNewsFilter";
 import {
   fetchPowerDashboard, invalidatePowerDashboard,
   fetchPowerGeneration24h, invalidatePowerGeneration24h,
-  type PowerDashboard, type PowerGenerationDay,
+  fetchPowerDailyTrend,
+  type PowerDashboard, type PowerGenerationDay, type PowerDailyTrendRow,
 } from "../../../data/energyLoader";
 
 const EMPTY_HEALTH: SourceHealthSummary = {
@@ -285,6 +286,7 @@ export function MonitorPanel({
   const [alertSeriesRows, setAlertSeriesRows] = useState<AlertSeriesPoint[]>([]);
   const [powerDashboard, setPowerDashboard] = useState<PowerDashboard | null>(null);
   const [powerDay, setPowerDay] = useState<PowerGenerationDay | null>(null);
+  const [powerTrend, setPowerTrend] = useState<PowerDailyTrendRow[]>([]);
   const [prisonLatest, setPrisonLatest] = useState<PrisonDay | null>(null);
 
   // 60s pressure + market + source health + trending（降載：TTL 已蓋住輪詢間隔）
@@ -338,6 +340,19 @@ export function MonitorPanel({
       window.clearInterval(idFast);
       window.clearInterval(idSlow);
     };
+  }, [open]);
+
+  // 30min Power daily trend（每日才變一次；PowerCard 為 timeline-isolated 卡片，不吃 currentTime）
+  useEffect(() => {
+    if (!open) return;
+    let alive = true;
+    const tick = () => {
+      fetchPowerDailyTrend().then((rows) => alive && setPowerTrend(rows))
+        .catch((e) => console.warn("[Monitor PowerDailyTrend]", e));
+    };
+    tick();
+    const id = window.setInterval(tick, 30 * 60_000);
+    return () => { alive = false; window.clearInterval(id); };
   }, [open]);
 
   // 30min Prison population (最新一筆，realtime.prison_population_daily PK=observed_date)
@@ -683,7 +698,7 @@ export function MonitorPanel({
     plaBoard: <PlaBoard open={open} />,
     foodPriceBoard: <FoodPriceBoard open={open} />,
     hazardStrip: <HazardWatchStrip />,
-    powerCard: <PowerCard dashboard={powerDashboard} day={powerDay} />,
+    powerCard: <PowerCard dashboard={powerDashboard} day={powerDay} trend={powerTrend} />,
     erCongestion: <ERCard open={open} />,
     prison: <PrisonCard latest={prisonLatest} />,
     airportPax: <AirportPaxCard open={open} />,

--- a/src/components/intel/monitor/PowerCard.tsx
+++ b/src/components/intel/monitor/PowerCard.tsx
@@ -2,11 +2,13 @@ import { useMemo } from "react";
 import { COLORS, FONT_CJK, FONT_DATA } from "../intelTokens";
 import { RADIUS, FONT_SIZE } from "../../../styles/designTokens";
 import { SectionLabel, Sparkline } from "./PressureRing";
+import { TimeseriesSparkline, type SparklinePoint } from "../../TimeseriesSparkline";
 import {
   RESERVE_INDICATOR_COLORS,
   RESERVE_INDICATOR_LABELS,
   type PowerDashboard,
   type PowerGenerationDay,
+  type PowerDailyTrendRow,
 } from "../../../data/energyLoader";
 import { fuelColorOf } from "../../../data/energyLoader";
 import { buildPowerCardModel, loadRateColor, summarisePowerKpis } from "./powerCardData";
@@ -14,14 +16,19 @@ import { buildPowerCardModel, loadRateColor, summarisePowerKpis } from "./powerC
 interface Props {
   dashboard: PowerDashboard | null;
   day: PowerGenerationDay | null;
+  /** 過去 30 天每日供電趨勢（RPC get_power_daily_trend）；卡片內獨立資料，與 timeline scrub 無關 */
+  trend: PowerDailyTrendRow[];
 }
+
+/** 一天 = 86400 秒；gapSec 給 1.5 天避免把單日缺快照的空隙誤畫成一路連線 */
+const TREND_GAP_SEC = 86400 * 1.5;
 
 function fmtMW(v: number | null | undefined): string {
   if (v == null) return "—";
   return v.toLocaleString("zh-TW", { maximumFractionDigits: 0 });
 }
 
-export function PowerCard({ dashboard, day }: Props) {
+export function PowerCard({ dashboard, day, trend }: Props) {
   const model = useMemo(() => buildPowerCardModel(dashboard, day), [dashboard, day]);
   const kpis = useMemo(() => summarisePowerKpis(day), [day]);
   const status = dashboard?.status ?? null;
@@ -230,7 +237,122 @@ export function PowerCard({ dashboard, day }: Props) {
           </div>
         )}
       </div>
+
+      {/* 30 天供電趨勢：備轉容量率為主圖，null 天濾除 + gapSec 斷線避免假趨勢 */}
+      <PowerTrend30d trend={trend} />
+
+      {/* 30 天供電能力 vs 尖峰負載：疊在同一張圖、共用 MW Y 軸，兩線間距即備轉容量 */}
+      <PowerCapacityVsLoad30d trend={trend} />
     </div>
+  );
+}
+
+function PowerTrend30d({ trend }: { trend: PowerDailyTrendRow[] }) {
+  const spark = useMemo<SparklinePoint[]>(
+    () =>
+      trend
+        .filter((r): r is PowerDailyTrendRow & { resv_rate: number } => r.resv_rate != null)
+        .map((r) => ({ t: r.day_ts, v: r.resv_rate })),
+    [trend],
+  );
+  const minRate = spark.length > 0 ? Math.min(...spark.map((p) => p.v)) : null;
+
+  return (
+    <div
+      data-testid="power-trend-30d"
+      style={{
+        borderRadius: RADIUS.xl,
+        border: `1px solid ${COLORS.panelBorder}`,
+        background: "rgba(255,255,255,0.02)",
+        padding: "11px 14px",
+        display: "flex", flexDirection: "column", gap: 9,
+      }}
+    >
+      <SectionLabel color={COLORS.accent}>
+        30 天趨勢 · 備轉容量率{minRate != null ? ` · 區間最低 ${minRate.toFixed(1)}%` : ""}
+      </SectionLabel>
+      {spark.length === 0 ? (
+        <div style={{ fontFamily: FONT_CJK, fontSize: FONT_SIZE.sm, color: COLORS.textFaint, padding: "8px 0" }}>
+          等待每日趨勢資料…
+        </div>
+      ) : (
+        <TimeseriesSparkline
+          data={spark}
+          unit="%"
+          height={64}
+          fillArea
+          lineColor={COLORS.accent}
+          gapSec={TREND_GAP_SEC}
+          showTooltip
+          tooltipDateFormat="date"
+        />
+      )}
+    </div>
+  );
+}
+
+/** 30 天供電能力 vs 尖峰負載：疊圖共用 MW Y 軸，兩線間距一眼看出哪幾天備轉吃緊 */
+function PowerCapacityVsLoad30d({ trend }: { trend: PowerDailyTrendRow[] }) {
+  const supplySpark = useMemo<SparklinePoint[]>(
+    () => trend.map((r) => ({ t: r.day_ts, v: r.max_supply_mw })),
+    [trend],
+  );
+  const loadSpark = useMemo<SparklinePoint[]>(
+    () => trend.map((r) => ({ t: r.day_ts, v: r.peak_load_mw })),
+    [trend],
+  );
+
+  return (
+    <div
+      data-testid="power-capacity-load-30d"
+      style={{
+        borderRadius: RADIUS.xl,
+        border: `1px solid ${COLORS.panelBorder}`,
+        background: "rgba(255,255,255,0.02)",
+        padding: "11px 14px",
+        display: "flex", flexDirection: "column", gap: 9,
+      }}
+    >
+      <div style={{ display: "flex", alignItems: "center", gap: 10, flexWrap: "wrap" }}>
+        <SectionLabel color={COLORS.accent}>30 天趨勢 · 供電能力 vs 尖峰負載</SectionLabel>
+        <div style={{ flex: 1 }} />
+        <TrendLegendDot color={COLORS.statusLive} label="供電能力" />
+        <TrendLegendDot color={COLORS.statusWarn} label="尖峰負載" />
+      </div>
+      {supplySpark.length === 0 ? (
+        <div style={{ fontFamily: FONT_CJK, fontSize: FONT_SIZE.sm, color: COLORS.textFaint, padding: "8px 0" }}>
+          等待每日趨勢資料…
+        </div>
+      ) : (
+        <TimeseriesSparkline
+          data={supplySpark}
+          extraSeries={{ data: loadSpark, color: COLORS.statusWarn, label: "尖峰負載" }}
+          seriesLabel="供電能力"
+          unit="MW"
+          height={64}
+          fillArea
+          lineColor={COLORS.statusLive}
+          gapSec={TREND_GAP_SEC}
+          compactYAxis
+          showTooltip
+          tooltipDateFormat="date"
+        />
+      )}
+    </div>
+  );
+}
+
+function TrendLegendDot({ color, label }: { color: string; label: string }) {
+  return (
+    <span
+      style={{
+        display: "inline-flex", alignItems: "center", gap: 4,
+        fontFamily: FONT_DATA, fontSize: 9, color: COLORS.textMuted,
+      }}
+    >
+      <span style={{ width: 6, height: 6, borderRadius: RADIUS.full, background: color }} />
+      {label}
+    </span>
   );
 }
 

--- a/src/data/energyLoader.ts
+++ b/src/data/energyLoader.ts
@@ -65,6 +65,28 @@ export const fetchPowerDashboard = (): Promise<PowerDashboard> => fetchPowerDash
 /** 強制刷新（測試 / 手動 refresh） */
 export const invalidatePowerDashboard = (): void => fetchPowerDashboardCached.invalidate();
 
+// ── 30 天供電趨勢（monitor PowerCard 卡片內趨勢圖，RPC get_power_daily_trend）──────
+
+export interface PowerDailyTrendRow {
+  day_ts: number;             // 台北當日午夜 epoch 秒
+  peak_load_mw: number;       // 當日實際尖峰負載
+  max_supply_mw: number;      // 當日實際最高供電能力
+  resv_rate: number | null;   // 台電定稿的當日尖峰備轉容量率（%）；隔日快照缺漏時可能 null
+  snap_cnt: number;           // 當日快照數，正常 144；偏低代表 collector 當日斷線
+}
+
+async function fetchPowerDailyTrendUncached(): Promise<PowerDailyTrendRow[]> {
+  const { data, error } = await withLoading(
+    "energy:dailyTrend",
+    "供電 30 天趨勢",
+    supabase.rpc("get_power_daily_trend"),
+  );
+  if (error) throw new Error(`get_power_daily_trend: ${error.message}`);
+  return (data ?? []) as PowerDailyTrendRow[];
+}
+const fetchPowerDailyTrendCached = cachedOnce(fetchPowerDailyTrendUncached, 30 * 60_000); // 每日才變，快取 30min
+export const fetchPowerDailyTrend = (): Promise<PowerDailyTrendRow[]> => fetchPowerDailyTrendCached();
+
 // ── Plants + output ────────────────────────────────────────────
 
 export interface PowerPlantRow {


### PR DESCRIPTION
## Summary

供電卡補上跨日趨勢（原本只有當下 snapshot 與 24h 機組出力），並修掉颱風卡「沒有活躍颱風就把 45 天趨勢柱一起吞掉」的 bug。

## Changes

**供電 30 天趨勢**（接 gis-platform PR #52 的 `get_power_daily_trend`）
- `src/data/energyLoader.ts` — `fetchPowerDailyTrend()`，30min TTL，走 `withLoading` 註冊 loadingRegistry
- `src/components/intel/monitor/PowerCard.tsx` — 卡片底部兩張圖：備轉容量率（標題附區間最低值）、供電能力 vs 尖峰負載雙線同軸（兩線間距即備轉容量）
- `src/components/intel/monitor/MonitorPanel.tsx` — 接線，deps 只有 `[open]`

**`TimeseriesSparkline` 擴充四項能力**，全部 optional、預設行為不變，不影響既有 4 個呼叫端（AirportPaxCard / ERCard 等）
- `showTooltip` + `tooltipDateFormat` — hover 顯示垂直指示線與該日數值，靠近右緣/上緣自動翻轉避免被卡片裁切
- `extraSeries` — 第二條線；Y 軸值域由新的 `computeCombinedYRange` 併算兩條線（只算主線會讓第二條溢出畫布），`gapSec` 斷線邏輯同樣套用
- `compactYAxis` — MW 這種五位數轉 `50k` 縮寫
- tooltip 數值走 `fmtTooltipValue`（四位數補千分位、單位前留空格），對齊卡片其他數字既有呈現

**颱風卡空狀態修復**
- `src/components/intel/monitor/HazardCards.tsx` — `TyphoonCard` 的 `if (!data)` 分支原本直接 return，而 proximity（RPC 349 的 45 天逐日接近程度）要到該 return 之後才被使用，導致沒有活躍颱風時，f393a2a / 158ac1d 做的兩排趨勢柱永遠畫不出來 —— 正好與 RPC 349「回答這段期間有沒有颱風靠近」的設計初衷相反
- 改為兩條路徑共用新抽出的 `TyphoonTrendSection`，只有 proximity 本身為空才退回純一句話的空狀態

## Test

- [x] `npx tsc -b` 通過
- [x] `npm test` 通過（606 tests / 44 files，含新增的 `TimeseriesSparkline.test.ts` 7 個 case 驗 `computeCombinedYRange`）
- [x] Browser 驗收 — Monitor Wall 模式實測：兩張供電圖渲染正確、琥珀線未被裁切、兩圖 hover（中段與最右緣）皆正常且移開後清除；颱風卡無活躍狀態下兩排柱正常顯示，點 08/08 展開「1 顆在 1000km 內 · Dolphin 316 km · 90 kt」與 DB 實查一致
- [x] RPC 效能 — `get_power_daily_trend(30)` EXPLAIN ANALYZE 10.6ms（來源表約 1 萬列走 index，未達 pre-aggregate 門檻）

## Risk / Rollback

- `TimeseriesSparkline` 是 4 張卡共用元件，但新能力全走 optional prop 且預設值等同舊行為，未傳新 prop 的呼叫端渲染路徑被 `extraSeries &&` / `showTooltip &&` 完全 gate 掉
- PowerCard 維持 timeline-isolated：趨勢是獨立 prop，沒進 `buildPowerCardModel`，`powerCardData.test.ts` 既有斷言未動
- 前端依賴 gis-platform PR #52（已 merged 並 apply 到正式 DB）。若該 RPC 被回滾，供電卡兩張趨勢圖會走 loading 失敗路徑，不影響卡片其餘部分
- 回滾：revert 本 PR 即可，無資料庫副作用

## Related

- Upstream: gis-platform PR #52（migration 351）— 需先合，已完成
- 颱風卡相關前作：f393a2a（接近程度 + 1000km 內顆數）、158ac1d（45 天 + 柱可點）、migration 349/350

## Note

本 PR 另含一個先前留在本地 master 未推的 commit `3d18bd5 docs: add GIS MCP architecture plan`（非本次工作，隨同步一併上遠端）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)