### PR TITLE
fix(gfw): harden grid popup hydration

### DIFF
--- a/src/data/__tests__/gfwHourlyDetailLoader.test.ts
+++ b/src/data/__tests__/gfwHourlyDetailLoader.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { __testOnly, canonicalGfwGridCellId, hasVerifiedGfwGridVesselList } from "../gfwHourlyDetailLoader";
+import { __testOnly, canonicalGfwGridCellId, hasVerifiedGfwGridVesselList, needsGfwGridDetailHydration } from "../gfwHourlyDetailLoader";
 import { gfwHourlyTrackFrameEndpoints, gfwHourlyTrackFrameTrail, parseGfwHourlyTrackFrame } from "../gfwHourlyTracksLoader";
 
 const vessels = [{ vessel_id: "v-1", mmsi: "123", ship_name: "ONE", vessel_type: "fishing", flag: "TW" }];
@@ -12,6 +12,12 @@ describe("GFW v3 detail/frame contract", () => {
     expect(hasVerifiedGfwGridVesselList({ ...base, vessels_json: "not-json" })).toBe(false);
     expect(hasVerifiedGfwGridVesselList({ ...base, vessels_json: "[]" })).toBe(false);
     expect(hasVerifiedGfwGridVesselList({ vessel_count: 2, vessels_json: JSON.stringify(vessels) })).toBe(false);
+    expect(needsGfwGridDetailHydration({ ...base, vessels_json: JSON.stringify(vessels) })).toBe(false);
+    expect(needsGfwGridDetailHydration({
+      ...base,
+      vessels_json: JSON.stringify(vessels),
+      geometry_semantics: "inferred_0_01_degree_footprint",
+    })).toBe(true);
   });
 
   it("grid click 將 cell_id、grid_id 或 feature.id 規範為 sidecar key", () => {

--- a/src/data/gfwHourlyDetailLoader.ts
+++ b/src/data/gfwHourlyDetailLoader.ts
@@ -49,6 +49,15 @@ export function hasVerifiedGfwGridVesselList(properties: Record<string, unknown>
   return vessels !== null && vessels.length > 0 && vessels.length === vesselCount;
 }
 
+/**
+ * v3 tile properties are only a rendering preview.  Even an apparently valid inline list
+ * must be verified against its content-addressed bucket before a full-fidelity popup claims
+ * to show all members.  v2 keeps its already-validated inline fallback.
+ */
+export function needsGfwGridDetailHydration(properties: Record<string, unknown>): boolean {
+  return properties.geometry_semantics === "inferred_0_01_degree_footprint" || !hasVerifiedGfwGridVesselList(properties);
+}
+
 /** Hooks own the current release; click plumbing only consumes this immutable snapshot. */
 export function setGfwHourlyGridDetailContext(manifest: GfwHourlyGridManifest | null): void {
   gridContext = manifest;

--- a/src/hooks/__tests__/useGfwHourlyGridLayer.test.ts
+++ b/src/hooks/__tests__/useGfwHourlyGridLayer.test.ts
@@ -32,6 +32,7 @@ const loader = vi.hoisted(() => ({
 }));
 const clock = vi.hoisted(() => ({ current: Date.parse("2026-08-15T00:20:00Z") / 1000 }));
 const notice = vi.hoisted(() => ({ show: vi.fn() }));
+const detailContext = vi.hoisted(() => ({ set: vi.fn() }));
 
 vi.mock("react", () => ({ useRef: harness.useRef, useEffect: harness.useEffect }));
 vi.mock("../useMapReadyTick", () => ({ useMapReadyTick: () => 0 }));
@@ -55,6 +56,7 @@ vi.mock("../../state/timeStore", () => ({
 vi.mock("../../lib/loadingRegistry", () => ({ keepLoadingUntilMapIdle: vi.fn() }));
 vi.mock("../../components/TransientNotice", () => ({ showTransientNotice: notice.show }));
 vi.mock("../../map/pmtilesSourceType", () => ({ registerPmtilesSourceTypeOnce: vi.fn() }));
+vi.mock("../../data/gfwHourlyDetailLoader", () => ({ setGfwHourlyGridDetailContext: detailContext.set }));
 
 import { useGfwHourlyGridLayer } from "../useGfwHourlyGridLayer";
 
@@ -91,6 +93,7 @@ describe("useGfwHourlyGridLayer timeline", () => {
     loader.loadManifest.mockReset();
     loader.loadHour.mockReset();
     notice.show.mockReset();
+    detailContext.set.mockReset();
   });
 
   it("同一 activation rerender 不重抓 manifest，close→open 會 refresh", async () => {
@@ -122,6 +125,20 @@ describe("useGfwHourlyGridLayer timeline", () => {
     expect(notice.show).toHaveBeenCalledWith("GFW 小時網格資料最新完整日：2026-08-15（UTC，非即時）");
     harness.rerender(); useGfwHourlyGridLayer(mapRef, true, 0.8);
     expect(notice.show).toHaveBeenCalledTimes(1);
+  });
+
+  it("opacity rerender 會重新綁定已載入 release 的 grid detail context", async () => {
+    const manifest = { hours: [], dateEndInclusive: "2026-08-15" };
+    loader.loadManifest.mockResolvedValue(manifest);
+    loader.loadHour.mockResolvedValue(FC);
+    const state = createMap();
+    const mapRef = { current: state.map } as RefObject<MapboxMap | null>;
+    useGfwHourlyGridLayer(mapRef, true, 0.6);
+    await flushAsync();
+    expect(detailContext.set).toHaveBeenLastCalledWith(manifest);
+
+    harness.rerender(); useGfwHourlyGridLayer(mapRef, true, 0.8);
+    expect(detailContext.set).toHaveBeenLastCalledWith(manifest);
   });
 
   it("快速跨小時時舊 response 不覆蓋新 exact-hour 資料", async () => {
@@ -232,6 +249,9 @@ describe("useGfwHourlyGridLayer timeline", () => {
     expect(state.sources.has("gfw-hourly-grid-pmtiles-next-source")).toBe(true);
     expect(state.layers.has("gfw-hourly-grid-pmtiles-fill")).toBe(true);
     expect(state.layers.has("gfw-hourly-grid-pmtiles-hit-fill")).toBe(true);
+    expect(state.layers.has("gfw-hourly-grid-pmtiles-count")).toBe(false);
+    expect(state.layers.has("gfw-hourly-grid-pmtiles-next-count")).toBe(false);
+    expect(state.map.setPaintProperty).not.toHaveBeenCalledWith("gfw-hourly-grid-pmtiles-count", "text-opacity", expect.anything());
     expect(loader.loadHour).not.toHaveBeenCalled();
   });
 });

--- a/src/hooks/__tests__/useMapInteraction.test.ts
+++ b/src/hooks/__tests__/useMapInteraction.test.ts
@@ -1,0 +1,102 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { RefObject } from "react";
+import type { Map as MapboxMap } from "mapbox-gl";
+
+const harness = vi.hoisted(() => {
+  let stateIndex = 0;
+  let click: ((event: {
+    point: { x: number; y: number };
+    lngLat: { lng: number; lat: number };
+  }) => void) | null = null;
+  const setFeatureInfo = vi.fn();
+  const hydrateGrid = vi.fn();
+  return {
+    reset: () => { stateIndex = 0; click = null; setFeatureInfo.mockReset(); hydrateGrid.mockReset(); },
+    useState: <T,>(initial: T) => {
+      const setter = stateIndex++ === 6 ? setFeatureInfo : vi.fn();
+      return [initial, setter] as const;
+    },
+    useRef: <T,>(initial: T) => ({ current: initial }),
+    setClick: (handler: typeof click) => { click = handler; },
+    click: () => click,
+    setFeatureInfo,
+    hydrateGrid,
+  };
+});
+
+vi.mock("react", () => ({
+  useState: harness.useState,
+  useRef: harness.useRef,
+  useEffect: () => undefined,
+}));
+vi.mock("../../map/realEstatePointsCustomLayer", () => ({ getRealEstatePointsScene: () => null }));
+vi.mock("../../data/climateFieldSampler", () => ({ sampleClimateFields: vi.fn() }));
+vi.mock("../../data/rasterProbeSampler", () => ({ sampleRasterProbes: vi.fn() }));
+vi.mock("../../lib/sessionTracker", () => ({ sessionTracker: { log: vi.fn() } }));
+vi.mock("../../data/gfwHourlyDetailLoader", async (importOriginal) => ({
+  ...await importOriginal<typeof import("../../data/gfwHourlyDetailLoader")>(),
+  hydrateGfwGridDetail: harness.hydrateGrid,
+}));
+
+import { GIS_LAYERS } from "../../map/gisClickRegistry";
+import { GFW_HOURLY_GRID_PMTILES_HIT_FILL_LAYER_ID } from "../useGfwHourlyGridLayer";
+import { useMapInteraction } from "../useMapInteraction";
+
+describe("useMapInteraction GFW grid click", () => {
+  beforeEach(() => harness.reset());
+
+  it("PMTiles hit fill 以 registry 的 gfwHourlyGrid type 將 v3 grid_id popup 依序 hydrate", async () => {
+    expect(GIS_LAYERS).toContainEqual({
+      layers: expect.arrayContaining([GFW_HOURLY_GRID_PMTILES_HIT_FILL_LAYER_ID]),
+      type: "gfwHourlyGrid",
+    });
+    harness.hydrateGrid.mockResolvedValue({
+      cell_id: "38a1",
+      grid_id: "38a1",
+      observed_at: "2026-08-20T16:00:00Z",
+      vessel_count: 1,
+      vessels_json: JSON.stringify([{ vessel_id: "v-1", mmsi: null, ship_name: "ONE", vessel_type: null, flag: null }]),
+      detail_status: "loaded",
+    });
+    const map = {
+      getContainer: () => ({ clientWidth: 100, clientHeight: 100 }),
+      getLayer: (id: string) => id === GFW_HOURLY_GRID_PMTILES_HIT_FILL_LAYER_ID ? {} : undefined,
+      queryRenderedFeatures: vi.fn((_bbox: unknown, options: { layers: string[] }) =>
+        options.layers.includes(GFW_HOURLY_GRID_PMTILES_HIT_FILL_LAYER_ID)
+          ? [{
+            id: "feature-id-ignored-after-grid-id",
+            properties: {
+              grid_id: "38a1",
+              observed_at: "2026-08-20T16:00:00Z",
+              vessel_count: 1,
+              // A v3 rendering preview may look valid, but sidecar remains authoritative.
+              vessels_json: JSON.stringify([{ vessel_id: "preview", mmsi: null, ship_name: "PREVIEW", vessel_type: null, flag: null }]),
+              geometry_semantics: "inferred_0_01_degree_footprint",
+            },
+            geometry: { type: "Polygon", coordinates: [] },
+          }]
+          : [],
+      ),
+      on: vi.fn((event: string, ...args: unknown[]) => {
+        if (event === "click" && typeof args[0] === "function") harness.setClick(args[0] as never);
+      }),
+      getCanvas: () => ({ style: {} }),
+    };
+    const ref = { current: map } as unknown as RefObject<MapboxMap | null>;
+    const interaction = useMapInteraction(ref, { current: null }, { current: [] }, { current: 0 });
+    interaction.bindEvents(map as never);
+
+    harness.click()?.({ point: { x: 5, y: 6 }, lngLat: { lng: 121, lat: 25 } });
+    expect(harness.hydrateGrid).toHaveBeenCalledWith(expect.objectContaining({ cell_id: "38a1", grid_id: "38a1" }));
+    expect(harness.setFeatureInfo).toHaveBeenNthCalledWith(1, expect.objectContaining({
+      layerType: "gfwHourlyGrid",
+      properties: expect.objectContaining({ cell_id: "38a1", detail_status: "loading" }),
+    }));
+
+    await Promise.resolve();
+    expect(harness.setFeatureInfo).toHaveBeenLastCalledWith(expect.objectContaining({
+      layerType: "gfwHourlyGrid",
+      properties: expect.objectContaining({ cell_id: "38a1", detail_status: "loaded", vessels_json: expect.stringContaining("v-1") }),
+    }));
+  });
+});

--- a/src/hooks/useGfwHourlyGridLayer.ts
+++ b/src/hooks/useGfwHourlyGridLayer.ts
@@ -32,10 +32,8 @@ export const GFW_HOURLY_GRID_PMTILES_NEXT_SOURCE_ID = "gfw-hourly-grid-pmtiles-n
 export const GFW_HOURLY_GRID_PMTILES_HIT_SOURCE_ID = "gfw-hourly-grid-pmtiles-hit-source";
 export const GFW_HOURLY_GRID_PMTILES_FILL_LAYER_ID = "gfw-hourly-grid-pmtiles-fill";
 export const GFW_HOURLY_GRID_PMTILES_OUTLINE_LAYER_ID = "gfw-hourly-grid-pmtiles-outline";
-export const GFW_HOURLY_GRID_PMTILES_COUNT_LAYER_ID = "gfw-hourly-grid-pmtiles-count";
 export const GFW_HOURLY_GRID_PMTILES_NEXT_FILL_LAYER_ID = "gfw-hourly-grid-pmtiles-next-fill";
 export const GFW_HOURLY_GRID_PMTILES_NEXT_OUTLINE_LAYER_ID = "gfw-hourly-grid-pmtiles-next-outline";
-export const GFW_HOURLY_GRID_PMTILES_NEXT_COUNT_LAYER_ID = "gfw-hourly-grid-pmtiles-next-count";
 export const GFW_HOURLY_GRID_PMTILES_HIT_FILL_LAYER_ID = "gfw-hourly-grid-pmtiles-hit-fill";
 export const GFW_HOURLY_GRID_CLICK_LAYERS = [
   GFW_HOURLY_GRID_HIT_CIRCLE_LAYER_ID,
@@ -166,7 +164,7 @@ function removePmtilesSlot(map: MapboxMap, sourceId: string, layerIds: readonly 
 function mountPmtilesSlot(
   map: MapboxMap,
   sourceId: string,
-  layerIds: readonly [string, string, string],
+  layerIds: readonly [string, string],
   url: string,
   sourceLayer: string,
   hitOnly = false,
@@ -175,7 +173,7 @@ function mountPmtilesSlot(
   // H/H+1 independent and never asks the browser to download a day GeoJSON fallback.
   removePmtilesSlot(map, sourceId, layerIds);
   map.addSource(sourceId, { type: PMTILES_SOURCE_TYPE, url, attribution: "Global Fishing Watch" } as never);
-  const [fillId, outlineId, countId] = layerIds;
+  const [fillId, outlineId] = layerIds;
   map.addLayer({ id: fillId, type: "fill", source: sourceId, "source-layer": sourceLayer,
     paint: hitOnly ? { "fill-opacity": 0 } : { "fill-color": "#fb923c", "fill-opacity": 0.24 },
     layout: { visibility: "visible" },
@@ -184,18 +182,13 @@ function mountPmtilesSlot(
   map.addLayer({ id: outlineId, type: "line", source: sourceId, "source-layer": sourceLayer,
     paint: { "line-color": "#7c2d12", "line-width": 1, "line-opacity": 0.85 }, layout: { visibility: "visible" },
   } as LineLayer);
-  map.addLayer({ id: countId, type: "symbol", source: sourceId, "source-layer": sourceLayer,
-    layout: { visibility: "visible", "text-field": ["case", [">", ["get", "vessel_count"], 1], ["to-string", ["get", "vessel_count"]], ""],
-      "text-size": 11, "text-font": ["DIN Offc Pro Medium", "Arial Unicode MS Bold"], "text-allow-overlap": true, "text-ignore-placement": true },
-    paint: { "text-color": "#fff7ed", "text-halo-color": "#431407", "text-halo-width": 0.8, "text-opacity": 0.9 },
-  } as SymbolLayer);
 }
 
 function setPmtilesVisibility(map: MapboxMap, visible: boolean): void {
   const value = visible ? "visible" : "none";
   for (const id of [
-    GFW_HOURLY_GRID_PMTILES_FILL_LAYER_ID, GFW_HOURLY_GRID_PMTILES_OUTLINE_LAYER_ID, GFW_HOURLY_GRID_PMTILES_COUNT_LAYER_ID,
-    GFW_HOURLY_GRID_PMTILES_NEXT_FILL_LAYER_ID, GFW_HOURLY_GRID_PMTILES_NEXT_OUTLINE_LAYER_ID, GFW_HOURLY_GRID_PMTILES_NEXT_COUNT_LAYER_ID,
+    GFW_HOURLY_GRID_PMTILES_FILL_LAYER_ID, GFW_HOURLY_GRID_PMTILES_OUTLINE_LAYER_ID,
+    GFW_HOURLY_GRID_PMTILES_NEXT_FILL_LAYER_ID, GFW_HOURLY_GRID_PMTILES_NEXT_OUTLINE_LAYER_ID,
     GFW_HOURLY_GRID_PMTILES_HIT_FILL_LAYER_ID,
   ]) if (map.getLayer(id)) map.setLayoutProperty(id, "visibility", value);
 }
@@ -261,6 +254,10 @@ export function useGfwHourlyGridLayer(
       currentHourRef.current = null;
       nextHourRef.current = null;
       dominantHourRef.current = null;
+    } else if (manifestRef.current) {
+      // effect 會隨 opacity / style tick 重跑；cleanup 已解除上一輪 detail context，
+      // 必須立即恢復目前 release，否則 grid click 只能 fail-closed，永遠無法 hydration。
+      setGfwHourlyGridDetailContext(manifestRef.current);
     }
 
     const clearData = () => {
@@ -274,9 +271,9 @@ export function useGfwHourlyGridLayer(
       source(map, GFW_HOURLY_GRID_HIT_SOURCE_ID)?.setData?.(EMPTY);
       pmtilesModeRef.current = false;
       pmtilesSlotUrlsRef.current.clear();
-      removePmtilesSlot(map, GFW_HOURLY_GRID_PMTILES_SOURCE_ID, [GFW_HOURLY_GRID_PMTILES_FILL_LAYER_ID, GFW_HOURLY_GRID_PMTILES_OUTLINE_LAYER_ID, GFW_HOURLY_GRID_PMTILES_COUNT_LAYER_ID]);
-      removePmtilesSlot(map, GFW_HOURLY_GRID_PMTILES_NEXT_SOURCE_ID, [GFW_HOURLY_GRID_PMTILES_NEXT_FILL_LAYER_ID, GFW_HOURLY_GRID_PMTILES_NEXT_OUTLINE_LAYER_ID, GFW_HOURLY_GRID_PMTILES_NEXT_COUNT_LAYER_ID]);
-      removePmtilesSlot(map, GFW_HOURLY_GRID_PMTILES_HIT_SOURCE_ID, [GFW_HOURLY_GRID_PMTILES_HIT_FILL_LAYER_ID, "", ""]);
+      removePmtilesSlot(map, GFW_HOURLY_GRID_PMTILES_SOURCE_ID, [GFW_HOURLY_GRID_PMTILES_FILL_LAYER_ID, GFW_HOURLY_GRID_PMTILES_OUTLINE_LAYER_ID]);
+      removePmtilesSlot(map, GFW_HOURLY_GRID_PMTILES_NEXT_SOURCE_ID, [GFW_HOURLY_GRID_PMTILES_NEXT_FILL_LAYER_ID, GFW_HOURLY_GRID_PMTILES_NEXT_OUTLINE_LAYER_ID]);
+      removePmtilesSlot(map, GFW_HOURLY_GRID_PMTILES_HIT_SOURCE_ID, [GFW_HOURLY_GRID_PMTILES_HIT_FILL_LAYER_ID, ""]);
     };
 
     const mountPmtilesPair = (manifest: GfwHourlyGridManifest, currentHour: string, nextHour: string) => {
@@ -286,9 +283,9 @@ export function useGfwHourlyGridLayer(
       if (!current && !next) return false;
       registerPmtilesSourceTypeOnce();
       pmtilesModeRef.current = true;
-      const slots: Array<[string, readonly [string, string, string], typeof current]> = [
-        [GFW_HOURLY_GRID_PMTILES_SOURCE_ID, [GFW_HOURLY_GRID_PMTILES_FILL_LAYER_ID, GFW_HOURLY_GRID_PMTILES_OUTLINE_LAYER_ID, GFW_HOURLY_GRID_PMTILES_COUNT_LAYER_ID], current],
-        [GFW_HOURLY_GRID_PMTILES_NEXT_SOURCE_ID, [GFW_HOURLY_GRID_PMTILES_NEXT_FILL_LAYER_ID, GFW_HOURLY_GRID_PMTILES_NEXT_OUTLINE_LAYER_ID, GFW_HOURLY_GRID_PMTILES_NEXT_COUNT_LAYER_ID], next],
+      const slots: Array<[string, readonly [string, string], typeof current]> = [
+        [GFW_HOURLY_GRID_PMTILES_SOURCE_ID, [GFW_HOURLY_GRID_PMTILES_FILL_LAYER_ID, GFW_HOURLY_GRID_PMTILES_OUTLINE_LAYER_ID], current],
+        [GFW_HOURLY_GRID_PMTILES_NEXT_SOURCE_ID, [GFW_HOURLY_GRID_PMTILES_NEXT_FILL_LAYER_ID, GFW_HOURLY_GRID_PMTILES_NEXT_OUTLINE_LAYER_ID], next],
       ];
       for (const [sourceId, layerIds, entry] of slots) {
         const url = entry ? pmtilesUrl(manifest, entry.path) : "";
@@ -329,14 +326,13 @@ export function useGfwHourlyGridLayer(
         map.setPaintProperty(fillId, "fill-opacity", 0.24 * clampedOpacity * weight);
         map.setPaintProperty(outlineId, "line-opacity", 0.85 * clampedOpacity * weight);
       }
-      for (const [fillId, outlineId, countId, weight] of [
-        [GFW_HOURLY_GRID_PMTILES_FILL_LAYER_ID, GFW_HOURLY_GRID_PMTILES_OUTLINE_LAYER_ID, GFW_HOURLY_GRID_PMTILES_COUNT_LAYER_ID, currentWeight],
-        [GFW_HOURLY_GRID_PMTILES_NEXT_FILL_LAYER_ID, GFW_HOURLY_GRID_PMTILES_NEXT_OUTLINE_LAYER_ID, GFW_HOURLY_GRID_PMTILES_NEXT_COUNT_LAYER_ID, nextWeight],
+      for (const [fillId, outlineId, weight] of [
+        [GFW_HOURLY_GRID_PMTILES_FILL_LAYER_ID, GFW_HOURLY_GRID_PMTILES_OUTLINE_LAYER_ID, currentWeight],
+        [GFW_HOURLY_GRID_PMTILES_NEXT_FILL_LAYER_ID, GFW_HOURLY_GRID_PMTILES_NEXT_OUTLINE_LAYER_ID, nextWeight],
       ] as const) {
         if (!map.getLayer(fillId)) continue;
         map.setPaintProperty(fillId, "fill-opacity", 0.24 * clampedOpacity * weight);
         map.setPaintProperty(outlineId, "line-opacity", 0.85 * clampedOpacity * weight);
-        map.setPaintProperty(countId, "text-opacity", clampedOpacity * weight);
       }
       const useNext = Boolean(nextDataRef.current && (!currentDataRef.current || progress >= 0.5));
       const dominantHour = useNext ? nextHourRef.current : currentHourRef.current;
@@ -347,7 +343,7 @@ export function useGfwHourlyGridLayer(
           const entry = manifest?.hours.find((hour) => hour.observedAt === dominantHour && hour.format === "pmtiles");
           if (manifest?.sourceLayer && entry) {
             mountPmtilesSlot(map, GFW_HOURLY_GRID_PMTILES_HIT_SOURCE_ID,
-              [GFW_HOURLY_GRID_PMTILES_HIT_FILL_LAYER_ID, "", ""], pmtilesUrl(manifest, entry.path), manifest.sourceLayer, true);
+              [GFW_HOURLY_GRID_PMTILES_HIT_FILL_LAYER_ID, ""], pmtilesUrl(manifest, entry.path), manifest.sourceLayer, true);
             pmtilesSlotUrlsRef.current.set(GFW_HOURLY_GRID_PMTILES_HIT_SOURCE_ID, entry.path);
           }
         } else source(map, GFW_HOURLY_GRID_HIT_SOURCE_ID)?.setData?.(

--- a/src/hooks/useMapInteraction.ts
+++ b/src/hooks/useMapInteraction.ts
@@ -14,7 +14,7 @@ import { compareIdFromReservoirId } from "../data/reservoirStatusLoader";
 import { sampleClimateFields } from "../data/climateFieldSampler";
 import { sampleRasterProbes } from "../data/rasterProbeSampler";
 import { sessionTracker } from "../lib/sessionTracker";
-import { canonicalGfwGridCellId, hasVerifiedGfwGridVesselList, hydrateGfwGridDetail, hydrateGfwTrackDetail } from "../data/gfwHourlyDetailLoader";
+import { canonicalGfwGridCellId, hydrateGfwGridDetail, hydrateGfwTrackDetail, needsGfwGridDetailHydration } from "../data/gfwHourlyDetailLoader";
 
 interface TooltipInfo {
   flight: Flight;
@@ -325,7 +325,7 @@ export function useMapInteraction(
             // PMTiles may expose the immutable key as `grid_id` or feature.id.  Normalise it
             // before both popup rendering and detail-bucket SHA selection.
             const properties = cellId ? { ...queriedProperties, cell_id: cellId } : queriedProperties;
-            const needsGridDetail = type === "gfwHourlyGrid" && cellId !== null && !hasVerifiedGfwGridVesselList(properties);
+            const needsGridDetail = type === "gfwHourlyGrid" && cellId !== null && needsGfwGridDetailHydration(properties);
             const needsTrackDetail = type === "gfwHourlyTrack" && typeof properties.track_id === "string" && typeof properties.vessels_json !== "string";
             const initialProperties = needsGridDetail || needsTrackDetail
               ? { ...properties, detail_status: "loading" }


### PR DESCRIPTION
## Summary
- force v3 full-fidelity grid clicks through the content-addressed sidecar instead of trusting tile preview fields
- restore the active grid detail context after opacity/style effect rerenders
- remove current/next PMTiles count symbols that trigger Mapbox placement loops; grid geometry and popup counts remain
- add a real click-handler regression covering registry hit fill, grid_id canonicalization, and loading-to-loaded popup state

## Production evidence
- latest bundle still skipped the popup sidecar and showed 1 vessel as an empty list
- grid-only reproduction still triggered Mapbox continuePlacement errors
- the sidecar itself is hash/byte verified and contains the expected vessel

## Verification
- focused tests: 15 passed
- full suite: 64 files, 731 passed, 1 skipped
- npx tsc -b
- production Vite build
- git diff --check