### PR TITLE
memory: 動物福利 browser 驗收補證（STATUS 增補 + REFLECTIONS 追加）

### DIFF
--- a/.claude/memory/REFLECTIONS.md
+++ b/.claude/memory/REFLECTIONS.md
@@ -1592,3 +1592,41 @@ DATA_SCOPE（12 assets＋coverage＋privacy boundary）／PRINCIPLES（wrap-up v
 - `INCIDENTS.md`：追加四個事件（估算錯 70 倍、容差診斷兩層錯、worktree 假綠、regex 誤改）。
 - `PRINCIPLES.md`：worktree 靜默 skip 跨 repo 測試（已隨 PR #150 merged）。
 - `STATUS.md`：重寫成 VW-9 資料層 current truth 與 7 個 PR 的 release 邊界。
+
+---
+
+## 2026-08-20 — 動物福利 service points RPC + browser 驗收補證
+
+### What worked
+
+- **先按上游 RPC 契約逐支做 production read-only probe**：adoption、pressure、service
+  points 的 summary/current/history 都先確認 HTTP 200 與欄位形狀，再接前端；服務點以
+  `p_limit=5000` 跑出 5,000 + 2,020 兩頁，避免把第一頁誤當全國總量。
+- **history 維持 click 後 lazy load**：初載只抓 7,020 個 canonical service points，
+  點 popup 才以 dataset id + record key 查 history，沒有製造 7,020 次 N+1 請求。
+- **All Off 起手逐層驗收**：本機 frontend 連 production RPC，分別驗 adoption 點位與
+  daily history、pressure 縣市填色與 monthly history、service points 七類 filter／legend／
+  popup history；clean reload 的 console 無 error／warn。
+
+### Didn't work / drift
+
+- **TypeScript 與單元測試都沒抓到 Mapbox expression runtime 限制**：service-point radius
+  把 zoom expression 放在 multiplication 內，瀏覽器才報 illegal expression。修法是直接
+  scale interpolate stop outputs，並補 regression test。
+- **worktree 測試的 649 passed + 1 skipped 不能當主樹完整綠燈**：skip 是跨 repo sibling
+  catalog 守門在隔離 worktree 找不到上游；後續整合 session 已在主樹補跑 650 passed、
+  0 skipped。兩種證據必須分開陳述。
+
+### Next-time rules
+
+1. 分頁 RPC 的驗收要留下每頁 row count、offset 與 key overlap 證據；不能只驗「第一頁有資料」。
+2. Mapbox paint expression 即使有 unit test，仍要在真地圖 toggle；zoom expression 的合法位置
+   是 runtime contract，不由 TypeScript 保證。
+3. browser evidence 必寫明環境：本次是 local frontend + production RPC，不等於 production
+   frontend deploy／HTTP 驗收。
+
+### Memory output
+
+- `REFLECTIONS.md`：追加本篇。
+- `STATUS.md`：把動物福利 browser 從 unknown 改為第一手 local acceptance done，並保留
+  production deploy／HTTP 未執行的邊界。

--- a/.claude/memory/STATUS.md
+++ b/.claude/memory/STATUS.md
@@ -1,6 +1,6 @@
 # Status
 
-**最後更新**：2026-08-20（VW-9 Vessel Zone Watch 資料層 + 動物福利三層合流，7 個 PR merged）
+**最後更新**：2026-08-20（VW-9 Vessel Zone Watch 資料層 + 動物福利三層合流與 browser 補證，7 個 PR merged）
 
 > 本檔只保留當前 release truth、blockers 與下一棒。歷史工作留在 git、
 > `docs/features/`、`BACKLOG.md` 與 `REFLECTIONS.md`。
@@ -21,12 +21,13 @@
 |---|---|---|---|---|---|---|
 | Vessel Zone 資料層（mig 361~366） | N/A | done：RPC + RLS，anon 角色實測可讀 | done：對帳九格逐格一致；627,686 筆 100% | done：已 apply 正式 DB；cron 實測 succeeded（0.13/0.08s） | N/A | N/A |
 | Monitor `VesselZoneCard` | done：`tsc -b` + 650 測試 | done：三處接線，monitorPacking 過 | N/A | **not run** | **not run** | **not run** |
-| 動物福利三層 | done：`tsc -b` + 650 測試 | done：六處登記簿 + golden fixture | N/A | **not run** | **not run** | **unknown**：codex session 宣稱通過，本 session 無第一手證據 |
+| 動物福利三層 | done：`tsc -b` + 650 測試 | done：六處登記簿 + golden fixture | N/A | **not run** | **not run** | **done（local）**：All Off 逐層驗 adoption／pressure／service points；連 production RPC，非正式站驗收 |
 | catalog_missing 修正（9 layer） | done | done | N/A | not run | not run | N/A：純宣告，無視覺變更 |
 | render-phase fix（PR #148） | done | done | N/A | not run | not run | **not run** |
 
-⚠️ 對 dev server 6002 做的是 `curl` 抓 module + HTTP 200，那是 **dev server 探測，不是 browser 驗收**。
-所有前端 unit 的 browser 欄一律 `not run`。
+⚠️ 對 dev server 6002 做的 `curl` 抓 module + HTTP 200 只是 **dev server 探測，不是 browser 驗收**。
+動物福利另有真實 browser 操作證據，但環境是 local frontend + production RPC；Vessel Zone、
+catalog_missing 與 render-phase fix 仍沒有 browser evidence，也沒有任何正式站 frontend 驗收。
 
 ## Current deliverables
 
@@ -45,13 +46,18 @@ approach_6 971/20、contiguous 1/1；`territorial` 全為 0。
 ### 動物福利三層（PR #147）
 
 adoption／shelter pressure／service points。service points 那層原本 21 個檔案停在工作區未 commit，
-本輪補 commit 並驗證（`tsc -b` + 650 測試 + 兩個登記簿守門）。實作與 browser 驗收由 codex session 完成。
+本輪補 commit 並驗證（`tsc -b` + 650 測試 + 兩個登記簿守門）。服務點 RPC 以 5,000 筆分頁
+取得 5,000 + 2,020 筆，history 僅在 popup 點擊後 lazy load；browser 已從 All Off 起手逐層驗證
+adoption daily history、pressure monthly history、service points 七類 filter／legend／popup history。
 
 ## Verification
 
 - **主樹（真環境）**：`npx tsc -b` 通過；Vitest **50 檔 650 passed / 0 failed / 0 skipped**。
 - ⚠️ 本輪前段多次回報的「649 測試全過」是在 worktree 跑的**假綠** ——
   `upstreamRegistry` 的 catalog 守門測試解不到 sibling repo 會靜默 skip。詳見 `INCIDENTS.md` 同日條目。
+- **動物福利 RPC／browser（第一手）**：production RPC read-only probes 全部 HTTP 200；service points
+  兩頁 7,020 keys 無重疊且座標有效。local frontend All Off 逐層操作完成，clean reload console
+  無 error／warn；這不代表 production frontend 已 deploy。
 - DB 數字全部以第一手 query 驗證，未採信 commit message 或子代理回報。
 
 ## Current blockers
@@ -70,6 +76,8 @@ adoption／shelter pressure／service points。service points 那層原本 21 �
    「只看接近船」toggle 可用；`tsc -b` + 全套測試**在主樹**跑過（worktree 綠燈不算數）。
 4. **未做的收尾**：`.gis-agent-system/journal/` 當月檔尚未 append 本輪；
    跨 repo handoff（`taipei-gis-analytics/docs/handoff/`）未建，見 VZ-11。
+5. 若之後取得 frontend deploy 授權，動物福利三層仍需補正式站 HTTP 與 browser acceptance；
+   不得把本機連 production RPC 的證據寫成 production frontend 已上線。
 
 詳細 active work 與 acceptance criteria 見 `BACKLOG.md`；
 VZ-* 執行細節見 `docs/features/vessel-watch/backlog.md`。


### PR DESCRIPTION
## 摘要

補上 PR #151 缺的那塊：動物福利三層的 browser 驗收**第一手證據**。純 memory，無程式碼變更。

| 檔案 | 動作 | numstat |
|---|---|---|
| `STATUS.md` | 增補 | 動物福利 browser 欄 `unknown` → `done（local）` |
| `REFLECTIONS.md` | 純追加 | **+38 / -0** |

## 為什麼這是增補而不是覆蓋

PR #151 寫 `STATUS` 時，我把動物福利的 browser 欄標成 **`unknown`**，理由是「codex session 宣稱通過，本 session 無第一手證據」。

那個 session 有證據，所以由它補最合適——**不該由沒做過驗收的人代寫驗收結果**。

本分支 base 已含 PR #151（`behind 0`），`REFLECTIONS` 是純追加沒動既有內容，`STATUS` 只改動物福利那一格與對應警語。

## 改後的 release truth 更精確

原本：

> ⚠️ 所有前端 unit 的 browser 欄一律 `not run`

改成：動物福利**有真實 browser 操作證據，但環境是 local frontend + production RPC，不是正式站驗收**；Vessel Zone、catalog_missing、render-phase fix 仍然沒有任何 browser evidence。

## REFLECTIONS 補的兩個細節

- 服務點以 `p_limit=5000` 跑出 **5,000 + 2,020 兩頁**——避免把第一頁誤當全國總量
- history 維持 click 後 lazy load，初載只抓 7,020 個 canonical points，**沒有製造 7,020 次 N+1 請求**

## 執行說明

實作與 browser 驗收由 `codex/animal-adoption-pulse` session 完成，本次僅代為 push 與 merge，並驗證 base、diff 範圍與無覆蓋。