### PR TITLE
fix(global-maritime): normalize UTC manifest hours

### DIFF
--- a/src/data/__tests__/gfwDarkVesselsLoader.test.ts
+++ b/src/data/__tests__/gfwDarkVesselsLoader.test.ts
@@ -52,7 +52,7 @@ function unifiedManifest() {
       date_start: "2026-08-15",
       date_end: RELEASE,
       hours: hours.map(({ observedAt, compact }, index) => ({
-        observed_at: observedAt,
+        observed_at: observedAt.replace("Z", "+00:00"),
         path: `releases/${RELEASE}/dark_vessels/hours/${compact}.geojson`,
         sha256: "c".repeat(64), bytes: 10,
         features: index === 0 ? 1 : 0,
@@ -72,7 +72,7 @@ function validHour() {
   return {
     type: "FeatureCollection",
     metadata: {
-      observed_at: HOUR,
+      observed_at: HOUR.replace("Z", "+00:00"),
       temporal_resolution: "HOURLY",
       spatial_resolution: "HIGH",
       semantic_label: "SAR detection unmatched to AIS",
@@ -84,7 +84,7 @@ function validHour() {
       type: "Feature",
       geometry: { type: "Point", coordinates: [123.5, 24.5] },
       properties: {
-        observed_at: HOUR,
+        observed_at: HOUR.replace("Z", "+00:00"),
         detections: 2,
         source_dataset: "public-global-sar-presence:v4.0",
         matched_to_ais: false,
@@ -118,6 +118,7 @@ describe("GFW SAR unmatched-to-AIS contract", () => {
     expect(parsed?.latestCompleteDate).toBe(RELEASE);
     expect(parsed?.hours.size).toBe(168);
     expect(parsed?.hours.get(HOUR)).toMatchObject({ features: 1, detections: 2 });
+    expect(parsed?.hours.get(HOUR)?.observedAt).toBe(HOUR);
 
     raw.dark_vessels.hours.splice(10, 1);
     expect(parseGfwDarkVesselsManifest(raw, "/global-maritime/gfw-hourly/manifest.json")).toBeNull();

--- a/src/data/gfwDarkVesselsLoader.ts
+++ b/src/data/gfwDarkVesselsLoader.ts
@@ -1,5 +1,6 @@
 import { withLoading } from "../lib/loadingRegistry";
 import {
+  normalizeGfwUtcHour,
   parseGfwHourlyUnifiedManifest,
   resolveGfwHourlyRootManifestUrl,
   type GfwUnifiedDarkVesselHour,
@@ -45,9 +46,11 @@ export function parseGfwDarkVesselsHour(
   raw: unknown,
   expectedHour: string,
 ): GeoJSON.FeatureCollection<GeoJSON.Point> | null {
+  const canonicalExpectedHour = normalizeGfwUtcHour(expectedHour);
   if (!isObject(raw) || raw.type !== "FeatureCollection" || !Array.isArray(raw.features)) return null;
   if (
-    !isObject(raw.metadata) || raw.metadata.observed_at !== expectedHour ||
+    !canonicalExpectedHour || !isObject(raw.metadata) ||
+    normalizeGfwUtcHour(raw.metadata.observed_at) !== canonicalExpectedHour ||
     raw.metadata.temporal_resolution !== "HOURLY" || raw.metadata.spatial_resolution !== "HIGH" ||
     raw.metadata.semantic_label !== "SAR detection unmatched to AIS" ||
     raw.metadata.not_proof_of_dark_or_illegal_vessel !== true ||
@@ -63,7 +66,8 @@ export function parseGfwDarkVesselsHour(
     if (!isObject(feature.properties)) return null;
     const p = feature.properties;
     if (
-      p.observed_at !== expectedHour || !Number.isInteger(p.detections) || (p.detections as number) < 1 ||
+      normalizeGfwUtcHour(p.observed_at) !== canonicalExpectedHour ||
+      !Number.isInteger(p.detections) || (p.detections as number) < 1 ||
       typeof p.source_dataset !== "string" || p.source_dataset.length === 0 ||
       p.matched_to_ais !== false || p.matching_semantics !== "SAR_detection_not_matched_to_AIS" ||
       p.coordinate_semantics !== "GFW_HIGH_grid_cell_center" ||

--- a/src/data/gfwHourlyReleaseManifest.ts
+++ b/src/data/gfwHourlyReleaseManifest.ts
@@ -8,9 +8,16 @@ const strictDate = (value: unknown): string | null => {
   const parsed = new Date(`${value}T00:00:00Z`);
   return Number.isFinite(parsed.getTime()) && parsed.toISOString().slice(0, 10) === value ? value : null;
 };
-const strictHour = (value: unknown): string | null =>
-  typeof value === "string" && /^\d{4}-\d{2}-\d{2}T\d{2}:00:00Z$/.test(value) && Number.isFinite(Date.parse(value))
-    ? value : null;
+export const normalizeGfwUtcHour = (value: unknown): string | null => {
+  if (
+    typeof value !== "string" ||
+    !/^\d{4}-\d{2}-\d{2}T\d{2}:00:00(?:Z|[+]00:00)$/.test(value)
+  ) return null;
+  const parsed = new Date(value);
+  return Number.isFinite(parsed.getTime())
+    ? parsed.toISOString().replace(".000Z", "Z")
+    : null;
+};
 const nonNegativeInt = (value: unknown): value is number => Number.isInteger(value) && (value as number) >= 0;
 const sha256 = (value: unknown): value is string => typeof value === "string" && /^[0-9a-f]{64}$/i.test(value);
 
@@ -129,7 +136,7 @@ export function parseGfwHourlyUnifiedManifest(
   const gridHours = new Map<string, GfwUnifiedGridHour>();
   for (const item of raw.grid.hours) {
     if (!isObject(item)) return null;
-    const observedAt = strictHour(item.observed_at);
+    const observedAt = normalizeGfwUtcHour(item.observed_at);
     const compact = observedAt?.replace(/[-:]/g, "").replace("T", "T").slice(0, 11);
     const expectedPath = observedAt ? `releases/${releaseId}/grid/hours/${compact}Z.geojson` : "";
     if (
@@ -164,7 +171,7 @@ export function parseGfwHourlyUnifiedManifest(
   let previousDarkHour = -Infinity;
   for (const item of raw.dark_vessels.hours) {
     if (!isObject(item)) return null;
-    const observedAt = strictHour(item.observed_at);
+    const observedAt = normalizeGfwUtcHour(item.observed_at);
     const compact = observedAt?.replace(/[-:]/g, "").slice(0, 11);
     const expectedPath = observedAt ? `releases/${releaseId}/dark_vessels/hours/${compact}Z.geojson` : "";
     const observedAtMs = observedAt ? Date.parse(observedAt) : Number.NaN;


### PR DESCRIPTION
## Summary

- accept equivalent UTC hourly timestamps ending in `Z` or `+00:00`
- canonicalize unified manifest hour keys to `Z` before path and continuity validation
- apply the same normalization to SAR hourly assets
- add regression coverage shaped like the production publisher output

## Production root cause

The current root v2 manifest publishes `dark_vessels.hours[].observed_at` as `+00:00`, while the frontend parser only accepted `Z`. Because the unified manifest is fail-closed, grid and tracks were also hidden even though their assets were valid.

## Verification

- production manifest parse: grid 168 hours, tracks 7 days, SAR 168 hours
- selected production grid asset: 5,193 features
- selected production SAR asset: valid empty hour
- `npm test`: 61 files, 705 passed, 1 skipped
- `npx tsc -b`
- `npm run build`
