### PR TITLE
feat(monitor): add China ISR territorial-pass dashboard

### DIFF
--- a/docs/features/isr-satellite-monitor/README.md
+++ b/docs/features/isr-satellite-monitor/README.md
@@ -1,10 +1,10 @@
 # 中國 ISR 衛星領海過境監測
 
 > **Slug**：`isr-satellite-monitor`
-> **狀態**：dev
+> **狀態**：release candidate
 > **Owner**：Mini Taiwan Pulse
-> **上線日期**：未上線
-> **相關 PR**：未建立
+> **上線日期**：frontend 待 PR #185 merge；production RPC 已於 2026-08-30 上線
+> **相關 PR**：#185
 
 ## 一句話說明
 
@@ -14,7 +14,7 @@
 
 | 名稱 | 類型 | 資料源 | 狀態 |
 |---|---|---|---|
-| 中國 ISR 衛星領海過境 | Monitor card | `public.get_isr_satellite_passes_daily` RPC | frontend ready，等待平台 RPC |
+| 中國 ISR 衛星領海過境 | Monitor card | `public.get_isr_satellite_passes_daily` RPC | production RPC/backfill ready，frontend 待發布 |
 
 ## 關鍵檔案
 

--- a/docs/features/isr-satellite-monitor/README.md
+++ b/docs/features/isr-satellite-monitor/README.md
@@ -1,0 +1,46 @@
+# 中國 ISR 衛星領海過境監測
+
+> **Slug**：`isr-satellite-monitor`
+> **狀態**：dev
+> **Owner**：Mini Taiwan Pulse
+> **上線日期**：未上線
+> **相關 PR**：未建立
+
+## 一句話說明
+
+在 Monitor 以每日直條呈現公開目錄中中國 ISR-capable 候選衛星的星下點穿越臺灣本島 12 浬領海範圍次數，並在 tooltip 顯示當日不重複衛星數。
+
+## 元件
+
+| 名稱 | 類型 | 資料源 | 狀態 |
+|---|---|---|---|
+| 中國 ISR 衛星領海過境 | Monitor card | `public.get_isr_satellite_passes_daily` RPC | frontend ready，等待平台 RPC |
+
+## 關鍵檔案
+
+- Loader：`src/data/isrSatellitePassesLoader.ts`
+- Card：`src/components/intel/monitor/IsrSatellitePassCard.tsx`
+- Dock 佈局：`src/components/intel/monitor/monitorLayout.ts`
+- Split 佈局：`src/components/intel/monitor/monitorSplitLayout.ts`
+
+本功能不是地圖圖層，不建立 `layerManifest` entry。
+
+## 指標語意
+
+- 主柱：`pass_count`，同一顆衛星同日多次穿越會計多次。
+- Tooltip／副值：`unique_satellite_count`，當日 distinct 衛星數。
+- v1 固定標示為 `YAOGAN / GAOFEN / JILIN` 三家族範圍，不宣稱全中國 ISR census。
+- `scope_coverage_complete=true` 且 count 明確為 `0`，才顯示 v1 scope 內的真零；`china_isr_census_complete=false` 不會擋住三家族範圍內的有效計數。
+- 缺日、null、stale 或 RPC error 都不補 0；`coverage_complete=false` 仍可呈現已計得的 partial registry 數字與範圍警示。
+- 圖表只呈現 `target_day <= latest_valid_day` 的完整日；較新的未完成列不進圖。
+- 星下點穿越只代表公開軌道推算，不代表 payload 開機、指向臺灣或實際蒐情。
+
+## 資料契約摘要
+
+看 [handoff.md](./handoff.md)。上游 SSOT 預定為 [taipei-gis-analytics handoff](../../../../taipei-gis-analytics/docs/handoff/isr-satellite-monitor.md)。
+
+## 相關文件
+
+- [Backlog](./backlog.md)
+- [Changelog](./changelog.md)
+- [開發規則](../../development-rules.md)

--- a/docs/features/isr-satellite-monitor/backlog.md
+++ b/docs/features/isr-satellite-monitor/backlog.md
@@ -4,8 +4,7 @@
 
 | ID | Category | Priority | State | Outcome | Next action | Acceptance |
 |---|---|---|---|---|---|---|
-| ISR-MON-1 | validation | P1 | waiting_external | 前端可讀到真實每日過境列 | 平台完成 RPC 後，以 anon 角色回讀預設參數 | RPC schema 對齊、最近完整日非空、缺日未補 0 |
-| ISR-MON-2 | validation | P1 | waiting_external | dock / split 已通過本機 error/null 與範圍警示驗收；真實柱仍待 RPC | 平台完成 RPC/backfill 後，檢查 30 日柱、tooltip、partial census、stale 與真零狀態 | live RPC Browser 截圖與互動證據 |
+| ISR-MON-2 | validation | P1 | in_progress | dock / split 已通過本機 error/null 與範圍警示驗收；production anon RPC 已有 30 日資料 | PR #185 發布後檢查真實柱、tooltip、partial census、stale 與真零狀態 | production Browser 截圖與互動證據 |
 | ISR-MON-3 | data-health | P1 | waiting_external | ISR registry 覆核日期可監測 | 上游確認 registry review SLA 與告警門檻 | `registry_reviewed_at` 有值且逾期狀態有規格 |
 
 ## Decision needed
@@ -16,8 +15,9 @@
 
 ## Completed / historical
 
-- [x] **ISR-MON-0**：完成 frontend loader、Monitor card、dock/split packing 與 null/zero contract tests — 2026-08-30，尚未 commit／PR；詳見 [changelog.md](./changelog.md)
+- [x] **ISR-MON-0**：完成 frontend loader、Monitor card、dock/split packing 與 null/zero contract tests — 2026-08-30，PR #185；詳見 [changelog.md](./changelog.md)
 - [x] **ISR-MON-0B**：localhost dock/split 均可見卡片；production RPC 尚未套用時正確顯示「更新失敗，不以 0 代替」與 v1 scope 警示 — 2026-08-30
+- [x] **ISR-MON-1**：production migrations、三種 tier mode 各 30 日 backfill 與 anon HTTP RPC 回讀通過 — 2026-08-30
 
 ## Explicitly not planned
 

--- a/docs/features/isr-satellite-monitor/backlog.md
+++ b/docs/features/isr-satellite-monitor/backlog.md
@@ -1,0 +1,25 @@
+# Backlog — 中國 ISR 衛星領海過境監測
+
+## Active work
+
+| ID | Category | Priority | State | Outcome | Next action | Acceptance |
+|---|---|---|---|---|---|---|
+| ISR-MON-1 | validation | P1 | waiting_external | 前端可讀到真實每日過境列 | 平台完成 RPC 後，以 anon 角色回讀預設參數 | RPC schema 對齊、最近完整日非空、缺日未補 0 |
+| ISR-MON-2 | validation | P1 | waiting_external | dock / split 已通過本機 error/null 與範圍警示驗收；真實柱仍待 RPC | 平台完成 RPC/backfill 後，檢查 30 日柱、tooltip、partial census、stale 與真零狀態 | live RPC Browser 截圖與互動證據 |
+| ISR-MON-3 | data-health | P1 | waiting_external | ISR registry 覆核日期可監測 | 上游確認 registry review SLA 與告警門檻 | `registry_reviewed_at` 有值且逾期狀態有規格 |
+
+## Decision needed
+
+| ID | Decision | Options / trade-off | Decision owner | Next action after decision |
+|---|---|---|---|---|
+| ISR-MON-4 | `twmain_12nm` 是否含哪些附屬島嶼 | 僅本島+澎湖較符合標題；擴大範圍需改名稱與比較基準 | Product / data owner | 固化 region registry 與 UI 中文標籤 |
+
+## Completed / historical
+
+- [x] **ISR-MON-0**：完成 frontend loader、Monitor card、dock/split packing 與 null/zero contract tests — 2026-08-30，尚未 commit／PR；詳見 [changelog.md](./changelog.md)
+- [x] **ISR-MON-0B**：localhost dock/split 均可見卡片；production RPC 尚未套用時正確顯示「更新失敗，不以 0 代替」與 v1 scope 警示 — 2026-08-30
+
+## Explicitly not planned
+
+- **實際蒐情次數**：公開 OMM/TLE 無 payload tasking、姿態或感測器開機資料，不能由過境事件推論。
+- **地圖 layer**：本期只做 Monitor card，不建立 `layerManifest` 或地圖 overlay。

--- a/docs/features/isr-satellite-monitor/changelog.md
+++ b/docs/features/isr-satellite-monitor/changelog.md
@@ -1,0 +1,11 @@
+# Changelog — 中國 ISR 衛星領海過境監測
+
+## 2026-08-30 — Unreleased
+
+- 新增 `get_isr_satellite_passes_daily` 暫定契約 loader 與 loadingRegistry。
+- 新增 Monitor 每日直柱卡：主值 `pass_count`、tooltip `unique_satellite_count`。
+- 接入 dock / split 佈局與 packing tests。
+- `p_days` 預設 30、上限 31，符合 RPC `1..31` 契約。
+- 明確區分 v1 scope 內真 0、缺日、null、partial China-wide census、stale 與 RPC error；固定標示三家族範圍不是全中國 ISR census。
+- localhost Browser 已驗證 dock/split 卡片接線與 RPC 未上線時的誠實錯誤狀態；live 30 日柱驗收仍待平台 migration/backfill。
+- Breaking：前端依賴平台提供本文 handoff 所列 RPC 欄位；尚未 commit、push 或 deploy。

--- a/docs/features/isr-satellite-monitor/changelog.md
+++ b/docs/features/isr-satellite-monitor/changelog.md
@@ -7,5 +7,7 @@
 - 接入 dock / split 佈局與 packing tests。
 - `p_days` 預設 30、上限 31，符合 RPC `1..31` 契約。
 - 明確區分 v1 scope 內真 0、缺日、null、partial China-wide census、stale 與 RPC error；固定標示三家族範圍不是全中國 ISR census。
-- localhost Browser 已驗證 dock/split 卡片接線與 RPC 未上線時的誠實錯誤狀態；live 30 日柱驗收仍待平台 migration/backfill。
-- Breaking：前端依賴平台提供本文 handoff 所列 RPC 欄位；尚未 commit、push 或 deploy。
+- localhost Browser 已驗證 dock/split 卡片接線與 RPC 未上線時的誠實錯誤狀態。
+- production migrations/backfill 已套用；anon HTTP RPC 回傳 30 日資料，最新完整日為 2026-08-29，v1 scope coverage complete 且不宣稱全中國 ISR census。
+- frontend 已建立 PR #185；production 真實柱與 tooltip 驗收待 PR merge／deploy。
+- Breaking：前端依賴平台提供本文 handoff 所列 RPC 欄位；RPC 已於 2026-08-30 上線。

--- a/docs/features/isr-satellite-monitor/handoff.md
+++ b/docs/features/isr-satellite-monitor/handoff.md
@@ -62,7 +62,7 @@ RPC 暫不直接回 `freshness`，前端依以下條件推導：
 
 ## 已知不對稱
 
-- 前端已完成暫定契約接線，但目前未在本 worktree 驗證 production RPC 回讀。
+- production anon HTTP RPC 已於 2026-08-30 驗證預設參數回傳 30 日資料；frontend production Browser 驗收仍待 PR #185 發布。
 - 過境是星下點與領海 polygon 的幾何事件，不等於感測器實際蒐情。
 - v1 registry 只承諾 YAOGAN／GAOFEN／JILIN 三家族 scope，不代表全中國 ISR census。
 - `twmain_12nm` 的精確 islands inclusion 由上游 region registry 定義，前端不自行 buffer 或改 geometry。

--- a/docs/features/isr-satellite-monitor/handoff.md
+++ b/docs/features/isr-satellite-monitor/handoff.md
@@ -1,0 +1,68 @@
+# Handoff — 中國 ISR 衛星領海過境監測（下游視角）
+
+> **上游 SSOT（預定）**：[taipei-gis-analytics/docs/handoff/isr-satellite-monitor.md](../../../../taipei-gis-analytics/docs/handoff/isr-satellite-monitor.md)
+>
+> 本檔只記前端硬依賴與目前暫定契約；正式 migration／RPC 以 gis-platform 與上游 handoff 為準。
+
+## 上游 handoff 摘要
+
+- RPC：`public.get_isr_satellite_passes_daily(p_days, p_region_key, p_tier_mode)`
+- 更新頻率：每日批次；前端每 30 分鐘檢查一次並以 30 分鐘 TTL 去重
+- 日界：Asia/Taipei
+- `p_days` 契約：`1..31`；前端預設 30，超過 31 會 clamp 為 31
+- 預設：`p_days=30`、`p_region_key='twmain_12nm'`、`p_tier_mode='confirmed_plus_dual_use'`
+- tier modes：`confirmed_only` / `confirmed_plus_dual_use` / `all_non_excluded`
+
+## 前端接線位置
+
+- Loader：`src/data/isrSatellitePassesLoader.ts`
+- Monitor card：`src/components/intel/monitor/IsrSatellitePassCard.tsx`
+- Dock / split：`monitorLayout.ts` / `monitorSplitLayout.ts`
+- 圖表：重用 `HazardTrendBars`；`pass_count` 為柱高，`unique_satellite_count` 放 tooltip。
+
+## 硬依賴欄位
+
+每日一列：
+
+- `target_day` — x 軸日期，`YYYY-MM-DD`。
+- `region_key` — 查詢實際套用的 region。
+- `tier_mode` — 查詢實際套用的分類模式。
+- `pass_count` — 每日穿越事件數；null 不得補 0。
+- `unique_satellite_count` — 當日 distinct 衛星數；null 不得補 0。
+- `latest_valid_day` — 最近完整有效日。
+- `computed_at` 或 `refreshed_at` — 批次計算時間。
+- `coverage_complete` — RPC 的整體／partial registry coverage 訊號；`false` 不等於無資料，非 null count 仍須呈現。
+- `registry_reviewed_at` — ISR registry 最近人工覆核時間，loader 保留供後續 UI 擴充。
+- `scope_coverage_complete` — v1 `YAOGAN / GAOFEN / JILIN` registry 分母是否完整；只有 `true` 時 `0` 才能解讀為 v1 scope 內真零。
+- `china_isr_census_complete` — 是否涵蓋全中國 ISR census；v1 預期為 `false`，不會因此隱藏三家族 scope 內的非 null 計數。
+
+缺少的 calendar day 不由前端補列，也不補 0。
+圖表只保留 `target_day <= latest_valid_day`；`latest_valid_day` 之後的未完成日不呈現。
+
+`coverage_complete=false` 可能仍回 partial registry 計數，前端會保留數字並搭配固定範圍警示；卡片不得將這種情況當成無資料。卡片固定顯示「v1 YAOGAN／GAOFEN／JILIN 範圍，非全中國 ISR census」。
+
+## Freshness 暫定推導
+
+RPC 暫不直接回 `freshness`，前端依以下條件推導：
+
+- `computed_at/refreshed_at` 距現在不超過 36 小時；且
+- `latest_valid_day` 的臺北日終距現在不超過 48 小時；
+- 兩者皆成立才是 `fresh`，任一超過為 `stale`，缺欄為 `unknown`。
+
+若平台後續回傳正式 `freshness` 欄位，前端優先採該欄並應同步更新本文件與 tests。
+
+## 上游改動 → 下游動作
+
+| 上游改動 | 下游動作 |
+|---|---|
+| RPC 或參數改名 | 更新 loader、contract test、handoff |
+| 日界改動 | 更新日期標籤、freshness 推導與 tooltip |
+| coverage 定義改動 | 重新驗證 scoped true-zero 與 partial China-wide census 的顯示規則 |
+| tier enum 改動 | 更新 TypeScript union 與預設模式 |
+
+## 已知不對稱
+
+- 前端已完成暫定契約接線，但目前未在本 worktree 驗證 production RPC 回讀。
+- 過境是星下點與領海 polygon 的幾何事件，不等於感測器實際蒐情。
+- v1 registry 只承諾 YAOGAN／GAOFEN／JILIN 三家族 scope，不代表全中國 ISR census。
+- `twmain_12nm` 的精確 islands inclusion 由上游 region registry 定義，前端不自行 buffer 或改 geometry。

--- a/src/components/intel/monitor/IsrSatellitePassCard.tsx
+++ b/src/components/intel/monitor/IsrSatellitePassCard.tsx
@@ -1,0 +1,211 @@
+import { useEffect, useMemo, useState } from "react";
+import { COLORS, FONT_CJK, FONT_DATA } from "../intelTokens";
+import { FONT_SIZE, RADIUS } from "../../../styles/designTokens";
+import { SectionLabel } from "./PressureRing";
+import { HazardTrendBars, type HazardBar } from "./HazardTrendBars";
+import {
+  fetchIsrSatellitePassesDaily,
+  ISR_PASSES_DEFAULT_DAYS,
+  ISR_PASSES_DEFAULT_REGION,
+  ISR_PASSES_DEFAULT_TIER_MODE,
+  type IsrSatellitePassReport,
+} from "../../../data/isrSatellitePassesLoader";
+
+export type LoadState = "loading" | "ready" | "error";
+
+export type IsrLatestDisplayKind =
+  | "loading"
+  | "error"
+  | "empty"
+  | "stale"
+  | "unknown_freshness"
+  | "incomplete"
+  | "ready";
+
+export interface IsrLatestDisplay {
+  kind: IsrLatestDisplayKind;
+  passCount: number | null;
+  uniqueSatelliteCount: number | null;
+  day: string | null;
+}
+
+/** 頭部只讀 latest_valid_day；全中國 census 不完整不會擋住 v1 scope 內計數。 */
+export function deriveIsrLatestDisplay(
+  report: IsrSatellitePassReport | null,
+  state: LoadState,
+): IsrLatestDisplay {
+  const empty = { passCount: null, uniqueSatelliteCount: null, day: report?.latestValidDay ?? null };
+  if (state === "loading" && !report) return { kind: "loading", ...empty };
+  if (state === "error") return { kind: "error", ...empty };
+  if (!report || !report.rows.length) return { kind: "empty", ...empty };
+  if (report.freshness === "stale") return { kind: "stale", ...empty };
+  if (report.freshness === "unknown") return { kind: "unknown_freshness", ...empty };
+  const latest = report.rows.find((row) => row.day === report.latestValidDay);
+  if (!latest || latest.passCount === null || latest.uniqueSatelliteCount === null) {
+    return { kind: "incomplete", ...empty };
+  }
+  if (latest.passCount === 0 && report.scopeCoverageComplete !== true) {
+    return { kind: "incomplete", ...empty };
+  }
+  return {
+    kind: "ready",
+    passCount: latest.passCount,
+    uniqueSatelliteCount: latest.uniqueSatelliteCount,
+    day: latest.day,
+  };
+}
+
+export function buildIsrPassBars(
+  rows: IsrSatellitePassReport["rows"],
+  scopeCoverageComplete: boolean | null,
+  latestValidDay: string | null,
+): HazardBar[] {
+  if (!latestValidDay) return [];
+  return rows.filter((row) => row.day <= latestValidDay).map((row) => ({
+    label: `${row.day.slice(5, 7)}/${row.day.slice(8, 10)}`,
+    key: row.day,
+    value: row.passCount !== null && (row.passCount !== 0 || scopeCoverageComplete === true)
+      ? row.passCount
+      : null,
+    level: 0,
+    note: row.passCount !== null && row.uniqueSatelliteCount !== null
+      ? `不重複衛星 ${row.uniqueSatelliteCount} 顆`
+      : "計數缺失，非 0",
+  }));
+}
+
+const DISPLAY_LABEL: Record<Exclude<IsrLatestDisplayKind, "ready">, string> = {
+  loading: "資料載入中…",
+  error: "更新失敗 · 不以 0 代替",
+  empty: "尚無可用日資料 · 不以 0 代替",
+  stale: "資料過期 · 不以 0 代替",
+  unknown_freshness: "新鮮度未知 · 不以 0 代替",
+  incomplete: "最近日計數或 v1 scope 完整度不足 · 不以 0 代替",
+};
+
+const FRESHNESS_LABEL = { fresh: "新鮮", stale: "過期", unknown: "未知" } as const;
+
+function formatTimestamp(value: string | null): string {
+  if (!value) return "—";
+  const parsed = Date.parse(value);
+  if (!Number.isFinite(parsed)) return "—";
+  return new Intl.DateTimeFormat("zh-TW", {
+    timeZone: "Asia/Taipei",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+  }).format(parsed);
+}
+
+export function IsrSatellitePassCard({ open = true }: { open?: boolean }) {
+  const [report, setReport] = useState<IsrSatellitePassReport | null>(null);
+  const [state, setState] = useState<LoadState>("loading");
+
+  useEffect(() => {
+    if (!open) return;
+    let cancelled = false;
+    const tick = () => {
+      setState((current) => (current === "ready" ? current : "loading"));
+      fetchIsrSatellitePassesDaily()
+        .then((next) => {
+          if (cancelled) return;
+          setReport(next);
+          setState("ready");
+        })
+        .catch((error) => {
+          if (cancelled) return;
+          console.warn("[IsrSatellitePassCard] daily", error);
+          setState("error");
+        });
+    };
+    tick();
+    const id = window.setInterval(tick, 30 * 60_000);
+    return () => { cancelled = true; window.clearInterval(id); };
+  }, [open]);
+
+  const latest = deriveIsrLatestDisplay(report, state);
+  const bars = useMemo(
+    () => buildIsrPassBars(
+      report?.rows ?? [],
+      report?.scopeCoverageComplete ?? null,
+      report?.latestValidDay ?? null,
+    ),
+    [report],
+  );
+  const countedBars = useMemo(
+    () => bars.filter((bar): bar is HazardBar & { value: number } => bar.value !== null),
+    [bars],
+  );
+  const peak = countedBars.length ? Math.max(...countedBars.map((bar) => bar.value)) : null;
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 8, fontFamily: FONT_CJK }}>
+      <SectionLabel color="#a78bfa">中國 ISR 衛星 · TERRITORIAL PASS MONITOR</SectionLabel>
+      <div
+        style={{
+          borderRadius: RADIUS.xl,
+          border: `1px solid ${COLORS.panelBorder}`,
+          background: "linear-gradient(160deg, rgba(139,92,246,0.08), rgba(255,255,255,0.012))",
+          padding: "11px 13px",
+          display: "flex", flexDirection: "column", gap: 9,
+        }}
+      >
+        <div style={{ display: "flex", alignItems: "baseline", gap: 9, flexWrap: "wrap" }}>
+          {latest.kind === "ready" ? (
+            <>
+              <span style={{ fontFamily: FONT_DATA, fontSize: 28, fontWeight: 700, lineHeight: 1, color: "#fff" }}>
+                {latest.passCount}
+              </span>
+              <span style={{ fontSize: FONT_SIZE.base, color: COLORS.textMuted }}>次過境</span>
+              <span style={{ fontFamily: FONT_DATA, fontSize: FONT_SIZE.sm, color: COLORS.textDim }}>
+                {latest.day} · {latest.uniqueSatelliteCount} 顆不重複衛星
+              </span>
+            </>
+          ) : (
+            <span style={{ fontSize: FONT_SIZE.base, color: latest.kind === "error" || latest.kind === "stale" ? COLORS.statusWarn : COLORS.textDim }}>
+              {DISPLAY_LABEL[latest.kind]}
+            </span>
+          )}
+        </div>
+
+        {bars.length > 0 && (
+          <HazardTrendBars
+            bars={bars}
+            levelColors={["#8b5cf6"]}
+            height={74}
+            unit="次"
+            caption={`${ISR_PASSES_DEFAULT_DAYS}D · 過境事件（柱）／不重複衛星（tooltip）`}
+            footer={peak === null ? undefined : `可呈現日 ${countedBars.length}/${bars.length} · 單日最高 ${peak} 次`}
+          />
+        )}
+
+        <div
+          style={{
+            display: "grid", gridTemplateColumns: "repeat(2, minmax(0, 1fr))",
+            gap: "3px 10px", fontFamily: FONT_DATA, fontSize: 9, color: COLORS.textFaint,
+          }}
+        >
+          <span>latest_valid_day: {report?.latestValidDay ?? "—"}</span>
+          <span>computed_at: {formatTimestamp(report?.computedAt ?? null)}</span>
+          <span>scope_coverage: {report?.scopeCoverageComplete === true ? "v1 完整" : report?.scopeCoverageComplete === false ? "v1 未完整" : "未知"}</span>
+          <span>china_isr_census: {report?.chinaIsrCensusComplete === true ? "完整" : report?.chinaIsrCensusComplete === false ? "非完整" : "未知"}</span>
+          <span>coverage_complete: {report?.coverageComplete === true ? "完整" : report?.coverageComplete === false ? "partial" : "未知"}</span>
+          <span>freshness: {FRESHNESS_LABEL[report?.freshness ?? "unknown"]}</span>
+          <span>registry_reviewed: {formatTimestamp(report?.registryReviewedAt ?? null)}</span>
+        </div>
+
+        <div style={{ fontSize: 9, color: COLORS.statusWarn, lineHeight: 1.5 }}>
+          v1 YAOGAN／GAOFEN／JILIN 範圍，非全中國 ISR census
+        </div>
+        <div style={{ fontSize: 9, color: COLORS.textFaint, lineHeight: 1.5 }}>
+          {ISR_PASSES_DEFAULT_REGION} · {ISR_PASSES_DEFAULT_TIER_MODE} · 地面投影穿越不等於實際蒐情；
+          缺日與 null 不補 0
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default IsrSatellitePassCard;

--- a/src/components/intel/monitor/MonitorPanel.tsx
+++ b/src/components/intel/monitor/MonitorPanel.tsx
@@ -44,6 +44,7 @@ import { VesselZoneCard } from "./VesselZoneCard";
 import { FoodPriceBoard } from "./FoodPriceBoard";
 import { TraDelayBoard } from "./TraDelayBoard";
 import { TelecomStatusCard } from "./TelecomStatusCard";
+import { IsrSatellitePassCard } from "./IsrSatellitePassCard";
 import {
   TyphoonCard, EarthquakeCard, RadiationCard, LightningCard,
 } from "./HazardCards";
@@ -733,6 +734,7 @@ export function MonitorPanel({
     vesselZone: <VesselZoneCard open={open} />,
     foodPriceBoard: <FoodPriceBoard open={open} />,
     traDelay: <TraDelayBoard open={open} />,
+    isrSatellitePasses: <IsrSatellitePassCard open={open} />,
     hazardStrip: <HazardWatchStrip />,
     powerCard: <PowerCard dashboard={powerDashboard} day={powerDay} dayStatus={powerDayStatus} trend={powerTrend} />,
     erCongestion: <ERCard open={open} />,

--- a/src/components/intel/monitor/__tests__/isrSatellitePassCard.test.ts
+++ b/src/components/intel/monitor/__tests__/isrSatellitePassCard.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import { buildIsrPassBars, deriveIsrLatestDisplay } from "../IsrSatellitePassCard";
+import type { IsrSatellitePassReport } from "../../../../data/isrSatellitePassesLoader";
+
+function report(overrides: Partial<IsrSatellitePassReport> = {}): IsrSatellitePassReport {
+  return {
+    rows: [{ day: "2026-08-29", passCount: 0, uniqueSatelliteCount: 0, coverageComplete: true }],
+    latestValidDay: "2026-08-29",
+    computedAt: "2026-08-30T01:00:00Z",
+    registryReviewedAt: "2026-08-28T00:00:00Z",
+    scopeCoverageComplete: true,
+    chinaIsrCensusComplete: false,
+    coverageComplete: true,
+    freshness: "fresh",
+    regionKey: "twmain_12nm",
+    tierMode: "confirmed_plus_dual_use",
+    ...overrides,
+  };
+}
+
+describe("ISR pass card zero/null semantics", () => {
+  it("shows zero only for a fresh, complete latest day", () => {
+    expect(deriveIsrLatestDisplay(report(), "ready")).toMatchObject({
+      kind: "ready", passCount: 0, uniqueSatelliteCount: 0,
+    });
+  });
+
+  it("does not expose a numeric headline for stale, incomplete, error or null states", () => {
+    expect(deriveIsrLatestDisplay(report({ freshness: "stale" }), "ready")).toMatchObject({ kind: "stale", passCount: null });
+    expect(deriveIsrLatestDisplay(report({ scopeCoverageComplete: false }), "ready")).toMatchObject({ kind: "incomplete", passCount: null });
+    expect(deriveIsrLatestDisplay(report(), "error")).toMatchObject({ kind: "error", passCount: null });
+    expect(deriveIsrLatestDisplay(report({ rows: [] }), "ready")).toMatchObject({ kind: "empty", passCount: null });
+  });
+
+  it("keeps v1-scope true zero and partial-census counts, but keeps missing counts null", () => {
+    const bars = buildIsrPassBars([
+      { day: "2026-08-28", passCount: 0, uniqueSatelliteCount: 0, coverageComplete: true },
+      { day: "2026-08-29", passCount: 0, uniqueSatelliteCount: 0, coverageComplete: false },
+      { day: "2026-08-30", passCount: null, uniqueSatelliteCount: null, coverageComplete: false },
+    ], true, "2026-08-30");
+    expect(bars.map((bar) => bar.value)).toEqual([0, 0, null]);
+  });
+
+  it("does not let an incomplete China-wide census suppress v1 scoped counts", () => {
+    expect(deriveIsrLatestDisplay(report({
+      coverageComplete: false,
+      scopeCoverageComplete: true,
+      chinaIsrCensusComplete: false,
+      rows: [{ day: "2026-08-29", passCount: 4, uniqueSatelliteCount: 3, coverageComplete: false }],
+    }), "ready")).toMatchObject({ kind: "ready", passCount: 4, uniqueSatelliteCount: 3 });
+  });
+
+  it("does not label a zero as true zero when the v1 registry scope is incomplete", () => {
+    expect(buildIsrPassBars([
+      { day: "2026-08-29", passCount: 0, uniqueSatelliteCount: 0, coverageComplete: false },
+    ], false, "2026-08-29")[0]?.value).toBeNull();
+  });
+
+  it("excludes rows after latest_valid_day because they are not complete days", () => {
+    const bars = buildIsrPassBars([
+      { day: "2026-08-29", passCount: 2, uniqueSatelliteCount: 2, coverageComplete: false },
+      { day: "2026-08-30", passCount: 1, uniqueSatelliteCount: 1, coverageComplete: false },
+    ], true, "2026-08-29");
+    expect(bars.map((bar) => bar.key)).toEqual(["2026-08-29"]);
+  });
+});

--- a/src/components/intel/monitor/__tests__/monitorPacking.test.ts
+++ b/src/components/intel/monitor/__tests__/monitorPacking.test.ts
@@ -4,6 +4,11 @@ import { buildMonitorTree, flattenNode, hasGridFallback, nodeWidth } from "../mo
 import { MONITOR_SPLIT_VISIBLE_LAYOUT } from "../monitorSplitLayout";
 
 describe("monitorPacking", () => {
+  it("ISR 衛星卡同時接入 dock 與 split 佈局", () => {
+    expect(MONITOR_VISIBLE_LAYOUT.some((item) => item.i === "isrSatellitePasses")).toBe(true);
+    expect(MONITOR_SPLIT_VISIBLE_LAYOUT.some((item) => item.i === "isrSatellitePasses")).toBe(true);
+  });
+
   it("實際佈局可完整拆解（不需要退回固定網格）", () => {
     const tree = buildMonitorTree(MONITOR_VISIBLE_LAYOUT);
     expect(hasGridFallback(tree)).toBe(false);

--- a/src/components/intel/monitor/__tests__/monitorPacking.test.ts
+++ b/src/components/intel/monitor/__tests__/monitorPacking.test.ts
@@ -51,6 +51,20 @@ describe("monitorPacking", () => {
     expect(bottom.children.map(nodeWidth)).toEqual([5, 7]);
   });
 
+  it("ISR 插入後 dock 左右兩欄同止於 y80", () => {
+    const leftEnd = Math.max(
+      ...MONITOR_VISIBLE_LAYOUT.filter((item) => item.x < 5 && item.y >= 55)
+        .map((item) => item.y + item.h),
+    );
+    const rightEnd = Math.max(
+      ...MONITOR_VISIBLE_LAYOUT.filter((item) => item.x >= 5 && item.y >= 55)
+        .map((item) => item.y + item.h),
+    );
+
+    expect(leftEnd).toBe(80);
+    expect(rightEnd).toBe(80);
+  });
+
   it("互卡佈局（風車形）退回固定網格而不是掉 widget", () => {
     // 四塊繞著中心互卡，找不到任何一條完整切線
     const pinwheel = [
@@ -123,5 +137,11 @@ describe("monitorPacking · split dock（右半邊窄版）", () => {
     expect(head.t).toBe("cols");
     if (head.t !== "cols") return;
     expect(head.children.map(nodeWidth)).toEqual([6, 6]);
+  });
+
+  it("軍事態勢尾段依序為 PLA、ISR、特殊船舶、台鐵", () => {
+    expect(
+      items.filter((item) => item.y >= 92).map((item) => item.i),
+    ).toEqual(["plaBoard", "isrSatellitePasses", "vesselZone", "traDelay"]);
   });
 });

--- a/src/components/intel/monitor/monitorLayout.ts
+++ b/src/components/intel/monitor/monitorLayout.ts
@@ -33,7 +33,8 @@ export type MonitorWidgetId =
   | "earthquake"
   | "radiation"
   | "lightning"
-  | "traDelay";
+  | "traDelay"
+  | "isrSatellitePasses";
 
 export interface MonitorGridItem {
   /** widget id（對應 MonitorPanel 的 widget 對照表） */
@@ -159,7 +160,9 @@ export const MONITOR_LAYOUT: MonitorGridItem[] = [
   // 迷你走勢圖會擠到看不出形狀；w7 每格約 280px 才讀得出趨勢。
   // h 9→12（2026-08-10）：多出的高度全部灌進四張卡的走勢圖（SPARK_H 34→52 + flex:1）。
   // y 48→56（同上，跟著 powerCard 下移）
-  { i: "foodPriceBoard", x: 5, y: 60, w: 7, h: 12, fit: "content" },
+  // h 12→20：fit:"content" 不改實際高度，只讓右欄跨過 y72、與新增的 ISR 卡同止 y80，
+  // 維持頂層「下方左右兩欄（5+7）」而不切出第三個全寬段。
+  { i: "foodPriceBoard", x: 5, y: 60, w: 7, h: 20, fit: "content" },
   // 特殊船舶接近帶（2026-08-20，VZ-4）：左欄收尾，與共機卡同寬 w5。
   // ⚠️ y61→72 是刻意算過的：原本左欄止於 y61（airportPax）、右欄止於 y72
   // （foodPriceBoard），兩欄不同止。本格補滿左欄到 y72 後**左右欄同時結束**，
@@ -175,6 +178,9 @@ export const MONITOR_LAYOUT: MonitorGridItem[] = [
   // 貫穿全寬的第三段，monitorPacking「頂層拆成上方三欄 + 下方左右兩欄」直接紅。
   // 版面要正式定稿請回沙盒拖完重新匯出整份 MONITOR_LAYOUT。
   { i: "traDelay", x: 0, y: 67, w: 5, h: 5, fit: "content" },
+  // 中國 ISR 衛星領海過境頻率：左欄軍事態勢尾段；右欄由 foodPriceBoard 的排序佔位
+  // 跨過 y72，兩欄同止 y80（fit h 只影響 packing，不改卡片實際高度）。
+  { i: "isrSatellitePasses", x: 0, y: 72, w: 5, h: 8, fit: "content" },
 ];
 
 /** 沙盒 hidden 清單 — 列在這裡的 widget 不渲染（histogram 與時間軸新聞密度重複，2026-07-26 移除） */

--- a/src/components/intel/monitor/monitorSplitLayout.ts
+++ b/src/components/intel/monitor/monitorSplitLayout.ts
@@ -126,10 +126,12 @@ export const MONITOR_LAYOUT_SPLIT: MonitorGridItem[] = [
   { i: "erCongestion", x: 0, y: 77, w: 12, h: 11, fit: "content" },
   { i: "situationOverview", x: 0, y: 88, w: 12, h: 4, fit: "content" },
   { i: "plaBoard", x: 0, y: 92, w: 12, h: 12, fit: "content" },
+  // 中國 ISR 衛星過境：與共機／特殊船舶同屬軍事態勢，窄版用全寬保留日柱可讀性。
+  { i: "isrSatellitePasses", x: 0, y: 104, w: 12, h: 8, fit: "content" },
   // 接在共機卡之後 —— 兩者同屬「軍事態勢」，一個看空域一個看海域
-  { i: "vesselZone", x: 0, y: 104, w: 12, h: 10, fit: "content" },
+  { i: "vesselZone", x: 0, y: 112, w: 12, h: 10, fit: "content" },
   // 台鐵誤點（2026-08-22）：窄版底部沿用全寬堆疊，不影響「兩欄同止」規則。
-  { i: "traDelay", x: 0, y: 114, w: 12, h: 8, fit: "content" },
+  { i: "traDelay", x: 0, y: 122, w: 12, h: 8, fit: "content" },
 ];
 
 /**

--- a/src/data/__tests__/isrSatellitePassesLoader.test.ts
+++ b/src/data/__tests__/isrSatellitePassesLoader.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+import {
+  deriveIsrPassFreshness,
+  hasIsrPassCounts,
+  normalizeIsrPassDays,
+  parseIsrSatellitePassReport,
+} from "../isrSatellitePassesLoader";
+
+const NOW = Date.parse("2026-08-30T12:00:00+08:00");
+
+describe("ISR satellite daily pass RPC contract", () => {
+  it("maps target_day and preserves a complete day's true zero", () => {
+    const report = parseIsrSatellitePassReport([
+      {
+        target_day: "2026-08-29",
+        region_key: "twmain_12nm",
+        tier_mode: "confirmed_plus_dual_use",
+        pass_count: 0,
+        unique_satellite_count: 0,
+        latest_valid_day: "2026-08-29",
+        computed_at: "2026-08-30T01:00:00Z",
+        coverage_complete: true,
+        scope_coverage_complete: true,
+        china_isr_census_complete: false,
+        registry_reviewed_at: "2026-08-28T00:00:00Z",
+      },
+    ], "twmain_12nm", "confirmed_plus_dual_use", NOW);
+
+    expect(report).toMatchObject({
+      latestValidDay: "2026-08-29",
+      coverageComplete: true,
+      scopeCoverageComplete: true,
+      chinaIsrCensusComplete: false,
+      freshness: "fresh",
+      regionKey: "twmain_12nm",
+      tierMode: "confirmed_plus_dual_use",
+    });
+    expect(report.rows[0]).toEqual({
+      day: "2026-08-29",
+      passCount: 0,
+      uniqueSatelliteCount: 0,
+      coverageComplete: true,
+    });
+    expect(hasIsrPassCounts(report.rows[0])).toBe(true);
+  });
+
+  it("keeps incomplete/null/malformed counts unknown instead of coercing them to zero", () => {
+    const report = parseIsrSatellitePassReport([
+      {
+        target_day: "2026-08-28",
+        pass_count: null,
+        unique_satellite_count: "bad",
+        latest_valid_day: "2026-08-28",
+        refreshed_at: "2026-08-30T01:00:00Z",
+        coverage_complete: false,
+      },
+    ], "twmain_12nm", "confirmed_plus_dual_use", NOW);
+
+    expect(report.rows[0]).toMatchObject({
+      passCount: null,
+      uniqueSatelliteCount: null,
+      coverageComplete: false,
+    });
+    expect(hasIsrPassCounts(report.rows[0])).toBe(false);
+  });
+
+  it("does not synthesize missing calendar days", () => {
+    const report = parseIsrSatellitePassReport([
+      { target_day: "2026-08-27", pass_count: 3, unique_satellite_count: 2, coverage_complete: true },
+      { target_day: "2026-08-29", pass_count: 4, unique_satellite_count: 3, coverage_complete: true },
+    ], "twmain_12nm", "confirmed_plus_dual_use", NOW);
+    expect(report.rows.map((row) => row.day)).toEqual(["2026-08-27", "2026-08-29"]);
+  });
+
+  it("normalizes p_days to the RPC's 1..31 contract", () => {
+    expect(normalizeIsrPassDays(1)).toBe(1);
+    expect(normalizeIsrPassDays(31)).toBe(31);
+    expect(normalizeIsrPassDays(90)).toBe(31);
+    expect(normalizeIsrPassDays(0)).toBe(30);
+    expect(normalizeIsrPassDays(1.5)).toBe(30);
+  });
+});
+
+describe("ISR pass freshness", () => {
+  it("requires both a recent computation and a recent latest valid day", () => {
+    expect(deriveIsrPassFreshness("2026-08-29", "2026-08-30T01:00:00Z", NOW)).toBe("fresh");
+    expect(deriveIsrPassFreshness("2026-08-20", "2026-08-30T01:00:00Z", NOW)).toBe("stale");
+    expect(deriveIsrPassFreshness("2026-08-29", "2026-08-25T01:00:00Z", NOW)).toBe("stale");
+    expect(deriveIsrPassFreshness(null, "2026-08-30T01:00:00Z", NOW)).toBe("unknown");
+  });
+});

--- a/src/data/isrSatellitePassesLoader.ts
+++ b/src/data/isrSatellitePassesLoader.ts
@@ -1,0 +1,208 @@
+import { supabase, supabaseConfigured } from "../lib/supabase";
+import { withLoading } from "../lib/loadingRegistry";
+import { keyedThunkCache } from "../lib/loaderCache";
+
+export const ISR_PASSES_DEFAULT_DAYS = 30;
+export const ISR_PASSES_MAX_DAYS = 31;
+export const ISR_PASSES_DEFAULT_REGION = "twmain_12nm";
+export const ISR_PASSES_DEFAULT_TIER_MODE = "confirmed_plus_dual_use";
+
+export type IsrPassTierMode =
+  | "confirmed_only"
+  | "confirmed_plus_dual_use"
+  | "all_non_excluded";
+
+export type IsrPassFreshness = "fresh" | "stale" | "unknown";
+
+export interface IsrSatellitePassDay {
+  /** Asia/Taipei 日界，YYYY-MM-DD */
+  day: string;
+  /** 同一顆衛星同日可多次穿越；null = 未知，不得補 0 */
+  passCount: number | null;
+  /** 當日有穿越的 distinct NORAD_CAT_ID；null = 未知，不得補 0 */
+  uniqueSatelliteCount: number | null;
+  /** RPC partial coverage 訊號；false 不等於無資料 */
+  coverageComplete: boolean;
+}
+
+export interface IsrSatellitePassReport {
+  rows: IsrSatellitePassDay[];
+  latestValidDay: string | null;
+  computedAt: string | null;
+  registryReviewedAt: string | null;
+  /** v1 registry（YAOGAN / GAOFEN / JILIN）內的分母是否完整 */
+  scopeCoverageComplete: boolean | null;
+  /** 是否聲稱涵蓋全中國 ISR census；v1 預期為 false */
+  chinaIsrCensusComplete: boolean | null;
+  /** 結果集 coverage 訊號；false 時仍可有可呈現的 partial registry counts */
+  coverageComplete: boolean | null;
+  freshness: IsrPassFreshness;
+  regionKey: string;
+  tierMode: IsrPassTierMode;
+}
+
+const CACHE_TTL_MS = 30 * 60_000;
+const cache = keyedThunkCache<IsrSatellitePassReport>(CACHE_TTL_MS);
+
+function dateString(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return /^\d{4}-\d{2}-\d{2}$/.test(trimmed) ? trimmed : null;
+}
+
+function timestampString(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed && Number.isFinite(Date.parse(trimmed)) ? trimmed : null;
+}
+
+function nonNegativeInt(value: unknown): number | null {
+  if (value === null || value === undefined || value === "") return null;
+  const parsed = Number(value);
+  return Number.isInteger(parsed) && parsed >= 0 ? parsed : null;
+}
+
+function freshness(value: unknown): IsrPassFreshness {
+  if (value === "fresh") return "fresh";
+  if (value === "stale") return "stale";
+  return "unknown";
+}
+
+function booleanOrNull(value: unknown): boolean | null {
+  return typeof value === "boolean" ? value : null;
+}
+
+function tierModeOrFallback(value: unknown, fallback: IsrPassTierMode): IsrPassTierMode {
+  return value === "confirmed_only"
+    || value === "confirmed_plus_dual_use"
+    || value === "all_non_excluded"
+    ? value
+    : fallback;
+}
+
+export function normalizeIsrPassDays(days: number): number {
+  return Number.isInteger(days) && days > 0
+    ? Math.min(days, ISR_PASSES_MAX_DAYS)
+    : ISR_PASSES_DEFAULT_DAYS;
+}
+
+/** 每日批次：計算時間 36h 內且最近完整日距今不超過 48h 才視為 fresh。 */
+export function deriveIsrPassFreshness(
+  latestValidDay: string | null,
+  computedAt: string | null,
+  nowMs = Date.now(),
+): IsrPassFreshness {
+  if (!latestValidDay || !computedAt) return "unknown";
+  const computedMs = Date.parse(computedAt);
+  const validDayEndMs = Date.parse(`${latestValidDay}T23:59:59+08:00`);
+  if (!Number.isFinite(computedMs) || !Number.isFinite(validDayEndMs)) return "unknown";
+  const computedAge = nowMs - computedMs;
+  const validDayAge = nowMs - validDayEndMs;
+  return computedAge <= 36 * 60 * 60_000 && validDayAge <= 48 * 60 * 60_000
+    ? "fresh"
+    : "stale";
+}
+
+function firstParsed<T>(
+  rows: Record<string, unknown>[],
+  parser: (value: unknown) => T | null,
+  field: string,
+): T | null {
+  for (let i = rows.length - 1; i >= 0; i--) {
+    const parsed = parser(rows[i]?.[field]);
+    if (parsed !== null) return parsed;
+  }
+  return null;
+}
+
+/**
+ * RPC envelope 正規化。缺欄、壞數字與不完整 coverage 一律保留為 unknown/null，
+ * 絕不把異常資料默默變成 0。
+ */
+export function parseIsrSatellitePassReport(
+  data: unknown,
+  regionKey = ISR_PASSES_DEFAULT_REGION,
+  tierMode: IsrPassTierMode = ISR_PASSES_DEFAULT_TIER_MODE,
+  nowMs = Date.now(),
+): IsrSatellitePassReport {
+  const rawRows = Array.isArray(data)
+    ? data.filter((row): row is Record<string, unknown> => Boolean(row) && typeof row === "object")
+    : [];
+
+  const rows = rawRows
+    .map<IsrSatellitePassDay | null>((row) => {
+      const day = dateString(row.target_day);
+      if (!day) return null;
+      return {
+        day,
+        passCount: nonNegativeInt(row.pass_count),
+        uniqueSatelliteCount: nonNegativeInt(row.unique_satellite_count),
+        coverageComplete: row.coverage_complete === true,
+      };
+    })
+    .filter((row): row is IsrSatellitePassDay => row !== null)
+    .sort((a, b) => a.day.localeCompare(b.day));
+
+  const latestValidDay = firstParsed(rawRows, dateString, "latest_valid_day");
+  const computedAt = firstParsed(rawRows, timestampString, "computed_at")
+    ?? firstParsed(rawRows, timestampString, "refreshed_at");
+  const registryReviewedAt = firstParsed(rawRows, timestampString, "registry_reviewed_at");
+  const freshnessRaw = [...rawRows].reverse().find((row) => row.freshness != null)?.freshness;
+  const parsedFreshness = freshness(freshnessRaw);
+  const latestRaw = latestValidDay
+    ? rawRows.find((row) => row.target_day === latestValidDay)
+    : rawRows[rawRows.length - 1];
+  const coverageComplete = latestRaw && typeof latestRaw.coverage_complete === "boolean"
+    ? latestRaw.coverage_complete
+    : null;
+
+  return {
+    rows,
+    latestValidDay,
+    computedAt,
+    registryReviewedAt,
+    scopeCoverageComplete: booleanOrNull(latestRaw?.scope_coverage_complete),
+    chinaIsrCensusComplete: booleanOrNull(latestRaw?.china_isr_census_complete),
+    coverageComplete,
+    freshness: parsedFreshness === "unknown"
+      ? deriveIsrPassFreshness(latestValidDay, computedAt, nowMs)
+      : parsedFreshness,
+    regionKey: String(latestRaw?.region_key ?? regionKey),
+    tierMode: tierModeOrFallback(latestRaw?.tier_mode, tierMode),
+  };
+}
+
+export function hasIsrPassCounts(
+  row: IsrSatellitePassDay | null | undefined,
+): row is IsrSatellitePassDay & { passCount: number; uniqueSatelliteCount: number } {
+  return Boolean(row && row.passCount !== null && row.uniqueSatelliteCount !== null);
+}
+
+async function fetchUncached(
+  days: number,
+  regionKey: string,
+  tierMode: IsrPassTierMode,
+): Promise<IsrSatellitePassReport> {
+  if (!supabaseConfigured) throw new Error("Supabase 尚未設定");
+  const { data, error } = await withLoading(
+    `monitor:isr-passes:${regionKey}:${tierMode}:${days}`,
+    "中國 ISR 衛星領海過境",
+    supabase.rpc("get_isr_satellite_passes_daily", {
+      p_days: days,
+      p_region_key: regionKey,
+      p_tier_mode: tierMode,
+    }),
+  );
+  if (error) throw new Error(`get_isr_satellite_passes_daily: ${error.message}`);
+  return parseIsrSatellitePassReport(data, regionKey, tierMode);
+}
+
+export function fetchIsrSatellitePassesDaily(
+  days = ISR_PASSES_DEFAULT_DAYS,
+  regionKey = ISR_PASSES_DEFAULT_REGION,
+  tierMode: IsrPassTierMode = ISR_PASSES_DEFAULT_TIER_MODE,
+): Promise<IsrSatellitePassReport> {
+  const safeDays = normalizeIsrPassDays(days);
+  const key = `${safeDays}|${regionKey}|${tierMode}`;
+  return cache(key, () => fetchUncached(safeDays, regionKey, tierMode));
+}


### PR DESCRIPTION
## Summary
- add 30-day China ISR territorial-pass bar chart to Monitor dock and split modes
- use pass_count as primary metric and distinct satellite count in tooltip
- expose freshness, registry review, coverage, and v1 census caveats
- preserve missing/null versus complete-scope zero semantics

## Validation
- TypeScript build passed
- production build passed
- 23 targeted tests passed
- full suite: 931 passed, 1 skipped; one unrelated Ookla timeout passed independently with a longer timeout
- local browser acceptance passed for dock/split and explicit RPC-error state

## Dependency
Merge only after production RPC returns verified anonymous results.

## Rollback
Revert the three commits or redeploy the previous successful Zeabur deployment.