### PR TITLE
fix(gfw): serialize hydrated vessel details

### DIFF
--- a/src/data/__tests__/gfwHourlyDetailLoader.test.ts
+++ b/src/data/__tests__/gfwHourlyDetailLoader.test.ts
@@ -1,11 +1,18 @@
 import { describe, expect, it } from "vitest";
 import { __testOnly, canonicalGfwGridCellId, hasVerifiedGfwGridVesselList, needsGfwGridDetailHydration } from "../gfwHourlyDetailLoader";
+import { parseGfwHourlyGridVessels, serializeGfwHourlyGridVessels } from "../gfwHourlyGridTypes";
 import { gfwHourlyTrackFrameEndpoints, gfwHourlyTrackFrameTrail, parseGfwHourlyTrackFrame } from "../gfwHourlyTracksLoader";
 
 const vessels = [{ vessel_id: "v-1", mmsi: "123", ship_name: "ONE", vessel_type: "fishing", flag: "TW" }];
 const epoch = Date.parse("2026-08-15T00:00:00Z") / 1000;
 
 describe("GFW v3 detail/frame contract", () => {
+  it("normalized vessel serializer 可回傳 popup parser 所需的 snake_case wire JSON", () => {
+    const normalized = [{ vesselId: "v-1", mmsi: "123", shipName: "ONE", vesselType: "fishing", flag: "TW" }];
+    expect(JSON.parse(serializeGfwHourlyGridVessels(normalized))).toEqual(vessels);
+    expect(parseGfwHourlyGridVessels(serializeGfwHourlyGridVessels(normalized))).toEqual(normalized);
+  });
+
   it("只有完整且船數相符的 inline vessels_json 才跳過 grid sidecar hydrate", () => {
     const base = { vessel_count: 1 };
     expect(hasVerifiedGfwGridVesselList({ ...base, vessels_json: JSON.stringify(vessels) })).toBe(true);
@@ -36,6 +43,16 @@ describe("GFW v3 detail/frame contract", () => {
     expect(__testOnly.parseGridEntries(raw, { releaseId: "2026-08-15", observedAt: "2026-08-15T00:00:00Z", bucket: "a" })?.get("cell-a")?.vessels).toHaveLength(1);
     raw.vessel_count = 2;
     expect(__testOnly.parseGridEntries(raw, { releaseId: "2026-08-15", observedAt: "2026-08-15T00:00:00Z", bucket: "a" })).toBeNull();
+  });
+
+  it("grid hydrate loaded 結果可被 popup parser 解析完整船舶清單", () => {
+    const props = __testOnly.loadedGfwGridDetailProperties(
+      { cell_id: "cell-a", vessel_count: 1 },
+      { vesselCount: 1, vessels: parseGfwHourlyGridVessels(vessels)! },
+      { label: "Global Fishing Watch", href: "https://globalfishingwatch.org/" },
+    );
+    expect(props).toMatchObject({ detail_status: "loaded", full_fidelity: 1, vessel_count: 1 });
+    expect(parseGfwHourlyGridVessels(props.vessels_json)).toEqual(parseGfwHourlyGridVessels(vessels));
   });
 
   it("track sidecar 拒絕 point count/time order 不自洽", () => {

--- a/src/data/gfwHourlyDetailLoader.ts
+++ b/src/data/gfwHourlyDetailLoader.ts
@@ -1,4 +1,4 @@
-import { parseGfwHourlyGridVessels, type GfwHourlyGridVessel } from "./gfwHourlyGridTypes";
+import { parseGfwHourlyGridVessels, serializeGfwHourlyGridVessels, type GfwHourlyGridVessel } from "./gfwHourlyGridTypes";
 import type { GfwDetailBucket } from "./gfwHourlyReleaseManifest";
 import { withLoading } from "../lib/loadingRegistry";
 import type { GfwHourlyGridManifest } from "./gfwHourlyGridLoader";
@@ -153,6 +153,17 @@ function bucketEntry(entries: readonly GfwDetailBucket[], bucket: string): GfwDe
   return entries.find((entry) => entry.bucket === bucket) ?? null;
 }
 
+function loadedGfwGridDetailProperties(
+  properties: Record<string, unknown>,
+  detail: GfwGridDetailEntry,
+  attribution: { label: string; href: string } | undefined,
+): Record<string, unknown> {
+  return {
+    ...properties, vessel_count: detail.vesselCount, vessels_json: serializeGfwHourlyGridVessels(detail.vessels), detail_status: "loaded",
+    full_fidelity: 1, attribution_label: attribution?.label ?? "Global Fishing Watch", attribution_href: attribution?.href ?? "https://globalfishingwatch.org/",
+  };
+}
+
 export async function loadGfwGridCellDetail(
   manifestUrl: string,
   releaseId: string,
@@ -195,10 +206,7 @@ export async function hydrateGfwGridDetail(properties: Record<string, unknown>):
   if (!detail || (typeof properties.vessel_count === "number" && properties.vessel_count !== detail.vesselCount)) {
     return { ...properties, detail_status: "error", detail_error: "完整船舶清單驗證失敗" };
   }
-  return {
-    ...properties, vessel_count: detail.vesselCount, vessels_json: JSON.stringify(detail.vessels), detail_status: "loaded",
-    full_fidelity: 1, attribution_label: gridContext.attribution?.label ?? "Global Fishing Watch", attribution_href: gridContext.attribution?.href ?? "https://globalfishingwatch.org/",
-  };
+  return loadedGfwGridDetailProperties(properties, detail, gridContext.attribution);
 }
 
 export async function hydrateGfwTrackDetail(properties: Record<string, unknown>): Promise<Record<string, unknown>> {
@@ -225,4 +233,4 @@ export async function hydrateGfwTrackDetail(properties: Record<string, unknown>)
   };
 }
 
-export const __testOnly = { parseGridEntries, parseTrackEntries, resolveAssetUrl };
+export const __testOnly = { parseGridEntries, parseTrackEntries, resolveAssetUrl, loadedGfwGridDetailProperties };

--- a/src/data/gfwHourlyGridTypes.ts
+++ b/src/data/gfwHourlyGridTypes.ts
@@ -6,6 +6,17 @@ export interface GfwHourlyGridVessel {
   flag: string | null;
 }
 
+/** Popup-facing wire contract: the parser intentionally accepts producer-style snake_case only. */
+export function serializeGfwHourlyGridVessels(vessels: readonly GfwHourlyGridVessel[]): string {
+  return JSON.stringify(vessels.map((vessel) => ({
+    vessel_id: vessel.vesselId,
+    mmsi: vessel.mmsi,
+    ship_name: vessel.shipName,
+    vessel_type: vessel.vesselType,
+    flag: vessel.flag,
+  })));
+}
+
 function optionalString(value: unknown): string | null | undefined {
   if (value === null || value === undefined || value === "") return null;
   return typeof value === "string" ? value : undefined;


### PR DESCRIPTION
Summary: serialize normalized grid detail vessels back to the snake_case popup wire contract and add round-trip plus loaded-detail regressions. Production evidence: the verified sidecar resolved successfully, but direct camelCase JSON serialization produced an empty popup list. Verification: focused 33; full suite 733 passed and 1 skipped; tsc; production build; diff check.