### PR TITLE
feat(layer): 新增海底等深線 Isobath 圖層

### DIFF
--- a/docs/features/isobath/README.md
+++ b/docs/features/isobath/README.md
@@ -1,0 +1,49 @@
+# 海底等深線 Isobath
+
+> **Slug**：`isobath`（與 taipei-gis-analytics handoff 一致，待上游補檔）
+> **狀態**：dev
+> **Owner**：（前端接線者，待補）
+> **上線日期**：（待 PR 合併）
+> **相關 PR**：（待補）
+
+## 一句話說明
+
+全球海底地形（GEBCO 2025 Grid，15 arc-second ≈450m）以「等深線 11 級 + 深度分帶 12 級」兩種形態疊在底圖上，3 種配色模式（單色藍反向強調 / Haxby 海洋學標準 / Turbo 最大反差）。
+
+## 圖層 / 元件
+
+| 名稱（layer key） | 類型 | 資料源 | 狀態 |
+|---|---|---|---|
+| isobath（fill sub-layer，`kind=band`） | polygon（深度分帶） | PMTiles | ✅ 前端接線完成，待上游 pmtiles 落地 |
+| isobath（line sub-layer，`kind=line`） | line（等深線） | PMTiles | ✅ 前端接線完成，待上游 pmtiles 落地 |
+
+## 關鍵檔案
+
+- 色票 SSOT：`src/data/isobathTypes.ts`（12 band 定義 + 3 mode 色階 + mapbox 表達式 + popup/legend 共用函式）
+- Overlay：`src/map/overlayRegistry.ts`（`id: "isobath"`，一筆 config 兩個 sub-layer，靠 `filter` 拆 `kind`）
+- 參數控件：`src/data/layerParamsSpec.ts`（`isobath` 4 個控件：配色 select / 分帶填色 toggle / 線透明度 slider / 填色濃度 slider）
+- Manifest：`src/data/layerManifest.ts`（`isobath` entry，`底圖 Base Map > 地形` 子群）
+- Catalog：`src/components/sidebar/layerCatalog.ts`（`地形` 子群 `fromManifest("isobath")`）
+- Legend：`src/components/LegendPanel.tsx`（`IsobathLegend`，12 級隨 modeIdx 換色）
+- Popup：`src/components/featureInfo/baseMapPanels.tsx`（`IsobathLinePanel` / `IsobathBandPanel`）+ `src/map/gisClickRegistry.ts`（`isobath-line` / `isobath-fill` 兩筆）
+
+## 資料契約摘要
+
+看 [handoff.md](./handoff.md)。上游 SSOT：`taipei-gis-analytics/docs/handoff/gebco_isobath.md`（待上游補檔）。
+
+## 相關 backlog
+
+看 [backlog.md](./backlog.md)。
+
+## 歷次改動
+
+看 [changelog.md](./changelog.md)。
+
+## 相關 ADR
+
+（無）
+
+## 相關文件
+
+- 上游 handoff：`../../../taipei-gis-analytics/docs/handoff/gebco_isobath.md`（待補）
+- 開發規則：`../development-rules.md`

--- a/docs/features/isobath/backlog.md
+++ b/docs/features/isobath/backlog.md
@@ -1,0 +1,47 @@
+# Backlog — 海底等深線 Isobath
+
+> 本 feature 的唯一細節 SSOT。核心 `.claude/memory/BACKLOG.md` 只保留索引。
+
+## 欄位規約
+
+每一筆 active item 都要能回答「現在能做什麼」；狀態與優先級分開，不要用 P0/P1 代替狀態。
+
+| 欄位 | 必填內容 |
+|---|---|
+| Category | `release` / `product` / `validation` / `tech-debt` / `data-health` / `security` / `research` / `decision` / `conditional` / `docs` |
+| Priority | `P0` 緊急 production incident 或無替代路徑的 release/security gate、`P1` 當期、`P2` 已規劃、`P3` 機會型；不用優先級代替 State |
+| State | `ready` / `in_progress` / `blocked` / `verifying` / `waiting_external` / `conditional` |
+| Outcome | 完成後可觀察到的結果 |
+| Next action | 下一個可直接執行的動作；不可只寫「追蹤」 |
+| Acceptance | 關閉證據：test、HTTP、browser、rows、checksum 等 |
+| Trigger | 僅 `conditional` 必填，寫清楚日期或外部事件 |
+| Canonical context | handoff、README、proposal 或上游文件連結 |
+
+## Active work（進行中／待辦）
+
+| ID | Category | Priority | State | Outcome | Next action | Acceptance |
+|---|---|---|---|---|---|---|
+| ISO-1 | release | P1 | waiting_external | `public/base_map/gebco_isobath.pmtiles` 落地，圖層可實際渲染 | 等上游 agent 產出 pmtiles 並放進 `public/base_map/` | browser 開圖層看得到等深線與分帶色塊 |
+| ISO-2 | docs | P2 | blocked | 上游 handoff 文件雙向校對完成 | 上游補 `taipei-gis-analytics/docs/handoff/gebco_isobath.md` 後對照本 feature 的 handoff.md 修正差異 | 兩份文件的欄位契約一致 |
+
+## Decision needed
+
+（無）
+
+## Conditional / triggered later
+
+（無）
+
+## Verifying
+
+| ID | Category | Priority | State | Missing evidence | Next action | Acceptance |
+|---|---|---|---|---|---|---|
+| ISO-3 | validation | P1 | verifying | pmtiles 落地前無法在瀏覽器實際檢視 fill/line 疊放順序、配色三模式、opacity 控件是否符合預期 | pmtiles 落地後用 agent-browser 開站驗證 4 個控件與 popup | 三種配色模式視覺正確、toggle 能開關分帶填色且不誤關整層、popup 顯示水深/深度區間正確 |
+
+## Completed / historical（已完成／歷史）
+
+- [x] **ISO-0**：前端接線（manifest / overlayRegistry / params / legend / popup / sidebar）全數完成，`npx tsc -b` 與 `npm test` 通過 — 2026-08-23，feat/isobath 分支（未合併）；詳見 [`changelog.md`](./changelog.md)
+
+## Explicitly not planned（明確不做）
+
+（無）

--- a/docs/features/isobath/changelog.md
+++ b/docs/features/isobath/changelog.md
@@ -1,0 +1,49 @@
+# Changelog — 海底等深線 Isobath
+
+> 逐 PR 變更紀錄。最新在上。
+
+格式：
+```
+## YYYY-MM-DD — PR #NN <squash commit hash>
+- <what changed>
+- <why (optional)>
+- <breaking? migration needed?>
+```
+
+---
+
+## 2026-08-23 — (未合併，feat/isobath 分支)
+
+- 新增「海底等深線」圖層前端接線：`isobath` LayerVisibility key、manifest entry、
+  overlayRegistry 一筆 config（fill=深度分帶 12 級 + line=等深線 11 級，靠 `kind` filter 分流）、
+  4 個參數控件（配色 select / 分帶填色 toggle / 線透明度 slider / 填色濃度 slider）、
+  LegendPanel 圖例（隨配色模式換色）、popup（line 顯示水深、band 顯示深度區間）
+- 色票 SSOT：`src/data/isobathTypes.ts`（單色藍反向強調 / Haxby / Turbo 三模式）
+- 資料源：GEBCO 2025 Grid（15 arc-second），public domain，圖例 / popup 已掛署名
+- Breaking：無
+- 上游資料已落地：`public/base_map/gebco_isobath.pmtiles`（2.8 MB，tippecanoe layer `isobath`，
+  z4–12，2,409 features＝line 2,397 ＋ band 12）；上游 pipeline `taipei-gis-analytics/
+  pipelines/base_map/gebco_isobath/`、catalog `gebco_isobath`、handoff 皆已建立
+- `line-width` 由固定 0.6 改為 zoom interpolate（z5 0.4 → z15 2.2）——
+  畫面實測 z13 時固定寬度細到幾乎看不見（layer-onboarding 線層 baseline）
+- `upstream.status` 由 `catalog_missing` 修正為 `verified` + `datasetId: gebco_isobath`
+  （上游 catalog 已建立；平行作業時的暫時狀態）
+
+### 驗收紀錄（2026-08-23）
+
+- `npx tsc -b` exit 0；`npm test` 50 檔 / 650 測試全綠
+- Browser 實測（localhost:3721，All Off → 只開本層）：
+  - `isobath-fill` / `isobath-line` 兩層皆建立，`queryRenderedFeatures` 於 z8 取得 511 筆
+    （band 69 / line 442），`kind` 兩種值與 `depth_m`／`dmin`~`dmax` 屬性皆正確
+  - popup 顯示「水深 4,000 m」＋ GEBCO 署名
+  - 圖例 12 帶完整、隨配色模式換色
+  - 分帶填色 toggle 關閉後 `fill-opacity=0` 而 `visibility` 仍為 `visible`（符合規則）
+  - 三種配色模式切換皆正常
+- 陸地誤塗驗證：福州／南平／廈門／台中四個內陸點皆**未**被任何深度帶覆蓋（環差 hole 正確）
+
+### 尚未完成（需拍板）
+
+- ⚠️ **正式環境未部署**：`.gitignore:107` 擋 `public/base_map/*.pmtiles`，
+  prod 的 `/base_map/` 是純 volume 無 dist fallback →
+  上線前必須手動跑 `scripts/deploy/upload-deploy-assets.sh`，否則正式站 404
+- 尚未 commit / 未開 PR

--- a/docs/features/isobath/handoff.md
+++ b/docs/features/isobath/handoff.md
@@ -1,0 +1,50 @@
+# Handoff — 海底等深線 Isobath（下游視角）
+
+> **上游 SSOT**：`../../../taipei-gis-analytics/docs/handoff/gebco_isobath.md`（詳細契約看那份；已於 2026-08-23 產出並與本檔校對過）
+>
+> 上游 catalog：`taipei-gis-analytics/docs/data-catalog/base_map/gebco_isobath.md`（dataset_id `gebco_isobath`）
+>
+> 本檔只放**前端接線的簡表 + 上游約定的差異點**。契約細節不重複寫，只反向引用。
+
+## 上游 handoff 摘要
+
+- 產物路徑：`public/base_map/gebco_isobath.pmtiles`（前端 URL：`./base_map/gebco_isobath.pmtiles`）
+- tippecanoe source-layer：`isobath`，zoom 4–12
+- feature 兩種，靠 `kind` 屬性區分：
+  - `kind="line"`：LineString 等深線，屬性 `depth_m`（整數負值，11 種：-20 -50 -100 -200 -500 -1000 -2000 -3000 -4000 -5000 -6000）
+  - `kind="band"`：Polygon 深度分帶（環差、自帶 hole，陸地已挖空），屬性 `dmin`/`dmax`（整數負值，dmin 較深），共 12 帶（-7000~-6000 … -20~0）
+- 資料源：GEBCO 2025（15 arc-sec ≈ 450m），public domain 但需標示來源
+- 座標系統：WGS84
+
+（完整契約 → 上游 handoff）
+
+## 前端接線位置
+
+- 色票 SSOT：`src/data/isobathTypes.ts`
+- Overlay：`src/map/overlayRegistry.ts`（`id: "isobath"`）
+- Manifest：`src/data/layerManifest.ts`（`isobath` entry）
+- UI toggle：`src/components/sidebar/layerCatalog.ts`（底圖 Base Map > 地形 子群）
+
+## 硬依賴欄位（改一定爆）
+
+- `kind`（`"line"` / `"band"`）— overlayRegistry 兩個 sub-layer 靠它 filter 分流，改名或改值集合會讓其中一層畫不出東西
+- `depth_m`（line）／`dmin` + `dmax`（band）— `isobathTypes.ts` 的 `match` 表達式硬編這些整數負值集合（11 級 / 12 級），上游若調整分級邊界，`ISOBATH_BANDS` / `ISOBATH_LINE_DEPTHS` 要同步改
+- source-layer 名稱 `isobath` — `overlayRegistry.ts` 的 `pmtiles.sourceLayer` 寫死
+
+## 上游改動 → 下游要跟改的觸發點
+
+| 上游改動 | 下游動作 |
+|---|---|
+| 調整深度分帶邊界（12 級的斷點值） | `src/data/isobathTypes.ts` 的 `ISOBATH_BANDS` / `ISOBATH_LINE_DEPTHS` 要同步改，三個色階陣列長度也要跟著調 |
+| 改 `kind` 值集合或欄位名 | `overlayRegistry.ts` 的兩個 `filter` 要同步改 |
+| 改 source-layer 名稱 | `overlayRegistry.ts` 的 `pmtiles.sourceLayer` + `layerManifest.ts` 的 `source.sourceLayer` 同步改 |
+| 上游 catalog dataset_id 改名 | `layerManifest.ts` 的 `upstream.datasets[].datasetId` 要同步改（現為 `gebco_isobath`） |
+
+## 已知不對稱
+
+- **正式環境尚未部署**：`.gitignore` 第 107 行 `public/base_map/*.pmtiles` 會擋掉這個檔案，
+  且 prod 的 nginx `/base_map/` 是純 volume 無 dist fallback → **上線前必須手動跑
+  `scripts/deploy/upload-deploy-assets.sh`** 把檔案送上 S3 `deploy-assets/base_map/`，
+  否則正式站 404。本機 dev 不受影響（檔案已落地，2.8 MB）。
+- 命名不對稱（刻意）：上游 dataset_id 為 `gebco_isobath`（analytics 的 snake_case 慣例），
+  下游 layer key 與 feature slug 為 `isobath`。兩邊文件已互相標註，改任一邊要同步。

--- a/src/components/LegendPanel.tsx
+++ b/src/components/LegendPanel.tsx
@@ -32,6 +32,7 @@ import {
   URBAN_HEAT_CREDIT, URBAN_HEAT_COVERAGE_NOTE,
 } from "../data/urbanHeatTypes";
 import { FOREST_RESERVE_TYPES } from "../data/forestReserveTypes";
+import { isobathLegendRows, ISOBATH_ATTRIBUTION } from "../data/isobathTypes";
 import { RE_PALETTES } from "../map/overlayRegistry";
 import { INFERNO, VIRIDIS, MAGMA, h3RampGradient } from "../map/demographicsLayerFactory";
 import { DIVERGING_STOPS } from "../three/TemperatureWaveScene";
@@ -462,6 +463,7 @@ export const LEGEND_REGISTRY: LegendEntry[] = [
   { id: "maritimeBoundary", render: () => <MaritimeBoundaryLegend /> },
   { id: "slopeVector", render: () => <SlopeVectorLegend /> },
   { id: "aspectVector", render: () => <AspectVectorLegend /> },
+  { id: "isobath", render: ({ overlayParams }) => <IsobathLegend modeIdx={overlayParams.isobathModeIdx ?? 0} /> },
   // 警察覆蓋分析 isochrone（共用 overlap_count 色階）
   {
     id: "policeIsoSubstation",
@@ -903,6 +905,23 @@ const ASPECT_VECTOR_CATS = [
   { color: "#984ea3", label: "NW 西北" },
   { color: "#bdbdbd", label: "平地" },
 ];
+
+// 海底等深線圖例：12 級深度分帶（深→淺），隨 modeIdx 換色（SSOT isobathTypes.ts）
+function IsobathLegend({ modeIdx = 0 }: { modeIdx?: number }) {
+  const t = useLegendTheme();
+  const rows = isobathLegendRows(modeIdx);
+  return (
+    <div>
+      <div style={{ fontSize: FONT_SIZE.xs, color: t.textDim, letterSpacing: 1, marginBottom: 4 }}>
+        海底等深線 ISOBATH（深 → 淺）
+      </div>
+      <FireCatRows cats={rows} square />
+      <div style={{ fontSize: FONT_SIZE.xs, color: t.textDim, marginTop: 4, lineHeight: 1.3 }}>
+        {ISOBATH_ATTRIBUTION}
+      </div>
+    </div>
+  );
+}
 
 function AspectVectorLegend() {
   const t = useLegendTheme();

--- a/src/components/featureInfo/baseMapPanels.tsx
+++ b/src/components/featureInfo/baseMapPanels.tsx
@@ -2,6 +2,7 @@ import { Row } from "./shared";
 import {
   maritimeBoundaryType, MARITIME_BOUNDARY_SOURCE_NOTE,
 } from "../../data/maritimeBoundaryTypes";
+import { formatIsobathRange, ISOBATH_ATTRIBUTION } from "../../data/isobathTypes";
 
 // Base map popup panels — 行政邊界 + 海域界線 + 等高線 + OSM 路網
 // PMTiles 來源 taipei-gis-analytics，欄位由 _manifest.json / catalog 各檔定義
@@ -149,6 +150,29 @@ export function AspectVectorPanel({ props }: { props: Record<string, unknown> })
     <div>
       <Row label="坡向" value={cls ? name : "無資料"} />
       <Row label="來源" value="坡面朝向 8 方位分級（DTM 20m 計算）" />
+    </div>
+  );
+}
+
+// 海底等深線（線）：depth_m 整數負值，11 級
+export function IsobathLinePanel({ props }: { props: Record<string, unknown> }) {
+  const depth = Number(props.depth_m ?? 0);
+  return (
+    <div>
+      <Row label="水深" value={depth ? `${Math.abs(depth).toLocaleString("zh-TW")} m` : ""} />
+      <Row label="來源" value={ISOBATH_ATTRIBUTION} />
+    </div>
+  );
+}
+
+// 海底等深線（深度分帶 band）：dmin/dmax 整數負值，12 級
+export function IsobathBandPanel({ props }: { props: Record<string, unknown> }) {
+  const dmin = Number(props.dmin ?? 0);
+  const dmax = Number(props.dmax ?? 0);
+  return (
+    <div>
+      <Row label="深度區間" value={formatIsobathRange(dmin, dmax)} />
+      <Row label="來源" value={ISOBATH_ATTRIBUTION} />
     </div>
   );
 }

--- a/src/components/featureInfo/registry.tsx
+++ b/src/components/featureInfo/registry.tsx
@@ -113,6 +113,7 @@ import {
   MaritimeBoundaryPanel,
   Contour25kPanel, ContourDtm20Panel, OsmRoadDrivePanel,
   SlopeVectorPanel, AspectVectorPanel,
+  IsobathLinePanel, IsobathBandPanel,
 } from "./baseMapPanels";
 import {
   PoliceStationPanel, WomenChildWarningPanel, SpeedCameraPanel, SpeedZoneSegmentPanel,
@@ -328,6 +329,8 @@ export const PANEL_REGISTRY: Partial<Record<FeatureInfo["layerType"], FC<PanelPr
   osmExpressway: OsmRoadDrivePanel,
   slopeVector: SlopeVectorPanel,
   aspectVector: AspectVectorPanel,
+  isobathLine: IsobathLinePanel,
+  isobathBand: IsobathBandPanel,
   // 警政司法民防 17 layer
   policeStation: PoliceStationPanel,
   womenChildWarning: WomenChildWarningPanel,
@@ -678,6 +681,8 @@ export const HEADER_LABELS: Record<FeatureInfo["layerType"], string> = {
   hillshade: "山體陰影",
   slopeVector: "坡度分級",
   aspectVector: "坡向",
+  isobathLine: "海底等深線",
+  isobathBand: "海底深度分帶",
   // 警政司法民防
   policeStation: "警察機關",
   womenChildWarning: "婦幼警示點",

--- a/src/components/sidebar/layerCatalog.ts
+++ b/src/components/sidebar/layerCatalog.ts
@@ -209,6 +209,8 @@ export const THEMES: ThemeDef[] = [
           fromManifest("hillshade"),
           fromManifest("slopeVector"),
           fromManifest("aspectVector"),
+          // 海底等深線：陸域等高線／坡度／坡向的海域對照物，同屬「地形」子群
+          fromManifest("isobath"),
         ],
       },
       {

--- a/src/data/__tests__/__fixtures__/layer-golden.json
+++ b/src/data/__tests__/__fixtures__/layer-golden.json
@@ -1,6 +1,6 @@
 {
   "meta": {
-    "keyCount": 376,
+    "keyCount": 377,
     "sections": [
       "gisLayers",
       "overlays",
@@ -1650,6 +1650,12 @@
     },
     {
       "layers": [
+        "isobath-line"
+      ],
+      "type": "isobathLine"
+    },
+    {
+      "layers": [
         "police-station-circle"
       ],
       "type": "policeStation"
@@ -1881,6 +1887,12 @@
     },
     {
       "layers": [
+        "isobath-fill"
+      ],
+      "type": "isobathBand"
+    },
+    {
+      "layers": [
         "h3-pop-count-fill",
         "h3-pop-count-ext"
       ],
@@ -2035,6 +2047,223 @@
       "rebuildOnParamChange": null,
       "sourceId": "urban-heat-lst",
       "sourceUrl": "./environment/urban_heat_lst_taiwan.pmtiles"
+    },
+    {
+      "dynamicData": null,
+      "filter": null,
+      "id": "isobath",
+      "layers": [
+        {
+          "filter": [
+            "==",
+            [
+              "get",
+              "kind"
+            ],
+            "band"
+          ],
+          "layout": null,
+          "minzoom": null,
+          "paint": {
+            "dark": {
+              "fill-color": [
+                "match",
+                [
+                  "get",
+                  "dmin"
+                ],
+                -7000,
+                "#f0faff",
+                -6000,
+                "#d6eefb",
+                -5000,
+                "#b0dcf5",
+                -4000,
+                "#86c8ee",
+                -3000,
+                "#5eaee0",
+                -2000,
+                "#3b8ec9",
+                -1000,
+                "#1d6fae",
+                -500,
+                "#0c568f",
+                -200,
+                "#0a4272",
+                -100,
+                "#083055",
+                -50,
+                "#06203a",
+                -20,
+                "#04121f",
+                "#04121f"
+              ],
+              "fill-opacity": 0.35
+            },
+            "light": {
+              "fill-color": [
+                "match",
+                [
+                  "get",
+                  "dmin"
+                ],
+                -7000,
+                "#f0faff",
+                -6000,
+                "#d6eefb",
+                -5000,
+                "#b0dcf5",
+                -4000,
+                "#86c8ee",
+                -3000,
+                "#5eaee0",
+                -2000,
+                "#3b8ec9",
+                -1000,
+                "#1d6fae",
+                -500,
+                "#0c568f",
+                -200,
+                "#0a4272",
+                -100,
+                "#083055",
+                -50,
+                "#06203a",
+                -20,
+                "#04121f",
+                "#04121f"
+              ],
+              "fill-opacity": 0.35
+            }
+          },
+          "suffix": "fill",
+          "type": "fill"
+        },
+        {
+          "filter": [
+            "==",
+            [
+              "get",
+              "kind"
+            ],
+            "line"
+          ],
+          "layout": null,
+          "minzoom": null,
+          "paint": {
+            "dark": {
+              "line-color": [
+                "match",
+                [
+                  "get",
+                  "depth_m"
+                ],
+                -6000,
+                "#d6eefb",
+                -5000,
+                "#b0dcf5",
+                -4000,
+                "#86c8ee",
+                -3000,
+                "#5eaee0",
+                -2000,
+                "#3b8ec9",
+                -1000,
+                "#1d6fae",
+                -500,
+                "#0c568f",
+                -200,
+                "#0a4272",
+                -100,
+                "#083055",
+                -50,
+                "#06203a",
+                -20,
+                "#04121f",
+                "#04121f"
+              ],
+              "line-opacity": 0.85,
+              "line-width": [
+                "interpolate",
+                [
+                  "linear"
+                ],
+                [
+                  "zoom"
+                ],
+                5,
+                0.4,
+                8,
+                0.7,
+                12,
+                1.4,
+                15,
+                2.2
+              ]
+            },
+            "light": {
+              "line-color": [
+                "match",
+                [
+                  "get",
+                  "depth_m"
+                ],
+                -6000,
+                "#d6eefb",
+                -5000,
+                "#b0dcf5",
+                -4000,
+                "#86c8ee",
+                -3000,
+                "#5eaee0",
+                -2000,
+                "#3b8ec9",
+                -1000,
+                "#1d6fae",
+                -500,
+                "#0c568f",
+                -200,
+                "#0a4272",
+                -100,
+                "#083055",
+                -50,
+                "#06203a",
+                -20,
+                "#04121f",
+                "#04121f"
+              ],
+              "line-opacity": 0.85,
+              "line-width": [
+                "interpolate",
+                [
+                  "linear"
+                ],
+                [
+                  "zoom"
+                ],
+                5,
+                0.4,
+                8,
+                0.7,
+                12,
+                1.4,
+                15,
+                2.2
+              ]
+            }
+          },
+          "suffix": "line",
+          "type": "line"
+        }
+      ],
+      "pmtiles": {
+        "maxzoom": 12,
+        "minzoom": 4,
+        "sourceLayer": "isobath"
+      },
+      "rebuildOnParamChange": null,
+      "sourceId": "isobath",
+      "sourceUrl": "./base_map/gebco_isobath.pmtiles"
     },
     {
       "dynamicData": null,
@@ -49324,6 +49553,46 @@
         "min": 0.1,
         "step": 0.05,
         "value": 0.9
+      }
+    ],
+    "isobath": [
+      {
+        "label": "配色",
+        "options": [
+          {
+            "label": "單色藍（反向強調）",
+            "value": "0"
+          },
+          {
+            "label": "Haxby",
+            "value": "1"
+          },
+          {
+            "label": "Turbo",
+            "value": "2"
+          }
+        ],
+        "type": "select",
+        "value": "0"
+      },
+      {
+        "label": "分帶填色",
+        "type": "toggle",
+        "value": true
+      },
+      {
+        "label": "透明度 0.85",
+        "max": 1,
+        "min": 0,
+        "step": 0.05,
+        "value": 0.85
+      },
+      {
+        "label": "填色濃度 0.35",
+        "max": 0.8,
+        "min": 0,
+        "step": 0.05,
+        "value": 0.35
       }
     ],
     "lakesPondsOsm": [

--- a/src/data/__tests__/layerGoldenSnapshot.test.ts
+++ b/src/data/__tests__/layerGoldenSnapshot.test.ts
@@ -109,7 +109,7 @@ describe("layer 黃金快照", () => {
 });
 
 describe("黃金快照覆蓋度", () => {
-  it("涵蓋全部 376 個 layer key", () => {
+  it("涵蓋全部 377 個 layer key", () => {
     const keys = allLayerKeys();
     // 2026-08-12：+1 = vesselWatch（特殊船舶）。這個數字是 ratchet，加層時一起加。
     // 2026-08-13：+1 = maritimeBoundary（領海界線）。
@@ -119,7 +119,8 @@ describe("黃金快照覆蓋度", () => {
     // 2026-08-18：+1 = internetExchangePoints（全球 IXP 點位）；+1 ANFR；+1 OSM 通訊候選點；+1 RIPE Atlas 量測節點；+2 Ookla 效能格網。
     // 2026-08-19：+1 = animalAdoption（每日待認養收容所摘要）；+1 = animalShelterPressure（官方月報縣市壓力）。
     // 2026-08-20：+1 = animalWelfarePoints（7 類動物福利服務據點）。
-    expect(keys.length).toBe(376);
+    // 2026-08-23：+1 = isobath（海底等深線 GEBCO 2025，等深線 11 級 + 深度分帶 12 級）。
+    expect(keys.length).toBe(377);
     expect(Object.keys(full.colors as object)).toHaveLength(keys.length);
     expect(Object.keys(full.icons as object)).toHaveLength(keys.length);
     expect(Object.keys(full.upstream as object)).toHaveLength(keys.length);

--- a/src/data/isobathTypes.ts
+++ b/src/data/isobathTypes.ts
@@ -1,0 +1,137 @@
+/**
+ * 海底等深線 GEBCO 2025（等深線 11 級 + 深度分帶 12 級）的顏色、分級單一真實來源。
+ * 給 overlayRegistry 配色（fill-color / line-color 表達式）、LegendPanel 圖例、
+ * featureInfo popup 三處共用（同 buildingsGbaTypes.ts / urbanHeatTypes.ts 慣例）。
+ *
+ * 資料源：GEBCO 2025 Grid（15 arc-second ≈ 450m），`public/base_map/gebco_isobath.pmtiles`，
+ * tippecanoe source-layer `isobath`，z4–12。
+ * feature 兩種，靠 `kind` 屬性區分：
+ *   `kind="line"`：LineString 等深線，`depth_m`（整數負值，11 種）
+ *   `kind="band"`：Polygon 深度分帶（環差、自帶 hole，陸地已挖空），`dmin`/`dmax`（整數負值，12 種）
+ * 授權 Public Domain，圖例仍須署名 GEBCO（見 `ISOBATH_ATTRIBUTION`）。
+ *
+ * ⚠️ 表達式不得含 `["zoom"]`：zoom 只能在最外層 interpolate/step（見 streetTreeColors.ts 註）。
+ */
+
+export interface IsobathBand {
+  /** 較深的下界（含），整數負值 */
+  dmin: number;
+  /** 較淺的上界（不含，band 最後一級為 0），整數負值或 0 */
+  dmax: number;
+}
+
+// 12 深度分帶（由深到淺；tippecanoe band polygon 的 dmin/dmax 契約）
+export const ISOBATH_BANDS: IsobathBand[] = [
+  { dmin: -7000, dmax: -6000 },
+  { dmin: -6000, dmax: -5000 },
+  { dmin: -5000, dmax: -4000 },
+  { dmin: -4000, dmax: -3000 },
+  { dmin: -3000, dmax: -2000 },
+  { dmin: -2000, dmax: -1000 },
+  { dmin: -1000, dmax: -500 },
+  { dmin: -500, dmax: -200 },
+  { dmin: -200, dmax: -100 },
+  { dmin: -100, dmax: -50 },
+  { dmin: -50, dmax: -20 },
+  { dmin: -20, dmax: 0 },
+];
+
+// 11 級等深線（由深到淺）——剛好等於上面 band 的 dmin 子集（缺 -7000，等深線無此級）
+export const ISOBATH_LINE_DEPTHS: number[] = [
+  -6000, -5000, -4000, -3000, -2000, -1000, -500, -200, -100, -50, -20,
+];
+
+type IsobathModeIdx = 0 | 1 | 2;
+
+// 模式 0：單色藍（反向：深處最亮）——暗色底圖上一般深藍會融進黑底看不見最深處，
+// 故深度越深給越亮的顏色，越淺給越暗的顏色。
+const MODE0_COLORS: string[] = [
+  "#f0faff", "#d6eefb", "#b0dcf5", "#86c8ee", "#5eaee0", "#3b8ec9",
+  "#1d6fae", "#0c568f", "#0a4272", "#083055", "#06203a", "#04121f",
+];
+
+// 模式 1：Haxby（海洋學製圖標準色階，深藍→青→黃→橘）
+const MODE1_COLORS: string[] = [
+  "#0A0079", "#1300A0", "#1F49C8", "#2E86E0", "#3FA9E8", "#56C4E4",
+  "#71D9D4", "#8FE0B8", "#B0E096", "#D0DC79", "#E8D26B", "#F0B268",
+];
+
+// 模式 2：Turbo（彩虹漸層，最大反差；12 個取樣點近似 turbo colormap）
+const MODE2_COLORS: string[] = [
+  "#30123B", "#414FB0", "#3B82F5", "#18B4E0", "#1FDFCB", "#4FF06C",
+  "#A4FC3B", "#E1DA37", "#FDB92E", "#FB7E21", "#E6491B", "#B91C1C",
+];
+
+const ISOBATH_MODE_COLORS: Record<IsobathModeIdx, string[]> = {
+  0: MODE0_COLORS,
+  1: MODE1_COLORS,
+  2: MODE2_COLORS,
+};
+
+/** 顯示模式 select 選項；index 對齊 overlayRegistry 讀的 isobathModeIdx */
+export const ISOBATH_MODES = [
+  { label: "單色藍（反向強調）", value: "0" },
+  { label: "Haxby", value: "1" },
+  { label: "Turbo", value: "2" },
+] as const;
+
+function paletteForMode(modeIdx: number): string[] {
+  return ISOBATH_MODE_COLORS[modeIdx as IsobathModeIdx] ?? MODE0_COLORS;
+}
+
+/** band.dmin（或等深線 depth_m，兩者共用同一組深度斷點）→ ISOBATH_BANDS 的位置 */
+function bandIndexForDepth(depth: number): number {
+  return ISOBATH_BANDS.findIndex((b) => b.dmin === depth);
+}
+
+/** 深度分帶 fill-color：依 `dmin` match 12 級（⚠️ 不含 ["zoom"]） */
+export function isobathBandColorExpr(modeIdx: number): unknown[] {
+  const palette = paletteForMode(modeIdx);
+  const expr: unknown[] = ["match", ["get", "dmin"]];
+  ISOBATH_BANDS.forEach((b, i) => expr.push(b.dmin, palette[i]!));
+  expr.push(palette[palette.length - 1]!); // fallback（理論不會落到這裡）
+  return expr;
+}
+
+/** 等深線 line-color：依 `depth_m` match 11 級，與相鄰 band 邊界同色（⚠️ 不含 ["zoom"]） */
+export function isobathLineColorExpr(modeIdx: number): unknown[] {
+  const palette = paletteForMode(modeIdx);
+  const expr: unknown[] = ["match", ["get", "depth_m"]];
+  ISOBATH_LINE_DEPTHS.forEach((depth) => {
+    const i = bandIndexForDepth(depth);
+    expr.push(depth, palette[i >= 0 ? i : 0]!);
+  });
+  expr.push(palette[palette.length - 1]!); // fallback
+  return expr;
+}
+
+/** 深度分帶色（純 JS 版，供 featureInfo popup / 圖例 dot 上色，不進 mapbox 表達式） */
+export function isobathBandColor(dmin: number, modeIdx: number): string {
+  const palette = paletteForMode(modeIdx);
+  const i = bandIndexForDepth(dmin);
+  return palette[i >= 0 ? i : 0]!;
+}
+
+/** 等深線色（純 JS 版，與相鄰 band 邊界同色） */
+export function isobathLineColor(depth: number, modeIdx: number): string {
+  return isobathBandColor(depth, modeIdx);
+}
+
+/** 深度區間顯示字串，例："6,000–7,000 m" */
+export function formatIsobathRange(dmin: number, dmax: number): string {
+  const fmt = (n: number) => Math.abs(n).toLocaleString("zh-TW");
+  return `${fmt(dmax)}–${fmt(dmin)} m`;
+}
+
+/** 圖例列（12 級，由深到淺）；隨 modeIdx 換色 */
+export function isobathLegendRows(modeIdx: number): { color: string; label: string }[] {
+  const palette = paletteForMode(modeIdx);
+  return ISOBATH_BANDS.map((b, i) => ({
+    color: palette[i]!,
+    label: formatIsobathRange(b.dmin, b.dmax),
+  }));
+}
+
+// 圖例／popup 必掛署名（Public Domain 但仍需標示來源）
+export const ISOBATH_ATTRIBUTION =
+  "GEBCO 2025 Grid（15 arc-second）· GEBCO Bathymetric Compilation Group · Public Domain";

--- a/src/data/layerManifest.ts
+++ b/src/data/layerManifest.ts
@@ -4685,6 +4685,39 @@ export const LAYER_MANIFEST = {
     topics: ["底圖", "地形", "坡向"],
   },
 
+  // 🌊 海底等深線 GEBCO 2025（15 arc-second，Public Domain）——單一 PMTiles source-layer
+  // `isobath` 混 LineString/Polygon，靠 `kind` 屬性拆兩個 OVERLAY_REGISTRY sub-layer
+  // （fill=band 12 級深度分帶、line=line 11 級等深線），popup 因此宣告成陣列，
+  // 順序＝GIS_LAYERS 出現序（line 排在陸域等高線旁，fill 因覆蓋全海域排在大面積面層那批）。
+  isobath: {
+    key: "isobath",
+    section: { theme: "底圖 Base Map", group: "地形" },
+    label: "海底等深線 Isobath",
+    labelMobile: "海底等深線",
+    expandable: true,
+    color: "#0a4272",
+    icon: Waves,
+    upstream: {
+      status: "verified",
+      datasets: [{ datasetId: "gebco_isobath", confidence: "HIGH" }],
+      note: "GEBCO 2025 Grid 海底地形（15 arc-second ≈450m）。上游 catalog docs/data-catalog/base_map/gebco_isobath.md、handoff docs/handoff/gebco_isobath.md 皆已建立（2026-08-23）。",
+    },
+    dataClass: "B",
+    source: {
+      kind: "pmtiles",
+      sourceId: "isobath",
+      url: "./base_map/gebco_isobath.pmtiles",
+      sourceLayer: "isobath",
+      minzoom: 4,
+      maxzoom: 12,
+    },
+    legend: "isobath",
+    popup: ["isobathLine", "isobathBand"],
+    params: { count: 4, kinds: ["select", "toggle", "slider", "slider"] },
+    description: "全球海底等深線（GEBCO，等深線 11 級 + 深度分帶 12 級，3 種配色模式）",
+    topics: ["底圖", "地形", "海洋", "等深線"],
+  },
+
   buildingsGba: {
     key: "buildingsGba",
     section: { theme: "底圖 Base Map", group: "建成環境" },

--- a/src/data/layerParamsSpec.ts
+++ b/src/data/layerParamsSpec.ts
@@ -69,6 +69,7 @@ import {
 } from "./welfareTypes";
 import { FIRE_ISOCHRONE_COUNTY_OPTIONS } from "./fireIsochroneCounties";
 import { URBAN_HEAT_MODES } from "./urbanHeatTypes";
+import { ISOBATH_MODES } from "./isobathTypes";
 import { SOIL_FERTILITY_METRIC_OPTIONS } from "./agriSoilFertilityMetrics";
 import { MOUNTAIN_RESCUE_YEARS } from "./mountainSafetyTypes";
 import {
@@ -2417,6 +2418,16 @@ export const LAYER_PARAMS_SPEC = {
       kind: "slider", name: "aspectVectorOpacity", labelPrefix: "透明度", digits: 2,
       default: 0.6, min: 0.3, max: 1, step: 0.05,
     },
+  ],
+  isobath: [
+    {
+      kind: "select", name: "isobathModeIdx", label: "配色", default: "0",
+      options: [...ISOBATH_MODES],
+      out: "isobathModeIdx", encodeNumeric: true,
+    },
+    { kind: "toggle", name: "isobathShowBands", label: "分帶填色", default: true },
+    { kind: "slider", name: "isobathOpacity", labelPrefix: "透明度", digits: 2, default: 0.85, min: 0, max: 1, step: 0.05 },
+    { kind: "slider", name: "isobathBandOpacity", labelPrefix: "填色濃度", digits: 2, default: 0.35, min: 0, max: 0.8, step: 0.05 },
   ],
   // 溫度網格 2D（與溫度波共用資料源）——值走 hook return 餵 useTemperatureGridLayer
   temperatureGrid: [

--- a/src/layers/__tests__/layerHookRegistry.test.ts
+++ b/src/layers/__tests__/layerHookRegistry.test.ts
@@ -141,7 +141,7 @@ const NO_HOOK_LEDGER = new Set<string>([
   "welfareGovOffices", "welfareLtcInstitutions", "welfareMentalHealth",
   "welfareNursingHomes", "welfareSocialWorkOrgs",
 
-  // ── OVERLAY_REGISTRY 的 PMTiles 層（63）──
+  // ── OVERLAY_REGISTRY 的 PMTiles 層（64）──
   "agriProduceWholesale", "agriRetail", "aquacultureIntegrated", "aquaculturePonds",
   "aquacultureWaterSatellite", "aquacultureWaterSatelliteMoa", "aquacultureWaterUnion",
   "busStationsCity", "canopyHeight", "cemeteryOsm", "civilDefenseShelter", "contour25k",
@@ -151,7 +151,7 @@ const NO_HOOK_LEDGER = new Set<string>([
   "eduCampusArea", "eduCampusPolygon", "eduCramSchool", "eduDistrictElementary",
   "eduDistrictJunior", "evIsland", "farmRoads", "fireHydrants", "forestCompartments",
   "forestReserve", "forestRoads", "gasCoverageAll", "gasCoverageCpc", "gasCoverageFpcc",
-  "gasCoverageTaisugar", "highways", "hikingTrails", "lakesPondsOsm", "maritimeBoundary",
+  "gasCoverageTaisugar", "highways", "hikingTrails", "isobath", "lakesPondsOsm", "maritimeBoundary",
   "medAED", "medClinic",
   "medLTC", "medPharmacy", "nonUrbanZoning", "osmExpressway", "osmRoadDrive",
   "policeIsoCityDept", "policeIsoPrecinct", "policeIsoSubstation", "propertyValueGrid",

--- a/src/map/gisClickRegistry.ts
+++ b/src/map/gisClickRegistry.ts
@@ -374,6 +374,9 @@ export const GIS_LAYERS: { layers: string[]; type: FeatureInfo["layerType"] }[] 
   { layers: ["base-county-boundary-line", "base-county-boundary-fill"], type: "countyBoundary" },
   { layers: ["base-contour-25k-line"], type: "contour25k" },
   { layers: ["base-contour-dtm20-line"], type: "contourDtm20" },
+  // 🌊 海底等深線（線）：陸域等高線的海域對照物，同樣是細線小目標 → 緊接排在後面
+  //    （fill band 覆蓋全海域故另排在下方大面積面層那批，見檔尾）
+  { layers: ["isobath-line"], type: "isobathLine" },
   // 警政司法民防 17 layer（layer id = `${sourceId}-${suffix}`，對齊 overlayRegistry）
   { layers: ["police-station-circle"], type: "policeStation" },
   { layers: ["women-child-warning-circle"], type: "womenChildWarning" },
@@ -429,6 +432,8 @@ export const GIS_LAYERS: { layers: string[]; type: FeatureInfo["layerType"] }[] 
   { layers: ["edu-district-k12-elementary-fill", "edu-district-k12-junior-fill"], type: "eduDistrictK12" },
   // 🎓 高中就學區：15 個面覆蓋全台，最不該搶點擊 → 整個陣列的最末
   { layers: ["edu-district-senior-fill"], type: "eduDistrictSenior" },
+  // 🌊 海底等深線（深度分帶 fill）：覆蓋全海域的大面積 fill，同「大面積面層放最末」原則
+  { layers: ["isobath-fill"], type: "isobathBand" },
   // 🔷 H3 指標格 6 層（W2）：三個 factory 現算的六邊形網格，皆鋪滿有資料的行政區域。
   //    放在既有面層之後、田區之前 —— 這六層歷來零點擊接線，排最尾端對既有命中順序零影響。
   //    ⚠️ 每層都必須收 `-fill` **與** `-ext` 兩個 id：3D toggle 讓兩者互斥

--- a/src/map/overlayRegistry.ts
+++ b/src/map/overlayRegistry.ts
@@ -48,6 +48,7 @@ import {
 import { canopyGiantDistColorExpr } from "../data/canopyGiantsTypes";
 import { urbanFormGridColorExpr, urbanFormGridOpacityExpr } from "../data/urbanFormGridTypes";
 import { resolveUrbanHeatMode, urbanHeatRasterColor } from "../data/urbanHeatTypes";
+import { isobathBandColorExpr, isobathLineColorExpr } from "../data/isobathTypes";
 import { urbanZoningColorExpr, URBAN_ZONING_CATEGORIES } from "../data/urbanZoningTypes";
 import { nonUrbanZoningColorExpr, nonUrbanZoningCodeFilter } from "../data/nonUrbanZoningTypes";
 import {
@@ -601,6 +602,46 @@ export const OVERLAY_REGISTRY: OverlayConfig[] = [
             "raster-color": urbanHeatRasterColor(p?.urbanHeatModeIdx ?? 0),
           };
         },
+      },
+    ],
+  },
+
+  // ── 🌊 海底等深線 Isobath（GEBCO 2025 15″ 網格，Public Domain）──
+  // 單一 tippecanoe source-layer `isobath` 混 LineString/Polygon，靠 `kind` 屬性
+  // 拆兩個 mapbox layer：fill 吃 kind=band（12 段深度分帶），line 吃 kind=line
+  // （11 級等深線）。fill 排在 line 之前，讓等深線疊在分帶色塊之上。
+  // toggle（分帶填色）與 opacity 一律用 opacity 壓 0 切換，不用 layout.visibility
+  // （同 forestCompartments 慣例，見 overlayManager.ts 對 visibility 誤判的說明）。
+  // ⚠️ 放在 registry 前段（緊接 urbanHeat）是刻意的：band fill 覆蓋全海域，
+  //    晚加會蓋掉沿海 POI（港口/燈塔/特殊船舶/海底電纜等）。
+  {
+    id: "isobath",
+    sourceUrl: "./base_map/gebco_isobath.pmtiles",
+    sourceId: "isobath",
+    pmtiles: { sourceLayer: "isobath", minzoom: 4, maxzoom: 12 },
+    attribution: "GEBCO 2025 Grid（15″，Public Domain）",
+    layers: [
+      {
+        suffix: "fill",
+        type: "fill",
+        filter: ["==", ["get", "kind"], "band"],
+        paint: (_isDark, p) => ({
+          "fill-color": isobathBandColorExpr(p?.isobathModeIdx ?? 0),
+          "fill-opacity": (p?.isobathShowBands ?? 1) ? (p?.isobathBandOpacity ?? 0.35) : 0,
+        }),
+      },
+      {
+        suffix: "line",
+        type: "line",
+        filter: ["==", ["get", "kind"], "line"],
+        paint: (_isDark, p) => ({
+          "line-color": isobathLineColorExpr(p?.isobathModeIdx ?? 0),
+          // 隨 zoom 縮放（layer-onboarding 線層 baseline：次要線 z6≈0.5 → z14≈2）。
+          // 固定寬度在 z13+ 會細到看不見（2026-08-23 畫面實測）。
+          // zoom 只出現在最外層 interpolate，符合 isobathTypes.ts 檔頭的表達式規則。
+          "line-width": ["interpolate", ["linear"], ["zoom"], 5, 0.4, 8, 0.7, 12, 1.4, 15, 2.2],
+          "line-opacity": p?.isobathOpacity ?? 0.85,
+        }),
       },
     ],
   },

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -788,6 +788,7 @@ export interface FeatureInfo {
     | "contour25k" | "contourDtm20" | "osmRoadDrive"
     | "osmExpressway" | "hillshade"
     | "slopeVector" | "aspectVector"
+    | "isobathLine" | "isobathBand"
     // 警政司法民防 17 layer
     | "policeStation" | "womenChildWarning" | "speedCamera" | "speedZoneSegment"
     | "court" | "prosecutorsOffice" | "correctionalFacility" | "courtJurisdiction"
@@ -1209,6 +1210,7 @@ export interface LayerVisibility {
   hillshade: boolean;          // 山體陰影 raster（灰階 PNG，烤過 colormap）
   slopeVector: boolean;        // 坡度分級向量（建管六級坡 PMTiles，可點選/疊圖）
   aspectVector: boolean;       // 坡向分級向量（8 方位 PMTiles，可點選/疊圖）
+  isobath: boolean;            // 海底等深線 GEBCO 2025（等深線 11 級 + 深度分帶 12 級，z4-12，PMTiles）
   // 警政司法民防 17 layer（資料來自 taipei-gis-analytics police_justice/）
   policeStation: boolean;             // 2,065 警察機關（分局/派出所/專業警隊/總局）
   womenChildWarning: boolean;         // 185 婦幼警示點


### PR DESCRIPTION
## 這個 PR 做什麼

新增「海底等深線」圖層 — GEBCO 2025 海底地形，**等深線 11 級 + 深度分帶 12 級**，用途是給船舶軌跡（`vesselWatch` / `ships`）當海域底圖。

上游 pipeline：taipei-gis-analytics PR #54（已 merged）。

## 設計

單一 PMTiles source（source-layer `isobath`，線面混合），靠 `kind` 屬性 filter 拆成兩個 sub-layer：

| sub-layer | filter | 內容 |
|---|---|---|
| `fill` | `kind="band"` | 12 段深度分帶（環差 polygon，自帶 hole → 陸地自動挖空） |
| `line` | `kind="line"` | 11 級等深線 |

**4 個控件**：配色 select（單色藍反向 / Haxby / Turbo）、分帶填色 toggle、線透明度 slider、填色濃度 slider。

## 三個實作決定

- **分帶切換用 `fill-opacity` 壓 0，不用 `layout.visibility`** — 後者是整層總開關，混用會被 `overlayManager` 誤判成使用者關掉整層（同 `forestCompartments` 慣例）
- **單色藍刻意反向（深處最亮）** — 暗色底圖上深藍會融進黑底，正常方向反而看不見最深處
- **`line-width` 隨 zoom 縮放**（z5 0.4 → z15 2.2）— 畫面實測固定寬度在 z13 細到幾乎看不見

## 四鐵則

opacity slider ✅ ｜ 12 帶離散圖例（隨配色模式換色）✅ ｜ popup 顯示水深 + GEBCO 署名 ✅ ｜ select 可用 ✅

## 驗收

- `npx tsc -b` exit 0；`npm test` 50 檔 / 650 測試全綠
- Browser 實測（All Off → 只開本層）：z8 取得 511 筆 render（band 69 / line 442）、popup 顯示「水深 4,000 m」、圖例 12 帶完整、填色 toggle 關閉後 `fill-opacity=0` 而 `visibility` 仍 `visible`、三配色切換正常
- **陸地誤塗驗證**：福州／南平／廈門／台中四個內陸點皆未被任何深度帶覆蓋

## 部署

PMTiles（2.8 MB）已上傳 S3 `deploy-assets/base_map/gebco_isobath.pmtiles`。`.gitignore` 擋 `public/base_map/*.pmtiles`，prod 該路徑是純 volume 無 dist fallback，容器啟動時 entrypoint 會自動背景 pull。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016dWEjBs3kR1hnJcy3VfNVH