### PR TITLE
feat(monitor): 新增台鐵誤點監測格

### DIFF
--- a/src/components/intel/monitor/MonitorPanel.tsx
+++ b/src/components/intel/monitor/MonitorPanel.tsx
@@ -42,6 +42,7 @@ import { ERCard } from "./ERCard";
 import { PlaBoard } from "./PlaBoard";
 import { VesselZoneCard } from "./VesselZoneCard";
 import { FoodPriceBoard } from "./FoodPriceBoard";
+import { TraDelayBoard } from "./TraDelayBoard";
 import {
   TyphoonCard, EarthquakeCard, RadiationCard, LightningCard,
 } from "./HazardCards";
@@ -729,6 +730,7 @@ export function MonitorPanel({
     plaBoard: <PlaBoard open={open} />,
     vesselZone: <VesselZoneCard open={open} />,
     foodPriceBoard: <FoodPriceBoard open={open} />,
+    traDelay: <TraDelayBoard open={open} />,
     hazardStrip: <HazardWatchStrip />,
     powerCard: <PowerCard dashboard={powerDashboard} day={powerDay} dayStatus={powerDayStatus} trend={powerTrend} />,
     erCongestion: <ERCard open={open} />,

--- a/src/components/intel/monitor/TraDelayBoard.tsx
+++ b/src/components/intel/monitor/TraDelayBoard.tsx
@@ -1,0 +1,344 @@
+import { useEffect, useMemo, useState, type MouseEvent as ReactMouseEvent } from "react";
+import { COLORS, FONT_CJK, FONT_DATA } from "../intelTokens";
+import { RADIUS, FONT_SIZE } from "../../../styles/designTokens";
+import { SectionLabel } from "./PressureRing";
+import {
+  fetchTraDelaySummary, fetchTraDelayTrains,
+  type TraDelayDay, type TraDelayTrain,
+} from "../../../data/intelLoaders";
+import { useChartTooltip } from "../../ChartHoverTooltip";
+
+/**
+ * 台鐵誤點監測（migration 369）
+ *
+ * 資料鏈：TDX TrainLiveBoard（每 2 分鐘全量快照，含 DelayTime）
+ *   → live.train_positions（只留 7 天）
+ *   → analytics.tra_train_delay_daily / tra_delay_summary_daily（每日 01:56 聚合，永久保留）
+ *
+ * ⚠️ 畫面上三件不可省的誠實標註：
+ *  1. **覆蓋率必須露出**：live board 只回報約 85% 的班表班次，
+ *     用「觀測到的班次」當分母算出的準點率會比用全量班表樂觀。不標等於謊報。
+ *  2. **誤點口徑有兩種**：主數字用「曾經誤點 ≥5 分」（含短暫誤點），
+ *     括號的 p90 是「多數時間誤點 ≥5 分」。上游偶有 6→95→7 分的假尖峰，
+ *     兩個並陳才看得出哪天是真的壞、哪天只是尖刺。
+ *  3. **不是官方準點率**：官方看的是到站誤點，而 live board 在列車抵達終點前
+ *     1~3 站就停止回報，拿不到真正的到站時刻。這裡的數字只能自己比自己。
+ */
+
+const WINDOW = 60;
+const TOP_N = 5;
+
+interface Props { open: boolean }
+
+function delayColor(min: number | null): string {
+  if (min === null) return COLORS.textDim;
+  if (min >= 30) return COLORS.statusErr;
+  if (min >= 10) return COLORS.statusWarn;
+  if (min >= 5) return "#eab308";
+  return COLORS.statusLive;
+}
+
+export function TraDelayBoard({ open }: Props) {
+  const [days, setDays] = useState<TraDelayDay[]>([]);
+  const [trains, setTrains] = useState<TraDelayTrain[]>([]);
+
+  useEffect(() => {
+    if (!open) return;
+    let cancelled = false;
+    const tick = () => {
+      fetchTraDelaySummary(WINDOW)
+        .then((r) => { if (!cancelled) setDays(r); })
+        .catch((e) => console.warn("[TraDelayBoard] summary", e));
+      fetchTraDelayTrains("", 5, TOP_N)
+        .then((r) => { if (!cancelled) setTrains(r); })
+        .catch((e) => console.warn("[TraDelayBoard] trains", e));
+    };
+    tick();
+    // 來源是 T+1 的每日聚合（pg_cron 01:56），一小時一次已遠快於需要
+    const id = window.setInterval(tick, 60 * 60_000);
+    return () => { cancelled = true; window.clearInterval(id); };
+  }, [open]);
+
+  // 主數字用「最後一個算得出到站誤點的日子」——最新一天可能剛好缺班表（實測 175 天內有 9 天）
+  const latest = useMemo(() => {
+    for (let i = days.length - 1; i >= 0; i--) {
+      if (days[i]!.nearDestTrains > 0) return days[i]!;
+    }
+    return null;
+  }, [days]);
+
+  if (!latest) {
+    return (
+      <div>
+        <SectionLabel>TRA DELAY</SectionLabel>
+        <div style={{ fontFamily: FONT_CJK, fontSize: FONT_SIZE.sm, color: COLORS.textDim }}>
+          尚無台鐵誤點資料
+        </div>
+      </div>
+    );
+  }
+
+  // 全部走口徑 C（到站誤點）：與下方三線圖同一口徑，避免同一格裡兩種定義並存
+  const delayedPct = (latest.nearDestOver5 / latest.nearDestTrains) * 100;
+  const delayedPct15 = (latest.nearDestOver15 / latest.nearDestTrains) * 100;
+
+  return (
+    <div>
+      <SectionLabel>TRA DELAY</SectionLabel>
+
+      {/* 三個主數字 */}
+      <div style={{ display: "flex", gap: 8, marginBottom: 10 }}>
+        <Stat
+          label="到站誤點"
+          value={`${delayedPct.toFixed(0)}%`}
+          sub={`逾 15 分 ${delayedPct15.toFixed(0)}%`}
+          color={delayedPct >= 15 ? COLORS.statusWarn : COLORS.textStrong}
+        />
+        <Stat
+          label="平均誤點"
+          value={latest.nearDestAvgDelay === null ? "—" : `${latest.nearDestAvgDelay.toFixed(1)}′`}
+          sub={`可判定 ${latest.nearDestTrains} 班`}
+          color={delayColor(latest.nearDestAvgDelay)}
+        />
+        {/* 這格刻意維持口徑 A：問的是「當日最糟到什麼程度」，本來就該看途中峰值 */}
+        <Stat
+          label="途中最大"
+          value={latest.maxDelayMin === null ? "—" : `${latest.maxDelayMin}′`}
+          sub={`${latest.observedTrains} 班在跑`}
+          color={delayColor(latest.maxDelayMin)}
+        />
+      </div>
+
+      {/* 近 60 天誤點比例走勢（三個閾值） */}
+      <DelayTrendChart days={days} />
+
+      {/* 最誤點車次 */}
+      {trains.length > 0 && (
+        <div style={{ marginBottom: 8 }}>
+          <div style={{
+            fontFamily: FONT_DATA, fontSize: FONT_SIZE.xs, color: COLORS.textDim, marginBottom: 4,
+          }}>
+            最誤點車次
+          </div>
+          {trains.map((t) => (
+            <div
+              key={t.trainNo}
+              style={{
+                display: "flex", alignItems: "center", gap: 6, padding: "3px 0",
+                borderBottom: `1px solid ${COLORS.borderSoft}`,
+              }}
+            >
+              <span style={{
+                fontFamily: FONT_DATA, fontSize: FONT_SIZE.sm, color: COLORS.textStrong,
+                minWidth: 38,
+              }}>
+                {t.trainNo}
+              </span>
+              <span style={{
+                fontFamily: FONT_CJK, fontSize: FONT_SIZE.xs, color: COLORS.textMuted,
+                minWidth: 52, whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis",
+              }}>
+                {t.trainType}
+              </span>
+              <span style={{
+                fontFamily: FONT_CJK, fontSize: FONT_SIZE.xs, color: COLORS.textDim,
+                flex: 1, whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis",
+              }}>
+                {t.originStation && t.destinationStation
+                  ? `${t.originStation}→${t.destinationStation}`
+                  : "班表外加班車"}
+              </span>
+              <span style={{
+                fontFamily: FONT_DATA, fontSize: FONT_SIZE.sm, color: delayColor(t.maxDelayMin),
+                minWidth: 32, textAlign: "right",
+              }}>
+                {t.maxDelayMin ?? "—"}′
+              </span>
+              {/* max 與 p90 落差大 = 上游尖刺，不是真的誤點這麼久 */}
+              {t.maxDelayMin !== null && t.p90DelayMin !== null
+                && t.maxDelayMin - t.p90DelayMin >= 20 && (
+                <span
+                  title={`多數時間僅 ${t.p90DelayMin} 分，此峰值疑為上游資料尖刺`}
+                  style={{ fontFamily: FONT_DATA, fontSize: FONT_SIZE.xs, color: COLORS.textFaint }}
+                >
+                  ⚠
+                </span>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+
+      <div style={{
+        fontFamily: FONT_CJK, fontSize: FONT_SIZE.xs, color: COLORS.textFaint, lineHeight: 1.5,
+      }}>
+        {latest.serviceDate}
+        {latest.coveragePct !== null && latest.scheduledTrains !== null && (
+          <> · 覆蓋 {latest.coveragePct.toFixed(0)}%（{latest.observedTrains}/{latest.scheduledTrains} 班）</>
+        )}
+        <br />
+        到站誤點口徑：取最後觀測（終點前 3 站內）的誤點，分母為可判定班次。
+        非官方數字 —— TDX 在列車抵達終點前 1~3 站即停止回報，拿不到真正到站時刻。
+      </div>
+    </div>
+  );
+}
+
+/**
+ * 誤點比例三線圖：超過 0 / 5 / 15 分鐘，**口徑 C（到站誤點）**。
+ *
+ * ⚠️ 為什麼用 C 不用 A：口徑 A（當日曾誤點）的「超過 0 分」常年是 92% 的平線
+ * —— 台鐵幾乎每班車一天當中都會誤個一兩分鐘，這條線沒有資訊量，卻因為數值最大
+ * 而主導整張圖的 scale，把「超過 15 分」壓到貼底。改用 C（到站時晚了沒）後
+ * 「超過 0 分」落在 37~47% 且有起伏，三條線分得開，也才對得上外部的官方統計。
+ *
+ * 分母是 nearDestTrains（最後觀測落在終點前 3 站內的班次），不是全部觀測班次。
+ * nearDestTrains = 0 的日子（班表缺漏）折線**斷開**，不補值連過去。
+ */
+const TREND_LINES = [
+  { label: "超過 0 分",  color: COLORS.accent,     pick: (d: TraDelayDay) => d.nearDestOver0 },
+  { label: "超過 5 分",  color: COLORS.statusWarn, pick: (d: TraDelayDay) => d.nearDestOver5 },
+  { label: "超過 15 分", color: COLORS.statusErr,  pick: (d: TraDelayDay) => d.nearDestOver15 },
+] as const;
+
+const CHART_H = 46;
+
+function DelayTrendChart({ days }: { days: TraDelayDay[] }) {
+  const tip = useChartTooltip();
+
+  const geom = useMemo(() => {
+    const pts = days.filter((d) => d.observedTrains > 0);
+    if (pts.filter((d) => d.nearDestTrains > 0).length < 2) return null;
+    // 分母為 0 的日子給 null，畫線時斷開（不可用 0 代入，會畫出假的谷底）
+    const ratios = TREND_LINES.map((l) =>
+      pts.map((d) => (d.nearDestTrains > 0 ? l.pick(d) / d.nearDestTrains : null)),
+    );
+    // scale 對齊最大的那條，三條共用同一 Y 軸才能互相比較
+    const max = Math.max(...ratios.flat().filter((v): v is number => v !== null), 0.05);
+    const x = (i: number) => (i / (pts.length - 1)) * 100;
+    const y = (v: number) => CHART_H - (v / max) * (CHART_H - 2);
+    const paths = ratios.map((r) => {
+      let d = "";
+      let pen = false;
+      r.forEach((v, i) => {
+        if (v === null) { pen = false; return; }
+        d += `${pen ? "L" : "M"}${x(i).toFixed(2)},${y(v).toFixed(2)}`;
+        pen = true;
+      });
+      return d;
+    });
+    const gaps = pts.filter((d) => d.nearDestTrains === 0).length;
+    return { pts, paths, max, gaps };
+  }, [days]);
+
+  if (!geom) return null;
+
+  function handleMove(e: ReactMouseEvent<SVGSVGElement>) {
+    const { pts } = geom!;
+    const rect = e.currentTarget.getBoundingClientRect();
+    if (rect.width === 0) return;
+    const ratio = (e.clientX - rect.left) / rect.width;
+    const i = Math.max(0, Math.min(Math.round(ratio * (pts.length - 1)), pts.length - 1));
+    const d = pts[i]!;
+    if (d.nearDestTrains === 0) {
+      tip.show(e.clientX, e.clientY, {
+        title: d.serviceDate,
+        rows: [{ label: "到站誤點", value: "無資料" }],
+        note: `當日缺班表，無法判斷是否抵達終點（觀測 ${d.observedTrains} 班）`,
+      });
+      return;
+    }
+    tip.show(e.clientX, e.clientY, {
+      title: d.serviceDate,
+      rows: TREND_LINES.map((l) => ({
+        dot: l.color,
+        label: l.label,
+        value: `${((100 * l.pick(d)) / d.nearDestTrains).toFixed(1)}%（${l.pick(d)} 班）`,
+      })),
+      note: `到站誤點口徑・可判定 ${d.nearDestTrains} 班（全日觀測 ${d.observedTrains} 班）`,
+    });
+  }
+
+  return (
+    <div style={{ marginBottom: 10 }}>
+      <div style={{
+        display: "flex", justifyContent: "space-between", alignItems: "baseline",
+        fontFamily: FONT_DATA, fontSize: FONT_SIZE.xs, color: COLORS.textDim, marginBottom: 3,
+      }}>
+        <span>到站誤點比例 近 {geom.pts.length} 天</span>
+        <span>{geom.gaps > 0 && `${geom.gaps} 天缺班表・`}上緣 {(geom.max * 100).toFixed(0)}%</span>
+      </div>
+
+      {/* ⚠️ 帶 viewBox 的 svg 有內建長寬比，直接放進 flex 會自己算高度把格子撐爆，
+          所以固定高度的 wrapper + absolute svg（同 FoodPriceBoard 的處理） */}
+      <div style={{ position: "relative", height: CHART_H }}>
+        <svg
+          viewBox={`0 0 100 ${CHART_H}`}
+          preserveAspectRatio="none"
+          style={{ position: "absolute", inset: 0, width: "100%", height: "100%", display: "block" }}
+          role="img"
+          aria-label={`近 ${geom.pts.length} 天到站誤點比例走勢，含超過 0、5、15 分鐘三條線`}
+          onMouseMove={handleMove}
+          onMouseLeave={tip.hide}
+        >
+          {geom.paths.map((d, i) => (
+            <path
+              key={TREND_LINES[i]!.label}
+              d={d}
+              fill="none"
+              stroke={TREND_LINES[i]!.color}
+              strokeWidth={1.2}
+              vectorEffect="non-scaling-stroke"
+              strokeLinejoin="round"
+              strokeLinecap="round"
+            />
+          ))}
+        </svg>
+      </div>
+
+      {/* 圖例 */}
+      <div style={{ display: "flex", gap: 10, marginTop: 4 }}>
+        {TREND_LINES.map((l) => (
+          <span key={l.label} style={{
+            display: "flex", alignItems: "center", gap: 4,
+            fontFamily: FONT_CJK, fontSize: FONT_SIZE.xs, color: COLORS.textDim,
+          }}>
+            <span style={{ width: 8, height: 2, background: l.color, display: "inline-block" }} />
+            {l.label}
+          </span>
+        ))}
+      </div>
+
+      {tip.node}
+    </div>
+  );
+}
+
+function Stat({ label, value, sub, color }: {
+  label: string; value: string; sub: string; color: string;
+}) {
+  return (
+    <div style={{
+      flex: 1, padding: "6px 8px", borderRadius: RADIUS.sm,
+      border: `1px solid ${COLORS.borderSoft}`, background: "rgba(255,255,255,0.02)",
+      minWidth: 0,
+    }}>
+      <div style={{
+        fontFamily: FONT_CJK, fontSize: FONT_SIZE.xs, color: COLORS.textDim, marginBottom: 2,
+      }}>
+        {label}
+      </div>
+      <div style={{ fontFamily: FONT_DATA, fontSize: FONT_SIZE.lg, color, lineHeight: 1.1 }}>
+        {value}
+      </div>
+      {sub && (
+        <div style={{
+          fontFamily: FONT_DATA, fontSize: FONT_SIZE.xs, color: COLORS.textFaint, marginTop: 2,
+          whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis",
+        }}>
+          {sub}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/intel/monitor/monitorLayout.ts
+++ b/src/components/intel/monitor/monitorLayout.ts
@@ -31,7 +31,8 @@ export type MonitorWidgetId =
   | "typhoon"
   | "earthquake"
   | "radiation"
-  | "lightning";
+  | "lightning"
+  | "traDelay";
 
 export interface MonitorGridItem {
   /** widget id（對應 MonitorPanel 的 widget 對照表） */
@@ -107,6 +108,8 @@ export const MONITOR_GRID_GAP = 10;
  * - 2026-08-05 七版 — 新增 foodPriceBoard（食品價格監測）
  * - 2026-08-10 八版 — TAIEX 拆出獨立 widget；plaBoard / foodPriceBoard 加高給圖表
  * - 2026-08-10 九版 — 資訊卡改 `fit: "content"`（高度跟內容、欄內流式下推）
+ * - 2026-08-22 十一版 — 新增 traDelay（台鐵誤點）；vesselZone h 11→6 讓出左欄尾段，
+ *   維持左右欄同止 y68。⚠ 本版座標為接線時暫定、非沙盒匯出，定稿請回沙盒重拖。
  */
 export const MONITOR_LAYOUT: MonitorGridItem[] = [
   { i: "newsFeed", x: 0, y: 0, w: 4, h: 12 },
@@ -158,7 +161,15 @@ export const MONITOR_LAYOUT: MonitorGridItem[] = [
   // 頂層才維持「上方三欄 + 下方左右兩欄(5+7)」的兩段結構
   // （monitorPacking.test.ts 有斷言；第一版放最底部全寬 w12 會多切出第三段）。
   // 也刻意不用 w12：全寬約 1200px，柱狀圖會被拉到看不出形狀，w5 與 plaBoard 一致。
-  { i: "vesselZone", x: 0, y: 57, w: 5, h: 11, fit: "content" },
+  // h 11→6（2026-08-22）：純粹讓出左欄尾段給 traDelay。兩格都是 fit:"content"，
+  // h 不是實際高度、只決定欄內順序與拆解，所以縮 h 不會壓縮畫面上的船舶卡。
+  { i: "vesselZone", x: 0, y: 57, w: 5, h: 6, fit: "content" },
+  // 台鐵誤點（2026-08-22，migration 369）。
+  // ⚠️ 為什麼卡在 y63–68 而不是接在最底部：左右兩欄必須**同時結束**於 y68。
+  // 先前試過放 y68（左欄延伸到 y76），y68 以下只剩左欄 → guillotine 在那裡切出
+  // 貫穿全寬的第三段，monitorPacking「頂層拆成上方三欄 + 下方左右兩欄」直接紅。
+  // 版面要正式定稿請回沙盒拖完重新匯出整份 MONITOR_LAYOUT。
+  { i: "traDelay", x: 0, y: 63, w: 5, h: 5, fit: "content" },
 ];
 
 /** 沙盒 hidden 清單 — 列在這裡的 widget 不渲染（histogram 與時間軸新聞密度重複，2026-07-26 移除） */

--- a/src/components/intel/monitor/monitorSplitLayout.ts
+++ b/src/components/intel/monitor/monitorSplitLayout.ts
@@ -127,6 +127,8 @@ export const MONITOR_LAYOUT_SPLIT: MonitorGridItem[] = [
   { i: "plaBoard", x: 0, y: 88, w: 12, h: 12, fit: "content" },
   // 接在共機卡之後 —— 兩者同屬「軍事態勢」，一個看空域一個看海域
   { i: "vesselZone", x: 0, y: 100, w: 12, h: 10, fit: "content" },
+  // 台鐵誤點（2026-08-22）：窄版底部沿用全寬堆疊，不影響「兩欄同止」規則。
+  { i: "traDelay", x: 0, y: 110, w: 12, h: 8, fit: "content" },
 ];
 
 /**

--- a/src/data/intelLoaders.ts
+++ b/src/data/intelLoaders.ts
@@ -859,3 +859,150 @@ const vesselZoneCache = cachedByKey(
 export function fetchVesselZoneDaily(windowDays = 120): Promise<VesselZoneDay[]> {
   return vesselZoneCache(String(windowDays));
 }
+
+// ── 台鐵誤點（migration 369）────────────────────────────────────
+
+/**
+ * 台鐵每日誤點彙總。
+ *
+ * 對應 gis-platform migration 369（`analytics.tra_delay_summary_daily` 預聚合表 + 薄 RPC）。
+ * 來源是 TDX TrainLiveBoard 每 2 分鐘快照 × 每日全量班表。
+ *
+ * ⚠️ 兩個必須誠實呈現的口徑問題：
+ *  1. **分母有兩個**：班表班次（scheduledTrains）與實際被觀測到的班次（observedTrains），
+ *     覆蓋率約 85%（live board 不是每班都回報）。用不同分母算準點率可差到 15pp，
+ *     所以畫面要標覆蓋率，不能只給一個「準點率」數字。
+ *  2. **誤點有兩種口徑**：delayedOver5 是「今天曾經誤點 5 分以上」、
+ *     delayedP90Over5 是「今天多數時間誤點 5 分以上」。前者對上游尖刺敏感
+ *     （實測 TDX 偶有 6→95→7 分的假尖峰），後者穩健但低估短時間誤點。
+ */
+export interface TraDelayDay {
+  serviceDate: string;
+  scheduledTrains: number | null;
+  observedTrains: number;
+  coveragePct: number | null;
+  delayedOver0: number;
+  delayedOver5: number;
+  delayedOver10: number;
+  delayedOver15: number;
+  delayedOver30: number;
+  delayedP90Over5: number;
+  /**
+   * 口徑 C（到站誤點近似）—— 分母是 nearDestTrains，不是 observedTrains。
+   * 只計「最後觀測落在終點前 3 站內」的班次，最接近一般人講的「這班車誤點了」。
+   * nearDestTrains = 0 代表當天沒有班表可對照（班表缺漏 6 天 + 班表開始前 3 天），
+   * 此組指標無意義，畫圖必須斷開不可補值連過去。
+   */
+  nearDestTrains: number;
+  nearDestOver0: number;
+  nearDestOver5: number;
+  nearDestOver15: number;
+  nearDestAvgDelay: number | null;
+  /** 準點率 %：分母為 observedTrains、閾值 5 分（口徑 A：途中曾誤點） */
+  ontimeRatePct: number | null;
+  avgDelayMin: number | null;
+  p90DelayMin: number | null;
+  maxDelayMin: number | null;
+  byTrainType: Record<string, TraDelayTypeStat> | null;
+}
+
+export interface TraDelayTypeStat {
+  trains: number;
+  delayed_5: number;
+  avg_delay: number;
+  max_delay: number;
+}
+
+export interface TraDelayTrain {
+  serviceDate: string;
+  trainNo: string;
+  trainType: string;
+  originStation: string | null;
+  destinationStation: string | null;
+  scheduledDeparture: string | null;
+  maxDelayMin: number | null;
+  p90DelayMin: number | null;
+  lastDelayMin: number | null;
+  /** 最後觀測是否落在終點前 3 站內；null = 落在通過站無法判斷 */
+  nearDestination: boolean | null;
+  obsCount: number;
+}
+
+async function _fetchTraDelaySummary(days: number): Promise<TraDelayDay[]> {
+  if (!supabaseConfigured) return [];
+  const { data, error } = await withLoading(
+    `tra-delay:summary:${days}`,
+    "台鐵誤點彙總",
+    supabase.rpc("get_tra_delay_summary", { p_days: days }),
+  );
+  if (error) {
+    console.warn("[Intel] get_tra_delay_summary failed:", error.message);
+    return [];
+  }
+  return asArray<Record<string, unknown>>(data).map((r) => ({
+    serviceDate: String(r.service_date),
+    scheduledTrains: num(r.scheduled_trains),
+    observedTrains: Number(r.observed_trains ?? 0),
+    coveragePct: num(r.coverage_pct),
+    delayedOver0: Number(r.delayed_over_0 ?? 0),
+    delayedOver5: Number(r.delayed_over_5 ?? 0),
+    delayedOver10: Number(r.delayed_over_10 ?? 0),
+    delayedOver15: Number(r.delayed_over_15 ?? 0),
+    delayedOver30: Number(r.delayed_over_30 ?? 0),
+    nearDestTrains: Number(r.near_dest_trains ?? 0),
+    nearDestOver0: Number(r.near_dest_over_0 ?? 0),
+    nearDestOver5: Number(r.near_dest_over_5 ?? 0),
+    nearDestOver15: Number(r.near_dest_over_15 ?? 0),
+    nearDestAvgDelay: num(r.near_dest_avg_delay),
+    delayedP90Over5: Number(r.delayed_p90_over_5 ?? 0),
+    ontimeRatePct: num(r.ontime_rate_pct),
+    avgDelayMin: num(r.avg_delay_min),
+    p90DelayMin: num(r.p90_delay_min),
+    maxDelayMin: num(r.max_delay_min),
+    byTrainType: (r.by_train_type as Record<string, TraDelayTypeStat> | null) ?? null,
+  }));
+}
+
+const traDelaySummaryCache = cachedByKey((k: string) => _fetchTraDelaySummary(Number(k)), TTL_DAILY);
+export function fetchTraDelaySummary(days = 60): Promise<TraDelayDay[]> {
+  return traDelaySummaryCache(String(days));
+}
+
+async function _fetchTraDelayTrains(key: string): Promise<TraDelayTrain[]> {
+  if (!supabaseConfigured) return [];
+  const [day, minDelay, limit] = key.split("|");
+  const { data, error } = await withLoading(
+    `tra-delay:trains:${key}`,
+    "台鐵誤點車次",
+    supabase.rpc("get_tra_delay_trains", {
+      p_day: day || null,
+      p_min_delay: Number(minDelay),
+      p_limit: Number(limit),
+    }),
+  );
+  if (error) {
+    console.warn("[Intel] get_tra_delay_trains failed:", error.message);
+    return [];
+  }
+  return asArray<Record<string, unknown>>(data).map((r) => ({
+    serviceDate: String(r.service_date),
+    trainNo: String(r.train_no),
+    trainType: String(r.train_type ?? ""),
+    originStation: r.origin_station ? String(r.origin_station) : null,
+    destinationStation: r.destination_station ? String(r.destination_station) : null,
+    scheduledDeparture: r.scheduled_departure ? String(r.scheduled_departure) : null,
+    maxDelayMin: num(r.max_delay_min),
+    p90DelayMin: num(r.p90_delay_min),
+    lastDelayMin: num(r.last_delay_min),
+    nearDestination: r.near_destination === null || r.near_destination === undefined
+      ? null
+      : Boolean(r.near_destination),
+    obsCount: Number(r.obs_count ?? 0),
+  }));
+}
+
+const traDelayTrainsCache = cachedByKey(_fetchTraDelayTrains, TTL_DAILY);
+/** @param day YYYY-MM-DD；空字串 = 昨日（RPC 預設） */
+export function fetchTraDelayTrains(day = "", minDelay = 5, limit = 20): Promise<TraDelayTrain[]> {
+  return traDelayTrainsCache(`${day}|${minDelay}|${limit}`);
+}


### PR DESCRIPTION
## 做了什麼

Monitor 新增 `traDelay` 一格，資料來自 gis-platform migration 369。

- **TraDelayBoard** — 到站誤點率 / 平均誤點 / 途中最大三個數字，近 60 天三閾值折線（超過 0、5、15 分）含 hover tooltip 與圖例
- **intelLoaders** — 接 `get_tra_delay_summary` / `get_tra_delay_trains`
- **monitorLayout 十一版** — `vesselZone` h 11→6 讓出左欄尾段給 `traDelay`

## 口徑選擇

整格統一用「到站誤點」，只有「途中最大」刻意保留當日峰值口徑（那格問的就是「當日最糟到什麼程度」）。

改用到站誤點是因為「當日曾誤點」口徑下，「超過 0 分」常年是 **92% 的平線** —— 台鐵幾乎每班車都會誤個一兩分鐘，該線沒有資訊量，卻因數值最大而主導整張圖的 scale，把「超過 15 分」壓到貼底。換成到站誤點後落在 37~47% 且有起伏，三條線分得開。

## ⚠️ 給 reviewer 的兩個重點

1. **`traDelay` 座標卡在 y63–68 不是隨意選的** — 下方左右兩欄必須同止 y68。放在最底部會讓 guillotine 切出貫穿全寬的第三段，`monitorPacking`「頂層拆成上方三欄 + 下方左右兩欄」直接紅（已實測踩過）。⚠️ 本版座標為**接線暫定值、非沙盒匯出**，版面定稿需回沙盒重拖並重新匯出整份 `MONITOR_LAYOUT`。
2. **班表缺漏日折線必須斷開** — 175 天內有 9 天 `nearDestTrains=0`（`rail_timetable` collector 漏抓班表），補 0 會畫出假的谷底。

## 驗證

- `npx tsc -b` 綠、`npm test` 650 passed
- browser 實測：格子渲染正常、tooltip 顯示三閾值與覆蓋率、班表缺漏日折線正確斷成 3 段

🤖 Generated with [Claude Code](https://claude.com/claude-code)