### PR TITLE
ci: pin Claude action before native install regression

### DIFF
--- a/.github/workflows/claude-mention.yml
+++ b/.github/workflows/claude-mention.yml
@@ -28,7 +28,9 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: anthropics/claude-code-action@v1
+      # v1.0.100+ may report a successful install without creating the CLI binary.
+      # Keep this pinned until anthropics/claude-code-action#1242 is fixed upstream.
+      - uses: anthropics/claude-code-action@v1.0.99
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           trigger_phrase: "@claude"

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -17,7 +17,9 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: anthropics/claude-code-action@v1
+      # v1.0.100+ may report a successful install without creating the CLI binary.
+      # Keep this pinned until anthropics/claude-code-action#1242 is fixed upstream.
+      - uses: anthropics/claude-code-action@v1.0.99
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |


### PR DESCRIPTION
## Problem
Claude review jobs report install success but then fail because /home/runner/.local/bin/claude does not exist. This matches anthropics/claude-code-action#1242.

## Fix
- pin auto-review workflow to anthropics/claude-code-action@v1.0.99
- pin @claude mention workflow to the same version
- leave an upstream issue note beside both pins

## Verification
- git diff --check: pass
- Ruby YAML parse for both workflows: pass
- normal test job: pass
- review reached Anthropic App authentication without the prior binary error, then hit the expected bootstrap rule because this PR changes the workflow itself
- after merge, verify with a no-diff canary PR whose workflow matches default branch