### PR TITLE
docs(monitor): 待拍板的在監 migration 編號 368 → 369（撞號）

### DIFF
--- a/docs/proposal/monitor-tweaks-2026-08-21/369_prison_population_window_anchor.sql
+++ b/docs/proposal/monitor-tweaks-2026-08-21/369_prison_population_window_anchor.sql
@@ -1,5 +1,7 @@
--- ⚠️ 編號 367 → 368（2026-08-21）：367 已被 public_health_weekly 去重那筆佔用
---    （公衛先 apply 到正式庫，故先取號）。本檔**尚未 apply**，等用戶拍板。
+-- ⚠️ 編號兩度順延（尚未 apply）：367 已被 public_health_weekly 去重那筆佔用、
+--    368 已被 religion PII revoke 佔用，故本檔取 369。
+--    取號前請再確認一次 gis-platform/migrations/ 的當前最大編號 —— 本工作區
+--    長期有平行 session，編號會被別人先拿走。
 -- ============================================================
 -- Migration 367: get_prison_population_window() 改錨定 max(observed_date)
 --                + 新增 public.get_prison_population_summary()
@@ -37,7 +39,7 @@
 --     SELECT * FROM public.get_prison_population_summary(365);
 --   ROLLBACK;
 --
--- 套用：psql "$SUPABASE_DB_URL" -f 368_prison_population_window_anchor.sql
+-- 套用：psql "$SUPABASE_DB_URL" -f 369_prison_population_window_anchor.sql
 -- 回滾：⚠️ **不要**重新套 264_rpc_prison_population_window.sql —— 該檔內文寫的是
 --       `FROM realtime.prison_population_daily`，而 schema 已被 312_move_realtime_to_live.sql
 --       搬到 live.*，照套會指向不存在的表。用下面這段（= apply 前 pg_get_functiondef 的實況）：

--- a/docs/proposal/monitor-tweaks-2026-08-21/README.md
+++ b/docs/proposal/monitor-tweaks-2026-08-21/README.md
@@ -62,7 +62,7 @@ TAIEX 之所以「看起來正常」只是它內容本來就超過 413px 被夾�
 | 動作 | 檔案 | 影響 |
 |---|---|---|
 | 回補 7 年歷史 | [`prison_backfill.sql`](./prison_backfill.sql)（2,501 天，2019-04-18 ~ 2026-05-15，`ON CONFLICT DO NOTHING`）| 跑完 365 天視窗內有 214 筆，趨勢圖立刻有東西。產生器：[`prison_backfill_build.py`](./prison_backfill_build.py) |
-| migration 367 | [`367_prison_population_window_anchor.sql`](./367_prison_population_window_anchor.sql) | RPC 視窗從 `now()` 錨改成 `max(observed_date)` 錨。不改的話上游不恢復時卡片會逐日縮水、約 2027-05 整張變空 |
+| migration 369 | [`369_prison_population_window_anchor.sql`](./369_prison_population_window_anchor.sql) | RPC 視窗從 `now()` 錨改成 `max(observed_date)` 錨。不改的話上游不恢復時卡片會逐日縮水、約 2027-05 整張變空 |
 | collector 加靜默斷供告警 | [`prison_collector_patch.md`](./prison_collector_patch.md) B 段 | 現在 `realtime_tables.yaml` 用 `collected_at` 判 freshness，而這是 PK=`observed_date` 的 upsert 表 → **結構上偵測不到「200 但內容三個月前」** |
 | `realtime_tables.yaml:128` `time_column: collected_at` → `observed_date` | data-collectors 共用登記檔 | 同上。共用檔，由人統一接線 |
 
@@ -189,7 +189,7 @@ TAIEX 之所以「看起來正常」只是它內容本來就超過 413px 被夾�
 順帶修：`TimeseriesSparkline` 的 X 軸步距階梯原本停在 7 天（設計時最長約 32 天），
 1Y 視窗的 268 天跨度會生出 38 個標籤疊成字牆 → 延長為 14/30/60 天步距，≤70 天維持原行為。
 
-**仍待拍板**：migration **368**（RPC 視窗改錨 `max(observed_date)`）。
+**仍待拍板**：migration **369**（RPC 視窗改錨 `max(observed_date)`）。
 不套也能用（RPC 錨 now() 仍回 214 筆，前端已自行錨在序列末日），
 但上游持續不恢復的話卡片會逐日縮水、約 2027-05 整張變空。
 


### PR DESCRIPTION
## Summary

平行 session 已在 `gis-platform` 本地 `main` 用掉 **368**（`368_religion_pii_revoke.sql`，尚未 push），撞到我在交接包裡預留給「在監 RPC 視窗改錨」的編號。

該檔第一輪原本取 367，因公衛去重先 apply 而讓號到 368，現在再讓一次到 **369**。

## Changes

- `368_prison_population_window_anchor.sql` → `369_prison_population_window_anchor.sql`
- 檔頭加註「取號前請再確認一次 `gis-platform/migrations/` 當前最大編號」—— 本工作區長期有平行 session，編號會被別人先拿走（repo 已有 358→366 的重編前例，commit `1bffc0a`）
- README 對應文字與失效連結修正

## Test

- 7 個相對連結全數驗過存在
- 純文件變更，無程式碼影響

## Risk / Rollback

無。該 migration **尚未 apply**，仍待拍板。

## Related

- 交接主檔：`docs/proposal/monitor-tweaks-2026-08-21/README.md`
- 已 apply 的 migration 367（公衛去重）：`gis-platform` PR #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017DGEB3pz9WjkKz5deXHkRu