### PR TITLE
feat(global-maritime): 接入 AISStream 與 GFW 獨立圖層

### DIFF
--- a/docs/features/global-maritime/README.md
+++ b/docs/features/global-maritime/README.md
@@ -27,9 +27,9 @@
 
 ## 上游 handoff
 
-- `gis-platform/migrations/371_aisstream_gfw_independent_contract.sql`：RPC 與 quality/age 欄位 SSOT。
-- `data-collectors`：AISStream API key、S3 cold archive 與 collector 狀態由該 repo 管理；S3 不設定 expiration。
-- GFW：待 `GFW_ACCESS_TOKEN` 申請完成後，再由 data-collectors 建立每日獨立快照，且保持原始 dataset/license/noncommercial caveat。
+- `gis-platform/migrations/371_aisstream_gfw_independent_contract.sql`：已完整套用至 production，是 RPC 與 quality/age 欄位 SSOT。
+- AISStream：production 已有 9 個相關 tables、5 個 RPCs、cron 與 retention；feed healthy，S3 cold archive 已以 read-only 證據驗證。
+- GFW：production tables/RPC 已存在，但 `GFW_ACCESS_TOKEN` 尚未就緒，token gate 下 collector runs 為 0，尚無可驗證 snapshot。後續快照仍需保持原始 dataset/license/noncommercial caveat。
 
 ## 驗收
 
@@ -38,4 +38,4 @@ npx tsc -b
 npm test -- --runInBand
 ```
 
-型別驗證不等於 production RPC/browser 驗證；需在 token 與 migration 已部署後，分別開啟兩層確認 viewport、popup、attribution 與 freshness 文案。
+上述 production 證據是 backend read-only 驗證，不等於 PostgREST 公開 RPC 回應或 browser 真實點位驗證。AISStream 仍需透過 PostgREST/browser 確認 viewport、popup、attribution 與 freshness；GFW 則須先解除 token gate 並產生 snapshot，才能進行同等驗收。

--- a/docs/features/global-maritime/README.md
+++ b/docs/features/global-maritime/README.md
@@ -1,0 +1,41 @@
+# Global Maritime 全球海事
+
+## 目的
+
+世界 tab 的兩個獨立船舶來源：
+
+- `aisstreamVessels`：AISStream 最近 30 分鐘船位，視 viewport 查詢；適合觀察目前可見的 AIS 回報。
+- `gfwVesselPresence`：Global Fishing Watch 每日／延遲 vessel presence，與 AISStream 分開呈現；不是即時 AIS，也不是暗船清單。
+
+兩層預設關閉，避免訪客一進站即發 RPC。透明度、圖例、popup、點選與 loading 均分開；前端只讀 `gis-platform` migration 371 的 public RPC，不直接讀 live table。
+
+## RPC contract
+
+| layer | RPC | freshness | query |
+|---|---|---|---|
+| AISStream | `public.get_aisstream_vessels_current` | 30 分鐘內（contract cap） | viewport bounds，limit 3000 |
+| GFW | `public.get_gfw_vessel_presence_current` | 最多 7 日（daily snapshot） | viewport bounds，limit 3000 |
+
+來源、`provider`、品質欄位與 attribution 保留在 GeoJSON properties；不得把兩源 union 成一個「總船數」。
+
+## 可信度與限制
+
+- AISStream 的點代表可收到的 AIS 訊息，不代表海上所有船；目的地是船方自報。
+- GFW 的 presence 是每日／延遲產品；GFW token 尚未取得時 loader 會安全回空資料，不能在 UI 宣稱 live 驗證。
+- GFW 可以協助找「AIS 看不到但有其他來源 presence」的候選，但目前 contract 不包含 SAR unmatched、dark vessel 清單或融合判定；本 layer 不做暗船結論。
+- 本期先接 current circle。AISStream trail 需要逐船呼叫 trail RPC 與額外的選取／採樣策略，尚未接入，避免把點連成不具資料支持的連續航跡。
+
+## 上游 handoff
+
+- `gis-platform/migrations/371_aisstream_gfw_independent_contract.sql`：RPC 與 quality/age 欄位 SSOT。
+- `data-collectors`：AISStream API key、S3 cold archive 與 collector 狀態由該 repo 管理；S3 不設定 expiration。
+- GFW：待 `GFW_ACCESS_TOKEN` 申請完成後，再由 data-collectors 建立每日獨立快照，且保持原始 dataset/license/noncommercial caveat。
+
+## 驗收
+
+```bash
+npx tsc -b
+npm test -- --runInBand
+```
+
+型別驗證不等於 production RPC/browser 驗證；需在 token 與 migration 已部署後，分別開啟兩層確認 viewport、popup、attribution 與 freshness 文案。

--- a/docs/features/global-maritime/backlog.md
+++ b/docs/features/global-maritime/backlog.md
@@ -1,0 +1,6 @@
+# Backlog
+
+- [ ] 取得 `GFW_ACCESS_TOKEN` 後，以每日 job 實際產出 snapshot，驗證 license/noncommercial 權限與 retry。
+- [ ] 補 GFW `gaps`、`SAR unmatched` 等獨立資料層；未完成前不能把 GFW presence 解讀成暗船。
+- [ ] 針對 AISStream 選取的 MMSI 接 `get_aisstream_vessel_trail`，明確標示取樣間隔與缺訊，不做平滑插值。
+- [ ] 在 production RPC / browser 上分別驗證兩層的 viewport bounds、3000 筆上限、空結果與 loading timeout。

--- a/docs/features/global-maritime/changelog.md
+++ b/docs/features/global-maritime/changelog.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## 2026-08-24
+
+- 新增 AISStream 船舶 layer：viewport bounds + 30 分鐘 current RPC、cyan circle、popup/legend。
+- 新增 GFW vessel presence layer：每日／延遲 current RPC、amber circle、獨立 popup/legend。
+- 新增 `全球海事 Global Maritime` 世界 tab 主題；兩層預設關閉。
+- 明確記錄 GFW token 尚未取得，且目前不宣稱暗船或 SAR unmatched。

--- a/docs/features/global-maritime/handoff.md
+++ b/docs/features/global-maritime/handoff.md
@@ -42,9 +42,16 @@
 - Collector handoff：`../../../data-collectors` 的 AISStream/GFW collector 文件與 S3 cold archive policy
 - UI implementation：`src/data/globalMaritimeLoader.ts`、`src/hooks/useGlobalMaritimeLayers.ts`
 
-## Acceptance after upstream deployment
+## Production evidence boundary (2026-08-24)
 
-1. 先分別用 production RPC 驗證 AISStream 與 GFW 的 bounds、limit、空資料與 freshness。
+- migration 371 已完整套用至 production。
+- AISStream 的 9 個相關 tables、5 個 RPCs、cron 與 retention 已存在；feed healthy，archive 已以 backend read-only 證據驗證。
+- GFW tables/RPC 已存在，但 `GFW_ACCESS_TOKEN` 尚未就緒，token gate 下 collector runs 為 0，尚無 snapshot 可做資料驗收。
+- 本次證據不包含 PostgREST 公開 RPC 回應或 browser 真實點位驗證。
+
+## Remaining PostgREST/browser acceptance
+
+1. 先透過 production PostgREST 分別驗證 AISStream 與 GFW 的 bounds、limit、空資料與 freshness；GFW 須等 token gate 解除且 snapshot 產生後才能完成。
 2. 開啟 AISStream，確認 cyan circle、MMSI popup、30 分鐘 age 與 attribution。
 3. 開啟 GFW，確認 amber circle、snapshot date、daily/延遲文案與 attribution。
 4. 切換底圖，確認 `style.load` 後兩個 source/layer 重新建立並重新餵資料。

--- a/docs/features/global-maritime/handoff.md
+++ b/docs/features/global-maritime/handoff.md
@@ -1,0 +1,51 @@
+# Global Maritime handoff
+
+## Downstream contract
+
+`mini-taiwan-pulse` 已接好兩個獨立 source/layer，但資料生命週期仍由上游 repo 負責：
+
+| source | owner | required contract | cadence |
+|---|---|---|---|
+| AISStream | `data-collectors` | `AISSTREAM_API_KEY`、常駐 WebSocket、S3 cold archive（無 expiration） | live ingest |
+| GFW | `data-collectors` | `GFW_ACCESS_TOKEN`、每日 snapshot、原始 dataset/license/noncommercial metadata | daily |
+| public RPC | `gis-platform` | migration `371_aisstream_gfw_independent_contract.sql` | frontend read |
+
+前端只呼叫：
+
+- `public.get_aisstream_vessels_current(p_min_lon, p_min_lat, p_max_lon, p_max_lat, p_max_age_minutes, p_limit)`
+- `public.get_gfw_vessel_presence_current(p_min_lon, p_min_lat, p_max_lon, p_max_lat, p_max_age_days, p_limit)`
+
+兩個 RPC 必須維持 provider/quality/freshness 欄位，且不可在 SQL 或 collector 端把 AISStream 與 GFW union 成同一資料源。前端依 viewport 查詢，limit 目前為 3000。
+
+## Hard dependencies
+
+### AISStream
+
+必須存在且可轉成有效資料的欄位：
+
+`provider`, `mmsi`, `ship_name`, `ship_type`, `imo`, `call_sign`, `destination`, `nav_status`, `speed_knots`, `course_over_ground`, `true_heading`, `longitude`, `latitude`, `observed_at`, `received_at`, `age_seconds`, `position_quality`, `quality_flags`, `coverage_zone`。
+
+`longitude` / `latitude` 非數字會被前端 loader 丟棄。`destination` 是船方自報，popup 不得當作已驗證目的地。
+
+### GFW
+
+必須存在且可轉成有效資料的欄位：
+
+`provider`, `vessel_id`, `mmsi`, `ship_name`, `vessel_type`, `flag`, `longitude`, `latitude`, `source_snapshot_date`, `observed_at`, `received_at`, `age_hours`, `presence_quality`, `quality_flags`, `source_dataset_id`。
+
+沒有 `GFW_ACCESS_TOKEN` 或 snapshot 尚未產生時，RPC/loader 可回空集合；不得用空集合冒充「沒有船」，也不得把 presence 推論為 dark vessel。
+
+## Cross-repo references
+
+- Platform contract：`../../../gis-platform/migrations/371_aisstream_gfw_independent_contract.sql`
+- Platform source catalog / lifecycle：`../../api-platforms/`、`../../DATA_LIFECYCLE.md`
+- Collector handoff：`../../../data-collectors` 的 AISStream/GFW collector 文件與 S3 cold archive policy
+- UI implementation：`src/data/globalMaritimeLoader.ts`、`src/hooks/useGlobalMaritimeLayers.ts`
+
+## Acceptance after upstream deployment
+
+1. 先分別用 production RPC 驗證 AISStream 與 GFW 的 bounds、limit、空資料與 freshness。
+2. 開啟 AISStream，確認 cyan circle、MMSI popup、30 分鐘 age 與 attribution。
+3. 開啟 GFW，確認 amber circle、snapshot date、daily/延遲文案與 attribution。
+4. 切換底圖，確認 `style.load` 後兩個 source/layer 重新建立並重新餵資料。
+5. 若要接 AIS trail，另立選取 MMSI 的請求策略；不可把 current 點位直接連成連續航跡。

--- a/src/components/LegendPanel.tsx
+++ b/src/components/LegendPanel.tsx
@@ -331,6 +331,8 @@ export const LEGEND_REGISTRY: LegendEntry[] = [
   { id: "newsEvents", render: () => <NewsEventsLegend /> },
   { id: "plaActivity", render: () => <PlaActivityLegend /> },
   { id: "vesselWatch", render: () => <VesselWatchLegend /> },
+  { id: "aisstreamVessels", render: () => <AisstreamVesselsLegend /> },
+  { id: "gfwVesselPresence", render: () => <GfwVesselPresenceLegend /> },
   { id: "iotWraRiver", render: () => <IotRiverLegend /> },
   { id: "iotWraStructure", render: () => <IotStructureLegend /> },
   { id: "agriCropSuitability", render: ({ overlayParams }) => <CropSuitabilityLegend cropId={overlayParams.agriCropSuitabilityCropId ?? 0} /> },
@@ -3903,6 +3905,42 @@ function VesselWatchLegend() {
       </div>
       <div style={{ fontSize: FONT_SIZE.xs, color: COLORS.textFaint, marginTop: 2 }}>
         分類由船名／MMSI 規則推斷；軍艦多為他國過境（中台海軍多靜默）
+      </div>
+    </div>
+  );
+}
+
+function AisstreamVesselsLegend() {
+  const t = useLegendTheme();
+  return (
+    <div>
+      <div style={{ fontSize: FONT_SIZE.xs, color: t.textDim, letterSpacing: 1, marginBottom: 4 }}>
+        AISSTREAM 船舶
+      </div>
+      <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
+        <div style={{ width: 10, height: 10, borderRadius: RADIUS.full, background: "#22d3ee", border: "1px solid #083344" }} />
+        <span style={{ fontSize: FONT_SIZE.xs, color: t.textMuted }}>最近 30 分鐘 AIS 回報</span>
+      </div>
+      <div style={{ fontSize: FONT_SIZE.xs, color: COLORS.textFaint, marginTop: 4 }}>
+        即時點位；目前未接逐船 trail
+      </div>
+    </div>
+  );
+}
+
+function GfwVesselPresenceLegend() {
+  const t = useLegendTheme();
+  return (
+    <div>
+      <div style={{ fontSize: FONT_SIZE.xs, color: t.textDim, letterSpacing: 1, marginBottom: 4 }}>
+        GFW VESSEL PRESENCE
+      </div>
+      <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
+        <div style={{ width: 10, height: 10, borderRadius: RADIUS.full, background: "#f59e0b", border: "1px solid #451a03" }} />
+        <span style={{ fontSize: FONT_SIZE.xs, color: t.textMuted }}>每日 / 延遲 vessel presence</span>
+      </div>
+      <div style={{ fontSize: FONT_SIZE.xs, color: COLORS.textFaint, marginTop: 4 }}>
+        非即時 AIS；不等於暗船或 SAR unmatched 清單
       </div>
     </div>
   );

--- a/src/components/featureInfo/globalClimatePanels.tsx
+++ b/src/components/featureInfo/globalClimatePanels.tsx
@@ -116,6 +116,42 @@ export function WorldTrashDebrisPanel({ props }: { props: Record<string, unknown
   );
 }
 
+function fmtMaritimeTime(value: unknown): string {
+  if (typeof value !== "string" || !value) return "—";
+  const d = new Date(value);
+  return Number.isNaN(d.getTime()) ? value : d.toLocaleString("zh-TW", { month: "2-digit", day: "2-digit", hour: "2-digit", minute: "2-digit", hour12: false });
+}
+
+export function AisstreamVesselPanel({ props }: { props: Record<string, unknown> }) {
+  return (
+    <div>
+      <Row label="船名" value={String(props.ship_name ?? "—")} />
+      <Row label="MMSI" value={String(props.mmsi ?? "—")} />
+      <Row label="船舶類型" value={String(props.ship_type ?? "—")} />
+      <Row label="航速 / 航向" value={`${props.speed_knots ?? "—"} kt / ${props.course_over_ground ?? "—"}°`} />
+      <Row label="目的地（自報）" value={String(props.destination ?? "—")} />
+      <Row label="觀測時間" value={fmtMaritimeTime(props.observed_at)} />
+      <Row label="訊息年齡" value={props.age_seconds == null ? "—" : `${Number(props.age_seconds).toFixed(0)} 秒`} />
+      <Row label="資料源" value="AISStream（AIS message feed）" />
+    </div>
+  );
+}
+
+export function GfwVesselPresencePanel({ props }: { props: Record<string, unknown> }) {
+  return (
+    <div>
+      <Row label="船名" value={String(props.ship_name ?? "—")} />
+      <Row label="Vessel ID" value={String(props.vessel_id ?? "—")} />
+      <Row label="MMSI / 旗國" value={`${props.mmsi ?? "—"} / ${props.flag ?? "—"}`} />
+      <Row label="船舶類型" value={String(props.vessel_type ?? "—")} />
+      <Row label="快照日期" value={String(props.source_snapshot_date ?? "—")} />
+      <Row label="觀測時間" value={fmtMaritimeTime(props.observed_at)} />
+      <Row label="資料年齡" value={props.age_hours == null ? "—" : `${Number(props.age_hours).toFixed(1)} 小時`} />
+      <Row label="資料源" value="Global Fishing Watch（daily vessel presence；非即時）" />
+    </div>
+  );
+}
+
 // ── 氣候場 click 讀值（風場 / 海流 UV 前端取樣）──
 
 const COMPASS_16 = [

--- a/src/components/featureInfo/registry.tsx
+++ b/src/components/featureInfo/registry.tsx
@@ -107,7 +107,10 @@ import {
   LightningStrikePanel, NuclearStationPanel, EarthquakePanel,
   EarthquakeReplayStationPanel, EarthquakeReplayTownPanel, MountainRescuePanel,
 } from "./hazardPanels";
-import { EarthquakeGlobalPanel, TyphoonTrackPanel, ClimateFieldPanel, WorldTrashDebrisPanel } from "./globalClimatePanels";
+import {
+  EarthquakeGlobalPanel, TyphoonTrackPanel, ClimateFieldPanel, WorldTrashDebrisPanel,
+  AisstreamVesselPanel, GfwVesselPresencePanel,
+} from "./globalClimatePanels";
 import {
   CountyBoundaryPanel, TownshipBoundaryPanel, VillageBoundaryPanel,
   MaritimeBoundaryPanel,
@@ -192,6 +195,8 @@ export const PANEL_REGISTRY: Partial<Record<FeatureInfo["layerType"], FC<PanelPr
   disasterAlert: DisasterAlertPanel,
   plaActivity: PlaActivityPanel,
   vesselWatch: VesselWatchPanel,
+  aisstreamVessel: AisstreamVesselPanel,
+  gfwVesselPresence: GfwVesselPresencePanel,
   roadEvent: RoadEventPanel,
   roadCongestion: RoadCongestionPanel,
   freewayCongestion: FreewayCongestionPanel,
@@ -669,6 +674,8 @@ export const HEADER_LABELS: Record<FeatureInfo["layerType"], string> = {
   rasterProbe: "圖層讀值",
   temperatureGrid: "溫度網格",
   worldTrashDebris: "全球垃圾殘骸",
+  aisstreamVessel: "AISStream 船舶",
+  gfwVesselPresence: "GFW 船舶 Presence",
   // Base map
   countyBoundary: "縣市界",
   townshipBoundary: "鄉鎮市區界",

--- a/src/components/sidebar/layerCatalog.ts
+++ b/src/components/sidebar/layerCatalog.ts
@@ -176,6 +176,7 @@ export const WORLD_TAB_THEME_TITLES: string[] = [
   WORLD_THEME_TITLE,
   COMMUNICATIONS_THEME_TITLE,
   "全球氣候 Global Climate",
+  "全球海事 Global Maritime",
 ];
 
 export const THEMES: ThemeDef[] = [
@@ -1396,6 +1397,20 @@ export const THEMES: ThemeDef[] = [
         title: "環境",
         layers: [
           fromManifest("worldTrashDebris"),
+        ],
+      },
+    ],
+  },
+
+  {
+    title: "全球海事 Global Maritime",
+    defaultCollapsed: true,
+    groups: [
+      {
+        title: "船舶",
+        layers: [
+          fromManifest("aisstreamVessels"),
+          fromManifest("gfwVesselPresence"),
         ],
       },
     ],

--- a/src/data/__tests__/__fixtures__/layer-golden.json
+++ b/src/data/__tests__/__fixtures__/layer-golden.json
@@ -1,6 +1,6 @@
 {
   "meta": {
-    "keyCount": 377,
+    "keyCount": 379,
     "sections": [
       "gisLayers",
       "overlays",
@@ -532,6 +532,18 @@
         "earthquakes-global-circle"
       ],
       "type": "earthquakeGlobal"
+    },
+    {
+      "layers": [
+        "global-maritime-aisstream-circle"
+      ],
+      "type": "aisstreamVessel"
+    },
+    {
+      "layers": [
+        "global-maritime-gfw-circle"
+      ],
+      "type": "gfwVesselPresence"
     },
     {
       "layers": [
@@ -46168,6 +46180,15 @@
         "value": 0.6
       }
     ],
+    "aisstreamVessels": [
+      {
+        "label": "透明度 0.90",
+        "max": 1,
+        "min": 0,
+        "step": 0.05,
+        "value": 0.9
+      }
+    ],
     "anfrWirelessSites": [
       {
         "label": "透明度 0.80",
@@ -49136,6 +49157,15 @@
         "min": 0.1,
         "step": 0.05,
         "value": 0.85
+      }
+    ],
+    "gfwVesselPresence": [
+      {
+        "label": "透明度 0.75",
+        "max": 1,
+        "min": 0,
+        "step": 0.05,
+        "value": 0.75
       }
     ],
     "govServiceOffices": [

--- a/src/data/__tests__/globalMaritimeLoader.test.ts
+++ b/src/data/__tests__/globalMaritimeLoader.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+import {
+  aisstreamToGeoJSON,
+  gfwToGeoJSON,
+  type AisstreamVessel,
+  type GfwVesselPresence,
+} from "../globalMaritimeLoader";
+
+const ais = (patch: Partial<AisstreamVessel> = {}): AisstreamVessel => ({
+  provider: "aisstream",
+  mmsi: "123456789",
+  shipName: "TEST AIS",
+  shipType: "cargo",
+  imo: "IMO123",
+  callSign: "CALL",
+  destination: "Naha",
+  navStatus: "under_way",
+  speedKnots: 12,
+  courseOverGround: 90,
+  trueHeading: 91,
+  longitude: 123.4,
+  latitude: 25.1,
+  observedAt: "2026-08-24T01:02:03Z",
+  receivedAt: "2026-08-24T01:02:04Z",
+  ageSeconds: 4,
+  positionQuality: "high",
+  qualityFlags: { source: "terrestrial" },
+  coverageZone: "taiwan-north",
+  ...patch,
+});
+
+const gfw = (patch: Partial<GfwVesselPresence> = {}): GfwVesselPresence => ({
+  provider: "global_fishing_watch",
+  vesselId: "gfw-1",
+  mmsi: "987654321",
+  shipName: "TEST GFW",
+  vesselType: "fishing",
+  flag: "TW",
+  longitude: 123.5,
+  latitude: 25.2,
+  sourceSnapshotDate: "2026-08-23",
+  observedAt: "2026-08-23T00:00:00Z",
+  receivedAt: "2026-08-24T01:00:00Z",
+  ageHours: 25,
+  presenceQuality: "medium",
+  qualityFlags: { matched: true },
+  sourceDatasetId: "gfw-public-v1",
+  ...patch,
+});
+
+describe("global maritime loader GeoJSON guards", () => {
+  it("跳過 AIS/GFW invalid coordinates，不把來源資料混成一層", () => {
+    const aisFc = aisstreamToGeoJSON([ais(), ais({ mmsi: "bad", longitude: Number.NaN })]);
+    const gfwFc = gfwToGeoJSON([gfw(), gfw({ vesselId: "bad", latitude: Infinity })]);
+
+    expect(aisFc.features).toHaveLength(1);
+    expect(gfwFc.features).toHaveLength(1);
+    expect(aisFc.features[0]?.properties?.layer_source).toBe("aisstream");
+    expect(gfwFc.features[0]?.properties?.layer_source).toBe("gfw");
+    expect(aisFc.features.some((f) => f.properties?.layer_source === "gfw")).toBe(false);
+    expect(gfwFc.features.some((f) => f.properties?.layer_source === "aisstream")).toBe(false);
+  });
+
+  it("保留各來源的 quality、觀測/接收時間與 freshness 欄位", () => {
+    const aisProps = aisstreamToGeoJSON([ais()]).features[0]!.properties!;
+    const gfwProps = gfwToGeoJSON([gfw()]).features[0]!.properties!;
+
+    expect(aisProps).toMatchObject({
+      quality_flags: { source: "terrestrial" },
+      position_quality: "high",
+      observed_at: "2026-08-24T01:02:03Z",
+      received_at: "2026-08-24T01:02:04Z",
+      age_seconds: 4,
+    });
+    expect(gfwProps).toMatchObject({
+      quality_flags: { matched: true },
+      presence_quality: "medium",
+      source_snapshot_date: "2026-08-23",
+      observed_at: "2026-08-23T00:00:00Z",
+      received_at: "2026-08-24T01:00:00Z",
+      age_hours: 25,
+    });
+  });
+});

--- a/src/data/__tests__/layerGoldenSnapshot.test.ts
+++ b/src/data/__tests__/layerGoldenSnapshot.test.ts
@@ -109,7 +109,7 @@ describe("layer 黃金快照", () => {
 });
 
 describe("黃金快照覆蓋度", () => {
-  it("涵蓋全部 377 個 layer key", () => {
+  it("涵蓋全部 379 個 layer key", () => {
     const keys = allLayerKeys();
     // 2026-08-12：+1 = vesselWatch（特殊船舶）。這個數字是 ratchet，加層時一起加。
     // 2026-08-13：+1 = maritimeBoundary（領海界線）。
@@ -120,7 +120,8 @@ describe("黃金快照覆蓋度", () => {
     // 2026-08-19：+1 = animalAdoption（每日待認養收容所摘要）；+1 = animalShelterPressure（官方月報縣市壓力）。
     // 2026-08-20：+1 = animalWelfarePoints（7 類動物福利服務據點）。
     // 2026-08-23：+1 = isobath（海底等深線 GEBCO 2025，等深線 11 級 + 深度分帶 12 級）。
-    expect(keys.length).toBe(377);
+    // 2026-08-24：+2 = aisstreamVessels / gfwVesselPresence（全球海事兩個獨立來源）。
+    expect(keys.length).toBe(379);
     expect(Object.keys(full.colors as object)).toHaveLength(keys.length);
     expect(Object.keys(full.icons as object)).toHaveLength(keys.length);
     expect(Object.keys(full.upstream as object)).toHaveLength(keys.length);

--- a/src/data/globalMaritimeLoader.ts
+++ b/src/data/globalMaritimeLoader.ts
@@ -1,0 +1,228 @@
+import { supabase, supabaseConfigured } from "../lib/supabase";
+import { withLoading } from "../lib/loadingRegistry";
+import { cachedByKey } from "../lib/loaderCache";
+
+export interface MaritimeBounds {
+  minLon: number;
+  minLat: number;
+  maxLon: number;
+  maxLat: number;
+}
+
+export interface AisstreamVessel {
+  provider: string;
+  mmsi: string;
+  shipName: string | null;
+  shipType: string | null;
+  imo: string | null;
+  callSign: string | null;
+  destination: string | null;
+  navStatus: string | null;
+  speedKnots: number | null;
+  courseOverGround: number | null;
+  trueHeading: number | null;
+  longitude: number;
+  latitude: number;
+  observedAt: string | null;
+  receivedAt: string | null;
+  ageSeconds: number | null;
+  positionQuality: string | null;
+  qualityFlags: unknown;
+  coverageZone: string | null;
+}
+
+export interface GfwVesselPresence {
+  provider: string;
+  vesselId: string;
+  mmsi: string | null;
+  shipName: string | null;
+  vesselType: string | null;
+  flag: string | null;
+  longitude: number;
+  latitude: number;
+  sourceSnapshotDate: string | null;
+  observedAt: string | null;
+  receivedAt: string | null;
+  ageHours: number | null;
+  presenceQuality: string | null;
+  qualityFlags: unknown;
+  sourceDatasetId: string | null;
+}
+
+const str = (value: unknown): string | null =>
+  value === null || value === undefined || value === "" ? null : String(value);
+const num = (value: unknown): number | null => {
+  if (value === null || value === undefined || value === "") return null;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+};
+
+function boundsKey(bounds: MaritimeBounds): string {
+  return [bounds.minLon, bounds.minLat, bounds.maxLon, bounds.maxLat].map((v) => v.toFixed(3)).join(",");
+}
+
+function rpcBounds(bounds: MaritimeBounds): Record<string, number> {
+  return {
+    p_min_lon: bounds.minLon,
+    p_min_lat: bounds.minLat,
+    p_max_lon: bounds.maxLon,
+    p_max_lat: bounds.maxLat,
+  };
+}
+
+async function fetchAisstreamUncached(key: string): Promise<AisstreamVessel[]> {
+  if (!supabaseConfigured) return [];
+  const bounds = key.split(",").map(Number) as [number, number, number, number];
+  const { data, error } = await withLoading(
+    `aisstream:vessels:${key}`,
+    "AISStream 船舶位置",
+    supabase.rpc("get_aisstream_vessels_current", {
+      ...rpcBounds({ minLon: bounds[0]!, minLat: bounds[1]!, maxLon: bounds[2]!, maxLat: bounds[3]! }),
+      p_max_age_minutes: 30,
+      p_limit: 3000,
+    }),
+  );
+  if (error) {
+    console.warn("[GlobalMaritime] AISStream RPC failed:", error.message);
+    return [];
+  }
+  const out: AisstreamVessel[] = [];
+  for (const row of (data ?? []) as Record<string, unknown>[]) {
+    const longitude = Number(row.longitude);
+    const latitude = Number(row.latitude);
+    if (!Number.isFinite(longitude) || !Number.isFinite(latitude)) continue;
+    out.push({
+      provider: String(row.provider ?? "aisstream"),
+      mmsi: String(row.mmsi ?? ""),
+      shipName: str(row.ship_name),
+      shipType: str(row.ship_type),
+      imo: str(row.imo),
+      callSign: str(row.call_sign),
+      destination: str(row.destination),
+      navStatus: str(row.nav_status),
+      speedKnots: num(row.speed_knots),
+      courseOverGround: num(row.course_over_ground),
+      trueHeading: num(row.true_heading),
+      longitude,
+      latitude,
+      observedAt: str(row.observed_at),
+      receivedAt: str(row.received_at),
+      ageSeconds: num(row.age_seconds),
+      positionQuality: str(row.position_quality),
+      qualityFlags: row.quality_flags ?? null,
+      coverageZone: str(row.coverage_zone),
+    });
+  }
+  return out;
+}
+
+async function fetchGfwUncached(key: string): Promise<GfwVesselPresence[]> {
+  if (!supabaseConfigured) return [];
+  const bounds = key.split(",").map(Number) as [number, number, number, number];
+  const { data, error } = await withLoading(
+    `gfw:vessel-presence:${key}`,
+    "Global Fishing Watch 船舶 presence",
+    supabase.rpc("get_gfw_vessel_presence_current", {
+      ...rpcBounds({ minLon: bounds[0]!, minLat: bounds[1]!, maxLon: bounds[2]!, maxLat: bounds[3]! }),
+      p_max_age_days: 7,
+      p_limit: 3000,
+    }),
+  );
+  if (error) {
+    console.warn("[GlobalMaritime] GFW RPC failed:", error.message);
+    return [];
+  }
+  const out: GfwVesselPresence[] = [];
+  for (const row of (data ?? []) as Record<string, unknown>[]) {
+    const longitude = Number(row.longitude);
+    const latitude = Number(row.latitude);
+    if (!Number.isFinite(longitude) || !Number.isFinite(latitude)) continue;
+    out.push({
+      provider: String(row.provider ?? "global_fishing_watch"),
+      vesselId: String(row.vessel_id ?? ""),
+      mmsi: str(row.mmsi),
+      shipName: str(row.ship_name),
+      vesselType: str(row.vessel_type),
+      flag: str(row.flag),
+      longitude,
+      latitude,
+      sourceSnapshotDate: str(row.source_snapshot_date),
+      observedAt: str(row.observed_at),
+      receivedAt: str(row.received_at),
+      ageHours: num(row.age_hours),
+      presenceQuality: str(row.presence_quality),
+      qualityFlags: row.quality_flags ?? null,
+      sourceDatasetId: str(row.source_dataset_id),
+    });
+  }
+  return out;
+}
+
+const fetchAisstreamCached = cachedByKey(fetchAisstreamUncached, 60_000, 8);
+const fetchGfwCached = cachedByKey(fetchGfwUncached, 6 * 60 * 60_000, 8);
+
+export function fetchAisstreamVessels(bounds: MaritimeBounds): Promise<AisstreamVessel[]> {
+  return fetchAisstreamCached(boundsKey(bounds));
+}
+
+export function fetchGfwVesselPresence(bounds: MaritimeBounds): Promise<GfwVesselPresence[]> {
+  return fetchGfwCached(boundsKey(bounds));
+}
+
+export function aisstreamToGeoJSON(rows: AisstreamVessel[]): GeoJSON.FeatureCollection {
+  return {
+    type: "FeatureCollection",
+    features: rows.filter((row) => Number.isFinite(row.longitude) && Number.isFinite(row.latitude)).map((row) => ({
+      type: "Feature",
+      geometry: { type: "Point", coordinates: [row.longitude, row.latitude] },
+      properties: {
+        provider: row.provider,
+        mmsi: row.mmsi,
+        ship_name: row.shipName,
+        ship_type: row.shipType,
+        imo: row.imo,
+        call_sign: row.callSign,
+        destination: row.destination,
+        nav_status: row.navStatus,
+        speed_knots: row.speedKnots,
+        course_over_ground: row.courseOverGround,
+        true_heading: row.trueHeading,
+        observed_at: row.observedAt,
+        received_at: row.receivedAt,
+        age_seconds: row.ageSeconds,
+        position_quality: row.positionQuality,
+        quality_flags: row.qualityFlags,
+        coverage_zone: row.coverageZone,
+        source_attribution: "AISStream（AIS message feed）",
+        layer_source: "aisstream",
+      },
+    })),
+  };
+}
+
+export function gfwToGeoJSON(rows: GfwVesselPresence[]): GeoJSON.FeatureCollection {
+  return {
+    type: "FeatureCollection",
+    features: rows.filter((row) => Number.isFinite(row.longitude) && Number.isFinite(row.latitude)).map((row) => ({
+      type: "Feature",
+      geometry: { type: "Point", coordinates: [row.longitude, row.latitude] },
+      properties: {
+        provider: row.provider,
+        vessel_id: row.vesselId,
+        mmsi: row.mmsi,
+        ship_name: row.shipName,
+        vessel_type: row.vesselType,
+        flag: row.flag,
+        source_snapshot_date: row.sourceSnapshotDate,
+        observed_at: row.observedAt,
+        received_at: row.receivedAt,
+        age_hours: row.ageHours,
+        presence_quality: row.presenceQuality,
+        quality_flags: row.qualityFlags,
+        source_dataset_id: row.sourceDatasetId,
+        source_attribution: "Global Fishing Watch（daily vessel presence）",
+        layer_source: "gfw",
+      },
+    })),
+  };
+}

--- a/src/data/layerManifest.ts
+++ b/src/data/layerManifest.ts
@@ -1060,6 +1060,58 @@ export const LAYER_MANIFEST = {
     topics: ["世界", "環境", "垃圾"],
   },
 
+  aisstreamVessels: {
+    key: "aisstreamVessels",
+    section: { theme: "全球海事 Global Maritime", group: "船舶" },
+    label: "AISStream 船舶 AISStream Vessels",
+    labelMobile: "AISStream 船舶",
+    expandable: true,
+    color: "#22d3ee",
+    icon: Ship,
+    upstream: {
+      status: "catalog_missing",
+      datasets: [],
+      processing: "Supabase RPC get_aisstream_vessels_current；依目前 viewport 查詢最近 30 分鐘的 AIS 點位",
+      note: "AISStream API key 由 data-collectors 管理；前端只讀 gis-platform migration 371 的公開 RPC，不直接碰 live table",
+    },
+    dataClass: "D",
+    source: {
+      kind: "custom",
+      note: "useGlobalMaritimeLayers 自建 global-maritime-aisstream-current GeoJSON source/circle；目前是即時點位，尚未將逐船 trail 接入",
+    },
+    legend: "aisstreamVessels",
+    popup: "aisstreamVessel",
+    params: { count: 1, kinds: ["slider"] },
+    description: "AISStream 最近 30 分鐘回報的船舶位置（視窗查詢；非全量船舶）",
+    topics: ["世界", "海事", "船舶", "AISStream"],
+  },
+
+  gfwVesselPresence: {
+    key: "gfwVesselPresence",
+    section: { theme: "全球海事 Global Maritime", group: "船舶" },
+    label: "GFW 船舶 Presence Global Fishing Watch",
+    labelMobile: "GFW 船舶 Presence",
+    expandable: true,
+    color: "#f59e0b",
+    icon: Fish,
+    upstream: {
+      status: "catalog_missing",
+      datasets: [],
+      processing: "Supabase RPC get_gfw_vessel_presence_current；每日快照/延遲資料依 viewport 查詢",
+      note: "GFW_ACCESS_TOKEN 尚未申請；本層先完成獨立接線，無 token 時保持空資料，不宣稱已即時驗證或可直接識別暗船",
+    },
+    dataClass: "D",
+    source: {
+      kind: "custom",
+      note: "useGlobalMaritimeLayers 自建 global-maritime-gfw-presence GeoJSON source/circle；每日/延遲資料，與 AISStream 完全分開",
+    },
+    legend: "gfwVesselPresence",
+    popup: "gfwVesselPresence",
+    params: { count: 1, kinds: ["slider"] },
+    description: "Global Fishing Watch 船舶 presence 每日/延遲快照（不是即時 AIS，也不是暗船清單）",
+    topics: ["世界", "海事", "船舶", "GFW"],
+  },
+
   // ⚠️ GIS_LAYERS 裡它的 layer id 陣列是**常數引用**（PLA_ACTIVITY_CLICK_LAYERS），
   //    字面陣列解析器抓不到 → 需 extractGisConstRefTypes 才驗得出 popup 宣告為真。
   plaActivity: {

--- a/src/data/layerParamsSpec.ts
+++ b/src/data/layerParamsSpec.ts
@@ -1176,6 +1176,12 @@ export const LAYER_PARAMS_SPEC = {
   worldTrashDebris: [
     { kind: "slider", name: "worldTrashDebrisOpacity", labelPrefix: "透明度", digits: 2, default: 0.85, min: 0, max: 1, step: 0.05 },
   ],
+  aisstreamVessels: [
+    { kind: "slider", name: "aisstreamVesselsOpacity", labelPrefix: "透明度", digits: 2, default: 0.9, min: 0, max: 1, step: 0.05 },
+  ],
+  gfwVesselPresence: [
+    { kind: "slider", name: "gfwVesselPresenceOpacity", labelPrefix: "透明度", digits: 2, default: 0.75, min: 0, max: 1, step: 0.05 },
+  ],
   dustForecast: [
     { kind: "slider", name: "dustForecastOpacity", labelPrefix: "透明度", digits: 2, default: 0.7, min: 0, max: 1, step: 0.05 },
   ],

--- a/src/hooks/__tests__/useGlobalMaritimeLayers.test.ts
+++ b/src/hooks/__tests__/useGlobalMaritimeLayers.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { Map as MapboxMap } from "mapbox-gl";
+import type { RefObject } from "react";
+
+const reactHarness = vi.hoisted(() => {
+  const refs: { current: unknown }[] = [];
+  let cursor = 0;
+  return {
+    reset: () => { cursor = 0; },
+    useRef: <T,>(initial: T) => (refs[cursor++] ??= { current: initial }) as { current: T },
+    useEffect: (effect: () => void | (() => void)) => { effect(); },
+    useCallback: <T extends (...args: never[]) => unknown>(callback: T) => callback,
+  };
+});
+
+vi.mock("react", () => ({
+  useRef: reactHarness.useRef,
+  useEffect: reactHarness.useEffect,
+  useCallback: reactHarness.useCallback,
+}));
+vi.mock("../useMapReadyTick", () => ({ useMapReadyTick: () => 0 }));
+vi.mock("../../data/globalMaritimeLoader", () => ({
+  fetchAisstreamVessels: () => Promise.resolve([]),
+  fetchGfwVesselPresence: () => Promise.resolve([]),
+  aisstreamToGeoJSON: () => ({ type: "FeatureCollection", features: [] }),
+  gfwToGeoJSON: () => ({ type: "FeatureCollection", features: [] }),
+}));
+vi.mock("../../lib/loadingRegistry", () => ({ keepLoadingUntilMapIdle: vi.fn() }));
+
+import { useGlobalMaritimeLayers } from "../useGlobalMaritimeLayers";
+
+function createMap() {
+  const sources = new Map<string, { setData: ReturnType<typeof vi.fn> }>();
+  const layers = new Map<string, unknown>();
+  const handlers = new Map<string, () => void>();
+  const map = {
+    isStyleLoaded: () => true,
+    getBounds: () => ({ getWest: () => 120, getEast: () => 125, getSouth: () => 20, getNorth: () => 28 }),
+    getSource: (id: string) => sources.get(id),
+    addSource: (id: string) => { sources.set(id, { setData: vi.fn() }); },
+    getLayer: (id: string) => layers.get(id),
+    addLayer: (layer: { id: string }) => { layers.set(layer.id, layer); },
+    setLayoutProperty: vi.fn(),
+    setPaintProperty: vi.fn(),
+    on: (event: string, handler: () => void) => { handlers.set(event, handler); },
+    off: vi.fn(),
+  } as unknown as MapboxMap;
+  return { map, sources, layers, handlers };
+}
+
+describe("useGlobalMaritimeLayers style lifecycle", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    reactHarness.reset();
+  });
+
+  it("底圖 style.load 後重建兩個 source/layer", () => {
+    vi.stubGlobal("window", { setInterval: () => 1, clearInterval: vi.fn() });
+    const state = createMap();
+    const mapRef = { current: state.map } as RefObject<MapboxMap | null>;
+    useGlobalMaritimeLayers(mapRef, true, true);
+
+    expect(state.sources.has("global-maritime-aisstream-current")).toBe(true);
+    expect(state.sources.has("global-maritime-gfw-presence")).toBe(true);
+    expect(state.layers.has("global-maritime-aisstream-circle")).toBe(true);
+    expect(state.layers.has("global-maritime-gfw-circle")).toBe(true);
+
+    state.sources.clear();
+    state.layers.clear();
+    state.handlers.get("style.load")?.();
+
+    expect(state.sources.has("global-maritime-aisstream-current")).toBe(true);
+    expect(state.sources.has("global-maritime-gfw-presence")).toBe(true);
+    expect(state.layers.has("global-maritime-aisstream-circle")).toBe(true);
+    expect(state.layers.has("global-maritime-gfw-circle")).toBe(true);
+  });
+});

--- a/src/hooks/useGlobalMaritimeLayers.ts
+++ b/src/hooks/useGlobalMaritimeLayers.ts
@@ -1,0 +1,130 @@
+import { useCallback, useEffect, useRef } from "react";
+import type { CircleLayer, Map as MapboxMap } from "mapbox-gl";
+import {
+  aisstreamToGeoJSON,
+  fetchAisstreamVessels,
+  fetchGfwVesselPresence,
+  gfwToGeoJSON,
+  type MaritimeBounds,
+} from "../data/globalMaritimeLoader";
+import { keepLoadingUntilMapIdle } from "../lib/loadingRegistry";
+import { useMapReadyTick } from "./useMapReadyTick";
+
+const AIS_SOURCE = "global-maritime-aisstream-current";
+const AIS_LAYER = "global-maritime-aisstream-circle";
+const GFW_SOURCE = "global-maritime-gfw-presence";
+const GFW_LAYER = "global-maritime-gfw-circle";
+
+export const GLOBAL_MARITIME_CLICK_LAYERS = [AIS_LAYER, GFW_LAYER] as const;
+
+const EMPTY_FC: GeoJSON.FeatureCollection = { type: "FeatureCollection", features: [] };
+
+function safeBounds(map: MapboxMap): MaritimeBounds {
+  const b = map.getBounds();
+  if (!b) return { minLon: -180, minLat: -85, maxLon: 180, maxLat: 85 };
+  const minLon = Math.max(-180, Math.min(180, b.getWest()));
+  const maxLon = Math.max(-180, Math.min(180, b.getEast()));
+  const minLat = Math.max(-85, Math.min(85, b.getSouth()));
+  const maxLat = Math.max(-85, Math.min(85, b.getNorth()));
+  return {
+    minLon: Math.min(minLon, maxLon),
+    minLat: Math.min(minLat, maxLat),
+    maxLon: Math.max(minLon, maxLon),
+    maxLat: Math.max(minLat, maxLat),
+  };
+}
+
+function ensureSources(map: MapboxMap): void {
+  if (!map.getSource(AIS_SOURCE)) map.addSource(AIS_SOURCE, { type: "geojson", data: EMPTY_FC, attribution: "AISStream" });
+  if (!map.getSource(GFW_SOURCE)) map.addSource(GFW_SOURCE, { type: "geojson", data: EMPTY_FC, attribution: "Global Fishing Watch" });
+  if (!map.getLayer(AIS_LAYER)) {
+    map.addLayer({
+      id: AIS_LAYER,
+      type: "circle",
+      source: AIS_SOURCE,
+      paint: {
+        "circle-radius": ["interpolate", ["linear"], ["zoom"], 1, 2, 5, 3.5, 10, 6, 14, 9],
+        "circle-color": "#22d3ee",
+        "circle-opacity": 0.9,
+        "circle-stroke-color": "#083344",
+        "circle-stroke-width": 0.7,
+      },
+      layout: { visibility: "none" },
+    } as CircleLayer);
+  }
+  if (!map.getLayer(GFW_LAYER)) {
+    map.addLayer({
+      id: GFW_LAYER,
+      type: "circle",
+      source: GFW_SOURCE,
+      paint: {
+        "circle-radius": ["interpolate", ["linear"], ["zoom"], 1, 2, 5, 3.5, 10, 6, 14, 9],
+        "circle-color": "#f59e0b",
+        "circle-opacity": 0.75,
+        "circle-stroke-color": "#451a03",
+        "circle-stroke-width": 0.7,
+      },
+      layout: { visibility: "none" },
+    } as CircleLayer);
+  }
+}
+
+export function useGlobalMaritimeLayers(
+  mapRef: React.RefObject<MapboxMap | null>,
+  aisVisible: boolean,
+  gfwVisible: boolean,
+  aisOpacity = 0.9,
+  gfwOpacity = 0.75,
+): void {
+  const mapTick = useMapReadyTick(mapRef, aisVisible || gfwVisible);
+  const aisDataRef = useRef<GeoJSON.FeatureCollection>(EMPTY_FC);
+  const gfwDataRef = useRef<GeoJSON.FeatureCollection>(EMPTY_FC);
+  const requestRef = useRef(0);
+
+  const update = useCallback(async () => {
+    const map = mapRef.current;
+    if (!map || !map.isStyleLoaded() || (!aisVisible && !gfwVisible)) return;
+    const bounds = safeBounds(map);
+    const requestId = ++requestRef.current;
+    const [ais, gfw] = await Promise.all([
+      aisVisible ? fetchAisstreamVessels(bounds) : Promise.resolve([]),
+      gfwVisible ? fetchGfwVesselPresence(bounds) : Promise.resolve([]),
+    ]);
+    if (requestId !== requestRef.current) return;
+    aisDataRef.current = aisstreamToGeoJSON(ais);
+    gfwDataRef.current = gfwToGeoJSON(gfw);
+    const aisSource = map.getSource(AIS_SOURCE) as { setData?: (fc: GeoJSON.FeatureCollection) => void } | undefined;
+    const gfwSource = map.getSource(GFW_SOURCE) as { setData?: (fc: GeoJSON.FeatureCollection) => void } | undefined;
+    aisSource?.setData?.(aisDataRef.current);
+    gfwSource?.setData?.(gfwDataRef.current);
+    keepLoadingUntilMapIdle(map, "global-maritime:render", "全球海事圖層繪製", null);
+  }, [aisVisible, gfwVisible, mapRef]);
+
+  useEffect(() => {
+    const map = mapRef.current;
+    if (!map) return;
+    const applyStyle = () => {
+      if (!map.isStyleLoaded()) return;
+      ensureSources(map);
+      if (map.getLayer(AIS_LAYER)) {
+        map.setLayoutProperty(AIS_LAYER, "visibility", aisVisible ? "visible" : "none");
+        map.setPaintProperty(AIS_LAYER, "circle-opacity", Math.max(0, Math.min(1, aisOpacity)));
+      }
+      if (map.getLayer(GFW_LAYER)) {
+        map.setLayoutProperty(GFW_LAYER, "visibility", gfwVisible ? "visible" : "none");
+        map.setPaintProperty(GFW_LAYER, "circle-opacity", Math.max(0, Math.min(1, gfwOpacity)));
+      }
+      if (aisVisible || gfwVisible) void update();
+    };
+    map.on("style.load", applyStyle);
+    applyStyle();
+    const onMoveEnd = () => { if (aisVisible || gfwVisible) void update(); };
+    map.on("moveend", onMoveEnd);
+    const interval = window.setInterval(() => { if (aisVisible || gfwVisible) void update(); }, aisVisible ? 60_000 : 6 * 60 * 60_000);
+    return () => {
+      map.off("style.load", applyStyle);
+      map.off("moveend", onMoveEnd);
+      window.clearInterval(interval);
+    };
+  }, [aisVisible, gfwVisible, aisOpacity, gfwOpacity, mapRef, mapTick, update]);
+}

--- a/src/layers/hosts/globalMaritimeHosts.tsx
+++ b/src/layers/hosts/globalMaritimeHosts.tsx
@@ -1,0 +1,17 @@
+import { bumpHostRender, type LayerHostComponent } from "../layerHostDeps";
+import { useGlobalMaritimeLayers } from "../../hooks/useGlobalMaritimeLayers";
+import { paramNum, useLayerParams } from "../layerParamsAccess";
+
+export const GlobalMaritimeHost: LayerHostComponent = ({ deps }) => {
+  bumpHostRender("useGlobalMaritimeLayers");
+  const aisValues = useLayerParams("aisstreamVessels");
+  const gfwValues = useLayerParams("gfwVesselPresence");
+  useGlobalMaritimeLayers(
+    deps.mapRef,
+    deps.layerVisibility.aisstreamVessels,
+    deps.layerVisibility.gfwVesselPresence,
+    paramNum(aisValues, "aisstreamVessels", "aisstreamVesselsOpacity"),
+    paramNum(gfwValues, "gfwVesselPresence", "gfwVesselPresenceOpacity"),
+  );
+  return null;
+};

--- a/src/layers/layerHookRegistry.tsx
+++ b/src/layers/layerHookRegistry.tsx
@@ -53,6 +53,7 @@ import {
   WindFieldHost, OceanCurrentsHost, DustForecastHost,
   DisasterAlertHost, PlaActivityHost, VesselWatchHost,
 } from "./hosts/climateHosts";
+import { GlobalMaritimeHost } from "./hosts/globalMaritimeHosts";
 import {
   SatellitesHost, RoadEventsHost, FireEventsHost, FireLatestHost,
   WasteCleaningSquadHost, FreewayHost, RoadCongestionHost,
@@ -217,6 +218,11 @@ export const LAYER_HOOK_REGISTRY: readonly LayerHookEntry[] = [
   // 新層（2026-08-12）：插在 plaActivity 之後 —— 既有 entry 的相對順序不變，
   // 本層的 source/layer 因此加在共機活動區之上（船點要壓在活動區面之上才點得到）
   { id: "useVesselWatchLayer", keys: ["vesselWatch"], Host: VesselWatchHost },
+  {
+    id: "useGlobalMaritimeLayers",
+    keys: ["aisstreamVessels", "gfwVesselPresence"],
+    Host: GlobalMaritimeHost,
+  },
 
   // ── 衛星（L1204）──
   {

--- a/src/map/gisClickRegistry.ts
+++ b/src/map/gisClickRegistry.ts
@@ -144,6 +144,8 @@ export const GIS_LAYERS: { layers: string[]; type: FeatureInfo["layerType"] }[] 
   // 全球氣候 GLOBAL CLIMATE
   { layers: ["earthquakes-global-circle"], type: "earthquakeGlobal" },
   // 🌍 世界 WORLD
+  { layers: ["global-maritime-aisstream-circle"], type: "aisstreamVessel" },
+  { layers: ["global-maritime-gfw-circle"], type: "gfwVesselPresence" },
   { layers: ["world-trash-debris-circle"], type: "worldTrashDebris" },
   { layers: ["typhoon-tracks-current-ring", "typhoon-tracks-current-dot", "typhoon-tracks-points"], type: "typhoonTrack" },
   { layers: ["port-polygons-fill", "port-polygons-line", "port-polygons-glow-1", "port-polygons-glow-2"], type: "port" },

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -108,7 +108,7 @@ export type ExpandableLayerKey =
   | "activeFaults"
   | "earthquakeReplay"
   | "mountainRescueIncidents"
-  | "newsEvents" | "plaActivity" | "vesselWatch"
+  | "newsEvents" | "plaActivity" | "vesselWatch" | "aisstreamVessels" | "gfwVesselPresence"
   | "livestockFarmPig" | "livestockFarmChicken" | "livestockFarmCattle"
   | "livestockFarmDuck" | "livestockFarmGoose" | "livestockFarmSheep" | "livestockFarmOther"
   | "livestockSlaughter" | "livestockFeed" | "livestockMarket"
@@ -686,6 +686,7 @@ export interface FeatureInfo {
     | "weatherStation" | "bikeStation" | "busStation" | "lighthouse" | "railStation"
     | "port" | "airport" | "ship" | "cctv" | "etcGantry" | "serviceArea" | "serviceAreaPolygon" | "taxiStand"
     | "activeFault" | "newsEvent" | "disasterAlert" | "plaActivity" | "vesselWatch"
+    | "aisstreamVessel" | "gfwVesselPresence"
     | "roadEvent" | "roadCongestion" | "freewayCongestion"
     | "provincialRoad" | "highway" | "cyclingRoute"
     | "fireEvent" | "fireStation" | "fireHydrant" | "fireIsochrone"
@@ -890,6 +891,10 @@ export interface LayerVisibility {
    * ⚠️ 與 `ships`（全量 AIS，Three.js ShipScene）是**兩層**，本層為純 Mapbox circle/line。
    */
   vesselWatch: boolean;
+  /** AISStream 最近回報船位（migration 371 RPC；獨立於全量 ships 與 GFW） */
+  aisstreamVessels: boolean;
+  /** Global Fishing Watch 每日/延遲 vessel presence（獨立於 AISStream） */
+  gfwVesselPresence: boolean;
   youbikeFullness: boolean;
   earthquakes: boolean;
   /** 地震回放：單一事件的震央→測站→等震度網格→鄉鎮面量圖→沙灘球五步動畫 */


### PR DESCRIPTION
## Summary
- 接入 AISStream current 船位與 GFW vessel presence 兩個獨立 layer
- 補齊 loader、hook、manifest、catalog、legend、popup、loading 與 feature docs
- 不將兩源融合，也不把 GFW presence 解讀為暗船

## Validation
- `npx tsc -b`
- `npm test -- --run`: 653 passed, 1 skipped
- `layerConsistency`: 9 passed
- `git diff --check`

## Production evidence boundary
- `gis-platform` migration 371 已完整套用至 production。
- AISStream 已有 9 個相關 tables、5 個 RPCs、cron 與 retention；feed healthy，S3 cold archive 已由 backend read-only evidence 驗證。
- GFW tables/RPC 已存在，但 `GFW_ACCESS_TOKEN` 尚未就緒，token gate 下 collector runs 為 0，尚無 snapshot 可做資料驗收。
- 上述證據不包含 PostgREST 公開 RPC 回應或 browser 真實點位驗證；合併不代表這兩項驗收已完成。AISStream 尚待 PostgREST/browser 驗收，GFW 尚須先解除 token gate 並產生 snapshot。