### PR TITLE
feat(monitor): add Taiwan internet health status

### DIFF
--- a/docs/features/internet-health/handoff.md
+++ b/docs/features/internet-health/handoff.md
@@ -1,0 +1,66 @@
+# Handoff — 臺灣電信與網路狀態 MVP
+
+## 產品目的
+
+在 Monitor 顯示臺灣目前的電信與網路狀態。這是多來源狀態卡，不是地圖圖層：
+Cloudflare Radar、IODA 與 NCDR evidence 只顯示文字／數值，不替 ASN、國家狀態或缺資料區域製造 geometry。
+
+## 上游契約
+
+- RPC：`public.get_internet_health_status`
+- 前端參數：
+  - `p_entity_type = 'country'`
+  - `p_entity_ids = ['TW']`
+  - `p_include_evidence = true`
+  - `p_limit = 500`
+- 預期欄位：
+
+```text
+row_type, source_observation_id, source, evidence_family, entity_type,
+entity_id, entity_name, signal, reported_status, effective_status,
+incident_kind, value, unit, baseline_value, change_ratio, confidence,
+sample_count, observed_at, source_updated_at, collected_at, age_seconds,
+is_stale, active_incident_id, incident_status, metadata
+```
+
+`effective_status` 是 UI 真相；`reported_status` 只保留溯源。前端接受的保守狀態為
+`normal / watch / degraded / outage / unknown`，並防禦性收斂少量舊別名。
+
+## 前端彙整規則
+
+1. `is_stale !== false`（包含欄位缺失）強制 `unknown`。
+2. 空 rows、RPC error、unavailable 與 null 都顯示「資料不足」，不補 0。
+3. RPC 的 `row_type = status` 中，`evidence_family = composite` 才正規化為 detector；其他 status rows 是 provider evidence，`official_evidence` 是 NCDR 正向證據。
+4. 有 fresh detector 時，以 detector composite 加 active official evidence 的 `effective_status` 為總體真相；沒有 detector 時才保守退回 fresh rows。
+5. `confidence` 的 RPC 值為 0–1；前端以 `<0.5 / 0.5–<0.8 / ≥0.8` 顯示 low / medium / high。
+6. `normal` 仍至少需要 Cloudflare Radar 與 IODA 兩個 fresh evidence 都是 normal。
+7. NCDR 無 row 或 0 alerts 只能顯示「未通報／無資料」，不可單獨證明正常。
+8. active incident 只列 entity name/id、類型與時間。
+9. 不新增 LayerVisibility、Mapbox source、overlay、popup 或 ASN geometry。
+
+## 前端觸點
+
+- `src/data/internetHealthLoader.ts`：RPC、runtime parser、來源／incident 彙整。
+- `src/components/intel/monitor/TelecomStatusCard.tsx`：5 分鐘輪詢與狀態卡。
+- `src/components/intel/monitor/MonitorPanel.tsx`：widget 接線。
+- `src/components/intel/monitor/monitorLayout.ts`：dock/wall 全寬位置。
+- `src/components/intel/monitor/monitorSplitLayout.ts`：split 全寬位置。
+
+既有 `lifelineAlerts` 仍負責 NCDR CAP 地圖：只有上游真的提供 geometry 才渲染；本卡不複製或推測其範圍。
+
+## 驗收邊界
+
+- RPC migration 未 apply 前，卡片應誠實顯示「資料不足」，不代表前端壞掉。
+- Browser live gate 必須把卡片與實際 RPC rows、`source_updated_at`、`is_stale` 逐項對照。
+- 單元測試覆蓋 stale、空資料、NCDR-only normal、雙來源 normal、incident 與 null 語意。
+- 正式上線仍需 migration apply、collector fresh data、RPC anonymous grant、browser QA 與 deploy 分別確認。
+
+## Browser live gate
+
+1. 確認 migration 已 apply，且 RPC 用 anonymous session 呼叫 country/TW 能回 fresh detector 與 provider rows。
+2. 啟動前端並開啟 Monitor；`電信與網路 · CONNECTIVITY` 應位於事件區下方、全寬、不壓到下方雙欄卡片。
+3. 在 browser Network 面板確認 request 是 `get_internet_health_status`，參數為 country、`[TW]`、include evidence、limit 500。
+4. 逐列對照 Cloudflare／IODA／NCDR 的狀態、metric、最後資料時間；null 必須是 `—`，NCDR 缺 row 必須是「未通報／無資料」。
+5. 用 stale 或空資料 fixture 驗證總體為「資料不足」且 fresh sources 為 0；用 RPC 失敗驗證舊 normal 不會繼續亮綠。
+6. 用 fresh detector + Cloudflare + IODA fixture 驗證 normal quorum；加入 active NCDR official evidence 時驗證 outage 與 incident 摘要。
+7. 縮窄視窗檢查來源列換行、卡片內容不裁切；Mapbox sources/layers 數量不應因本卡增加。

--- a/src/components/intel/monitor/MonitorPanel.tsx
+++ b/src/components/intel/monitor/MonitorPanel.tsx
@@ -43,6 +43,7 @@ import { PlaBoard } from "./PlaBoard";
 import { VesselZoneCard } from "./VesselZoneCard";
 import { FoodPriceBoard } from "./FoodPriceBoard";
 import { TraDelayBoard } from "./TraDelayBoard";
+import { TelecomStatusCard } from "./TelecomStatusCard";
 import {
   TyphoonCard, EarthquakeCard, RadiationCard, LightningCard,
 } from "./HazardCards";
@@ -692,6 +693,7 @@ export function MonitorPanel({
         nowTs={now}
       />
     ),
+    internetHealth: <TelecomStatusCard open={open} nowTs={now} />,
     histogram: <HourlyHistogramWidget events={allEventsToday} />,
     timeline: (
       <TimelineDock

--- a/src/components/intel/monitor/TelecomStatusCard.tsx
+++ b/src/components/intel/monitor/TelecomStatusCard.tsx
@@ -1,0 +1,281 @@
+/**
+ * 台灣電信與網路狀態卡。
+ *
+ * 這是 Monitor widget，不是地圖 layer：ASN / country 狀態只顯示文字證據，
+ * 不建立 Mapbox source，也不推測 coverage geometry。
+ */
+import { useEffect, useState } from "react";
+import { COLORS, FONT_CJK, FONT_DATA, relTime } from "../intelTokens";
+import { RADIUS, FONT_SIZE } from "../../../styles/designTokens";
+import { SectionLabel } from "./PressureRing";
+import {
+  fetchInternetHealthStatus,
+  invalidateInternetHealthStatus,
+  type InternetHealthIncident,
+  type InternetHealthSourceSummary,
+  type InternetHealthStatus,
+  type InternetHealthSummary,
+} from "../../../data/internetHealthLoader";
+
+export type InternetHealthPhase = "loading" | "ready" | "error";
+
+const STATUS_META: Record<InternetHealthStatus, { label: string; en: string; color: string; tint: string }> = {
+  normal: { label: "目前正常", en: "NORMAL", color: COLORS.statusLive, tint: "rgba(34,197,94,0.07)" },
+  watch: { label: "需要留意", en: "WATCH", color: COLORS.statusWarn, tint: "rgba(250,204,21,0.07)" },
+  degraded: { label: "局部異常", en: "DEGRADED", color: "#fb923c", tint: "rgba(251,146,60,0.08)" },
+  outage: { label: "中斷訊號", en: "OUTAGE", color: COLORS.statusErr, tint: "rgba(239,68,68,0.09)" },
+  unknown: { label: "資料不足", en: "UNKNOWN", color: COLORS.textDim, tint: "rgba(148,163,184,0.05)" },
+};
+
+function timeLabel(iso: string | null, nowTs: number): string {
+  if (!iso) return "—";
+  const ts = Math.floor(Date.parse(iso) / 1000);
+  return Number.isFinite(ts) ? relTime(ts, nowTs) : "—";
+}
+
+function metricLabel(source: InternetHealthSourceSummary): string {
+  if (source.change_ratio != null) {
+    const pct = source.change_ratio * 100;
+    return `${pct > 0 ? "+" : ""}${pct.toFixed(Math.abs(pct) < 10 ? 1 : 0)}%`;
+  }
+  if (source.value == null) return "—";
+  return `${source.value.toLocaleString("zh-TW", { maximumFractionDigits: 2 })}${source.unit ? ` ${source.unit}` : ""}`;
+}
+
+function sourceStatusLabel(source: InternetHealthSourceSummary): string {
+  if (!source.fresh) return source.key === "ncdr" ? "未通報／無資料" : "無資料";
+  return STATUS_META[source.status].label;
+}
+
+function SourceEvidenceRow({ source, nowTs }: { source: InternetHealthSourceSummary; nowTs: number }) {
+  const meta = STATUS_META[source.fresh ? source.status : "unknown"];
+  return (
+    <div
+      data-testid={`internet-health-source-${source.key}`}
+      style={{
+        display: "grid", gridTemplateColumns: "minmax(110px, 1fr) auto",
+        alignItems: "center", gap: 9, padding: "7px 9px", borderRadius: RADIUS.lg,
+        background: "rgba(255,255,255,0.025)", border: `1px solid ${COLORS.borderSoft}`,
+      }}
+    >
+      <span style={{ display: "flex", alignItems: "center", gap: 7, minWidth: 0 }}>
+        <span
+          style={{
+            width: 7, height: 7, borderRadius: RADIUS.full, background: meta.color,
+            boxShadow: source.fresh ? `0 0 5px ${meta.color}` : "none", flexShrink: 0,
+          }}
+        />
+        <span
+          style={{
+            fontFamily: FONT_DATA, fontSize: FONT_SIZE.sm, fontWeight: 700,
+            color: COLORS.textDefault, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap",
+          }}
+        >
+          {source.label}
+        </span>
+      </span>
+      <span style={{ minWidth: 0, gridColumn: "1 / -1", gridRow: 2 }}>
+        <span style={{ fontFamily: FONT_CJK, fontSize: FONT_SIZE.sm, color: meta.color }}>
+          {sourceStatusLabel(source)}
+        </span>
+        <span
+          style={{
+            display: "block", marginTop: 1, fontFamily: FONT_DATA, fontSize: FONT_SIZE.xs,
+            color: COLORS.textFaint, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap",
+          }}
+          title={source.signal ?? undefined}
+        >
+          {source.signal ?? "—"} · {timeLabel(source.source_updated_at ?? source.observed_at, nowTs)}
+        </span>
+      </span>
+      <span
+        style={{
+          gridColumn: 2, gridRow: 1,
+          fontFamily: FONT_DATA, fontSize: FONT_SIZE.base, fontWeight: 700,
+          color: source.fresh ? meta.color : COLORS.textFaint, whiteSpace: "nowrap",
+        }}
+      >
+        {metricLabel(source)}
+      </span>
+    </div>
+  );
+}
+
+const INCIDENT_KIND_LABELS: Record<string, string> = {
+  single_asn_outage: "單一電信商異常",
+  multi_asn_partial_outage: "多家電信商局部異常",
+  national_outage: "全臺大規模中斷",
+  international_path_degradation: "國際路徑異常",
+  selective_service_blocking: "特定服務異常",
+};
+
+function IncidentRow({ incident, nowTs }: { incident: InternetHealthIncident; nowTs: number }) {
+  const meta = STATUS_META[incident.severity];
+  const kind = incident.kind ? (INCIDENT_KIND_LABELS[incident.kind] ?? incident.kind.replace(/_/g, " ")) : "網路異常";
+  const entity = incident.entity_name ?? incident.entity_id;
+  return (
+    <div
+      data-testid="internet-health-incident"
+      style={{
+        display: "flex", gap: 8, alignItems: "flex-start", padding: "6px 8px",
+        borderRadius: RADIUS.lg, background: meta.tint, border: `1px solid ${meta.color}44`,
+      }}
+    >
+      <span style={{ width: 7, height: 7, marginTop: 4, borderRadius: RADIUS.full, background: meta.color, flexShrink: 0 }} />
+      <span style={{ minWidth: 0, flex: 1 }}>
+        <span style={{ display: "block", fontFamily: FONT_CJK, fontSize: FONT_SIZE.sm, color: COLORS.textDefault }}>
+          {entity} · {kind}
+        </span>
+        <span style={{ display: "block", marginTop: 1, fontFamily: FONT_DATA, fontSize: FONT_SIZE.xs, color: COLORS.textFaint }}>
+          {incident.source} · {timeLabel(incident.observed_at, nowTs)} · confidence {incident.confidence}
+        </span>
+      </span>
+    </div>
+  );
+}
+
+export function TelecomStatusCardView({
+  summary, phase, nowTs,
+}: {
+  summary: InternetHealthSummary | null;
+  phase: InternetHealthPhase;
+  nowTs: number;
+}) {
+  // 載入失敗時即使留有上次成功資料，也不能繼續亮 normal。
+  const effectiveStatus: InternetHealthStatus = phase === "error"
+    ? "unknown"
+    : (summary?.overall_status ?? "unknown");
+  const meta = STATUS_META[effectiveStatus];
+  const description = phase === "loading"
+    ? "正在取得多來源觀測…"
+    : phase === "error"
+      ? "本次更新失敗，暫時無法判斷"
+      : (summary?.summary ?? "核心來源不足，暫時無法判斷");
+  const sources = (summary?.sources ?? []).map((source) => phase === "error"
+    ? { ...source, status: "unknown" as const, fresh: false }
+    : source);
+  const incidents = summary?.incidents ?? [];
+  const confidence = phase === "error" ? "unknown" : (summary?.confidence ?? "unknown");
+  const freshSourceCount = phase === "error" ? 0 : (summary?.fresh_source_count ?? 0);
+
+  return (
+    <div data-testid="internet-health-card" style={{ display: "flex", flexDirection: "column", gap: 10 }}>
+      <SectionLabel color="#22d3ee">電信與網路 · CONNECTIVITY</SectionLabel>
+      <div
+        style={{
+          borderRadius: RADIUS.xl, border: `1px solid ${meta.color}55`,
+          background: `linear-gradient(145deg, ${meta.tint}, rgba(255,255,255,0.012) 48%)`,
+          padding: "12px 14px", display: "grid",
+          gridTemplateColumns: "repeat(auto-fit, minmax(min(100%, 250px), 1fr))",
+          gap: 14, alignItems: "stretch",
+        }}
+      >
+        <div style={{ display: "flex", flexDirection: "column", justifyContent: "space-between", gap: 10 }}>
+          <div>
+            <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
+              <span
+                data-testid="internet-health-status-dot"
+                style={{
+                  width: 12, height: 12, borderRadius: RADIUS.full, background: meta.color,
+                  boxShadow: effectiveStatus === "unknown" ? "none" : `0 0 8px ${meta.color}`,
+                }}
+              />
+              <span
+                data-testid="internet-health-status-label"
+                style={{ fontFamily: FONT_CJK, fontSize: FONT_SIZE.lg, fontWeight: 700, color: meta.color }}
+              >
+                {meta.label}
+              </span>
+            </div>
+            <div style={{ marginTop: 4, fontFamily: FONT_DATA, fontSize: FONT_SIZE.xs, letterSpacing: "1.6px", color: COLORS.textFaint }}>
+              {meta.en} · confidence {confidence}
+            </div>
+          </div>
+          <div style={{ fontFamily: FONT_CJK, fontSize: FONT_SIZE.sm, lineHeight: 1.45, color: COLORS.textMuted }}>
+            {description}
+          </div>
+          <div style={{ display: "flex", gap: 14, flexWrap: "wrap" }}>
+            <span style={{ fontFamily: FONT_DATA, fontSize: FONT_SIZE.xs, color: COLORS.textFaint }}>
+              FRESH SOURCES<br />
+              <b style={{ fontSize: FONT_SIZE.md, color: COLORS.textDefault }}>
+                {freshSourceCount}/{summary?.source_total ?? 3}
+              </b>
+            </span>
+            <span style={{ fontFamily: FONT_DATA, fontSize: FONT_SIZE.xs, color: COLORS.textFaint }}>
+              LAST UPDATE<br />
+              <b style={{ fontSize: FONT_SIZE.sm, color: COLORS.textDefault }}>
+                {timeLabel(summary?.last_updated_at ?? null, nowTs)}
+              </b>
+            </span>
+          </div>
+        </div>
+
+        <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+          <span style={{ fontFamily: FONT_DATA, fontSize: FONT_SIZE.xs, letterSpacing: "1.2px", color: COLORS.textDim }}>
+            SOURCE EVIDENCE
+          </span>
+          {sources.length > 0
+            ? sources.map((source) => <SourceEvidenceRow key={source.key} source={source} nowTs={nowTs} />)
+            : (["Cloudflare Radar", "IODA", "NCDR"] as const).map((label) => (
+              <div key={label} style={{ padding: "7px 9px", borderRadius: RADIUS.lg, border: `1px solid ${COLORS.borderSoft}`, color: COLORS.textFaint, fontFamily: FONT_DATA, fontSize: FONT_SIZE.sm }}>
+                {label} · —
+              </div>
+            ))}
+        </div>
+
+        <div style={{ display: "flex", flexDirection: "column", gap: 6, minWidth: 0 }}>
+          <span style={{ fontFamily: FONT_DATA, fontSize: FONT_SIZE.xs, letterSpacing: "1.2px", color: COLORS.textDim }}>
+            ACTIVE INCIDENTS
+          </span>
+          {incidents.length > 0
+            ? incidents.slice(0, 3).map((incident) => <IncidentRow key={incident.id} incident={incident} nowTs={nowTs} />)
+            : (
+              <div
+                style={{
+                  flex: 1, minHeight: 54, display: "flex", alignItems: "center", justifyContent: "center",
+                  borderRadius: RADIUS.lg, border: `1px dashed ${COLORS.borderMid}`,
+                  fontFamily: FONT_CJK, fontSize: FONT_SIZE.sm, color: COLORS.textFaint, textAlign: "center",
+                }}
+              >
+                {effectiveStatus === "normal" ? "目前沒有 active incident" : "沒有可確認的 incident 資料"}
+              </div>
+            )}
+          <span style={{ marginTop: "auto", fontFamily: FONT_CJK, fontSize: FONT_SIZE.xs, lineHeight: 1.4, color: COLORS.textFaint }}>
+            Cloudflare Radar + IODA + NCDR；多來源觀測，不代表完整臺灣網路普查。ASN 僅列文字，不推測服務範圍。
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function TelecomStatusCard({ open, nowTs }: { open: boolean; nowTs: number }) {
+  const [summary, setSummary] = useState<InternetHealthSummary | null>(null);
+  const [phase, setPhase] = useState<InternetHealthPhase>("loading");
+
+  useEffect(() => {
+    if (!open) return;
+    let cancelled = false;
+    const tick = (force = false) => {
+      if (force) invalidateInternetHealthStatus();
+      fetchInternetHealthStatus()
+        .then((next) => {
+          if (cancelled) return;
+          setSummary(next);
+          setPhase("ready");
+        })
+        .catch((error) => {
+          console.warn("[TelecomStatusCard] get_internet_health_status failed", error);
+          if (!cancelled) setPhase("error");
+        });
+    };
+    tick();
+    const id = window.setInterval(() => tick(true), 5 * 60_000);
+    return () => {
+      cancelled = true;
+      window.clearInterval(id);
+    };
+  }, [open]);
+
+  return <TelecomStatusCardView summary={summary} phase={phase} nowTs={nowTs} />;
+}

--- a/src/components/intel/monitor/__tests__/TelecomStatusCard.test.ts
+++ b/src/components/intel/monitor/__tests__/TelecomStatusCard.test.ts
@@ -1,0 +1,69 @@
+import { createElement } from "react";
+import { describe, expect, it } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import { aggregateInternetHealthRows } from "../../../../data/internetHealthLoader";
+import { TelecomStatusCardView } from "../TelecomStatusCard";
+
+const freshNormal = (source: string) => ({
+  row_type: "status",
+  source_observation_id: `${source}-1`,
+  entity_type: "country",
+  entity_id: "TW",
+  entity_name: "臺灣",
+  source,
+  evidence_family: "network",
+  signal: "reachability",
+  reported_status: "normal",
+  effective_status: "normal",
+  incident_kind: null,
+  value: null,
+  unit: null,
+  baseline_value: null,
+  change_ratio: null,
+  confidence: "high",
+  sample_count: 12,
+  observed_at: "2026-08-30T04:00:00Z",
+  source_updated_at: "2026-08-30T04:01:00Z",
+  collected_at: "2026-08-30T04:02:00Z",
+  age_seconds: 60,
+  is_stale: false,
+  active_incident_id: null,
+  incident_status: null,
+  metadata: {},
+});
+
+const renderCard = (
+  summary: ReturnType<typeof aggregateInternetHealthRows>,
+  phase: "loading" | "ready" | "error",
+) => renderToStaticMarkup(createElement(TelecomStatusCardView, {
+  summary, phase, nowTs: 1_788_060_000,
+}));
+
+describe("TelecomStatusCardView", () => {
+  it("renders missing data as unknown, not a green normal state", () => {
+    const html = renderCard(aggregateInternetHealthRows([]), "ready");
+    expect(html).toContain("資料不足");
+    expect(html).toContain("Cloudflare Radar");
+    expect(html).toContain("internet-health-source-cloudflare");
+    expect(html).not.toContain("目前正常");
+  });
+
+  it("shows normal only with two fresh independent network sources", () => {
+    const html = renderCard(
+      aggregateInternetHealthRows([freshNormal("cloudflare_radar"), freshNormal("ioda")]),
+      "ready",
+    );
+    expect(html).toContain("目前正常");
+    expect(html).toContain("2/3");
+    expect(html).toContain("NCDR");
+    expect(html).toContain("未通報／無資料");
+  });
+
+  it("a refresh error overrides a previous normal snapshot", () => {
+    const summary = aggregateInternetHealthRows([freshNormal("cloudflare_radar"), freshNormal("ioda")]);
+    const html = renderCard(summary, "error");
+    expect(html).toContain("資料不足");
+    expect(html).toContain("本次更新失敗");
+    expect(html).not.toContain("目前正常");
+  });
+});

--- a/src/components/intel/monitor/__tests__/monitorPacking.test.ts
+++ b/src/components/intel/monitor/__tests__/monitorPacking.test.ts
@@ -34,12 +34,13 @@ describe("monitorPacking", () => {
   // guillotine 會先在那裡把版面切成上下兩段 —— 右欄底部那塊於是從「右欄」變成
   // 撐滿 12 欄的獨立區塊（寬度爆掉、與上方右欄對不齊）。
   // 新 widget 要接在右欄下方時，左欄必須有格子跨過那條線，或改插進右欄中段。
-  it("頂層拆成「上方三欄」+「下方左右兩欄（5 + 7）」", () => {
+  it("頂層拆成「上方三欄」+「全寬網路狀態」+「下方左右兩欄（5 + 7）」", () => {
     const tree = buildMonitorTree(MONITOR_VISIBLE_LAYOUT);
     expect(tree.t).toBe("rows");
     if (tree.t !== "rows") return;
-    expect(tree.children).toHaveLength(2);
-    const bottom = tree.children[1]!;
+    expect(tree.children).toHaveLength(3);
+    expect(flattenNode(tree.children[1]!).map((it) => it.i)).toEqual(["internetHealth"]);
+    const bottom = tree.children[2]!;
     expect(bottom.t).toBe("cols");
     if (bottom.t !== "cols") return;
     expect(bottom.children.map(nodeWidth)).toEqual([5, 7]);

--- a/src/components/intel/monitor/monitorLayout.ts
+++ b/src/components/intel/monitor/monitorLayout.ts
@@ -12,6 +12,7 @@
 export type MonitorWidgetId =
   | "newsFeed"
   | "alertBoard"
+  | "internetHealth"
   | "histogram"
   | "timeline"
   | "triage"
@@ -110,6 +111,8 @@ export const MONITOR_GRID_GAP = 10;
  * - 2026-08-10 九版 — 資訊卡改 `fit: "content"`（高度跟內容、欄內流式下推）
  * - 2026-08-22 十一版 — 新增 traDelay（台鐵誤點）；vesselZone h 11→6 讓出左欄尾段，
  *   維持左右欄同止 y68。⚠ 本版座標為接線時暫定、非沙盒匯出，定稿請回沙盒重拖。
+ * - 2026-08-30 十二版 — 上半事件區與下半雙欄之間插入全寬 internetHealth 狀態卡；
+ *   下半整體 +4，左右欄同止改為 y72。
  */
 export const MONITOR_LAYOUT: MonitorGridItem[] = [
   { i: "newsFeed", x: 0, y: 0, w: 4, h: 12 },
@@ -117,59 +120,61 @@ export const MONITOR_LAYOUT: MonitorGridItem[] = [
   { i: "timeline", x: 7, y: 0, w: 5, h: 9 },
   { i: "hotZones", x: 4, y: 7, w: 3, h: 5 },
   { i: "triage", x: 7, y: 9, w: 5, h: 3 },
-  { i: "situationOverview", x: 0, y: 12, w: 5, h: 5, fit: "content" },
-  { i: "liveWall", x: 5, y: 12, w: 7, h: 14, fit: "content" },
+  // 電信／網路狀態是 country/ASN 文字證據，不建立 map geometry。
+  { i: "internetHealth", x: 0, y: 12, w: 12, h: 4, fit: "content" },
+  { i: "situationOverview", x: 0, y: 16, w: 5, h: 5, fit: "content" },
+  { i: "liveWall", x: 5, y: 16, w: 7, h: 14, fit: "content" },
   // TAIEX 從 situationOverview 右側拆出成獨立 widget（2026-08-10）：
   // 原本擠在壓力環旁邊只放得下 150×24 的日線，拆出後給 260×44。
   // 其下同欄 widget y 各 +3。
-  { i: "taiex", x: 0, y: 17, w: 5, h: 3, fit: "content" },
+  { i: "taiex", x: 0, y: 21, w: 5, h: 3, fit: "content" },
   // PLA 從 situationCards 拆出成獨立 plaBoard（2026-08-03）：嚴重度分級 + 120 天趨勢
   // + 空域方位 + 侵擾方式四段。
   // situationCards 只剩健康卡 → h 6→3；其下同欄 widget y 各 +12。
-  { i: "situationCards", x: 0, y: 20, w: 5, h: 3, fit: "content" },
+  { i: "situationCards", x: 0, y: 24, w: 5, h: 3, fit: "content" },
   // h 15→13（2026-08-10）：空域方位／侵擾方式改單欄（4+6 列，原本各佔 2+3 列）後，
   // 其餘區塊固定高約 450px，剩下的全歸 120 天趨勢柱狀圖（TrendRow flex:1）。
   // h13 → 柱狀圖約 190px（原本固定 54px）；再加高只會讓柱子過胖，量過才定的值。
-  { i: "plaBoard", x: 0, y: 23, w: 5, h: 13, fit: "content" },
-  { i: "erCongestion", x: 0, y: 36, w: 5, h: 15, fit: "content" },
-  { i: "hazardStrip", x: 5, y: 26, w: 7, h: 8, fit: "content" },
+  { i: "plaBoard", x: 0, y: 27, w: 5, h: 13, fit: "content" },
+  { i: "erCongestion", x: 0, y: 40, w: 5, h: 15, fit: "content" },
+  { i: "hazardStrip", x: 5, y: 30, w: 7, h: 8, fit: "content" },
   // 災害監看四卡（2026-08-10 十版）：颱風／地震／輻射／落雷，接在災防直播下方
   // 形成「影像 + 數據」的災害區塊。右欄 w7 拆 4+3，每格仍有 ~280px 以上。
   //
-  // ⚠️ 位置不能改放到最下面（試過會壞）：左欄止於 y57，右欄若在那之後還有格線，
+  // ⚠️ 位置不能改放到最下面（試過會壞）：左欄止於 y61，右欄若在那之後還有格線，
   // 那條格線就成為**貫穿全寬**的橫切線 —— guillotine 會先在那裡把版面切成上下兩段，
   // 右欄那塊就不再是「右欄」而是撐滿 12 欄的獨立區塊（monitorPacking.test.ts
-  // 的「rows 子節點寬度 = 自身寬度」會抓到）。右欄在 y57 之後只能留一個
-  // 跨過 57 的格子（現為 foodPriceBoard 56–68）。
-  { i: "typhoon", x: 5, y: 34, w: 4, h: 4, fit: "content" },
-  { i: "earthquake", x: 9, y: 34, w: 3, h: 4, fit: "content" },
-  { i: "radiation", x: 5, y: 38, w: 4, h: 4, fit: "content" },
-  { i: "lightning", x: 9, y: 38, w: 3, h: 4, fit: "content" },
+  // 的「rows 子節點寬度 = 自身寬度」會抓到）。右欄在 y61 之後只能留一個
+  // 跨過 61 的格子（現為 foodPriceBoard 60–72）。
+  { i: "typhoon", x: 5, y: 38, w: 4, h: 4, fit: "content" },
+  { i: "earthquake", x: 9, y: 38, w: 3, h: 4, fit: "content" },
+  { i: "radiation", x: 5, y: 42, w: 4, h: 4, fit: "content" },
+  { i: "lightning", x: 9, y: 42, w: 3, h: 4, fit: "content" },
   // y 34→42（四卡插隊 8 列）
-  { i: "powerCard", x: 5, y: 42, w: 7, h: 14, fit: "content" },
-  { i: "prison", x: 0, y: 51, w: 2, h: 4, fit: "content" },
-  { i: "airportPax", x: 2, y: 51, w: 3, h: 6, fit: "content" },
+  { i: "powerCard", x: 5, y: 46, w: 7, h: 14, fit: "content" },
+  { i: "prison", x: 0, y: 55, w: 2, h: 4, fit: "content" },
+  { i: "airportPax", x: 2, y: 55, w: 3, h: 6, fit: "content" },
   // 食品價格監測（2026-08-05）：四指數 2×2 × 180 天。
   // 走右欄 w7 而非比照 PLA 的 w5 —— 2×2 在 w5 每格只剩 ~190px，
   // 迷你走勢圖會擠到看不出形狀；w7 每格約 280px 才讀得出趨勢。
   // h 9→12（2026-08-10）：多出的高度全部灌進四張卡的走勢圖（SPARK_H 34→52 + flex:1）。
   // y 48→56（同上，跟著 powerCard 下移）
-  { i: "foodPriceBoard", x: 5, y: 56, w: 7, h: 12, fit: "content" },
+  { i: "foodPriceBoard", x: 5, y: 60, w: 7, h: 12, fit: "content" },
   // 特殊船舶接近帶（2026-08-20，VZ-4）：左欄收尾，與共機卡同寬 w5。
-  // ⚠️ y57→68 是刻意算過的：原本左欄止於 y57（airportPax）、右欄止於 y68
-  // （foodPriceBoard），兩欄不同止。本格補滿左欄到 y68 後**左右欄同時結束**，
+  // ⚠️ y61→72 是刻意算過的：原本左欄止於 y61（airportPax）、右欄止於 y72
+  // （foodPriceBoard），兩欄不同止。本格補滿左欄到 y72 後**左右欄同時結束**，
   // 頂層才維持「上方三欄 + 下方左右兩欄(5+7)」的兩段結構
   // （monitorPacking.test.ts 有斷言；第一版放最底部全寬 w12 會多切出第三段）。
   // 也刻意不用 w12：全寬約 1200px，柱狀圖會被拉到看不出形狀，w5 與 plaBoard 一致。
   // h 11→6（2026-08-22）：純粹讓出左欄尾段給 traDelay。兩格都是 fit:"content"，
   // h 不是實際高度、只決定欄內順序與拆解，所以縮 h 不會壓縮畫面上的船舶卡。
-  { i: "vesselZone", x: 0, y: 57, w: 5, h: 6, fit: "content" },
+  { i: "vesselZone", x: 0, y: 61, w: 5, h: 6, fit: "content" },
   // 台鐵誤點（2026-08-22，migration 369）。
-  // ⚠️ 為什麼卡在 y63–68 而不是接在最底部：左右兩欄必須**同時結束**於 y68。
-  // 先前試過放 y68（左欄延伸到 y76），y68 以下只剩左欄 → guillotine 在那裡切出
+  // ⚠️ 為什麼卡在 y67–72 而不是接在最底部：左右兩欄必須**同時結束**於 y72。
+  // 先前試過接在同止點（左欄再向下延伸），其下只剩左欄 → guillotine 在那裡切出
   // 貫穿全寬的第三段，monitorPacking「頂層拆成上方三欄 + 下方左右兩欄」直接紅。
   // 版面要正式定稿請回沙盒拖完重新匯出整份 MONITOR_LAYOUT。
-  { i: "traDelay", x: 0, y: 63, w: 5, h: 5, fit: "content" },
+  { i: "traDelay", x: 0, y: 67, w: 5, h: 5, fit: "content" },
 ];
 
 /** 沙盒 hidden 清單 — 列在這裡的 widget 不渲染（histogram 與時間軸新聞密度重複，2026-07-26 移除） */

--- a/src/components/intel/monitor/monitorSplitLayout.ts
+++ b/src/components/intel/monitor/monitorSplitLayout.ts
@@ -83,7 +83,7 @@ export const MONITOR_SPLIT_CAMERA = {
  * 結構：**上半 2 欄（兩欄同止於 y17）＋ 下半以全寬為主的縱向流**
  *   y0–16   newsFeed(w6)     | timeline → alertBoard → hotZones（右欄三段）
  *           triage(w6, y14)  |
- *   y17–    liveWall → hazardStrip → 颱風（全寬）→ 其餘三卡（一列 w4）→ foodPriceBoard
+ *   y17–    internetHealth → liveWall → hazardStrip → 颱風（全寬）→ 其餘三卡（一列 w4）→ foodPriceBoard
  *           → taiex|situationCards → prison|airportPax → powerCard
  *           → erCongestion → situationOverview → plaBoard
  *
@@ -106,29 +106,30 @@ export const MONITOR_LAYOUT_SPLIT: MonitorGridItem[] = [
   { i: "triage", x: 0, y: 14, w: 6, h: 3 },
 
   // ── 下半：全寬縱向流 ──
-  { i: "liveWall", x: 0, y: 17, w: 12, h: 13, fit: "content" },
-  { i: "hazardStrip", x: 0, y: 30, w: 12, h: 7, fit: "content" },
+  { i: "internetHealth", x: 0, y: 17, w: 12, h: 4, fit: "content" },
+  { i: "liveWall", x: 0, y: 21, w: 12, h: 13, fit: "content" },
+  { i: "hazardStrip", x: 0, y: 34, w: 12, h: 7, fit: "content" },
   // 颱風卡獨立一列全寬（2026-08-16）：它有上下兩排趨勢圖（接近程度 + 1000km 內顆數），
   // 比其他三張高一截。留在同一列的話，`renderMonitorNode` 的等高規則（並排葉節點
   // stretch）會把輻射／落雷／地震一起拉到颱風的高度，底下拖三塊空白。
-  { i: "typhoon", x: 0, y: 37, w: 12, h: 6, fit: "content" },
+  { i: "typhoon", x: 0, y: 41, w: 12, h: 6, fit: "content" },
   // 其餘三卡一列三格（各 w4 ≈ 275px，比原本四格的 200px 還寬鬆）
-  { i: "radiation", x: 0, y: 43, w: 4, h: 4, fit: "content" },
-  { i: "lightning", x: 4, y: 43, w: 4, h: 4, fit: "content" },
-  { i: "earthquake", x: 8, y: 43, w: 4, h: 4, fit: "content" },
-  { i: "foodPriceBoard", x: 0, y: 47, w: 12, h: 7, fit: "content" },
-  { i: "taiex", x: 0, y: 54, w: 6, h: 3, fit: "content" },
-  { i: "situationCards", x: 6, y: 54, w: 6, h: 3, fit: "content" },
-  { i: "prison", x: 0, y: 57, w: 6, h: 5, fit: "content" },
-  { i: "airportPax", x: 6, y: 57, w: 6, h: 5, fit: "content" },
-  { i: "powerCard", x: 0, y: 62, w: 12, h: 11, fit: "content" },
-  { i: "erCongestion", x: 0, y: 73, w: 12, h: 11, fit: "content" },
-  { i: "situationOverview", x: 0, y: 84, w: 12, h: 4, fit: "content" },
-  { i: "plaBoard", x: 0, y: 88, w: 12, h: 12, fit: "content" },
+  { i: "radiation", x: 0, y: 47, w: 4, h: 4, fit: "content" },
+  { i: "lightning", x: 4, y: 47, w: 4, h: 4, fit: "content" },
+  { i: "earthquake", x: 8, y: 47, w: 4, h: 4, fit: "content" },
+  { i: "foodPriceBoard", x: 0, y: 51, w: 12, h: 7, fit: "content" },
+  { i: "taiex", x: 0, y: 58, w: 6, h: 3, fit: "content" },
+  { i: "situationCards", x: 6, y: 58, w: 6, h: 3, fit: "content" },
+  { i: "prison", x: 0, y: 61, w: 6, h: 5, fit: "content" },
+  { i: "airportPax", x: 6, y: 61, w: 6, h: 5, fit: "content" },
+  { i: "powerCard", x: 0, y: 66, w: 12, h: 11, fit: "content" },
+  { i: "erCongestion", x: 0, y: 77, w: 12, h: 11, fit: "content" },
+  { i: "situationOverview", x: 0, y: 88, w: 12, h: 4, fit: "content" },
+  { i: "plaBoard", x: 0, y: 92, w: 12, h: 12, fit: "content" },
   // 接在共機卡之後 —— 兩者同屬「軍事態勢」，一個看空域一個看海域
-  { i: "vesselZone", x: 0, y: 100, w: 12, h: 10, fit: "content" },
+  { i: "vesselZone", x: 0, y: 104, w: 12, h: 10, fit: "content" },
   // 台鐵誤點（2026-08-22）：窄版底部沿用全寬堆疊，不影響「兩欄同止」規則。
-  { i: "traDelay", x: 0, y: 110, w: 12, h: 8, fit: "content" },
+  { i: "traDelay", x: 0, y: 114, w: 12, h: 8, fit: "content" },
 ];
 
 /**

--- a/src/data/__tests__/internetHealthLoader.test.ts
+++ b/src/data/__tests__/internetHealthLoader.test.ts
@@ -1,0 +1,178 @@
+import { describe, expect, it } from "vitest";
+import {
+  aggregateInternetHealthRows,
+  parseInternetHealthEvidence,
+} from "../internetHealthLoader";
+
+const row = (overrides: Record<string, unknown> = {}) => ({
+  row_type: "status",
+  source_observation_id: "observation-1",
+  entity_type: "country",
+  entity_id: "TW",
+  entity_name: "臺灣",
+  source: "cloudflare_radar",
+  evidence_family: "traffic",
+  signal: "http_requests",
+  reported_status: "normal",
+  effective_status: "normal",
+  incident_kind: null,
+  value: 0.98,
+  unit: "normalized",
+  baseline_value: 1,
+  change_ratio: -0.02,
+  confidence: "high",
+  sample_count: 20,
+  observed_at: "2026-08-30T04:00:00Z",
+  source_updated_at: "2026-08-30T04:02:00Z",
+  collected_at: "2026-08-30T04:03:00Z",
+  age_seconds: 60,
+  is_stale: false,
+  active_incident_id: null,
+  incident_status: null,
+  metadata: {},
+  ...overrides,
+});
+
+describe("internet health RPC contract", () => {
+  it("requires Cloudflare + IODA fresh normal evidence before overall normal", () => {
+    const summary = aggregateInternetHealthRows([
+      row(),
+      row({ source: "ioda", evidence_family: "active_probing", signal: "reachability" }),
+    ]);
+    expect(summary.overall_status).toBe("normal");
+    expect(summary.fresh_source_count).toBe(2);
+    expect(summary.source_total).toBe(3);
+    expect(summary.sources.find((source) => source.key === "ncdr")).toMatchObject({
+      status: "unknown", fresh: false, value: null,
+    });
+  });
+
+  it("does not treat NCDR no-alert row as proof of normal internet", () => {
+    const summary = aggregateInternetHealthRows([
+      row({ source: "ncdr", signal: "mobile_outage_alerts", value: 0, unit: "alerts" }),
+    ]);
+    expect(summary.overall_status).toBe("unknown");
+    expect(summary.summary).toContain("無法判斷");
+  });
+
+  it("stale overrides effective_status and cannot become outage or normal", () => {
+    const parsed = parseInternetHealthEvidence(row({
+      effective_status: "outage",
+      is_stale: true,
+      value: null,
+      change_ratio: null,
+    }));
+    expect(parsed).toMatchObject({ status: "unknown", is_stale: true, value: null, change_ratio: null });
+
+    const summary = aggregateInternetHealthRows([row({ effective_status: "outage", is_stale: true })]);
+    expect(summary.overall_status).toBe("unknown");
+    expect(summary.fresh_source_count).toBe(0);
+  });
+
+  it("missing is_stale is conservative unknown for an older RPC shape", () => {
+    const input: Record<string, unknown> = { ...row() };
+    Reflect.deleteProperty(input, "is_stale");
+    expect(parseInternetHealthEvidence(input)?.status).toBe("unknown");
+  });
+
+  it("uses effective_status rather than reported_status and preserves active incident scope as text", () => {
+    const summary = aggregateInternetHealthRows([
+      row({
+        source: "ioda",
+        entity_type: "asn",
+        entity_id: "AS3462",
+        entity_name: "HiNet",
+        reported_status: "outage",
+        effective_status: "degraded",
+        incident_kind: "single_asn_outage",
+        active_incident_id: "incident-1",
+        incident_status: "open",
+        confidence: "medium",
+      }),
+    ]);
+    expect(summary.overall_status).toBe("degraded");
+    expect(summary.incidents).toEqual([
+      expect.objectContaining({
+        id: "incident-1",
+        entity_type: "asn",
+        entity_id: "AS3462",
+        entity_name: "HiNet",
+        severity: "degraded",
+      }),
+    ]);
+    expect(JSON.stringify(summary.incidents)).not.toContain("geometry");
+  });
+
+  it("uses a fresh detector composite as overall truth when evidence rows are included", () => {
+    const summary = aggregateInternetHealthRows([
+      row({
+        row_type: "status",
+        source: "multi_source_detector",
+        evidence_family: "composite",
+        reported_status: "outage",
+        effective_status: "watch",
+        confidence: 0.65,
+      }),
+      row({ source: "cloudflare_radar", effective_status: "degraded" }),
+      row({ source: "ioda", effective_status: "normal" }),
+    ]);
+    expect(summary.overall_status).toBe("watch");
+    expect(summary.confidence).toBe("medium");
+    expect(summary.evidence[0]).toMatchObject({
+      row_type: "detector",
+      source_observation_id: "observation-1",
+    });
+  });
+
+  it("maps numeric RPC confidence and active official evidence conservatively", () => {
+    const summary = aggregateInternetHealthRows([
+      row({
+        row_type: "status",
+        source: "internet_health_detector_v1",
+        evidence_family: "composite",
+        effective_status: "normal",
+        confidence: 0.9,
+      }),
+      row({
+        row_type: "official_evidence",
+        source: "ncdr",
+        evidence_family: "official",
+        signal: "mobile_network_outage_alert",
+        reported_status: "outage",
+        effective_status: "outage",
+        incident_kind: "telecom_service_disruption",
+        confidence: null,
+      }),
+    ]);
+    expect(summary.overall_status).toBe("outage");
+    expect(summary.evidence).toEqual(expect.arrayContaining([
+      expect.objectContaining({ row_type: "detector", confidence: "high" }),
+      expect.objectContaining({ row_type: "official", confidence: "unknown" }),
+    ]));
+    expect(summary.incidents).toEqual([
+      expect.objectContaining({
+        id: "official:observation-1",
+        kind: "telecom_service_disruption",
+        severity: "outage",
+        source: "ncdr",
+      }),
+    ]);
+  });
+
+  it("keeps null metrics as null instead of inventing zero", () => {
+    const parsed = parseInternetHealthEvidence(row({
+      value: null,
+      baseline_value: null,
+      change_ratio: null,
+      sample_count: null,
+      observed_at: null,
+    }));
+    expect(parsed).toMatchObject({
+      value: null,
+      baseline_value: null,
+      change_ratio: null,
+      sample_count: null,
+      observed_at: null,
+    });
+  });
+});

--- a/src/data/internetHealthLoader.ts
+++ b/src/data/internetHealthLoader.ts
@@ -1,0 +1,369 @@
+/**
+ * 台灣電信與網路狀態 loader。
+ *
+ * 資料只走 public.get_internet_health_status RPC；前端不直打 Cloudflare / IODA，
+ * 也不把 ASN 或 country status 轉成地圖 geometry。
+ *
+ * 保守語意：
+ * - effective_status 是 UI 狀態真相，reported_status 只留作溯源。
+ * - stale / unavailable / 缺列都只能是 unknown，不能安靜變成 normal 或 0。
+ * - normal 至少需要 Cloudflare Radar + IODA 兩個 fresh network evidence 都是 normal；
+ *   NCDR 無通報只能表示「未通報」，不能單獨證明網路正常。
+ */
+import { supabase, supabaseConfigured } from "../lib/supabase";
+import { withLoading } from "../lib/loadingRegistry";
+import { cachedOnce } from "../lib/loaderCache";
+
+export type InternetHealthStatus = "normal" | "watch" | "degraded" | "outage" | "unknown";
+export type InternetHealthConfidence = "low" | "medium" | "high" | "unknown";
+export type InternetHealthSourceKey = "cloudflare" | "ioda" | "ncdr";
+export type InternetHealthRowType = "detector" | "evidence" | "official" | "unknown";
+
+export interface InternetHealthEvidence {
+  row_type: InternetHealthRowType;
+  source_observation_id: string | null;
+  entity_type: string;
+  entity_id: string;
+  entity_name: string | null;
+  source: string;
+  source_key: InternetHealthSourceKey | "other";
+  evidence_family: string | null;
+  signal: string | null;
+  reported_status: string | null;
+  status: InternetHealthStatus;
+  incident_kind: string | null;
+  value: number | null;
+  unit: string | null;
+  baseline_value: number | null;
+  change_ratio: number | null;
+  confidence: InternetHealthConfidence;
+  sample_count: number | null;
+  observed_at: string | null;
+  source_updated_at: string | null;
+  collected_at: string | null;
+  age_seconds: number | null;
+  is_stale: boolean;
+  active_incident_id: string | null;
+  incident_status: string | null;
+  metadata: Record<string, unknown>;
+}
+
+export interface InternetHealthSourceSummary {
+  key: InternetHealthSourceKey;
+  label: string;
+  status: InternetHealthStatus;
+  fresh: boolean;
+  observed_at: string | null;
+  source_updated_at: string | null;
+  signal: string | null;
+  value: number | null;
+  unit: string | null;
+  change_ratio: number | null;
+  confidence: InternetHealthConfidence;
+  evidence_count: number;
+}
+
+export interface InternetHealthIncident {
+  id: string;
+  kind: string | null;
+  status: string | null;
+  entity_type: string;
+  entity_id: string;
+  entity_name: string | null;
+  severity: InternetHealthStatus;
+  confidence: InternetHealthConfidence;
+  observed_at: string | null;
+  source: string;
+}
+
+export interface InternetHealthSummary {
+  overall_status: InternetHealthStatus;
+  confidence: InternetHealthConfidence;
+  summary: string;
+  last_updated_at: string | null;
+  fresh_source_count: number;
+  source_total: number;
+  sources: InternetHealthSourceSummary[];
+  incidents: InternetHealthIncident[];
+  evidence: InternetHealthEvidence[];
+}
+
+const SOURCE_LABELS: Record<InternetHealthSourceKey, string> = {
+  cloudflare: "Cloudflare Radar",
+  ioda: "IODA",
+  ncdr: "NCDR",
+};
+
+const STATUS_RANK: Record<InternetHealthStatus, number> = {
+  unknown: 0,
+  normal: 1,
+  watch: 2,
+  degraded: 3,
+  outage: 4,
+};
+
+const CONFIDENCE_RANK: Record<InternetHealthConfidence, number> = {
+  unknown: 0,
+  low: 1,
+  medium: 2,
+  high: 3,
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function text(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const out = value.trim();
+  return out || null;
+}
+
+function num(value: unknown): number | null {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string" && value.trim()) {
+    const out = Number(value);
+    return Number.isFinite(out) ? out : null;
+  }
+  return null;
+}
+
+function timestamp(value: unknown): string | null {
+  const out = text(value);
+  if (!out || !Number.isFinite(Date.parse(out))) return null;
+  return out;
+}
+
+export function normalizeInternetHealthStatus(value: unknown): InternetHealthStatus {
+  const raw = text(value)?.toLowerCase().replace(/[\s-]+/g, "_") ?? "";
+  if (["normal", "ok", "healthy", "clear"].includes(raw)) return "normal";
+  if (["watch", "warning", "anomaly", "suspected"].includes(raw)) return "watch";
+  if ([
+    "degraded", "partial_outage", "single_asn_outage", "multi_asn_partial_outage",
+    "international_path_degradation", "selective_service_blocking",
+  ].includes(raw)) return "degraded";
+  if (["outage", "down", "major_outage", "national_outage"].includes(raw)) return "outage";
+  return "unknown";
+}
+
+function normalizeConfidence(value: unknown): InternetHealthConfidence {
+  const numeric = num(value);
+  if (numeric !== null && numeric >= 0 && numeric <= 1) {
+    if (numeric >= 0.8) return "high";
+    if (numeric >= 0.5) return "medium";
+    return "low";
+  }
+  const raw = text(value)?.toLowerCase() ?? "";
+  if (raw === "low" || raw === "medium" || raw === "high") return raw;
+  return "unknown";
+}
+
+function sourceKeyOf(value: unknown): InternetHealthSourceKey | "other" {
+  const raw = text(value)?.toLowerCase() ?? "";
+  if (raw.includes("cloudflare") || raw.includes("radar")) return "cloudflare";
+  if (raw.includes("ioda")) return "ioda";
+  if (raw.includes("ncdr")) return "ncdr";
+  return "other";
+}
+
+function rowTypeOf(value: unknown, evidenceFamily: string | null): InternetHealthRowType {
+  const raw = text(value)?.toLowerCase() ?? "";
+  if (raw === "status") return evidenceFamily === "composite" ? "detector" : "evidence";
+  if (raw === "official_evidence") return "official";
+  // 防禦性相容早期前端 fixture，不是 production RPC 的 canonical 值。
+  if (raw === "detector" || raw === "evidence" || raw === "official") return raw;
+  return "unknown";
+}
+
+/** 單列 parser；欄位缺失時保守保留 null，不補 0。 */
+export function parseInternetHealthEvidence(raw: unknown): InternetHealthEvidence | null {
+  if (!isRecord(raw)) return null;
+  const entityType = text(raw.entity_type);
+  const entityId = text(raw.entity_id);
+  const source = text(raw.source);
+  if (!entityType || !entityId || !source) return null;
+
+  // RPC contract 明確要求 is_stale。缺欄也視為 stale，避免舊 RPC 靜默顯示正常。
+  const isStale = raw.is_stale !== false;
+  const effective = normalizeInternetHealthStatus(raw.effective_status);
+  const status = isStale ? "unknown" : effective;
+  const evidenceFamily = text(raw.evidence_family);
+
+  return {
+    row_type: rowTypeOf(raw.row_type, evidenceFamily),
+    source_observation_id: text(raw.source_observation_id),
+    entity_type: entityType,
+    entity_id: entityId,
+    entity_name: text(raw.entity_name),
+    source,
+    source_key: sourceKeyOf(source),
+    evidence_family: evidenceFamily,
+    signal: text(raw.signal),
+    reported_status: text(raw.reported_status),
+    status,
+    incident_kind: text(raw.incident_kind),
+    value: num(raw.value),
+    unit: text(raw.unit),
+    baseline_value: num(raw.baseline_value),
+    change_ratio: num(raw.change_ratio),
+    confidence: normalizeConfidence(raw.confidence),
+    sample_count: num(raw.sample_count),
+    observed_at: timestamp(raw.observed_at),
+    source_updated_at: timestamp(raw.source_updated_at),
+    collected_at: timestamp(raw.collected_at),
+    age_seconds: num(raw.age_seconds),
+    is_stale: isStale,
+    active_incident_id: text(raw.active_incident_id),
+    incident_status: text(raw.incident_status),
+    metadata: isRecord(raw.metadata) ? raw.metadata : {},
+  };
+}
+
+function latestTimestamp(rows: InternetHealthEvidence[]): string | null {
+  let latest: string | null = null;
+  let latestMs = -Infinity;
+  for (const row of rows) {
+    const candidate = row.source_updated_at ?? row.observed_at ?? row.collected_at;
+    if (!candidate) continue;
+    const ms = Date.parse(candidate);
+    if (ms > latestMs) {
+      latestMs = ms;
+      latest = candidate;
+    }
+  }
+  return latest;
+}
+
+function worstStatus(rows: InternetHealthEvidence[]): InternetHealthStatus {
+  let out: InternetHealthStatus = "unknown";
+  for (const row of rows) {
+    if (STATUS_RANK[row.status] > STATUS_RANK[out]) out = row.status;
+  }
+  return out;
+}
+
+function conservativeConfidence(rows: InternetHealthEvidence[]): InternetHealthConfidence {
+  const known = rows.map((row) => row.confidence).filter((c) => c !== "unknown");
+  if (!known.length) return "unknown";
+  return known.reduce((a, b) => CONFIDENCE_RANK[a] <= CONFIDENCE_RANK[b] ? a : b);
+}
+
+function sourceSummary(key: InternetHealthSourceKey, rows: InternetHealthEvidence[]): InternetHealthSourceSummary {
+  const sourceRows = rows.filter((row) => row.source_key === key);
+  const freshRows = sourceRows.filter((row) => !row.is_stale && row.status !== "unknown");
+  const status = worstStatus(freshRows);
+  const candidates = freshRows.filter((row) => row.status === status);
+  const notable = [...(candidates.length ? candidates : sourceRows)].sort((a, b) => {
+    const ta = Date.parse(a.source_updated_at ?? a.observed_at ?? "") || 0;
+    const tb = Date.parse(b.source_updated_at ?? b.observed_at ?? "") || 0;
+    return tb - ta;
+  })[0] ?? null;
+  return {
+    key,
+    label: SOURCE_LABELS[key],
+    status,
+    fresh: freshRows.length > 0,
+    observed_at: notable?.observed_at ?? null,
+    source_updated_at: notable?.source_updated_at ?? null,
+    signal: notable?.signal ?? null,
+    value: notable?.value ?? null,
+    unit: notable?.unit ?? null,
+    change_ratio: notable?.change_ratio ?? null,
+    confidence: conservativeConfidence(candidates),
+    evidence_count: sourceRows.length,
+  };
+}
+
+function activeIncidents(rows: InternetHealthEvidence[]): InternetHealthIncident[] {
+  const byId = new Map<string, InternetHealthIncident>();
+  for (const row of rows) {
+    const id = row.active_incident_id
+      ?? (row.row_type === "official" && row.status !== "normal" && row.status !== "unknown"
+        ? row.source_observation_id && `official:${row.source_observation_id}`
+        : null);
+    const incidentStatus = row.incident_status?.toLowerCase() ?? null;
+    if (!id || incidentStatus === "closed" || incidentStatus === "resolved") continue;
+    const candidate: InternetHealthIncident = {
+      id,
+      kind: row.incident_kind,
+      status: row.incident_status,
+      entity_type: row.entity_type,
+      entity_id: row.entity_id,
+      entity_name: row.entity_name,
+      severity: row.status,
+      confidence: row.confidence,
+      observed_at: row.observed_at,
+      source: row.source,
+    };
+    const current = byId.get(id);
+    if (!current || STATUS_RANK[candidate.severity] > STATUS_RANK[current.severity]) byId.set(id, candidate);
+  }
+  return [...byId.values()].sort((a, b) => STATUS_RANK[b.severity] - STATUS_RANK[a.severity]);
+}
+
+function summaryText(status: InternetHealthStatus): string {
+  if (status === "normal") return "多來源未見明顯網路異常";
+  if (status === "watch") return "部分訊號需要持續觀察";
+  if (status === "degraded") return "偵測到局部或服務品質下降";
+  if (status === "outage") return "偵測到網路中斷訊號";
+  return "核心來源不足，暫時無法判斷";
+}
+
+/** 將 RPC evidence rows 彙整成 Monitor 卡片模型。 */
+export function aggregateInternetHealthRows(rawRows: unknown): InternetHealthSummary {
+  const evidence = Array.isArray(rawRows)
+    ? rawRows.map(parseInternetHealthEvidence).filter((row): row is InternetHealthEvidence => row !== null)
+    : [];
+  const sources = (["cloudflare", "ioda", "ncdr"] as const).map((key) => sourceSummary(key, evidence));
+  const freshEvidence = evidence.filter((row) => !row.is_stale && row.status !== "unknown");
+  const freshDetectors = freshEvidence.filter((row) => row.row_type === "detector");
+  const freshOfficial = freshEvidence.filter((row) => row.row_type === "official");
+  // Provider evidence 是 detector 的輸入，不可蓋過 composite；NCDR active official evidence
+  // 則保留為獨立正向中斷證據。
+  const primaryRows = freshDetectors.length ? [...freshDetectors, ...freshOfficial] : freshEvidence;
+  let overall = worstStatus(primaryRows);
+
+  // normal 是唯一需要 quorum 的狀態：NCDR 無通報不能單獨證明正常。
+  if (overall === "normal") {
+    const cloudflare = sources.find((source) => source.key === "cloudflare");
+    const ioda = sources.find((source) => source.key === "ioda");
+    if (!cloudflare?.fresh || cloudflare.status !== "normal" || !ioda?.fresh || ioda.status !== "normal") {
+      overall = "unknown";
+    }
+  }
+  if (!primaryRows.length) overall = "unknown";
+
+  const contributing = primaryRows.filter((row) => row.status === overall);
+  return {
+    overall_status: overall,
+    confidence: conservativeConfidence(contributing),
+    summary: summaryText(overall),
+    last_updated_at: latestTimestamp(evidence),
+    fresh_source_count: sources.filter((source) => source.fresh).length,
+    source_total: sources.length,
+    sources,
+    incidents: activeIncidents(evidence),
+    evidence,
+  };
+}
+
+async function fetchInternetHealthStatusUncached(): Promise<InternetHealthSummary> {
+  if (!supabaseConfigured) throw new Error("Supabase not configured");
+  const { data, error } = await withLoading(
+    "internet-health:status",
+    "電信與網路狀態",
+    supabase.rpc("get_internet_health_status", {
+      p_entity_type: "country",
+      p_entity_ids: ["TW"],
+      p_include_evidence: true,
+      p_limit: 500,
+    }),
+  );
+  if (error) throw new Error(`get_internet_health_status: ${error.message}`);
+  return aggregateInternetHealthRows(data);
+}
+
+export const fetchInternetHealthStatus = cachedOnce(fetchInternetHealthStatusUncached, 4 * 60_000);
+export function invalidateInternetHealthStatus(): void {
+  fetchInternetHealthStatus.invalidate();
+}


### PR DESCRIPTION
Adds the Monitor status card and loader for conservative Taiwan internet-health status, freshness, source evidence, and official NCDR alerts.