### PR TITLE
fix(gfw): proxy production releases in local dev

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,8 +15,12 @@ FR24_API_TOKEN=your_flightradar24_api_token_here
 # VITE_IMAGERY_CDN_BASE=https://pub-eae6980c040441adbd1eaded2870d3d2.r2.dev
 
 # GFW 海事資料可選 CDN origin override（不含 global-maritime/gfw-hourly）。
-# Production 未設時走同域 /global-maritime/gfw-hourly/；Vite dev 優先 local POC adapters。
+# Production 未設時走同域 /global-maritime/gfw-hourly/；DEV 也固定同源，交由 Vite proxy，忽略本值以避免 CORS。
 # VITE_GLOBAL_MARITIME_CDN_BASE=https://<cloudflare-custom-domain>
+# 一般 DEV checkout 不含 POC artifact；只有離線 fixture 驗收才設 true。
+# VITE_GFW_HOURLY_USE_LOCAL_POC=true
+# gis-up 要驗證與目前 v3 production path 相同的 release，需明確開 shadow（預設仍 canonical root）。
+# VITE_GFW_HOURLY_V3_SHADOW_ENABLED=true
 
 # S3 (upload script)
 S3_BUCKET=migu-gis-data-collector

--- a/docs/features/global-maritime/README.md
+++ b/docs/features/global-maritime/README.md
@@ -25,7 +25,7 @@ segment，均不得冒充原始 AIS 精確軌跡或官方格界。
 - gfwHourlyTracks：canonical v2 仍是目前路徑；v3 shadow 用 hourly frame 建構 0.5/1/2/3 小時真實裁切拖尾（預設 0.5 小時），不顯示整日 edge 當作 timeline trail，full audit 已通過，仍待 deploy/browser gate。
 - `gfwDarkVessels`：GFW SAR 偵測中未與 AIS 匹配的獨立時間軸圖層；位置是 HIGH grid cell center，不是精確 SAR 座標，也不是違法、暗船或刻意關 AIS 認定。
 
-四層預設關閉，避免訪客一進站即發 RPC 或下載 POC。透明度、圖例、popup、點選與 loading 均分開；前端只讀 public RPC／本機 POC artifact，不直接讀 live table。
+四層預設關閉，避免訪客一進站即發 RPC 或下載 release assets。透明度、圖例、popup、點選與 loading 均分開；前端只讀 public RPC／已發佈 release artifact，不直接讀 live table；本機 POC 僅在明確 opt-in 時使用。
 
 ## RPC contract
 
@@ -93,12 +93,12 @@ metrics 為準。
 - 入口：`世界 World → 全球海事 Global Maritime → GFW 抽樣近似航跡`；預設關閉。
 - 視覺沿用既有 Ships 六類色票：貨船、油輪、客船、漁船、作業／拖船、其他；航跡線與船頭同色，popup 同時保留 GFW 原始船種。
 - 每次開啟圖層且 manifest 契約載入成功後，底部短暫通知會顯示 `latest_complete_date` 的最新完整 UTC 日，並明示非即時；不以 `generated_at` 代替資料日期。
-- Production 先載入 unified v2 root manifest；Vite dev 分別使用 tracks/grid local POC adapter。每次開層都 no-cache refresh manifest，時間軸只載入選定 UTC 日的單檔。日檔含 3h lookback 與 1h lookahead，足以支援最長 3h 拖尾與跨日內插；不再一次載入七日整包。
+- Production 與 Vite dev 預設都先載入同源 unified root manifest；DEV 由 `/global-maritime/gfw-hourly` proxy 轉送 production origin。只有 `VITE_GFW_HOURLY_USE_LOCAL_POC=true` 才使用 tracks/grid local POC adapter。每次開層都 no-cache refresh manifest，時間軸只載入選定 UTC 日的單檔。日檔含 3h lookback 與 1h lookahead，足以支援最長 3h 拖尾與跨日內插；不再一次載入七日整包。
 
 ### GFW 航跡 CDN 讀取契約
 
 - S3 key prefix：`deploy-assets/global-maritime/gfw-hourly/`；public CDN path：`/global-maritime/gfw-hourly/`。
-- Production 預設同域 `/global-maritime/gfw-hourly/manifest.json`；`VITE_GLOBAL_MARITIME_CDN_BASE` 僅是可選 origin override，不需要 Zeabur 額外 env。Vite dev 優先使用 `/gfw_hourly_tracks_poc/manifest.json` 與 `/gfw_hourly_grid_poc/manifest.json`；dev 沒有 SAR unified fixture 時 `gfwDarkVessels` fail closed。
+- Production 預設同域 `/global-maritime/gfw-hourly/manifest.json`；`VITE_GLOBAL_MARITIME_CDN_BASE` 僅是 production 可選 origin override，不需要 Zeabur 額外 env。Vite dev 固定同源 URL，由 `/global-maritime/gfw-hourly` proxy 讀 production release，刻意忽略該 override 以避免 CORS；只有 `VITE_GFW_HOURLY_USE_LOCAL_POC=true` 才使用 `/gfw_hourly_tracks_poc/manifest.json` 與 `/gfw_hourly_grid_poc/manifest.json`。`gis-up` 若要與目前 v3 production path 對齊，必須明確設 `VITE_GFW_HOURLY_V3_SHADOW_ENABLED=true`；未設仍是 canonical root。
 - Unified v2 root 以 `tracks.days[]` / `grid.hours[]` / `dark_vessels.hours[]` 分開索引。各 `path` 依 manifest URL origin 解析，對應 `releases/<release_id>/tracks/days/...`、`grid/hours/...` 與 `dark_vessels/hours/...`。
 - Cache-Control 邊界：root `manifest.json` 為 `public,max-age=60,s-maxage=60,stale-while-revalidate=300`；`releases/<release_id>/...` 為 `public,max-age=604800,s-maxage=604800,immutable`（7 日，與 release retention 一致）。前端也分別使用 fetch `cache: "no-cache"` 與 `cache: "force-cache"`。
 - `public/gfw_hourly_tracks_poc.geojson` 與 `public/gfw_hourly_tracks_poc/` 都是 localhost 驗收產物，同時 gitignore 且由 Vite closeBundle strip，不可進 production dist。

--- a/docs/features/global-maritime/changelog.md
+++ b/docs/features/global-maritime/changelog.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 2026-08-26 — localhost production release proxy
+
+- Vite dev 預設以同源 `/global-maritime/gfw-hourly` proxy 讀公開 production release；只有
+  `VITE_GFW_HOURLY_USE_LOCAL_POC=true` 才改讀 local POC fixture。
+- DEV 刻意忽略 `VITE_GLOBAL_MARITIME_CDN_BASE`，避免 localhost 繞過 proxy 後遭 CORS
+  阻擋；proxy 不轉送 cookie／authorization，並保留 PMTiles Range request。
+- `gis-up` 的 Mini Taiwan Pulse 啟動分支明確設定 v3 shadow flag，讓 6002 與目前
+  production full-fidelity path 對齊；其他 GIS 專案不受影響。
+
 ## 2026-08-26 — GFW full-fidelity v3 shadow (not deployed)
 
 - 完成 v3 full-fidelity collector/frontend contract、strict count/detail/frame validation、PMTiles

--- a/docs/features/global-maritime/handoff.md
+++ b/docs/features/global-maritime/handoff.md
@@ -108,9 +108,9 @@ status、metrics 與 rollback gate 以本文開頭的 2026-08-26 表格為準。
 
 ### Main-site sampled track layer
 
-主站 layer key `gfwHourlyTracks` 在 production 先讀 unified v2 root manifest（dev adapter 為 `gfw_hourly_tracks_poc/manifest.json`），再依 timeStore 選定 UTC 日讀取 `tracks.days[].path` 指向的 immutable daily GeoJSON。前端不 fallback 到舊的七日整包；日期越界或契約違反即清空。每個 feature 必須有與 LineString coordinates 等長的 `observed_times`，而且是明確 UTC、嚴格遞增，`start_at/end_at` 必須等於首末時間；任一 feature 違約即該日 fail closed。
+主站 layer key `gfwHourlyTracks` 在 production 與標準 Vite dev 都先讀同源 unified root manifest；DEV 的 `/global-maritime/gfw-hourly` proxy 轉送 production origin。只有 `VITE_GFW_HOURLY_USE_LOCAL_POC=true` 才使用 `gfw_hourly_tracks_poc/manifest.json`。再依 timeStore 選定 UTC 日讀取 `tracks.days[].path` 指向的 immutable daily GeoJSON。前端不 fallback 到舊的七日整包；日期越界或契約違反即清空。每個 feature 必須有與 LineString coordinates 等長的 `observed_times`，而且是明確 UTC、嚴格遞增，`start_at/end_at` 必須等於首末時間；任一 feature 違約即該日 fail closed。
 
-Production 供應契約為 S3 `deploy-assets/global-maritime/gfw-hourly/` → 同域 `/global-maritime/gfw-hourly/`。前端未設 env 時預設讀 `/global-maritime/gfw-hourly/manifest.json`；`VITE_GLOBAL_MARITIME_CDN_BASE` 僅作可選 CDN origin override。Root manifest cache 為 60s + `stale-while-revalidate=300`；release assets 為 7 日 `max-age/s-maxage=604800, immutable`。Container 每 6h 只 re-sync GFW prefix，先落地 release assets，再以 tmp+mv 原子切換 root manifest。
+Production 供應契約為 S3 `deploy-assets/global-maritime/gfw-hourly/` → 同域 `/global-maritime/gfw-hourly/`。前端 production 未設 env 時預設讀 `/global-maritime/gfw-hourly/manifest.json`；`VITE_GLOBAL_MARITIME_CDN_BASE` 僅在 production 作可選 CDN origin override。Vite dev 非 local POC 時固定讀同源 URL，經 proxy 避免 CORS；`VITE_GFW_HOURLY_USE_LOCAL_POC=true` 才使用 fixture。`gis-up` 若需與目前 v3 production path parity，必須明確設 `VITE_GFW_HOURLY_V3_SHADOW_ENABLED=true`，未設仍走 canonical root。Root manifest cache 為 60s + `stale-while-revalidate=300`；release assets 為 7 日 `max-age/s-maxage=604800, immutable`。Container 每 6h 只 re-sync GFW prefix，先落地 release assets，再以 tmp+mv 原子切換 root manifest。
 
 schema v2 artifact 已 live 重建；frontend parser 實測接受 989 tracks。以 `2026-08-21T23:00:00Z`、12h 拖尾產生 727 lines 與 645 個 exact-observation endpoints。主站 browser 另以 300x 播放至 00:32，endpoint popup 顯示 `08/21 16:32（線性內插）`，console 無 error/warning。
 
@@ -120,7 +120,7 @@ hook 採 Vessel Watch 的純 Mapbox line + endpoint 模式，不新增 Three.js 
 
 ### SAR unmatched 獨立圖層
 
-相同 bbox 的 `public-global-sar-presence:v4.0`、`matched='false'` 已 live-verified，wrapper schema 與空 tile 契約都通過；七日範圍可能仍為 0 detections。因此 `gfwDarkVessels` 已正式加入 Global Maritime catalog（預設 off），依時間軸 exact UTC hour lazy-load `dark_vessels.hours[]`。圓點位置固定說明為 GFW HIGH grid cell center；popup 及 legend 固定告知「SAR 偵測未與 AIS 匹配，非違法認定／非確認關 AIS」。它不與 AIS gaps 或 presence union。Vite dev 若沒有 unified SAR fixture 則 fail closed，不借用 grid 假裝 SAR。
+相同 bbox 的 `public-global-sar-presence:v4.0`、`matched='false'` 已 live-verified，wrapper schema 與空 tile 契約都通過；七日範圍可能仍為 0 detections。因此 `gfwDarkVessels` 已正式加入 Global Maritime catalog（預設 off），依時間軸 exact UTC hour lazy-load `dark_vessels.hours[]`。圓點位置固定說明為 GFW HIGH grid cell center；popup 及 legend 固定告知「SAR 偵測未與 AIS 匹配，非違法認定／非確認關 AIS」。它不與 AIS gaps 或 presence union。Vite dev 預設同源 proxy；僅 local POC opt-in 才可能因未提供 SAR fixture fail closed，且不借用 grid 假裝 SAR。
 
 ### Track construction contract
 

--- a/src/data/__tests__/gfwHourlyGridLoader.test.ts
+++ b/src/data/__tests__/gfwHourlyGridLoader.test.ts
@@ -96,15 +96,16 @@ describe("GFW hourly grid contract", () => {
     vi.unstubAllEnvs();
   });
 
-  it("production 共用同域 unified root 並可 override，dev 優先 local grid manifest", () => {
+  it("production 共用同域 unified root 並可 override，dev 預設也走 production root", () => {
     expect(resolveGfwHourlyGridManifestUrl("https://cdn.example/", false, false))
       .toBe("https://cdn.example/global-maritime/gfw-hourly/manifest.json");
-    expect(resolveGfwHourlyGridManifestUrl("", true, false)).toBe("/gfw_hourly_grid_poc/manifest.json");
-    expect(resolveGfwHourlyGridManifestUrl("https://cdn.example/", true, false)).toBe("/gfw_hourly_grid_poc/manifest.json");
+    expect(resolveGfwHourlyGridManifestUrl("", true, false)).toBe("/global-maritime/gfw-hourly/manifest.json");
+    expect(resolveGfwHourlyGridManifestUrl("https://cdn.example/", true, false))
+      .toBe("/global-maritime/gfw-hourly/manifest.json");
     expect(resolveGfwHourlyGridManifestUrl("", false, false)).toBe("/global-maritime/gfw-hourly/manifest.json");
     expect(resolveGfwHourlyGridManifestUrl("https://cdn.example/", false, true))
       .toBe("https://cdn.example/global-maritime/gfw-hourly/v3-shadow/manifest.json");
-    expect(resolveGfwHourlyGridManifestUrl("", true, true)).toBe("/gfw_hourly_grid_poc/manifest.json");
+    expect(resolveGfwHourlyGridManifestUrl("", true, true)).toBe("/global-maritime/gfw-hourly/v3-shadow/manifest.json");
   });
   it("將 timeline 秒數向下取 UTC 整點，跨時才換 key", () => {
     expect(floorUtcHourIso(Date.parse("2026-08-15T00:00:00Z") / 1000)).toBe("2026-08-15T00:00:00Z");

--- a/src/data/__tests__/gfwHourlyReleaseManifest.test.ts
+++ b/src/data/__tests__/gfwHourlyReleaseManifest.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import {
+  GFW_HOURLY_V3_SHADOW_ROOT_PATH,
+  resolveGfwHourlyRootManifestUrl,
+} from "../gfwHourlyReleaseManifest";
+
+describe("resolveGfwHourlyRootManifestUrl", () => {
+  const localPoc = "/gfw_hourly_grid_poc/manifest.json";
+
+  it("DEV 預設走同域 production root，讓 Vite proxy 接手", () => {
+    expect(resolveGfwHourlyRootManifestUrl(localPoc, "", true, false, false))
+      .toBe("/global-maritime/gfw-hourly/manifest.json");
+    expect(resolveGfwHourlyRootManifestUrl(localPoc, "https://cdn.example/", true, true, false))
+      .toBe(`/${GFW_HOURLY_V3_SHADOW_ROOT_PATH}`);
+  });
+
+  it("只有明確 local POC opt-in 才在 DEV 使用 fallback", () => {
+    expect(resolveGfwHourlyRootManifestUrl(localPoc, "https://cdn.example/", true, false, true))
+      .toBe(localPoc);
+    expect(resolveGfwHourlyRootManifestUrl(localPoc, "https://cdn.example/", true, true, true))
+      .toBe(localPoc);
+  });
+
+  it("production 忽略 local POC opt-in，仍遵守 CDN 與 shadow 選擇", () => {
+    expect(resolveGfwHourlyRootManifestUrl(localPoc, "https://cdn.example/", false, false, true))
+      .toBe("https://cdn.example/global-maritime/gfw-hourly/manifest.json");
+    expect(resolveGfwHourlyRootManifestUrl(localPoc, "https://cdn.example/", false, true, true))
+      .toBe(`https://cdn.example/${GFW_HOURLY_V3_SHADOW_ROOT_PATH}`);
+  });
+});

--- a/src/data/__tests__/gfwHourlyTracksLoader.test.ts
+++ b/src/data/__tests__/gfwHourlyTracksLoader.test.ts
@@ -158,13 +158,13 @@ describe("GFW hourly sampled-track contract", () => {
     vi.unstubAllEnvs();
   });
 
-  it("production 預設同域 CDN path 並可 override，dev 優先 local POC", () => {
+  it("production 預設同域 CDN path 並可 override，dev 預設也走 production root", () => {
     expect(resolveGfwHourlyTracksManifestUrl("https://cdn.example/", false, false))
       .toBe("https://cdn.example/global-maritime/gfw-hourly/manifest.json");
     expect(resolveGfwHourlyTracksManifestUrl("", true, false))
-      .toBe("/gfw_hourly_tracks_poc/manifest.json");
+      .toBe("/global-maritime/gfw-hourly/manifest.json");
     expect(resolveGfwHourlyTracksManifestUrl("https://cdn.example/", true, false))
-      .toBe("/gfw_hourly_tracks_poc/manifest.json");
+      .toBe("/global-maritime/gfw-hourly/manifest.json");
     expect(resolveGfwHourlyTracksManifestUrl("", false, false))
       .toBe("/global-maritime/gfw-hourly/manifest.json");
     expect(resolveGfwHourlyTracksManifestUrl("", false, true))
@@ -176,7 +176,7 @@ describe("GFW hourly sampled-track contract", () => {
     vi.stubGlobal("fetch", fetchMock);
     await expect(loadGfwHourlyTrackManifest()).resolves.toMatchObject({ releaseId: "2026-08-21" });
     expect(fetchMock).toHaveBeenCalledWith(
-      "/gfw_hourly_tracks_poc/manifest.json",
+      "/global-maritime/gfw-hourly/manifest.json",
       { cache: "no-cache" },
     );
   });

--- a/src/data/gfwHourlyReleaseManifest.ts
+++ b/src/data/gfwHourlyReleaseManifest.ts
@@ -120,10 +120,13 @@ export function resolveGfwHourlyRootManifestUrl(
   cdnBase = import.meta.env.VITE_GLOBAL_MARITIME_CDN_BASE ?? "",
   isDev = import.meta.env.DEV,
   shadowEnabled = import.meta.env.VITE_GFW_HOURLY_V3_SHADOW_ENABLED === "true",
+  useLocalPoc = import.meta.env.VITE_GFW_HOURLY_USE_LOCAL_POC === "true",
 ): string | null {
-  if (isDev) return localFallback;
-  const normalized = cdnBase.trim().replace(/\/+$/, "");
   const path = shadowEnabled ? GFW_HOURLY_V3_SHADOW_ROOT_PATH : ROOT_PATH;
+  // 一般 checkout 刻意不含 local POC；DEV 預設經 Vite 同源 proxy 走 production root，
+  // 也刻意忽略 CDN override，避免 local browser 產生 CORS 分支。只有明確 opt-in 才回退 fixture。
+  if (isDev) return useLocalPoc ? localFallback : `/${path}`;
+  const normalized = cdnBase.trim().replace(/\/+$/, "");
   if (normalized) return `${normalized}/${path}`;
   return `/${path}`;
 }

--- a/src/data/layerManifest.ts
+++ b/src/data/layerManifest.ts
@@ -1130,7 +1130,7 @@ export const LAYER_MANIFEST = {
     dataClass: "D",
     source: {
       kind: "custom",
-      note: "useGfwHourlyGridLayer 依 timeStore 讀取 H/H+1 並 crossfade；v3 只在 root full_fidelity=true 時標示完整性",
+      note: "useGfwHourlyGridLayer 依 timeStore 讀取 H/H+1 並 crossfade；DEV 預設經同源 production proxy，只有 VITE_GFW_HOURLY_USE_LOCAL_POC=true 才讀 POC；v3 只在 root full_fidelity=true 時標示完整性",
       staticAssets: ["./gfw_hourly_grid_poc/manifest.json"],
     },
     legend: "gfwHourlyGrid",
@@ -1157,7 +1157,7 @@ export const LAYER_MANIFEST = {
     dataClass: "D",
     source: {
       kind: "custom",
-      note: "production 預設同域 /global-maritime/gfw-hourly/manifest.json，VITE_GLOBAL_MARITIME_CDN_BASE 僅作可選 override；再依 timeStore UTC 日只載入一個 immutable daily partition；dev 才 fallback local POC",
+      note: "production 預設同域 /global-maritime/gfw-hourly/manifest.json，VITE_GLOBAL_MARITIME_CDN_BASE 僅在 production 作可選 override；DEV 同源 proxy，只有 VITE_GFW_HOURLY_USE_LOCAL_POC=true 才 fallback POC；再依 timeStore UTC 日只載入 immutable partition",
       staticAssets: ["./gfw_hourly_tracks_poc/manifest.json"],
     },
     legend: "gfwHourlyTracks",
@@ -1184,7 +1184,7 @@ export const LAYER_MANIFEST = {
     dataClass: "D",
     source: {
       kind: "custom",
-      note: "production 預設同域 /global-maritime/gfw-hourly/manifest.json（env 可選 override），unified v2 dark_vessels.hours exact-hour lazy load；dev 無 SAR fixture 時 fail closed",
+      note: "production 預設同域 /global-maritime/gfw-hourly/manifest.json（env 僅在 production 可選 override），unified v2 dark_vessels.hours exact-hour lazy load；DEV 預設同源 proxy，local POC opt-in 時才可能 fail closed",
       staticAssets: [],
     },
     legend: "gfwDarkVessels",

--- a/src/map/__tests__/deployContract.test.ts
+++ b/src/map/__tests__/deployContract.test.ts
@@ -314,6 +314,7 @@ describe("deploy 契約（manifest 逐檔）", () => {
     expect(gfwManifestContract).toContain("VITE_GLOBAL_MARITIME_CDN_BASE");
     expect(gfwManifestContract).toContain("global-maritime/gfw-hourly/manifest.json");
     expect(gfwManifestContract).toContain("VITE_GFW_HOURLY_V3_SHADOW_ENABLED");
+    expect(gfwManifestContract).toContain("VITE_GFW_HOURLY_USE_LOCAL_POC");
     expect(gfwManifestContract).toContain("global-maritime/gfw-hourly/v3-shadow/manifest.json");
     expect(gfwManifestContract).toContain("const path = shadowEnabled ? GFW_HOURLY_V3_SHADOW_ROOT_PATH : ROOT_PATH");
     expect(gfwTracksLoader).toContain('fetch(manifestUrl, { cache: "no-cache" })');
@@ -323,6 +324,12 @@ describe("deploy 契約（manifest 逐檔）", () => {
     expect(viteConfig).toContain('"gfw_hourly_tracks_poc.geojson"');
     expect(viteConfig).toContain('"gfw_hourly_tracks_poc"');
     expect(viteConfig).toContain('"gfw_hourly_grid_poc"');
+    expect(viteConfig).toContain('"/global-maritime/gfw-hourly"');
+    expect(viteConfig).not.toContain('"/global-maritime":');
+    expect(viteConfig).toContain('target: "https://mini-taiwan-pulse.itsmigu.com"');
+    expect(viteConfig).toContain('proxyReq.removeHeader("authorization")');
+    expect(viteConfig).toContain('proxyReq.removeHeader("cookie")');
+    expect(viteConfig).toContain('proxyReq.setHeader("range", range)');
   });
 
   it("GFW S3 先同步 immutable releases 再原子切 root，container 週期追新", () => {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -53,6 +53,21 @@ export default defineConfig({
         target: "http://localhost:8000",
         changeOrigin: true,
       },
+      // DEV 經 production origin 讀 GFW immutable releases；顯式轉送 Range，
+      // 讓 PMTiles 收到與 production 相同的 206 response。
+      "/global-maritime/gfw-hourly": {
+        target: "https://mini-taiwan-pulse.itsmigu.com",
+        changeOrigin: true,
+        configure: (proxy) => {
+          proxy.on("proxyReq", (proxyReq, request) => {
+            // 這條只代理公開 release assets；不要把 localhost session 帶到 production origin。
+            proxyReq.removeHeader("authorization");
+            proxyReq.removeHeader("cookie");
+            const range = request.headers.range;
+            if (typeof range === "string") proxyReq.setHeader("range", range);
+          });
+        },
+      },
     },
   },
 });


### PR DESCRIPTION
## Summary

讓 gis-up 啟動的 localhost:6002 經同源 Vite proxy 讀 GFW production release，修正本機圖層與最新資料日期通知為空。

## Changes

- DEV 預設 proxy `/global-maritime/gfw-hourly`，僅明確 opt-in 才用 local POC
- DEV 忽略 CDN override 以避免 CORS；proxy 移除 cookie/authorization 並保留 Range
- 更新 resolver、manifest、文件與 deploy contract tests

## Test

- [x] `npm run build`（含 `npx tsc -b`）
- [x] `npm test`：65 files，736 passed，1 skipped
- [x] Browser：localhost v3 通知顯示 2026-08-21，8/20 圖層有資料，console 0 error/warning
- [x] Proxy smoke：manifest 200、PMTiles Range 206
- [x] Supabase RPC：不涉及

## Risk / Rollback

- 僅影響 Vite DEV；production build resolver 行為不變。回滾此 PR 即恢復 local POC 預設。

## Related

- Feature: `docs/features/global-maritime/`
- Upstream handoff: N/A（未變更資料契約）

## Checklist

- [x] Branch 使用 Codex 規定的 `codex/` prefix
- [x] Commit prefix 走 Conventional Commits
- [x] 未新增 layer，不需 layer-onboarding
- [x] 未變更上游資料契約
- [x] changelog 已更新