### PR TITLE
docs(imagery): track R2 CORS retirement gate

### DIFF
--- a/docs/features/imagery/backlog.md
+++ b/docs/features/imagery/backlog.md
@@ -10,6 +10,7 @@
 
 - [ ] **IMG-rain-history-label** · `data-health` · P3 · `ready`：雨量 collector 自 2026-06-05 才開始收，早期日期需明確顯示「無資料」而非讓使用者誤解為零；Next action：在時間軸/空狀態補資料起始日；Acceptance：早期日期 browser evidence 與測試。
 - [ ] **IMG-upstream-handoff** · `governance` · P2 · `waiting_external`：上游 `taipei-gis-analytics/docs/handoff/imagery.md` 尚未建立；Next action：上游補契約，並將 `cwaImageryLoader.ts`、`aqiImageryLoader.ts`、`precipRasterLoader.ts`、`useCwaImageryLayer.ts`、`useAqiImageryLayer.ts`、`usePrecipRasterLayer.ts` 寫入 handoff；Acceptance：相對連結有效、dataset/RPC/更新頻率可核對。
+- [ ] **IMG-cwa-r2-cors** · `release-governance` · P1 · `blocked`：R2 custom domain 尚未對 production origin 提供可用 CORS；現在移除 DB fallback 會讓雲圖／雷達中斷，migration 344 不可 apply。Trigger：GET/OPTIONS 回正確 CORS headers 且 production browser 能讀影像。Next action：設定 CORS → production browser 驗雲圖、雷達、timeline 與零 legacy calls → 從最新 master 重做 `929e4b6` 的退役意圖 → `tsc`／tests → 另經批准 apply migration 344 並 readback。Acceptance：browser 無 CORS/console error、影像走 manifest+CDN、三支 legacy RPC 零呼叫且在獨立 DB release 下架。本項不包含刪除 14 日 bytea 副本或停止 collector 雙寫。
 
 ## Completed / historical（已完成／歷史）
 


### PR DESCRIPTION
## Scope
- 將 R2 CORS／legacy RPC 退役條件記入 feature backlog
- 保留 14 日 DB copy 與 collector dual-write
- 明確禁止在 production browser gate 前套用 migration 344

## Verification
- git diff --check
- docs-only；不改 runtime、DB 或 deploy