### PR TITLE
memory: close business registry and telecom integration

### DIFF
--- a/.claude/memory/REFLECTIONS.md
+++ b/.claude/memory/REFLECTIONS.md
@@ -1511,3 +1511,33 @@ PLAYBOOKS（+PB-40 純接線棒）／GLOSSARY（+3 詞）／BACKLOG（+welfare �
 
 STATUS（2026-08-19 current truth＋4-row release matrix）／BACKLOG（BR/WU blockers-next-acceptance）／
 DATA_SCOPE（12 assets＋coverage＋privacy boundary）／PRINCIPLES（wrap-up v2、overview/detail、publication whitelist）／本篇。
+
+---
+
+## 2026-08-19 — Business Registry＋世界通訊跨 worktree 整合
+
+### Worked
+
+- **用隔離 integration worktree 做雙 repo merge**：原本的 Business Registry、telecom 與其他既有 worktree 都不改寫；兩邊都用 merge commit 保留原子歷史，再由 PR 合進 `master`。
+- **三個 golden/contract conflict 採 union 解法**：Business Registry 與 telecom 都新增 layer contract，衝突不是二選一；合併 key、補齊兩邊欄位後重新產生 golden，最後固定為 373 keys。
+- **讓 clean-checkout CI 當第四層證據**：本地 637 tests 與 TypeScript 皆綠，但 CI 仍抓到被 global gitignore 排除的 B3 r2 JSON；force-add canonical artifact 後，run #355 才真正成功。
+- **把授權限制保留成缺席圖層**：PeeringDB／CAIDA 沒因為「世界圖想多一點」就硬塞進 public assets；permission-required 仍是明確 release gate。
+
+### Didn't work / drift
+
+- **把「同名 branch 曾有 PR merged」誤當成「較新的本機 commits 已在 master」**：PR #142 只包含遠端 `b64a5ac`，本機同名 branch 後續仍 ahead 14。branch 名稱、commit message 或既有 PR 連結都不能證明最新 local head 已合入。
+- **隔離 worktree 缺 ignored artifacts 造成 12 個假紅燈**：測試依賴 raw/intermediate/PMTiles，但新 worktree 按 Git tree 建立；先確認缺檔來源並連回 canonical data 後 12/12 才通過。
+- **本地現成 ignored file 遮蔽 clean checkout 缺檔**：`company_filters_202608_r2.json` 在原工作區存在且 checksum 正確，卻沒有被追蹤；本地測試無法替代 `git ls-files` 與 CI checkout 證據。
+
+### Next-time rules
+
+1. 要證明本機工作已進遠端主線，至少同時查 remote head SHA、`git merge-base --is-ancestor <local-head> origin/master` 與 topic range/tree diff；「PR merged」只證明該 PR 當時的 remote head。
+2. 新增 runtime artifact 時，commit 前跑 `git check-ignore -v <path>` 與 `git ls-files --error-unmatch <path>`；本機檔案存在不等於 clean checkout 會有。
+3. 隔離 worktree 跑資料測試前先列出 Git-tracked 與 gitignored fixtures；缺 ignored data 要標成環境缺口，補 canonical data 後只重跑受影響 cases，不把它混寫成 code regression。
+4. 兩條功能線同時擴 manifest/golden 時，衝突預設視為 set union，再由契約測試與 golden generator 驗證；不能只選 ours/theirs。
+5. 完成功能 PR merge 後才寫最終 STATUS，並用獨立 memory PR 合入，避免 STATUS 在 merge 前預告尚未發生的 release truth。
+
+### Memory output
+
+- Analytics `STATUS.md`：重寫成 PR #46、telecom data truth、驗證邊界與 deploy next step。
+- Pulse `REFLECTIONS.md`：追加本篇；Pulse `STATUS.md`：最後重寫成 PR #143、CI #355 與八個世界通訊圖層的 current truth。

--- a/.claude/memory/STATUS.md
+++ b/.claude/memory/STATUS.md
@@ -1,6 +1,6 @@
 # Status
 
-**最後更新**：2026-08-19（Business Registry / Factory production staging；wrap-up v2 checkpoint）
+**最後更新**：2026-08-19（Business Registry r2＋世界通訊圖層整合完成）
 
 > 本檔只保留當前 release truth、blockers 與下一棒。歷史工作留在 git、
 > `docs/features/`、`BACKLOG.md` 與 `REFLECTIONS.md`。
@@ -9,52 +9,59 @@
 
 | repo / system | current truth |
 |---|---|
-| **taipei-gis-analytics** | `codex/business-registry-production`；worktree clean、無 upstream；相對本機 `origin/master` behind 0 / ahead 28。Business Registry scope 約 20 commits，最新 r2 為 7 個 atomic commits；發布前必須隔離 topic-only range，不能整支 branch 直接推送。 |
-| **mini-taiwan-pulse** | `codex/business-registry-common-addresses`，tracking `origin/codex/business-registry-common-addresses`；本次 closeout 完成後 behind 0 / ahead 14，range `b64a5ac..HEAD`。`b64a5ac` 已在 `origin/master`；ahead commits 包含 5 個 Business Registry、wrap-up memory 與 v2 skill/docs，發布前必須依 release unit 隔離。 |
-| **Pulse worktree** | wrap-up v2 已以 `07fd324`（implementation＋routing contract）與 `284445a`（docs sync）提交；memory closure 依 exact path atomic commit。closeout 後 target paths、cached set 與 worktree clean。 |
-| **S3** | 12 個 immutable assets 已 upload，並逐檔完成 SHA-256、size、object metadata readback。 |
-| **Production** | server pull、Zeabur deploy、正式站 HTTP／Range／404 與 browser smoke 尚未完成。正式站：`https://mini-taiwan-pulse.itsmigu.com`。 |
+| **mini-taiwan-pulse** | `master` 已由 PR #143 合併 Business Registry r2、wrap-up v2 與世界通訊圖層；merge commit `d70c039`。layer golden key count 373。 |
+| **taipei-gis-analytics** | 上游 PR #46 已合併 Business Registry production pipeline 與 telecom world pipelines；merge commit `f021c43`。 |
+| **Business Registry assets** | 12 個 immutable assets 已 upload 並完成 checksum／metadata readback；B3 r2 filter contract 已 force-add 追蹤，SHA-256 `eac748b7…0599f`。 |
+| **Telecom assets** | 8 個可視 layer 已納入前端契約：OSM 海纜／登陸站、PCH IXP、ANFR、OSM 通訊候選、RIPE Atlas、Ookla mobile/fixed。靜態資產走 `/geo/` dist fallback。 |
+| **Production** | 本輪完成 code/contract/PR/CI merge，未做 server pull、Zeabur deploy、正式站 HTTP／Range／404 或整合版 browser acceptance。 |
 
 ## Release truth matrix
 
-| release unit | build | contract/wire | stage | upload | readback | pull | deploy | HTTP | browser |
-|---|---|---|---|---|---|---|---|---|---|
-| 公司 B1/B2/B3/A4 r2 | done | done | done | done | done | blocked：follow-up PR／授權 | blocked：尚未 merge | blocked：尚未 deploy | blocked：尚未 deploy，且 browser runtime unavailable |
-| 共同地址 B4 r2 | done | done | done | done | done | blocked：follow-up PR／授權 | blocked：尚未 merge | blocked：尚未 deploy | blocked：尚未 deploy，且 browser runtime unavailable |
-| 工廠／園區 A1/A2/A5/A6 | done | done | done | done | done | blocked：follow-up PR／授權 | blocked：尚未 merge | blocked：尚未 deploy | blocked：尚未 deploy，且 browser runtime unavailable |
-| A3 membership assertions | done | done：contract only | N/A | N/A | N/A | N/A | N/A | N/A | N/A |
+| release unit | build | contract/wire | assets | CI | merge | deploy | HTTP | browser |
+|---|---|---|---|---|---|---|---|---|
+| Business Registry r2 | done | done | upload/readback done | done：run #355 | done：PR #143 | blocked：未授權／未執行 | not run | not run：整合版 |
+| Telecom world 8 layers | done | done | done：Git static assets | done：run #355 | done：PR #143 | blocked：未執行 | not run | not run：整合版 |
+| PeeringDB／CAIDA future layers | N/A | docs only | N/A | N/A | N/A | blocked：需再散布許可 | N/A | N/A |
 
-`upload/readback done` 只代表 object storage 有正確資產；不得寫成 production deployed 或 browser verified。
+`assets done`、`CI done` 與 `merge done` 不代表 production deployed；沒有正式站
+HTTP 與 browser evidence 前，不使用「已上線」描述。
 
 ## Current deliverables
 
-- **B1 / A4 公司點位**：654,165 detail points；1.5km overview 5,745 cells，守恆 654,165 companies／184,944 manufacturing companies。z4–11 overview、z12+ detail；detail 可顯示公司名稱，不公開統編、代表人或完整地址。
-- **B2 資本額網格**：150m／450m／1500m 共 89,754／26,834／5,745 cells；三尺度公司數皆守恆 654,165。
-- **B3 filters**：89 個 industry-mid options、21 縣市與 9 個 filter dimensions；overview 不支援個別公司屬性篩選。
-- **B4 共同登記地址**：11,121 points／198,606 memberships；5–800 threshold slider，公開 `capital_sum` 與 `capital_median`。
-- **A1 工廠**：100,624 active；90,652 located，9,972 misses；overview 3,673 cells。工廠座標不以公司座標替代。
-- **A2/A5/A6**：215 industrial-park polygons（不含科學園區）；A5 127,795 active／80,732 located／47,063 misses；A6 保留 coverage-bias 與 aggregate-zero 語意。
-- **A3**：1,505 assertions／1,124 uniform-number summaries；science/bonded/service-provider flags 分離，不發布籠統 `is_in_park`，不由 assertion 推測 geometry。
+### Business Registry / Factory
+
+- B1/A4：654,165 公司 detail points；overview 5,745 cells；184,944 manufacturing companies。
+- B2：150m／450m／1500m 資本額格網 89,754／26,834／5,745 cells。
+- B3：89 個 industry-mid options、21 縣市、9 個 filter dimensions；r2 filter contract 已進版控。
+- B4：11,121 共同地址 points／198,606 memberships；threshold 5–800，公開 `capital_sum`／`capital_median`。
+- A1：100,624 active factories；90,652 located，9,972 misses；overview 3,673 cells。
+- A2/A5/A6：215 industrial-park polygons、127,795 active cohort／80,732 located／47,063 misses；A3 保留 assertion-only 語意。
+
+### Communications — World
+
+- `submarineCables`：104 條 OSM/OpenInfraMap z2 generalized crowd 海纜。
+- `landingStations`：58 個 OSM 登陸站。
+- `internetExchangePoints`：892 個 PCH Active IXP。
+- `anfrWirelessSites`：8,000／33,761 個 ANFR 5G 3500 官方站點穩定概覽。
+- `osmCommunicationSites`：6 個區域、916 個 OSM 通訊候選點。
+- `ripeAtlasProbes`：3,000／13,534 個量測節點，147 國；座標已模糊化。
+- `ooklaMobilePerformance`／`ooklaFixedPerformance`：2026 Q1 的 751／893 個 z6 效能格網。
+
+各層維持獨立證據語意：官方站點、crowd geometry、IXP、measurement node、performance sample
+不得合併推論成基地臺、機房、coverage 或實際流量。
 
 ## Verification
 
-- 2026-08-19 現場重跑 `npx tsc -b`：pass。
-- 2026-08-19 現場重跑 `npm test`：46 files／633 tests pass；PMTiles contract 86/86。
-- 12 assets 的 exact size/checksum/object metadata 證據在三份 feature handoff；本檔不重複 checksum。
-- Browser runtime 曾回傳空清單；沒有 production visual evidence，因此 browser 維持 blocked。
-
-## Blockers
-
-1. Analytics branch ahead 28 且無 upstream；要先隔離 Business Registry topic commits。
-2. Pulse ahead commits 包含 Business Registry、memory 與 wrap-up v2 三種 release units；Business Registry 5 commits 尚未形成 topic-only follow-up PR。
-3. Analytics A2/A5 handoff 的 upload／coverage 敘述與 Pulse current contract 漂移，需 targeted sync。
-4. 尚未取得 production pull/deploy 授權；HTTP、Range、404 與 browser QA 皆無證據。
+- 本地 TypeScript：`npx tsc -b --pretty false` pass。
+- 本地 Vitest：46 files；637 passed／1 skipped。
+- 跨 repo targeted：19 tests pass。
+- GitHub Actions run #355：success；Claude Code Review run #169：success，無 PR comments。
+- 首輪 CI 抓到 `company_filters_202608_r2.json` 被 global gitignore 排除；已以 atomic fix `d8e2dd3` 納入，clean checkout CI 複驗成功。
+- 本輪未做 merge 後正式站視覺驗收；browser 欄維持 not run。
 
 ## Next-session entry
 
-- **Target repos / branches**：Pulse `codex/business-registry-common-addresses`；Analytics `codex/business-registry-production`。
-- **第一個可執行步驟**：把兩 repo 的 Business Registry 變更隔離成 topic-only follow-up branches／PRs；不要整支目前的 mixed-scope Pulse／Analytics branch 直接發布。
-- **Merge 後**：取得 deploy 授權，pull 12 個 immutable assets、部署、做正式站 HTTP 200/206 與 404 probe。
-- **Browser acceptance**：All Off 起手；驗 B1/A4 overview-detail split＋公司名稱、B2 三尺度、B4 threshold＋總資本額、A1 overview-detail、A2/A5/A6 popup/legend、dark-map 可讀性與 console/network 0 error。
-
-詳細待辦與 acceptance criteria 見 `BACKLOG.md` 的 BR/WU 區；完整資產／coverage 見 `DATA_SCOPE.md`。
+1. 取得 deploy 授權後，從已合併的 `master` 部署；先確認 12 個 Business Registry immutable assets 可被 production pull。
+2. 正式站做 HTTP 200/206、404、cache probe，確認 telecom `/geo/` assets 與 Business Registry PMTiles 都可讀。
+3. Browser 從 All Off 起手，切到世界 tab 的 `通訊 Communications`，依序驗海纜、登陸站、IXP、ANFR、OSM、RIPE、Ookla mobile/fixed。
+4. 每層驗 popup、legend、attribution、抽樣／偏差聲明、dark-map 可讀性，以及 console/network 0 error；再驗 Business Registry overview/detail 與 filters。


### PR DESCRIPTION
## Summary
- append the cross-worktree integration reflection for Business Registry and telecom
- rewrite STATUS after Analytics PR #46 and Pulse PR #143 merged
- record CI, asset, licensing, deploy, HTTP, and browser evidence boundaries

## Scope
Only these public project-memory files change:
- `.claude/memory/REFLECTIONS.md`
- `.claude/memory/STATUS.md`

## Validation
- path-scoped atomic commits (`a4062ee`, `637ee74`)
- `git diff --check origin/master..HEAD`
- `bash -n .claude/memory/load-session.sh`
- load-session output parses as JSON
- worktree and staging clean

## Boundary
No application code, runtime asset, migration, deployment, production HTTP probe, or browser acceptance is included.