### PR TITLE
feat(world): 上線日本宗教設施三個 raw layers

### DIFF
--- a/docs/features/jp-religion-layers/README.md
+++ b/docs/features/jp-religion-layers/README.md
@@ -1,0 +1,40 @@
+# 日本宗教設施三源圖層
+
+> **Slug**：`jp-religion-layers`
+> **狀態**：dev
+> **Owner**：mini-taiwan-pulse
+> **上線日期**：待 release
+> **相關 PR**：待建立
+
+## 一句話說明
+
+在「世界 World」rail tab 提供 GSI、OpenStreetMap、Wikidata 三個彼此獨立的原始點層。
+
+## 圖層
+
+| layer key | 類型 | 資料源 | 筆數 | 預設 |
+|---|---|---|---:|---|
+| `jpReligionGsi` | circle | PMTiles | 167,037 | off |
+| `jpReligionOsm` | circle | GeoJSON | 71,040 | off |
+| `jpReligionWikidata` | circle | GeoJSON | 37,154 | off |
+
+三源不可直接融合或加總：來源涵蓋不同且 OSM 採 ODbL。每層皆可調整透明度與點位大小。
+
+## 關鍵檔案
+
+- 契約／色票：`src/data/jpReligionTypes.ts`
+- Loader：`src/data/jpReligionLoader.ts`
+- Hook：`src/hooks/useJpReligionLayers.ts`
+- Catalog：`src/components/sidebar/layerCatalog.ts`
+- Legend：`src/components/LegendPanel.tsx`
+- Popup：`src/components/featureInfo/religionPanels.tsx`
+
+## 資料契約
+
+見 [handoff.md](./handoff.md)。上游 SSOT：`taipei-gis-analytics/docs/handoff/jp-religion-layers.md`。
+
+## 相關文件
+
+- [Backlog](./backlog.md)
+- [Changelog](./changelog.md)
+- [開發規則](../../development-rules.md)

--- a/docs/features/jp-religion-layers/backlog.md
+++ b/docs/features/jp-religion-layers/backlog.md
@@ -1,0 +1,21 @@
+# Backlog — 日本宗教設施三源圖層
+
+## Active work
+
+目前無 active item。
+
+## Conditional / triggered later
+
+| ID | Category | Priority | State | Trigger | Next action | Acceptance |
+|---|---|---|---|---|---|---|
+| JPR-2 | release | P2 | conditional | 本 feature 要走獨立 S3 deploy asset release | 補 world upload 清單並上傳三檔 | object HEAD、下載 checksum 與正式 HTTP 均一致 |
+
+## Completed / historical
+
+- [x] **JPR-0**：三個靜態資產與上游契約驗收相符 — 2026-08-24；詳見 [changelog.md](./changelog.md)。
+- [x] **JPR-1**：三源已接入世界 tab；tsc、650 tests、All Off、逐層 attribution／popup 與 GSI z15.6／z16.6 browser 驗收通過 — 2026-08-24；詳見 [changelog.md](./changelog.md)。
+- [x] **JPR-1a**：三源新增獨立點位大小 slider，保留各來源原始 zoom radius baseline — 2026-08-24；詳見 [changelog.md](./changelog.md)。
+
+## Explicitly not planned
+
+- **JPR-X1**：融合三源或相加筆數 — OSM 的 ODbL 授權與跨源重複／漏失使此結果不具可解釋性。

--- a/docs/features/jp-religion-layers/changelog.md
+++ b/docs/features/jp-religion-layers/changelog.md
@@ -1,0 +1,10 @@
+# Changelog — 日本宗教設施三源圖層
+
+## 2026-08-24 — Unreleased
+
+- 接入 `jpReligionGsi`、`jpReligionOsm`、`jpReligionWikidata` 三個獨立世界圖層，預設全 off。
+- GSI 採主站 `mapbox-pmtiles` custom source type，固定 `source-layer=jp_religion_gsi` 與 source maxzoom 14。
+- 三源共用宗教分類色票，新增 opacity、popup fallback、來源 attribution 與完整度 disclaimer。
+- 三源皆新增點位大小 slider（0.3×–3×）；scale 直接重算 zoom stops，避免非法 Mapbox `zoom` expression 巢狀。
+- 資料源：GSI 167,037／OSM 71,040／Wikidata 37,154。
+- Breaking：無；不依賴 Supabase runtime。

--- a/docs/features/jp-religion-layers/handoff.md
+++ b/docs/features/jp-religion-layers/handoff.md
@@ -1,0 +1,48 @@
+# Handoff — 日本宗教設施三源圖層（下游視角）
+
+> **上游 SSOT**：`../../../taipei-gis-analytics/docs/handoff/jp-religion-layers.md`
+>
+> 本檔只記前端硬依賴與接線差異；完整研究與資料契約以上游 handoff 為準。
+
+## 上游產物
+
+| layer | 靜態產物 | 筆數 | 授權 |
+|---|---|---:|---|
+| GSI | `public/world/jp_religion_gsi.pmtiles` | 167,037 | 国土地理院規約 |
+| OSM | `public/world/jp_religion_osm.geojson` | 71,040 | ODbL |
+| Wikidata | `public/world/jp_religion_wikidata.geojson` | 37,154 | CC0 |
+
+座標系統皆為 WGS84 Point。三者是獨立來源，不做 UNION 或融合。
+
+## 前端接線位置
+
+- Loader：`src/data/jpReligionLoader.ts`（OSM／Wikidata）
+- Hook：`src/hooks/useJpReligionLayers.ts`（含 GSI PMTiles source）
+- Host：`src/layers/hosts/climateHosts.tsx`
+- UI：`src/components/sidebar/layerCatalog.ts` 的 `世界 World · 宗教`
+- Legend／popup：`src/components/LegendPanel.tsx`、`src/components/featureInfo/religionPanels.tsx`
+
+## 硬依賴欄位
+
+- `religion` — `shinto | buddhist | christian`，用於三源共用分色；GSI／Wikidata 沒有 christian。
+- `name` — optional；缺值時 key 不存在，popup 必須 fallback。
+- `id` — OSM element id／Wikidata QID；GSI PMTiles 刻意不含此欄。
+- GSI vector source-layer 固定為 `jp_religion_gsi`，source `maxzoom` 固定 14，地圖 z15+ 依 overzoom 顯示。
+
+## 授權與資料誠實度
+
+LegendPanel 必須依開啟來源顯示：
+
+- `© OpenStreetMap contributors, ODbL`
+- `出典：国土地理院最適化ベクトルタイル`
+- `Wikidata, CC0`
+
+日本沒有官方全國宗教設施圖層。任何單一來源都不是全量，三者數字不可相加。大阪府清冊實測 GSI 對上 62%，三源聯集仍漏 25.9%。
+
+## 驗收
+
+- All Off 時 globe 無宗教點；三層預設皆 off。
+- 三層逐一開啟可見，色票一致，opacity slider 有效。
+- popup 不顯示 `undefined`；GSI 無名點顯示地圖記號 fallback。
+- Legend 顯示當前來源 attribution 與不可加總 disclaimer。
+- GSI 在 z15／z16 仍可見。

--- a/src/components/LegendPanel.tsx
+++ b/src/components/LegendPanel.tsx
@@ -17,6 +17,7 @@ import { VESSEL_CLASSES } from "../data/vesselWatchTypes";
 // 船種色票／航班識別色 —— 皆為 three-free 出處（見 ShipsLegend / FlightsLegend 註解）
 import { SHIP_TYPE_LEGEND, SHIP_TYPE_COLORS_DARK } from "../data/shipTrails";
 import { LAYER_COLORS } from "./sidebar/layerCatalog";
+import { JP_RELIGION_CATEGORIES } from "../data/jpReligionTypes";
 import { legendKeys } from "../data/legendGroups";
 import { TRA_TRAIN_TYPES } from "../constants/traTrainTypes";
 import { railLegendLines, railMetroOperatorNames, resolveRailCodes } from "../constants/railLines";
@@ -304,6 +305,7 @@ export const LEGEND_REGISTRY: LegendEntry[] = [
   { id: "earthquakeReplay", render: () => <EarthquakeReplayLegend /> },
   { id: "earthquakesGlobal", render: () => <EarthquakeGlobalLegend /> },
   { id: "worldTrashDebris", render: () => <WorldTrashDebrisLegend /> },
+  { id: "jpReligion", render: ({ visibility }) => <JpReligionLegend visibility={visibility} /> },
   { id: "typhoonTracks", render: () => <TyphoonTrackLegend /> },
   { id: "windField", render: () => <WindFieldLegend /> },
   { id: "oceanCurrents", render: () => <OceanCurrentsLegend /> },
@@ -4337,6 +4339,39 @@ function WorldTrashDebrisLegend() {
       <div style={{ fontSize: FONT_SIZE.xs, color: t.textDim, marginTop: 2, lineHeight: 1.3 }}>
         資料：Outerview (CC-BY-4.0)
       </div>
+    </div>
+  );
+}
+
+function JpReligionLegend({ visibility }: { visibility: LayerVisibility }) {
+  const t = useLegendTheme();
+  const attributions = [
+    visibility.jpReligionGsi ? "出典：国土地理院最適化ベクトルタイル" : null,
+    visibility.jpReligionOsm ? "© OpenStreetMap contributors, ODbL" : null,
+    visibility.jpReligionWikidata ? "Wikidata, CC0" : null,
+  ].filter((value): value is string => Boolean(value));
+  return (
+    <div>
+      <div style={{ fontSize: FONT_SIZE.xs, color: t.textDim, letterSpacing: 1, marginBottom: 4 }}>
+        日本宗教設施 JAPAN RELIGION
+      </div>
+      <div style={{ display: "flex", flexDirection: "column", gap: 3 }}>
+        {JP_RELIGION_CATEGORIES.map((category) => (
+          <div key={category.value} style={{ display: "flex", alignItems: "center", gap: 6 }}>
+            <div style={{ width: 8, height: 8, borderRadius: RADIUS.full, background: category.color, flexShrink: 0 }} />
+            <span style={{ fontSize: FONT_SIZE.xs, color: t.textMuted }}>{category.label}</span>
+          </div>
+        ))}
+      </div>
+      <div style={{ fontSize: FONT_SIZE.xs, color: t.textDim, marginTop: 5, lineHeight: 1.35 }}>
+        日本無官方全國宗教設施圖層。任何單一圖層都不是全量，三者數字也不應相加；
+        大阪府清冊實測 GSI 僅對上 62%，三源聯集仍漏 25.9%。建議一次只開一個來源。
+      </div>
+      {attributions.map((attribution) => (
+        <div key={attribution} style={{ fontSize: FONT_SIZE.xs, color: t.textDim, marginTop: 3, lineHeight: 1.35 }}>
+          {attribution}
+        </div>
+      ))}
     </div>
   );
 }

--- a/src/components/featureInfo/registry.tsx
+++ b/src/components/featureInfo/registry.tsx
@@ -49,6 +49,7 @@ import {
 import {
   TemplePanel, ChurchPanel, AncestralHallPanel, FoundationPanel,
   OtherWorshipPanel, ReligionTop100Panel,
+  JpReligionGsiPanel, JpReligionOsmPanel, JpReligionWikidataPanel,
 } from "./religionPanels";
 import {
   FuneralFacilityPanel, FuneralOperatorPanel, FuneralOperatorDensityPanel,
@@ -315,6 +316,9 @@ export const PANEL_REGISTRY: Partial<Record<FeatureInfo["layerType"], FC<PanelPr
   rasterProbe: RasterProbePanel,
   temperatureGrid: TemperatureGridPanel,
   worldTrashDebris: WorldTrashDebrisPanel,
+  jpReligionGsi: JpReligionGsiPanel,
+  jpReligionOsm: JpReligionOsmPanel,
+  jpReligionWikidata: JpReligionWikidataPanel,
   // Base map
   countyBoundary: CountyBoundaryPanel,
   townshipBoundary: TownshipBoundaryPanel,
@@ -669,6 +673,9 @@ export const HEADER_LABELS: Record<FeatureInfo["layerType"], string> = {
   rasterProbe: "圖層讀值",
   temperatureGrid: "溫度網格",
   worldTrashDebris: "全球垃圾殘骸",
+  jpReligionGsi: "日本宗教設施 GSI",
+  jpReligionOsm: "日本宗教設施 OSM",
+  jpReligionWikidata: "日本宗教設施 Wikidata",
   // Base map
   countyBoundary: "縣市界",
   townshipBoundary: "鄉鎮市區界",

--- a/src/components/featureInfo/religionPanels.tsx
+++ b/src/components/featureInfo/religionPanels.tsx
@@ -5,6 +5,9 @@ import {
   deityFamilyColor, deityFamilyLabel, ancestralHallTypeLabel,
   ANCESTRAL_HALL_TYPES, ANCESTRAL_HALL_MISSING_COLOR, RELIGION_LAYER_COLORS,
 } from "../../data/religionTypes";
+import {
+  JP_RELIGION_COLORS, jpReligionLabel, religionNameFallback,
+} from "../../data/jpReligionTypes";
 
 // 本檔 Title 為極簡本地版（同 urbanPanels / fisheryPanels 慣例）。
 function Title({ color, children }: { color: string; children: string }) {
@@ -156,4 +159,62 @@ export function ReligionTop100Panel({ props }: { props: Record<string, unknown> 
       <Row label="地址" value={str(props.address)} />
     </>
   );
+}
+
+type JpReligionSource = "gsi" | "osm" | "wikidata";
+
+const JP_RELIGION_SOURCE_LABEL: Record<JpReligionSource, string> = {
+  gsi: "国土地理院最適化ベクトルタイル",
+  osm: "OpenStreetMap contributors（ODbL）",
+  wikidata: "Wikidata（CC0）",
+};
+
+function JpReligionPanel({
+  props,
+  source,
+}: {
+  props: Record<string, unknown>;
+  source: JpReligionSource;
+}) {
+  const t = useFeatureTheme();
+  const religion = str(props.religion);
+  const name = str(props.name) || religionNameFallback(religion, source === "gsi");
+  const id = str(props.id);
+  const color = JP_RELIGION_COLORS[religion as keyof typeof JP_RELIGION_COLORS]
+    ?? JP_RELIGION_COLORS.other;
+  return (
+    <>
+      <Title color={color}>{name}</Title>
+      <Row label="類別" value={jpReligionLabel(religion)} color={color} />
+      {source === "gsi" && !str(props.name) ? (
+        <div style={{ fontSize: FONT_SIZE.xs, color: t.textDim, marginTop: 4, lineHeight: 1.4 }}>
+          此點來自地圖符號，官方未提供名稱。
+        </div>
+      ) : null}
+      {id ? <Row label={source === "wikidata" ? "Wikidata" : "ID"} value={id} /> : null}
+      {source === "wikidata" && /^Q\d+$/.test(id) ? (
+        <a
+          href={`https://www.wikidata.org/wiki/${id}`}
+          target="_blank"
+          rel="noopener noreferrer"
+          style={{ color: t.link, fontSize: FONT_SIZE.base, display: "inline-block", marginTop: 5 }}
+        >
+          開啟 Wikidata ↗
+        </a>
+      ) : null}
+      <Row label="資料源" value={JP_RELIGION_SOURCE_LABEL[source]} />
+    </>
+  );
+}
+
+export function JpReligionGsiPanel({ props }: { props: Record<string, unknown> }) {
+  return <JpReligionPanel props={props} source="gsi" />;
+}
+
+export function JpReligionOsmPanel({ props }: { props: Record<string, unknown> }) {
+  return <JpReligionPanel props={props} source="osm" />;
+}
+
+export function JpReligionWikidataPanel({ props }: { props: Record<string, unknown> }) {
+  return <JpReligionPanel props={props} source="wikidata" />;
 }

--- a/src/components/sidebar/layerCatalog.ts
+++ b/src/components/sidebar/layerCatalog.ts
@@ -1398,6 +1398,14 @@ export const THEMES: ThemeDef[] = [
           fromManifest("worldTrashDebris"),
         ],
       },
+      {
+        title: "宗教",
+        layers: [
+          fromManifest("jpReligionGsi"),
+          fromManifest("jpReligionOsm"),
+          fromManifest("jpReligionWikidata"),
+        ],
+      },
     ],
   },
 

--- a/src/data/__tests__/__fixtures__/layer-golden.json
+++ b/src/data/__tests__/__fixtures__/layer-golden.json
@@ -1,6 +1,6 @@
 {
   "meta": {
-    "keyCount": 377,
+    "keyCount": 380,
     "sections": [
       "gisLayers",
       "overlays",
@@ -538,6 +538,24 @@
         "world-trash-debris-circle"
       ],
       "type": "worldTrashDebris"
+    },
+    {
+      "layers": [
+        "jp-religion-wikidata-circle"
+      ],
+      "type": "jpReligionWikidata"
+    },
+    {
+      "layers": [
+        "jp-religion-osm-circle"
+      ],
+      "type": "jpReligionOsm"
+    },
+    {
+      "layers": [
+        "jp-religion-gsi-circle"
+      ],
+      "type": "jpReligionGsi"
     },
     {
       "layers": [
@@ -49593,6 +49611,54 @@
         "min": 0,
         "step": 0.05,
         "value": 0.35
+      }
+    ],
+    "jpReligionGsi": [
+      {
+        "label": "透明度 0.60",
+        "max": 1,
+        "min": 0,
+        "step": 0.05,
+        "value": 0.6
+      },
+      {
+        "label": "大小 1.0",
+        "max": 3,
+        "min": 0.3,
+        "step": 0.1,
+        "value": 1
+      }
+    ],
+    "jpReligionOsm": [
+      {
+        "label": "透明度 0.75",
+        "max": 1,
+        "min": 0,
+        "step": 0.05,
+        "value": 0.75
+      },
+      {
+        "label": "大小 1.0",
+        "max": 3,
+        "min": 0.3,
+        "step": 0.1,
+        "value": 1
+      }
+    ],
+    "jpReligionWikidata": [
+      {
+        "label": "透明度 0.75",
+        "max": 1,
+        "min": 0,
+        "step": 0.05,
+        "value": 0.75
+      },
+      {
+        "label": "大小 1.0",
+        "max": 3,
+        "min": 0.3,
+        "step": 0.1,
+        "value": 1
       }
     ],
     "lakesPondsOsm": [

--- a/src/data/__tests__/layerGoldenSnapshot.test.ts
+++ b/src/data/__tests__/layerGoldenSnapshot.test.ts
@@ -109,7 +109,7 @@ describe("layer 黃金快照", () => {
 });
 
 describe("黃金快照覆蓋度", () => {
-  it("涵蓋全部 377 個 layer key", () => {
+  it("涵蓋全部 380 個 layer key", () => {
     const keys = allLayerKeys();
     // 2026-08-12：+1 = vesselWatch（特殊船舶）。這個數字是 ratchet，加層時一起加。
     // 2026-08-13：+1 = maritimeBoundary（領海界線）。
@@ -120,7 +120,8 @@ describe("黃金快照覆蓋度", () => {
     // 2026-08-19：+1 = animalAdoption（每日待認養收容所摘要）；+1 = animalShelterPressure（官方月報縣市壓力）。
     // 2026-08-20：+1 = animalWelfarePoints（7 類動物福利服務據點）。
     // 2026-08-23：+1 = isobath（海底等深線 GEBCO 2025，等深線 11 級 + 深度分帶 12 級）。
-    expect(keys.length).toBe(377);
+    // 2026-08-24：+3 = jpReligionGsi / jpReligionOsm / jpReligionWikidata（日本宗教設施三獨立源）。
+    expect(keys.length).toBe(380);
     expect(Object.keys(full.colors as object)).toHaveLength(keys.length);
     expect(Object.keys(full.icons as object)).toHaveLength(keys.length);
     expect(Object.keys(full.upstream as object)).toHaveLength(keys.length);

--- a/src/data/jpReligionLoader.ts
+++ b/src/data/jpReligionLoader.ts
@@ -1,0 +1,43 @@
+// 日本宗教設施靜態 GeoJSON loader。GSI 是 PMTiles，由 layer hook 直接接 source。
+import { withLoading } from "../lib/loadingRegistry";
+import { cachedOnce } from "../lib/loaderCache";
+
+export type JpReligionGeoJsonSource = "osm" | "wikidata";
+
+const BASE = `${import.meta.env.BASE_URL ?? "/"}world`;
+const CACHE_TTL_MS = 30 * 60_000;
+
+function fetchGeoJsonUncached(
+  source: JpReligionGeoJsonSource,
+  label: string,
+): Promise<GeoJSON.FeatureCollection> {
+  const url = `${BASE}/jp_religion_${source}.geojson`;
+  return withLoading(
+    `jp-religion-${source}`,
+    label,
+    fetch(url).then((response) => {
+      if (!response.ok) throw new Error(`HTTP ${response.status}`);
+      return response.json() as Promise<GeoJSON.FeatureCollection>;
+    }),
+  );
+}
+
+const fetchJpReligionOsmCached = cachedOnce(
+  () => fetchGeoJsonUncached("osm", "日本宗教設施 OpenStreetMap"),
+  CACHE_TTL_MS,
+);
+
+const fetchJpReligionWikidataCached = cachedOnce(
+  () => fetchGeoJsonUncached("wikidata", "日本宗教設施 Wikidata"),
+  CACHE_TTL_MS,
+);
+
+/** 首次開啟才由 hook 呼叫；module-level cache 避免重複下載 10.9 MB。 */
+export function fetchJpReligionOsm(): Promise<GeoJSON.FeatureCollection> {
+  return fetchJpReligionOsmCached();
+}
+
+/** 首次開啟才由 hook 呼叫；module-level cache 避免重複下載 5.9 MB。 */
+export function fetchJpReligionWikidata(): Promise<GeoJSON.FeatureCollection> {
+  return fetchJpReligionWikidataCached();
+}

--- a/src/data/jpReligionTypes.ts
+++ b/src/data/jpReligionTypes.ts
@@ -1,0 +1,46 @@
+/** 日本宗教設施三源圖層共用分類與配色。 */
+
+export type JpReligionCategory = "shinto" | "buddhist" | "christian";
+
+export const JP_RELIGION_COLORS = {
+  shinto: "#ef4444",
+  buddhist: "#f59e0b",
+  christian: "#3b82f6",
+  other: "#94a3b8",
+} as const;
+
+/** Legend、popup 與 Mapbox paint 共用同一份分類語意。 */
+export const JP_RELIGION_CATEGORIES = [
+  { value: "shinto", label: "神道 Shinto", color: JP_RELIGION_COLORS.shinto },
+  { value: "buddhist", label: "佛教 Buddhist", color: JP_RELIGION_COLORS.buddhist },
+  { value: "christian", label: "基督宗教 Christian", color: JP_RELIGION_COLORS.christian },
+] as const satisfies readonly {
+  value: JpReligionCategory;
+  label: string;
+  color: string;
+}[];
+
+/** properties.religion → 共用色相；未知值統一落在 other。 */
+export const JP_RELIGION_COLOR_EXPRESSION = [
+  "match", ["get", "religion"],
+  "shinto", JP_RELIGION_COLORS.shinto,
+  "buddhist", JP_RELIGION_COLORS.buddhist,
+  "christian", JP_RELIGION_COLORS.christian,
+  JP_RELIGION_COLORS.other,
+] as const;
+
+export function jpReligionLabel(religion: unknown): string {
+  return JP_RELIGION_CATEGORIES.find((row) => row.value === religion)?.label ?? "其他 Other";
+}
+
+/**
+ * name 缺席時的 popup 標題。GSI 96.7% 是無名地圖記號，不能顯示
+ * `undefined`，也不應自行推定特定設施名稱。
+ */
+export function religionNameFallback(religion: unknown, mapSymbol = false): string {
+  const suffix = mapSymbol ? "（地図記号）" : "";
+  if (religion === "shinto") return `神社${suffix}`;
+  if (religion === "buddhist") return `寺院${suffix}`;
+  if (religion === "christian") return `基督宗教設施${suffix}`;
+  return `宗教設施${suffix}`;
+}

--- a/src/data/layerManifest.ts
+++ b/src/data/layerManifest.ts
@@ -101,6 +101,7 @@ import {
 import type { LayerVisibility, FeatureInfo } from "../types";
 import type { UpstreamRef } from "./upstreamRegistry";
 import { RELIGION_LAYER_COLORS } from "./religionTypes";
+import { JP_RELIGION_COLORS } from "./jpReligionTypes";
 import { FUNERAL_LAYER_COLORS } from "./funeralTypes";
 import { WELFARE_LAYER_COLORS } from "./welfareTypes";
 import { EDUCATION_LAYER_COLORS } from "./educationTypes";
@@ -1058,6 +1059,87 @@ export const LAYER_MANIFEST = {
     params: { count: 1, kinds: ["slider"] },
     description: "Outerview 全球垃圾殘骸 ~25k 點（⚠️ 點密度是街景覆蓋度，不是垃圾分佈）",
     topics: ["世界", "環境", "垃圾"],
+  },
+
+  jpReligionGsi: {
+    key: "jpReligionGsi",
+    section: { theme: "世界 World", group: "宗教" },
+    label: "日本宗教設施 GSI",
+    labelMobile: "日本宗教 GSI",
+    expandable: true,
+    color: JP_RELIGION_COLORS.shinto,
+    icon: Landmark,
+    upstream: {
+      status: "verified",
+      datasets: [{ datasetId: "jp_religion_gsi", confidence: "HIGH" }],
+      processing: "国土地理院最適化ベクトルタイル的寺院／神社地圖記號，PMTiles z4-14",
+      note: "日本無官方全國宗教設施圖層；GSI 與另外兩源不可視為全量或相加",
+    },
+    dataClass: "D",
+    source: {
+      kind: "custom",
+      note: "useJpReligionLayers 自建 mapbox-pmtiles source；source-layer=jp_religion_gsi，maxzoom=14",
+      staticAssets: ["./world/jp_religion_gsi.pmtiles"],
+    },
+    legend: "jpReligion",
+    popup: "jpReligionGsi",
+    params: { count: 2, kinds: ["slider", "slider"] },
+    description: "国土地理院寺院／神社地圖記號 167,037 點（96.7% 無名稱）",
+    topics: ["世界", "日本", "宗教", "神社", "寺院"],
+  },
+
+  jpReligionOsm: {
+    key: "jpReligionOsm",
+    section: { theme: "世界 World", group: "宗教" },
+    label: "日本宗教設施 OSM",
+    labelMobile: "日本宗教 OSM",
+    expandable: true,
+    color: JP_RELIGION_COLORS.buddhist,
+    icon: MapPin,
+    upstream: {
+      status: "verified",
+      datasets: [{ datasetId: "jp_religion_osm", confidence: "HIGH" }],
+      processing: "OpenStreetMap 日本宗教設施靜態 GeoJSON；神社／佛寺／基督教三類",
+      note: "© OpenStreetMap contributors, ODbL；維持獨立圖層避免授權混合",
+    },
+    dataClass: "D",
+    source: {
+      kind: "custom",
+      note: "useJpReligionLayers lazy-load 靜態 GeoJSON，自建 circle source/layer",
+      staticAssets: ["./world/jp_religion_osm.geojson"],
+    },
+    legend: "jpReligion",
+    popup: "jpReligionOsm",
+    params: { count: 2, kinds: ["slider", "slider"] },
+    description: "OpenStreetMap 日本宗教設施 71,040 點（唯一含基督教；ODbL）",
+    topics: ["世界", "日本", "宗教", "OpenStreetMap"],
+  },
+
+  jpReligionWikidata: {
+    key: "jpReligionWikidata",
+    section: { theme: "世界 World", group: "宗教" },
+    label: "日本宗教設施 Wikidata",
+    labelMobile: "日本宗教 Wikidata",
+    expandable: true,
+    color: JP_RELIGION_COLORS.christian,
+    icon: Church,
+    upstream: {
+      status: "verified",
+      datasets: [{ datasetId: "jp_religion_wikidata", confidence: "HIGH" }],
+      processing: "Wikidata 日本宗教設施靜態 GeoJSON；id 為 QID",
+      note: "Wikidata, CC0；日本無官方全國宗教設施圖層，單一來源並非全量",
+    },
+    dataClass: "D",
+    source: {
+      kind: "custom",
+      note: "useJpReligionLayers lazy-load 靜態 GeoJSON，自建 circle source/layer",
+      staticAssets: ["./world/jp_religion_wikidata.geojson"],
+    },
+    legend: "jpReligion",
+    popup: "jpReligionWikidata",
+    params: { count: 2, kinds: ["slider", "slider"] },
+    description: "Wikidata 日本宗教設施 37,154 點（99.9% 有名稱；QID 可追溯）",
+    topics: ["世界", "日本", "宗教", "Wikidata"],
   },
 
   // ⚠️ GIS_LAYERS 裡它的 layer id 陣列是**常數引用**（PLA_ACTIVITY_CLICK_LAYERS），

--- a/src/data/layerParamsSpec.ts
+++ b/src/data/layerParamsSpec.ts
@@ -1176,6 +1176,18 @@ export const LAYER_PARAMS_SPEC = {
   worldTrashDebris: [
     { kind: "slider", name: "worldTrashDebrisOpacity", labelPrefix: "透明度", digits: 2, default: 0.85, min: 0, max: 1, step: 0.05 },
   ],
+  jpReligionGsi: [
+    { kind: "slider", name: "jpReligionGsiOpacity", labelPrefix: "透明度", digits: 2, default: 0.6, min: 0, max: 1, step: 0.05 },
+    scaleSlider("jpReligionGsiScale", 1),
+  ],
+  jpReligionOsm: [
+    { kind: "slider", name: "jpReligionOsmOpacity", labelPrefix: "透明度", digits: 2, default: 0.75, min: 0, max: 1, step: 0.05 },
+    scaleSlider("jpReligionOsmScale", 1),
+  ],
+  jpReligionWikidata: [
+    { kind: "slider", name: "jpReligionWikidataOpacity", labelPrefix: "透明度", digits: 2, default: 0.75, min: 0, max: 1, step: 0.05 },
+    scaleSlider("jpReligionWikidataScale", 1),
+  ],
   dustForecast: [
     { kind: "slider", name: "dustForecastOpacity", labelPrefix: "透明度", digits: 2, default: 0.7, min: 0, max: 1, step: 0.05 },
   ],

--- a/src/hooks/__tests__/useJpReligionLayers.test.ts
+++ b/src/hooks/__tests__/useJpReligionLayers.test.ts
@@ -1,0 +1,154 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { Map as MapboxMap } from "mapbox-gl";
+import type { RefObject } from "react";
+
+const reactHarness = vi.hoisted(() => {
+  const refs: { current: unknown }[] = [];
+  const states: unknown[] = [];
+  let cursor = 0;
+
+  return {
+    resetRender: () => { cursor = 0; },
+    useEffect: (effect: () => void | (() => void)) => { effect(); },
+    useRef: <T,>(initial: T) => {
+      const index = cursor++;
+      return (refs[index] ??= { current: initial }) as { current: T };
+    },
+    useState: <T,>(initial: T) => {
+      const index = cursor++;
+      states[index] ??= initial;
+      return [states[index] as T, (value: T | ((current: T) => T)) => {
+        states[index] = typeof value === "function"
+          ? (value as (current: T) => T)(states[index] as T)
+          : value;
+      }] as const;
+    },
+  };
+});
+
+vi.mock("react", () => ({
+  useEffect: reactHarness.useEffect,
+  useRef: reactHarness.useRef,
+  useState: reactHarness.useState,
+}));
+
+vi.mock("../useMapReadyTick", () => ({ useMapReadyTick: () => 0 }));
+vi.mock("../../data/jpReligionLoader", () => ({
+  fetchJpReligionOsm: () => Promise.resolve({ type: "FeatureCollection", features: [] }),
+  fetchJpReligionWikidata: () => Promise.resolve({ type: "FeatureCollection", features: [] }),
+}));
+
+import { useJpReligionLayers } from "../useJpReligionLayers";
+
+type CircleLayer = { id: string; paint: Record<string, unknown> };
+
+function createMap() {
+  const sources = new Set<string>();
+  const layers = new Map<string, CircleLayer>();
+  const setPaintProperty = vi.fn();
+
+  const map = {
+    getSource: (id: string) => sources.has(id) ? {} : undefined,
+    addSource: (id: string) => { sources.add(id); },
+    getLayer: (id: string) => layers.get(id),
+    addLayer: (layer: CircleLayer) => { layers.set(layer.id, layer); },
+    setLayoutProperty: vi.fn(),
+    setPaintProperty,
+    on: vi.fn(),
+    off: vi.fn(),
+  } as unknown as MapboxMap;
+
+  return { map, layers, setPaintProperty };
+}
+
+const visibility = {
+  jpReligionGsi: true,
+  jpReligionOsm: true,
+  jpReligionWikidata: true,
+};
+
+const opacity = {
+  jpReligionGsi: 0.6,
+  jpReligionOsm: 0.75,
+  jpReligionWikidata: 0.75,
+};
+
+describe("useJpReligionLayers scale", () => {
+  beforeEach(() => {
+    vi.stubGlobal("window", { location: { href: "http://localhost/" } });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("三層 radius 維持 top-level zoom interpolate，且 scale 變更會更新 paint", async () => {
+    const { map, layers, setPaintProperty } = createMap();
+    const mapRef = { current: map } as RefObject<MapboxMap | null>;
+
+    const render = (scale: {
+      jpReligionGsi: number;
+      jpReligionOsm: number;
+      jpReligionWikidata: number;
+    }) => {
+      reactHarness.resetRender();
+      useJpReligionLayers(mapRef, visibility, opacity, scale);
+    };
+
+    render({
+      jpReligionGsi: 1,
+      jpReligionOsm: 1.5,
+      jpReligionWikidata: 2,
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+    render({
+      jpReligionGsi: 1,
+      jpReligionOsm: 1.5,
+      jpReligionWikidata: 2,
+    });
+
+    const expectTopLevelZoomRadius = (layerId: string, expected: unknown[]) => {
+      const radius = layers.get(layerId)?.paint["circle-radius"];
+      expect(radius).toEqual(expected);
+      expect((radius as unknown[])[0]).toBe("interpolate");
+      expect((radius as unknown[])[2]).toEqual(["zoom"]);
+      expect(JSON.stringify(radius).match(/\["zoom"\]/g)).toHaveLength(1);
+    };
+
+    expectTopLevelZoomRadius(
+      "jp-religion-gsi-circle",
+      ["interpolate", ["linear"], ["zoom"], 6, 1.5, 12, 4],
+    );
+    expectTopLevelZoomRadius(
+      "jp-religion-osm-circle",
+      ["interpolate", ["linear"], ["zoom"], 6, 3.75, 12, 7.5],
+    );
+    expectTopLevelZoomRadius(
+      "jp-religion-wikidata-circle",
+      ["interpolate", ["linear"], ["zoom"], 6, 5, 12, 10],
+    );
+    setPaintProperty.mockClear();
+    render({
+      jpReligionGsi: 2,
+      jpReligionOsm: 0.5,
+      jpReligionWikidata: 1.2,
+    });
+
+    expect(setPaintProperty).toHaveBeenCalledWith(
+      "jp-religion-gsi-circle",
+      "circle-radius",
+      ["interpolate", ["linear"], ["zoom"], 6, 3, 12, 8],
+    );
+    expect(setPaintProperty).toHaveBeenCalledWith(
+      "jp-religion-osm-circle",
+      "circle-radius",
+      ["interpolate", ["linear"], ["zoom"], 6, 1.25, 12, 2.5],
+    );
+    expect(setPaintProperty).toHaveBeenCalledWith(
+      "jp-religion-wikidata-circle",
+      "circle-radius",
+      ["interpolate", ["linear"], ["zoom"], 6, 3, 12, 6],
+    );
+  });
+});

--- a/src/hooks/useJpReligionLayers.ts
+++ b/src/hooks/useJpReligionLayers.ts
@@ -1,0 +1,249 @@
+import { useEffect, useRef, useState } from "react";
+import type { CircleLayer, ExpressionSpecification, Map as MapboxMap } from "mapbox-gl";
+import {
+  fetchJpReligionOsm,
+  fetchJpReligionWikidata,
+} from "../data/jpReligionLoader";
+import { JP_RELIGION_COLOR_EXPRESSION } from "../data/jpReligionTypes";
+import { PMTILES_SOURCE_TYPE } from "../map/pmtilesConstants";
+import { registerPmtilesSourceTypeOnce } from "../map/pmtilesSourceType";
+import { useMapReadyTick } from "./useMapReadyTick";
+
+const GSI_SOURCE_ID = "jp-religion-gsi";
+const GSI_SOURCE_LAYER = "jp_religion_gsi";
+const GSI_LAYER_ID = "jp-religion-gsi-circle";
+const OSM_SOURCE_ID = "jp-religion-osm";
+const OSM_LAYER_ID = "jp-religion-osm-circle";
+const WIKIDATA_SOURCE_ID = "jp-religion-wikidata";
+const WIKIDATA_LAYER_ID = "jp-religion-wikidata-circle";
+
+function scaledRadius(
+  scale: number,
+  zoom6Radius: number,
+  zoom12Radius: number,
+): ExpressionSpecification {
+  return [
+    "interpolate", ["linear"], ["zoom"],
+    6, zoom6Radius * scale,
+    12, zoom12Radius * scale,
+  ] as unknown as ExpressionSpecification;
+}
+
+function clampOpacity(opacity: number): number {
+  return Math.max(0, Math.min(1, opacity));
+}
+
+function circleLayer(
+  id: string,
+  source: string,
+  radius: ExpressionSpecification,
+  opacity: number,
+  sourceLayer?: string,
+  strokeColor: string | ExpressionSpecification = "rgba(15, 23, 42, 0.45)",
+): CircleLayer {
+  return {
+    id,
+    type: "circle",
+    source,
+    ...(sourceLayer ? { "source-layer": sourceLayer } : {}),
+    layout: { visibility: "none" },
+    paint: {
+      "circle-radius": radius,
+      "circle-color": JP_RELIGION_COLOR_EXPRESSION as unknown as ExpressionSpecification,
+      "circle-opacity": clampOpacity(opacity),
+      "circle-stroke-color": strokeColor,
+      "circle-stroke-width": 0.35,
+    },
+  } as CircleLayer;
+}
+
+function gsiAbsoluteUrl(): string {
+  const relative = `${import.meta.env.BASE_URL ?? "/"}world/jp_religion_gsi.pmtiles`;
+  return new URL(relative, window.location.href).href;
+}
+
+function useGsiLayer(
+  mapRef: React.RefObject<MapboxMap | null>,
+  visible: boolean,
+  opacity: number,
+  scale: number,
+) {
+  const mapTick = useMapReadyTick(mapRef, visible);
+
+  useEffect(() => {
+    const map = mapRef.current;
+    if (!map) return;
+    if (!visible) {
+      if (map.getLayer(GSI_LAYER_ID)) map.setLayoutProperty(GSI_LAYER_ID, "visibility", "none");
+      return;
+    }
+
+    const mount = () => {
+      registerPmtilesSourceTypeOnce();
+      if (!map.getSource(GSI_SOURCE_ID)) {
+        map.addSource(GSI_SOURCE_ID, {
+          type: PMTILES_SOURCE_TYPE,
+          url: gsiAbsoluteUrl(),
+          minzoom: 4,
+          maxzoom: 14,
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } as any);
+      }
+      if (!map.getLayer(GSI_LAYER_ID)) {
+        // 圖層不設 maxzoom；z15+ 必須 overzoom z14 tiles，不能變空白。
+        map.addLayer(circleLayer(
+          GSI_LAYER_ID,
+          GSI_SOURCE_ID,
+          scaledRadius(scale, 1.5, 4),
+          opacity,
+          GSI_SOURCE_LAYER,
+        ));
+      }
+      if (map.getLayer(GSI_LAYER_ID)) {
+        map.setLayoutProperty(GSI_LAYER_ID, "visibility", "visible");
+        map.setPaintProperty(GSI_LAYER_ID, "circle-opacity", clampOpacity(opacity));
+        map.setPaintProperty(GSI_LAYER_ID, "circle-radius", scaledRadius(scale, 1.5, 4));
+      }
+    };
+
+    mount();
+    map.on("style.load", mount);
+    return () => { map.off("style.load", mount); };
+  }, [mapRef, visible, opacity, scale, mapTick]);
+}
+
+interface GeoJsonLayerConfig {
+  sourceId: string;
+  layerId: string;
+  fetcher: () => Promise<GeoJSON.FeatureCollection>;
+  logName: string;
+  strokeColor?: string | ExpressionSpecification;
+}
+
+function useGeoJsonLayer(
+  mapRef: React.RefObject<MapboxMap | null>,
+  visible: boolean,
+  opacity: number,
+  scale: number,
+  config: GeoJsonLayerConfig,
+) {
+  const mapTick = useMapReadyTick(mapRef, visible);
+  const dataRef = useRef<GeoJSON.FeatureCollection | null>(null);
+  const [dataTick, setDataTick] = useState(0);
+
+  useEffect(() => {
+    if (!visible || dataRef.current) return;
+    let cancelled = false;
+    config.fetcher()
+      .then((data) => {
+        if (cancelled) return;
+        dataRef.current = data;
+        setDataTick((tick) => tick + 1);
+      })
+      .catch((error) => console.warn(`[JpReligion:${config.logName}] load failed:`, error));
+    return () => { cancelled = true; };
+  }, [visible, config.fetcher, config.logName]);
+
+  useEffect(() => {
+    const map = mapRef.current;
+    if (!map) return;
+    if (!visible) {
+      if (map.getLayer(config.layerId)) {
+        map.setLayoutProperty(config.layerId, "visibility", "none");
+      }
+      return;
+    }
+    if (!dataRef.current) return;
+
+    const mount = () => {
+      if (!dataRef.current) return;
+      if (!map.getSource(config.sourceId)) {
+        map.addSource(config.sourceId, { type: "geojson", data: dataRef.current });
+      }
+      if (!map.getLayer(config.layerId)) {
+        map.addLayer(circleLayer(
+          config.layerId,
+          config.sourceId,
+          scaledRadius(scale, 2.5, 5),
+          opacity,
+          undefined,
+          config.strokeColor,
+        ));
+      }
+      if (map.getLayer(config.layerId)) {
+        map.setLayoutProperty(config.layerId, "visibility", "visible");
+        map.setPaintProperty(config.layerId, "circle-opacity", clampOpacity(opacity));
+        map.setPaintProperty(config.layerId, "circle-radius", scaledRadius(scale, 2.5, 5));
+      }
+    };
+
+    mount();
+    map.on("style.load", mount);
+    return () => { map.off("style.load", mount); };
+  }, [
+    mapRef,
+    visible,
+    opacity,
+    scale,
+    mapTick,
+    dataTick,
+    config.sourceId,
+    config.layerId,
+  ]);
+}
+
+const OSM_CONFIG: GeoJsonLayerConfig = {
+  sourceId: OSM_SOURCE_ID,
+  layerId: OSM_LAYER_ID,
+  fetcher: fetchJpReligionOsm,
+  logName: "OSM",
+};
+
+const WIKIDATA_CONFIG: GeoJsonLayerConfig = {
+  sourceId: WIKIDATA_SOURCE_ID,
+  layerId: WIKIDATA_LAYER_ID,
+  fetcher: fetchJpReligionWikidata,
+  logName: "Wikidata",
+};
+
+export interface JpReligionLayerVisibility {
+  jpReligionGsi: boolean;
+  jpReligionOsm: boolean;
+  jpReligionWikidata: boolean;
+}
+
+export interface JpReligionLayerOpacity {
+  jpReligionGsi: number;
+  jpReligionOsm: number;
+  jpReligionWikidata: number;
+}
+
+export interface JpReligionLayerScale {
+  jpReligionGsi: number;
+  jpReligionOsm: number;
+  jpReligionWikidata: number;
+}
+
+/** 三個 raw source/layer 保持獨立，不做前端融合。 */
+export function useJpReligionLayers(
+  mapRef: React.RefObject<MapboxMap | null>,
+  visibility: JpReligionLayerVisibility,
+  opacity: JpReligionLayerOpacity,
+  scale: JpReligionLayerScale,
+) {
+  useGsiLayer(mapRef, visibility.jpReligionGsi, opacity.jpReligionGsi, scale.jpReligionGsi);
+  useGeoJsonLayer(
+    mapRef,
+    visibility.jpReligionOsm,
+    opacity.jpReligionOsm,
+    scale.jpReligionOsm,
+    OSM_CONFIG,
+  );
+  useGeoJsonLayer(
+    mapRef,
+    visibility.jpReligionWikidata,
+    opacity.jpReligionWikidata,
+    scale.jpReligionWikidata,
+    WIKIDATA_CONFIG,
+  );
+}

--- a/src/layers/hosts/climateHosts.tsx
+++ b/src/layers/hosts/climateHosts.tsx
@@ -4,6 +4,7 @@
 import { useEarthquakesGlobalLayer } from "../../hooks/useEarthquakesGlobalLayer";
 import { useTyphoonTracksLayer, type TyphoonSource } from "../../hooks/useTyphoonTracksLayer";
 import { useWorldTrashDebrisLayer } from "../../hooks/useWorldTrashDebrisLayer";
+import { useJpReligionLayers } from "../../hooks/useJpReligionLayers";
 import { useClimateParticleLineLayer } from "../../hooks/useClimateParticleLineLayer";
 import { useDustForecastLayer } from "../../hooks/useDustForecastLayer";
 import { useDisasterAlertLayer } from "../../hooks/useDisasterAlertLayer";
@@ -54,6 +55,33 @@ export const WorldTrashDebrisHost: LayerHostComponent = ({ deps }) => {
     deps.mapRef,
     deps.layerVisibility.worldTrashDebris,
     p.worldTrashDebrisOpacity ?? 0.85,
+  );
+  return null;
+};
+
+/** 🌍 世界 WORLD：日本宗教設施三個彼此獨立的 raw source layer。 */
+export const JpReligionHost: LayerHostComponent = ({ deps }) => {
+  bumpHostRender("useJpReligionLayers");
+  const gsi = useKeyOverlayParams("jpReligionGsi");
+  const osm = useKeyOverlayParams("jpReligionOsm");
+  const wikidata = useKeyOverlayParams("jpReligionWikidata");
+  useJpReligionLayers(
+    deps.mapRef,
+    {
+      jpReligionGsi: deps.layerVisibility.jpReligionGsi,
+      jpReligionOsm: deps.layerVisibility.jpReligionOsm,
+      jpReligionWikidata: deps.layerVisibility.jpReligionWikidata,
+    },
+    {
+      jpReligionGsi: gsi.jpReligionGsiOpacity ?? 0.6,
+      jpReligionOsm: osm.jpReligionOsmOpacity ?? 0.75,
+      jpReligionWikidata: wikidata.jpReligionWikidataOpacity ?? 0.75,
+    },
+    {
+      jpReligionGsi: gsi.jpReligionGsiScale ?? 1,
+      jpReligionOsm: osm.jpReligionOsmScale ?? 1,
+      jpReligionWikidata: wikidata.jpReligionWikidataScale ?? 1,
+    },
   );
   return null;
 };

--- a/src/layers/layerHookRegistry.tsx
+++ b/src/layers/layerHookRegistry.tsx
@@ -49,7 +49,7 @@ import {
   LibrarySeatsHost, ParkingHost, EarthquakeHost, EarthquakeReplayHost,
 } from "./hosts/hazardHosts";
 import {
-  EarthquakesGlobalHost, TyphoonTracksHost, WorldTrashDebrisHost,
+  EarthquakesGlobalHost, TyphoonTracksHost, WorldTrashDebrisHost, JpReligionHost,
   WindFieldHost, OceanCurrentsHost, DustForecastHost,
   DisasterAlertHost, PlaActivityHost, VesselWatchHost,
 } from "./hosts/climateHosts";
@@ -203,6 +203,11 @@ export const LAYER_HOOK_REGISTRY: readonly LayerHookEntry[] = [
   { id: "useEarthquakesGlobalLayer", keys: ["earthquakesGlobal"], Host: EarthquakesGlobalHost },
   { id: "useTyphoonTracksLayer", keys: ["typhoonTracks"], Host: TyphoonTracksHost },
   { id: "useWorldTrashDebrisLayer", keys: ["worldTrashDebris"], Host: WorldTrashDebrisHost },
+  {
+    id: "useJpReligionLayers",
+    keys: ["jpReligionGsi", "jpReligionOsm", "jpReligionWikidata"],
+    Host: JpReligionHost,
+  },
   { id: "useClimateParticleLineLayer:wind", keys: ["windField"], Host: WindFieldHost },
   { id: "useClimateParticleLineLayer:ocean", keys: ["oceanCurrents"], Host: OceanCurrentsHost },
   { id: "useDustForecastLayer", keys: ["dustForecast"], Host: DustForecastHost },

--- a/src/map/gisClickRegistry.ts
+++ b/src/map/gisClickRegistry.ts
@@ -145,6 +145,10 @@ export const GIS_LAYERS: { layers: string[]; type: FeatureInfo["layerType"] }[] 
   { layers: ["earthquakes-global-circle"], type: "earthquakeGlobal" },
   // 🌍 世界 WORLD
   { layers: ["world-trash-debris-circle"], type: "worldTrashDebris" },
+  // raw 三源之間優先命中內容最完整者，避免 GSI 無名記號點搶走 popup。
+  { layers: ["jp-religion-wikidata-circle"], type: "jpReligionWikidata" },
+  { layers: ["jp-religion-osm-circle"], type: "jpReligionOsm" },
+  { layers: ["jp-religion-gsi-circle"], type: "jpReligionGsi" },
   { layers: ["typhoon-tracks-current-ring", "typhoon-tracks-current-dot", "typhoon-tracks-points"], type: "typhoonTrack" },
   { layers: ["port-polygons-fill", "port-polygons-line", "port-polygons-glow-1", "port-polygons-glow-2"], type: "port" },
   { layers: ["airport-boundaries-fill", "airport-boundaries-line", "airport-boundaries-glow-1", "airport-boundaries-glow-2"], type: "airport" },

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -356,7 +356,8 @@ export type ExpandableLayerKey =
   | "pollutionPenaltyCritical" | "pollutionPenaltyGeneral" | "pollutionPenaltyMobile"
   | "pollutionSite"
   // 🌍 世界 World
-  | "worldTrashDebris";
+  | "worldTrashDebris"
+  | "jpReligionGsi" | "jpReligionOsm" | "jpReligionWikidata";
 
 /** 渲染模式：3D（Three.js 含高度）或 2D（Mapbox 原生平面） */
 export type RenderMode = "3d" | "2d";
@@ -800,6 +801,8 @@ export interface FeatureInfo {
     | "pollutionFacility" | "pollutionPenalty" | "pollutionSite"
     // 🌍 世界 World（Outerview 全球垃圾殘骸點）
     | "worldTrashDebris"
+    // 🌍 世界 World（日本宗教設施三個獨立來源）
+    | "jpReligionGsi" | "jpReligionOsm" | "jpReligionWikidata"
     // 航空器空域（eAIP，含 floor/ceiling，分管制 vs 禁限航 兩 layerType）
     | "aviationControl" | "aviationRestricted"
     // 無人機禁/限航區（PMTiles polygon，filter 拆兩 layerType）
@@ -1246,6 +1249,9 @@ export interface LayerVisibility {
   pollutionSite: boolean;       // 污染場址（EMS_S_07；8,253；S4 確認污染）
   // ── 🌍 世界 WORLD ──
   worldTrashDebris: boolean;    // 全球垃圾殘骸（Outerview，~25k Point，region+id；點密度反映 Mapillary 街景覆蓋，CC-BY-4.0）
+  jpReligionGsi: boolean;       // 日本宗教設施（国土地理院 PMTiles，167,037；多數無名稱）
+  jpReligionOsm: boolean;       // 日本宗教設施（OpenStreetMap GeoJSON，71,040；ODbL）
+  jpReligionWikidata: boolean;  // 日本宗教設施（Wikidata GeoJSON，37,154；CC0）
 }
 
 // ── 空氣品質 ──


### PR DESCRIPTION
## Summary
- 接入 GSI PMTiles、OSM GeoJSON、Wikidata GeoJSON 三個獨立 raw layers
- 補齊 manifest、catalog、loader、hook、legend、popup、opacity/size params 與 feature docs
- 三源維持獨立，不融合、不加總
- 明確排除研究用 canonical POC asset、manifest、deploy contract 與 production wiring

## Validation
- npx tsc -b
- npm test -- --run: 650 passed, 1 skipped
- layerConsistency: 9 passed
- git diff --check
- branch object audit: prohibited canonical asset absent

## Browser
- Local browser checked All Off、三個 toggle、GSI/OSM/Wikidata attribution 與 opacity/size controls；無 console warning/error。
- Exact Japan viewport point rendering and popup click were not rerun in this clean worktree; raw implementation matches the previously browser-accepted research branch, minus the prohibited POC layer。