### PR TITLE
fix(map): attribution 為 undefined 時不要塞進 source spec（161 個 source 建不出來）

### DIFF
--- a/src/map/overlayManager.ts
+++ b/src/map/overlayManager.ts
@@ -180,7 +180,14 @@ export function addOverlay(
       map.addSource(config.sourceId, {
         type: "geojson",
         data: { type: "FeatureCollection", features: [] } as GeoJSON.FeatureCollection,
-        attribution: config.attribution,
+        // ⚠️ 只在有值時才帶這個鍵，不可寫成 `attribution: config.attribution`：
+        // Mapbox 的 style 驗證對 `attribution: undefined` 會直接判 fail
+        // （`sources.<id>.attribution: string expected, undefined found`），
+        // **整個 source 不會被建立**，接著該 overlay 的每一層都會噴
+        // `layers.<id>: source "<id>" not found`。
+        // 實測（2026-08-22，`map.addSource` 探針）：帶 undefined → NOT added；
+        // 不帶這個鍵 → added。registry 裡絕大多數 overlay 都沒有 attribution。
+        ...(config.attribution ? { attribution: config.attribution } : {}),
         ...geojsonSourceOptions(config),
       });
     }


### PR DESCRIPTION
## Summary

使用者回報 console 一堆這種錯：

```
Error: sources.tour-heritage.attribution: string expected, undefined found
Error: layers.tour-heritage-glow: source "tour-heritage" not found
Error: layers.tour-scenic-areas-line: source "tour-scenic-areas" not found
```

`1980b73 fix(religion): 靜態檔改用發布版 + 圖層來源顯名常駐標示` 在 geojson source spec 加了 `attribution: config.attribution`。但 registry 裡**絕大多數 overlay 沒有 attribution 欄位**，傳進去的是 `undefined` —— Mapbox 的 style 驗證對此直接判 fail，**整個 source 不會被建立**，該 overlay 的每一層接著都噴 `source not found`。

看起來只有「幾個 tour 圖層有錯」，是因為只有 6 個 religion overlay 有 attribution、PMTiles 類走另一條分支，其餘全中。

## Changes

`src/map/overlayManager.ts` — 改成只在有值時才帶這個鍵：

```diff
-        attribution: config.attribution,
+        ...(config.attribution ? { attribution: config.attribution } : {}),
```

## Test

`map.addSource` 探針實測（2026-08-22，6002 實機）：

| source spec | 結果 |
|---|---|
| `{ …, attribution: undefined }` | **NOT added** |
| 不帶這個鍵 | added |

修前 / 修後（同一台 dev server，重新載入）：

| 指標 | 修前 | 修後 |
|---|---|---|
| `getStyle().sources` 數 | **103** | **264** |
| 孤兒層（layer 指向不存在的 source） | 多 | **0** |
| `tour-*` source / layer | 0 / 0 | 11 / 22 |

- [x] `npx tsc -b` 通過
- [x] `npm test` 通過（650 passed）
- [x] Browser 實測如上

## Risk / Rollback

- 單行條件式展開，行為只有「undefined 時不帶這個鍵」一項差異
- 有填 attribution 的 6 個 religion overlay 行為完全不變（AttributionControl 照常顯示）
- 回滾：還原該行

## Related

- 肇因 commit：`1980b73 fix(religion): 靜態檔改用發布版 + 圖層來源顯名常駐標示`

### 建議後續（本 PR 未做）

現在沒有任何測試會抓到「source 建不出來」。`layerConsistency` 驗的是 manifest 完整性，不碰執行期 style。可考慮加一條契約測試：對 registry 每個 geojson overlay 斷言 source spec 不含值為 `undefined` 的鍵。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017DGEB3pz9WjkKz5deXHkRu