### PR TITLE
fix(gfw): hydrate grid details and remove count symbol

### DIFF
--- a/src/data/__tests__/__fixtures__/layer-golden.json
+++ b/src/data/__tests__/__fixtures__/layer-golden.json
@@ -563,7 +563,6 @@
     },
     {
       "layers": [
-        "gfw-hourly-tracks-endpoint-count",
         "gfw-hourly-tracks-endpoint",
         "gfw-hourly-tracks-line"
       ],

--- a/src/data/__tests__/gfwHourlyDetailLoader.test.ts
+++ b/src/data/__tests__/gfwHourlyDetailLoader.test.ts
@@ -1,11 +1,27 @@
 import { describe, expect, it } from "vitest";
-import { __testOnly } from "../gfwHourlyDetailLoader";
+import { __testOnly, canonicalGfwGridCellId, hasVerifiedGfwGridVesselList } from "../gfwHourlyDetailLoader";
 import { gfwHourlyTrackFrameEndpoints, gfwHourlyTrackFrameTrail, parseGfwHourlyTrackFrame } from "../gfwHourlyTracksLoader";
 
 const vessels = [{ vessel_id: "v-1", mmsi: "123", ship_name: "ONE", vessel_type: "fishing", flag: "TW" }];
 const epoch = Date.parse("2026-08-15T00:00:00Z") / 1000;
 
 describe("GFW v3 detail/frame contract", () => {
+  it("只有完整且船數相符的 inline vessels_json 才跳過 grid sidecar hydrate", () => {
+    const base = { vessel_count: 1 };
+    expect(hasVerifiedGfwGridVesselList({ ...base, vessels_json: JSON.stringify(vessels) })).toBe(true);
+    expect(hasVerifiedGfwGridVesselList({ ...base, vessels_json: "not-json" })).toBe(false);
+    expect(hasVerifiedGfwGridVesselList({ ...base, vessels_json: "[]" })).toBe(false);
+    expect(hasVerifiedGfwGridVesselList({ vessel_count: 2, vessels_json: JSON.stringify(vessels) })).toBe(false);
+  });
+
+  it("grid click 將 cell_id、grid_id 或 feature.id 規範為 sidecar key", () => {
+    expect(canonicalGfwGridCellId({ cell_id: "cell-primary", grid_id: "cell-secondary" }, "feature-id")).toBe("cell-primary");
+    expect(canonicalGfwGridCellId({ grid_id: "cell-secondary" }, "feature-id")).toBe("cell-secondary");
+    expect(canonicalGfwGridCellId({}, "feature-id")).toBe("feature-id");
+    expect(canonicalGfwGridCellId({ cell_id: "", grid_id: "cell-secondary" }, "feature-id")).toBe("cell-secondary");
+    expect(canonicalGfwGridCellId({}, undefined)).toBeNull();
+  });
+
   it("grid bucket 必須和 release/hour/bucket/count/member 全部相符", () => {
     const raw = {
       schema_version: 1, release_id: "2026-08-15", observed_at: "2026-08-15T00:00:00Z", bucket: "a", key: "cell_id",

--- a/src/data/gfwHourlyDetailLoader.ts
+++ b/src/data/gfwHourlyDetailLoader.ts
@@ -29,6 +29,26 @@ type TrackDetailDay = { displayDate: string; detailBuckets: readonly GfwDetailBu
 let gridContext: GfwHourlyGridManifest | null = null;
 let tracksContext: GfwHourlyTrackManifest | null = null;
 
+/** Normalise the producer's tile identifier aliases before sidecar hashing/click hydration. */
+export function canonicalGfwGridCellId(properties: Record<string, unknown>, featureId?: unknown): string | null {
+  for (const candidate of [properties.cell_id, properties.grid_id, featureId]) {
+    if (typeof candidate === "string" && candidate.trim() !== "") return candidate;
+  }
+  return null;
+}
+
+/**
+ * PMTiles feature properties are an untrusted preview.  A present string is not sufficient:
+ * only a strict, non-empty member list whose length matches the rendered count can skip the
+ * lazy sidecar verification.  Every other form must hydrate (or fail closed there).
+ */
+export function hasVerifiedGfwGridVesselList(properties: Record<string, unknown>): boolean {
+  const vesselCount = properties.vessel_count;
+  if (!isNonNegativeInt(vesselCount) || vesselCount === 0) return false;
+  const vessels = parseGfwHourlyGridVessels(properties.vessels_json);
+  return vessels !== null && vessels.length > 0 && vessels.length === vesselCount;
+}
+
 /** Hooks own the current release; click plumbing only consumes this immutable snapshot. */
 export function setGfwHourlyGridDetailContext(manifest: GfwHourlyGridManifest | null): void {
   gridContext = manifest;

--- a/src/hooks/__tests__/useGfwHourlyTracksLayer.test.ts
+++ b/src/hooks/__tests__/useGfwHourlyTracksLayer.test.ts
@@ -157,6 +157,7 @@ describe("useGfwHourlyTracksLayer timeline", () => {
 
     expect(state.layers.has("gfw-hourly-tracks-line")).toBe(true);
     expect(state.layers.has("gfw-hourly-tracks-endpoint")).toBe(true);
+    expect(state.layers.has("gfw-hourly-tracks-endpoint-count")).toBe(false);
     expect(loader.frame).toHaveBeenCalledTimes(1);
     expect(loader.frame.mock.calls[0]?.[2]).toBe(0.5);
     expect(harness.getThrottleMs()).toBe(100);
@@ -164,6 +165,7 @@ describe("useGfwHourlyTracksLayer timeline", () => {
     expect(loader.loadDay).toHaveBeenCalledWith(manifest, "2026-08-15");
     expect(notice.show).toHaveBeenCalledWith("GFW 航跡資料最新完整日：2026-08-21（UTC，非即時）");
     expect(state.map.setPaintProperty).toHaveBeenCalledWith("gfw-hourly-tracks-line", "line-opacity", 0.75 * 0.45);
+    expect(state.map.setPaintProperty).not.toHaveBeenCalledWith("gfw-hourly-tracks-endpoint-count", "text-opacity", expect.anything());
 
     // 完全相同時刻的重複 callback 不做無意義重算。
     harness.tick(Date.parse("2026-08-15T03:20:00Z") / 1000);

--- a/src/hooks/useGfwHourlyTracksLayer.ts
+++ b/src/hooks/useGfwHourlyTracksLayer.ts
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from "react";
-import type { CircleLayer, ExpressionSpecification, GeoJSONSource, LineLayer, Map as MapboxMap, SymbolLayer } from "mapbox-gl";
+import type { CircleLayer, ExpressionSpecification, GeoJSONSource, LineLayer, Map as MapboxMap } from "mapbox-gl";
 import {
   gfwHourlyTracksFrame,
   gfwHourlyTrackFrameTrail,
@@ -25,9 +25,7 @@ export const GFW_HOURLY_TRACKS_SOURCE_ID = "gfw-hourly-tracks-source";
 export const GFW_HOURLY_TRACKS_ENDPOINT_SOURCE_ID = "gfw-hourly-tracks-endpoint-source";
 export const GFW_HOURLY_TRACKS_LINE_LAYER_ID = "gfw-hourly-tracks-line";
 export const GFW_HOURLY_TRACKS_ENDPOINT_LAYER_ID = "gfw-hourly-tracks-endpoint";
-export const GFW_HOURLY_TRACKS_ENDPOINT_COUNT_LAYER_ID = "gfw-hourly-tracks-endpoint-count";
 export const GFW_HOURLY_TRACKS_CLICK_LAYERS = [
-  GFW_HOURLY_TRACKS_ENDPOINT_COUNT_LAYER_ID,
   GFW_HOURLY_TRACKS_ENDPOINT_LAYER_ID,
   GFW_HOURLY_TRACKS_LINE_LAYER_ID,
 ] as const;
@@ -95,27 +93,11 @@ function ensureLayers(map: MapboxMap, isDarkTheme: boolean): void {
       layout: { visibility: "none" },
     } as CircleLayer);
   }
-  if (!map.getLayer(GFW_HOURLY_TRACKS_ENDPOINT_COUNT_LAYER_ID)) {
-    map.addLayer({
-      id: GFW_HOURLY_TRACKS_ENDPOINT_COUNT_LAYER_ID,
-      type: "symbol",
-      source: GFW_HOURLY_TRACKS_ENDPOINT_SOURCE_ID,
-      layout: {
-        visibility: "none",
-        "text-field": ["case", [">", ["get", "vessel_count"], 1], ["to-string", ["get", "vessel_count"]], ""],
-        "text-size": 10,
-        "text-font": ["DIN Offc Pro Medium", "Arial Unicode MS Bold"],
-        "text-allow-overlap": true,
-        "text-ignore-placement": true,
-      },
-      paint: { "text-color": "#f0fdfa", "text-halo-color": "#134e4a", "text-halo-width": 0.8, "text-opacity": 0.9 },
-    } as SymbolLayer);
-  }
 }
 
 function setVisibility(map: MapboxMap, visible: boolean): void {
   const visibility = visible ? "visible" : "none";
-  for (const id of [GFW_HOURLY_TRACKS_LINE_LAYER_ID, GFW_HOURLY_TRACKS_ENDPOINT_LAYER_ID, GFW_HOURLY_TRACKS_ENDPOINT_COUNT_LAYER_ID]) {
+  for (const id of [GFW_HOURLY_TRACKS_LINE_LAYER_ID, GFW_HOURLY_TRACKS_ENDPOINT_LAYER_ID]) {
     if (map.getLayer(id)) map.setLayoutProperty(id, "visibility", visibility);
   }
 }
@@ -330,7 +312,6 @@ export function useGfwHourlyTracksLayer(
         map.setPaintProperty(GFW_HOURLY_TRACKS_LINE_LAYER_ID, "line-opacity", clamped * 0.45);
         map.setPaintProperty(GFW_HOURLY_TRACKS_ENDPOINT_LAYER_ID, "circle-opacity", clamped);
         map.setPaintProperty(GFW_HOURLY_TRACKS_ENDPOINT_LAYER_ID, "circle-stroke-opacity", clamped);
-        map.setPaintProperty(GFW_HOURLY_TRACKS_ENDPOINT_COUNT_LAYER_ID, "text-opacity", clamped);
         const colors = colorExpression(isDarkTheme);
         map.setPaintProperty(GFW_HOURLY_TRACKS_LINE_LAYER_ID, "line-color", colors);
         map.setPaintProperty(GFW_HOURLY_TRACKS_ENDPOINT_LAYER_ID, "circle-color", colors);

--- a/src/hooks/useMapInteraction.ts
+++ b/src/hooks/useMapInteraction.ts
@@ -14,7 +14,7 @@ import { compareIdFromReservoirId } from "../data/reservoirStatusLoader";
 import { sampleClimateFields } from "../data/climateFieldSampler";
 import { sampleRasterProbes } from "../data/rasterProbeSampler";
 import { sessionTracker } from "../lib/sessionTracker";
-import { hydrateGfwGridDetail, hydrateGfwTrackDetail } from "../data/gfwHourlyDetailLoader";
+import { canonicalGfwGridCellId, hasVerifiedGfwGridVesselList, hydrateGfwGridDetail, hydrateGfwTrackDetail } from "../data/gfwHourlyDetailLoader";
 
 interface TooltipInfo {
   flight: Flight;
@@ -313,7 +313,7 @@ export function useMapInteraction(
             if (!coords) coords = [e.lngLat.lng, e.lngLat.lat];
             // roadCongestion 的 level / temperatureGrid 的 temp / earthquakeReplayTown 的 eqi
             // / funeralOperatorDensity 的 operatorCount 在 feature-state（非 baked properties）→ 併入
-            const properties =
+            const queriedProperties =
               type === "roadCongestion" ||
               type === "temperatureGrid" ||
               type === "earthquakeReplayTown" ||
@@ -321,7 +321,11 @@ export function useMapInteraction(
               type === "animalShelterPressure"
                 ? { ...(f.properties ?? {}), ...(f.state ?? {}) }
                 : (f.properties ?? {});
-            const needsGridDetail = type === "gfwHourlyGrid" && typeof properties.cell_id === "string" && typeof properties.vessels_json !== "string";
+            const cellId = type === "gfwHourlyGrid" ? canonicalGfwGridCellId(queriedProperties, f.id) : null;
+            // PMTiles may expose the immutable key as `grid_id` or feature.id.  Normalise it
+            // before both popup rendering and detail-bucket SHA selection.
+            const properties = cellId ? { ...queriedProperties, cell_id: cellId } : queriedProperties;
+            const needsGridDetail = type === "gfwHourlyGrid" && cellId !== null && !hasVerifiedGfwGridVesselList(properties);
             const needsTrackDetail = type === "gfwHourlyTrack" && typeof properties.track_id === "string" && typeof properties.vessels_json !== "string";
             const initialProperties = needsGridDetail || needsTrackDetail
               ? { ...properties, detail_status: "loading" }


### PR DESCRIPTION
## Summary
- canonicalize GFW grid identifiers from cell_id, grid_id, or feature id before lazy sidecar hydration
- only trust inline vessel lists when strict JSON parsing succeeds and member count matches vessel_count
- remove the track endpoint count symbol that triggers a Mapbox placement render loop; circle radius still encodes grouped vessel count
- reconcile click/golden contracts and regressions

## Production evidence
- production sidecar hash/bytes/schema are valid and the failing cell contains 1 vessel
- browser popup showed count 1 but skipped hydration because the rendered key was not canonical cell_id
- disabling Hourly Tracks stopped the continuePlacement error loop; grid remained active

## Verification
- focused tests: 40 passed
- full suite: 63 files, 729 passed, 1 skipped
- npx tsc -b
- production Vite build
- git diff --check