### PR TITLE
fix(infrastructure): cache bundled Ookla assets

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -12,6 +12,20 @@ server {
         add_header Cache-Control "public";
     }
 
+    # Ookla publication assets are bundled in dist.  The generic /geo/ fallback
+    # jumps to @dist and loses that location's cache headers, so keep these four
+    # large, quarterly assets on an explicit cacheable path.
+    location ~ ^/geo/ookla_(fixed_global|mobile_global|tw_z14|tw_z16)\.(geojson|pmtiles)$ {
+        root /usr/share/nginx/html;
+        try_files $uri =404;
+        types {
+            application/geo+json geojson;
+            application/vnd.pmtiles pmtiles;
+        }
+        expires 1d;
+        add_header Cache-Control "public";
+    }
+
     # 靜態 GeoJSON：先找 /data/geo/（S3 大檔），找不到 fallback 到 dist（git 小檔）
     location /geo/ {
         root /data;

--- a/src/map/__tests__/deployContract.test.ts
+++ b/src/map/__tests__/deployContract.test.ts
@@ -257,6 +257,20 @@ function isEmptyShell(path: string): boolean {
 // ══════════════════════════════════════════════════════════════════
 
 describe("deploy 契約（nginx + pull script）", () => {
+  it("Ookla dist publication assets retain cache headers, MIME types, and Range-capable static serving", () => {
+    const match = nginxConf.match(
+      /location ~ \^\/geo\/ookla_\(fixed_global\|mobile_global\|tw_z14\|tw_z16\).*?\{([\s\S]*?)\n    \}/,
+    );
+    expect(match, "Ookla exact publication location missing").not.toBeNull();
+    const body = match?.[1] ?? "";
+    expect(body).toContain("root /usr/share/nginx/html;");
+    expect(body).toContain("try_files $uri =404;");
+    expect(body).toContain("application/geo+json geojson;");
+    expect(body).toContain("application/vnd.pmtiles pmtiles;");
+    expect(body).toContain("expires 1d;");
+    expect(body).toContain('add_header Cache-Control "public";');
+  });
+
   it("前端引用的每個 public/ 子目錄都有 nginx location", () => {
     const missing = [...referencedDirs].filter((d) => !nginxCovers(d));
     expect(


### PR DESCRIPTION
## Summary
- give the four bundled Ookla publication assets an exact Nginx location
- preserve one-day cache headers after the /geo to @dist fallback
- serve GeoJSON and PMTiles with explicit MIME types
- keep Range-capable static file serving for large assets

## Verification
- deployContract: 16 passed
- nginx -t: syntax is ok and test is successful
- git diff --check clean

## Production evidence before fix
- Ookla Range requests returned 206 but Cloudflare reported BYPASS and no Cache-Control because @dist lost the parent location headers