### PR TITLE
fix(gfw): validate track endpoint radius expression

### DIFF
--- a/src/hooks/__tests__/useGfwHourlyTracksLayer.test.ts
+++ b/src/hooks/__tests__/useGfwHourlyTracksLayer.test.ts
@@ -1,6 +1,8 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { Map as MapboxMap } from "mapbox-gl";
 import type { RefObject } from "react";
+// @ts-expect-error — style-spec 的 CJS 入口無型別宣告（mapbox-gl 未導出），僅測試用
+import { validate } from "mapbox-gl/dist/style-spec/index.cjs";
 
 const harness = vi.hoisted(() => {
   const refs: { current: unknown }[] = [];
@@ -171,6 +173,29 @@ describe("useGfwHourlyTracksLayer timeline", () => {
     expect(loader.frame).toHaveBeenCalledTimes(2);
     harness.tick(Date.parse("2026-08-15T04:00:00Z") / 1000);
     expect(loader.frame).toHaveBeenCalledTimes(3);
+  });
+
+  it("endpoint 半徑 expression 通過 Mapbox style-spec，避免整層被 runtime 拒收", async () => {
+    loader.loadManifest.mockResolvedValue(makeManifest());
+    loader.loadDay.mockResolvedValue({ tracks: [], displayDate: "2026-08-15" });
+    loader.frame.mockReturnValue({ lines: EMPTY, endpoints: EMPTY });
+    const state = createMap();
+    const mapRef = { current: state.map } as RefObject<MapboxMap | null>;
+
+    useGfwHourlyTracksLayer(mapRef, true, 0.75, 0.5, true);
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const endpointLayer = state.layers.get("gfw-hourly-tracks-endpoint");
+    const errors = (validate({
+      version: 8,
+      sources: {
+        "gfw-hourly-tracks-endpoint-source": { type: "geojson", data: EMPTY },
+      },
+      layers: [endpointLayer],
+    }) as { message: string }[]).map((error) => error.message);
+    expect(errors).toEqual([]);
   });
 
   it("每次 false→true 載入成功只通知一次，style/rerender 不重複", async () => {

--- a/src/hooks/useGfwHourlyTracksLayer.ts
+++ b/src/hooks/useGfwHourlyTracksLayer.ts
@@ -78,9 +78,13 @@ function ensureLayers(map: MapboxMap, isDarkTheme: boolean): void {
       source: GFW_HOURLY_TRACKS_ENDPOINT_SOURCE_ID,
       paint: {
         "circle-radius": [
-          "*",
-          ["interpolate", ["linear"], ["zoom"], 4, 1.8, 8, 3.5, 12, 5.5],
-          ["sqrt", ["max", 1, ["to-number", ["get", "vessel_count"], 1]]],
+          // Mapbox requires zoom to be the direct input of the outermost step/interpolate.
+          // Keep the vessel-count multiplier in each stop output; nesting zoom under `*`
+          // makes Mapbox reject the entire endpoint layer at runtime.
+          "interpolate", ["linear"], ["zoom"],
+          4, ["*", 1.8, ["sqrt", ["max", 1, ["to-number", ["get", "vessel_count"], 1]]]],
+          8, ["*", 3.5, ["sqrt", ["max", 1, ["to-number", ["get", "vessel_count"], 1]]]],
+          12, ["*", 5.5, ["sqrt", ["max", 1, ["to-number", ["get", "vessel_count"], 1]]]],
         ],
         "circle-color": colors,
         "circle-opacity": 0.9,


### PR DESCRIPTION
## Summary
- make Mapbox zoom the direct input of the endpoint radius interpolate expression
- preserve vessel-count scaling at each zoom stop
- validate the generated endpoint layer with Mapbox style-spec in regression tests

## Verification
- focused GFW tests: 29 passed
- full suite: 63 files, 727 passed, 1 skipped
- npx tsc -b
- git diff --check

## Production evidence
- fixes the browser error that rejected gfw-hourly-tracks-endpoint and caused follow-up setPaintProperty errors