### PR TITLE
docs(monitor): record ISR production acceptance

### DIFF
--- a/docs/features/isr-satellite-monitor/README.md
+++ b/docs/features/isr-satellite-monitor/README.md
@@ -1,9 +1,9 @@
 # 中國 ISR 衛星領海過境監測
 
 > **Slug**：`isr-satellite-monitor`
-> **狀態**：release candidate
+> **狀態**：production
 > **Owner**：Mini Taiwan Pulse
-> **上線日期**：frontend 待 PR #185 merge；production RPC 已於 2026-08-30 上線
+> **上線日期**：2026-08-30
 > **相關 PR**：#185
 
 ## 一句話說明
@@ -14,7 +14,7 @@
 
 | 名稱 | 類型 | 資料源 | 狀態 |
 |---|---|---|---|
-| 中國 ISR 衛星領海過境 | Monitor card | `public.get_isr_satellite_passes_daily` RPC | production RPC/backfill ready，frontend 待發布 |
+| 中國 ISR 衛星領海過境 | Monitor card | `public.get_isr_satellite_passes_daily` RPC | ✅ production verified |
 
 ## 關鍵檔案
 

--- a/docs/features/isr-satellite-monitor/backlog.md
+++ b/docs/features/isr-satellite-monitor/backlog.md
@@ -4,8 +4,8 @@
 
 | ID | Category | Priority | State | Outcome | Next action | Acceptance |
 |---|---|---|---|---|---|---|
-| ISR-MON-2 | validation | P1 | in_progress | dock / split 已通過本機 error/null 與範圍警示驗收；production anon RPC 已有 30 日資料 | PR #185 發布後檢查真實柱、tooltip、partial census、stale 與真零狀態 | production Browser 截圖與互動證據 |
 | ISR-MON-3 | data-health | P1 | waiting_external | ISR registry 覆核日期可監測 | 上游確認 registry review SLA 與告警門檻 | `registry_reviewed_at` 有值且逾期狀態有規格 |
+| ISR-MON-5 | data-health | P1 | investigating | collector deploy 後 aggregate `refreshed_at` 已更新，證明排程有執行；但 `metadata.collector_status` 尚無專屬列 | 確認 direct-SQL runtime heartbeat 的 role/RLS，或正式指定 aggregate `refreshed_at` 為健康 SSOT | 專屬 heartbeat 可讀，或文件／告警統一採 aggregate freshness |
 
 ## Decision needed
 
@@ -18,6 +18,7 @@
 - [x] **ISR-MON-0**：完成 frontend loader、Monitor card、dock/split packing 與 null/zero contract tests — 2026-08-30，PR #185；詳見 [changelog.md](./changelog.md)
 - [x] **ISR-MON-0B**：localhost dock/split 均可見卡片；production RPC 尚未套用時正確顯示「更新失敗，不以 0 代替」與 v1 scope 警示 — 2026-08-30
 - [x] **ISR-MON-1**：production migrations、三種 tier mode 各 30 日 backfill 與 anon HTTP RPC 回讀通過 — 2026-08-30
+- [x] **ISR-MON-2**：production Dock／Split 均顯示 30 日柱；最新日 72 次／53 顆，tooltip、freshness、scope 與 census 警示驗收通過，console 無 error — 2026-08-30
 
 ## Explicitly not planned
 

--- a/docs/features/isr-satellite-monitor/changelog.md
+++ b/docs/features/isr-satellite-monitor/changelog.md
@@ -1,6 +1,6 @@
 # Changelog — 中國 ISR 衛星領海過境監測
 
-## 2026-08-30 — Unreleased
+## 2026-08-30 — Released
 
 - 新增 `get_isr_satellite_passes_daily` 暫定契約 loader 與 loadingRegistry。
 - 新增 Monitor 每日直柱卡：主值 `pass_count`、tooltip `unique_satellite_count`。
@@ -9,5 +9,7 @@
 - 明確區分 v1 scope 內真 0、缺日、null、partial China-wide census、stale 與 RPC error；固定標示三家族範圍不是全中國 ISR census。
 - localhost Browser 已驗證 dock/split 卡片接線與 RPC 未上線時的誠實錯誤狀態。
 - production migrations/backfill 已套用；anon HTTP RPC 回傳 30 日資料，最新完整日為 2026-08-29，v1 scope coverage complete 且不宣稱全中國 ISR census。
-- frontend 已建立 PR #185；production 真實柱與 tooltip 驗收待 PR merge／deploy。
+- frontend PR #185 已以 merge commit `f78f24a` 發布；master CI 與 Zeabur deployment 成功。
+- production Browser 驗證 Dock／Split 皆顯示 30 日柱；最新日 72 次／53 顆，tooltip、freshness、scope/census 警示正確，console 無 error。
+- collector PR #64 deployment 後 aggregate `refreshed_at` 已自動更新；專屬 metadata heartbeat 尚無資料列，列入 ISR-MON-5，不以此誤報整體 collector 健康。
 - Breaking：前端依賴平台提供本文 handoff 所列 RPC 欄位；RPC 已於 2026-08-30 上線。

--- a/docs/features/isr-satellite-monitor/handoff.md
+++ b/docs/features/isr-satellite-monitor/handoff.md
@@ -62,7 +62,7 @@ RPC 暫不直接回 `freshness`，前端依以下條件推導：
 
 ## 已知不對稱
 
-- production anon HTTP RPC 已於 2026-08-30 驗證預設參數回傳 30 日資料；frontend production Browser 驗收仍待 PR #185 發布。
+- production anon HTTP RPC 與 frontend Dock／Split Browser 已於 2026-08-30 完成驗收。
 - 過境是星下點與領海 polygon 的幾何事件，不等於感測器實際蒐情。
 - v1 registry 只承諾 YAOGAN／GAOFEN／JILIN 三家族 scope，不代表全中國 ISR census。
 - `twmain_12nm` 的精確 islands inclusion 由上游 region registry 定義，前端不自行 buffer 或改 geometry。


### PR DESCRIPTION
## Summary
- mark ISR Monitor as production after PR #185 deployment
- record Dock/Split live-browser acceptance and observed 72 passes / 53 distinct satellites for 2026-08-29
- preserve the remaining collector heartbeat gap as active ISR-MON-5 rather than claiming it is green

## Evidence
- frontend master CI and Zeabur deployment succeeded
- production anon RPC returned 30 rows
- Dock and Split rendered live 30-day bars
- latest bar tooltip showed 08/29, 72 passes, 53 distinct satellites
- console errors: none
- collector aggregate refreshed after deployment; metadata heartbeat row still absent

## Rollback
Revert commit 43d49b8; documentation only.