### PR TITLE
feat(monitor): add ISR 30D/90D/120D median comparison

### DIFF
--- a/docs/features/isr-satellite-monitor/README.md
+++ b/docs/features/isr-satellite-monitor/README.md
@@ -8,7 +8,7 @@
 
 ## 一句話說明
 
-在 Monitor 以每日直條呈現公開目錄中中國 ISR-capable 候選衛星的星下點穿越臺灣本島 12 浬領海範圍次數，並在 tooltip 顯示當日不重複衛星數。
+在 Monitor 以每日直條呈現公開目錄中中國 ISR-capable 候選衛星的星下點穿越臺灣本島 12 浬領海範圍次數，並在 tooltip 顯示當日不重複衛星數；可切換 30／90／120 個日曆日並比較最新日與期間中位數。
 
 ## 元件
 
@@ -29,6 +29,9 @@
 
 - 主柱：`pass_count`，同一顆衛星同日多次穿越會計多次。
 - Tooltip／副值：`unique_satellite_count`，當日 distinct 衛星數。
+- UI 預設 30D；前端一次取得 120 日資料，30D／90D／120D 切換不重新呼叫 RPC。
+- 各期間以 `latest_valid_day` 為終點往前算真實日曆日，不以「最後 N 筆」代替；明示「可呈現日 X/window」，缺日不補列。
+- 中位數只納入可呈現的非 null `pass_count`；合法真 0 納入，偶數筆取兩個中央值平均。最新日顯示相對中位數的高／低／相等與絕對差。
 - v1 固定標示為 `YAOGAN / GAOFEN / JILIN` 三家族範圍，不宣稱全中國 ISR census。
 - `scope_coverage_complete=true` 且 count 明確為 `0`，才顯示 v1 scope 內的真零；`china_isr_census_complete=false` 不會擋住三家族範圍內的有效計數。
 - 缺日、null、stale 或 RPC error 都不補 0；`coverage_complete=false` 仍可呈現已計得的 partial registry 數字與範圍警示。

--- a/docs/features/isr-satellite-monitor/backlog.md
+++ b/docs/features/isr-satellite-monitor/backlog.md
@@ -19,6 +19,7 @@
 - [x] **ISR-MON-0B**：localhost dock/split 均可見卡片；production RPC 尚未套用時正確顯示「更新失敗，不以 0 代替」與 v1 scope 警示 — 2026-08-30
 - [x] **ISR-MON-1**：production migrations、三種 tier mode 各 30 日 backfill 與 anon HTTP RPC 回讀通過 — 2026-08-30
 - [x] **ISR-MON-2**：production Dock／Split 均顯示 30 日柱；最新日 72 次／53 顆，tooltip、freshness、scope 與 census 警示驗收通過，console 無 error — 2026-08-30
+- [x] **ISR-MON-6**：frontend 完成 30D／90D／120D 日曆窗、期間中位數、最新日差異與 X/window 缺日揭露；production release 仍待上游 `p_days<=120` 與整體發布驗收 — 2026-08-30
 
 ## Explicitly not planned
 

--- a/docs/features/isr-satellite-monitor/changelog.md
+++ b/docs/features/isr-satellite-monitor/changelog.md
@@ -6,6 +6,7 @@
 - 新增期間 `pass_count` 中位數與最新日高／低／相等、絕對差；median 排除 null、保留合法 0，偶數筆取兩中央平均。
 - 顯示「可呈現日 X/window」，不補缺日、不把過境解讀為實際蒐情。
 - Dock／Split 皆將本卡排在「特殊船舶接近帶」後面。
+- 面板底色改為與其他 Monitor 卡一致的中性灰，不再使用紫色漸層。
 - Breaking dependency：RPC `p_days` 上限需由 31 擴至 120。
 
 ## 2026-08-30 — Released

--- a/docs/features/isr-satellite-monitor/changelog.md
+++ b/docs/features/isr-satellite-monitor/changelog.md
@@ -1,11 +1,19 @@
 # Changelog — 中國 ISR 衛星領海過境監測
 
+## Unreleased
+
+- 新增 30D／90D／120D 期間切換，預設 30D；前端一次取 120 日後依 `latest_valid_day` 日曆窗篩選，切窗不重打 RPC。
+- 新增期間 `pass_count` 中位數與最新日高／低／相等、絕對差；median 排除 null、保留合法 0，偶數筆取兩中央平均。
+- 顯示「可呈現日 X/window」，不補缺日、不把過境解讀為實際蒐情。
+- Dock／Split 皆將本卡排在「特殊船舶接近帶」後面。
+- Breaking dependency：RPC `p_days` 上限需由 31 擴至 120。
+
 ## 2026-08-30 — Released
 
 - 新增 `get_isr_satellite_passes_daily` 暫定契約 loader 與 loadingRegistry。
 - 新增 Monitor 每日直柱卡：主值 `pass_count`、tooltip `unique_satellite_count`。
 - 接入 dock / split 佈局與 packing tests。
-- `p_days` 預設 30、上限 31，符合 RPC `1..31` 契約。
+- 當時前端明確請求 `p_days=30`，RPC 上限 31；後續期間切換擴約見 Unreleased。
 - 明確區分 v1 scope 內真 0、缺日、null、partial China-wide census、stale 與 RPC error；固定標示三家族範圍不是全中國 ISR census。
 - localhost Browser 已驗證 dock/split 卡片接線與 RPC 未上線時的誠實錯誤狀態。
 - production migrations/backfill 已套用；anon HTTP RPC 回傳 30 日資料，最新完整日為 2026-08-29，v1 scope coverage complete 且不宣稱全中國 ISR census。

--- a/docs/features/isr-satellite-monitor/handoff.md
+++ b/docs/features/isr-satellite-monitor/handoff.md
@@ -9,8 +9,10 @@
 - RPC：`public.get_isr_satellite_passes_daily(p_days, p_region_key, p_tier_mode)`
 - 更新頻率：每日批次；前端每 30 分鐘檢查一次並以 30 分鐘 TTL 去重
 - 日界：Asia/Taipei
-- `p_days` 契約：`1..31`；前端預設 30，超過 31 會 clamp 為 31
-- 預設：`p_days=30`、`p_region_key='twmain_12nm'`、`p_tier_mode='confirmed_plus_dual_use'`
+- `p_days` 契約：`1..120`；前端固定取 120 日，超過 120 會 clamp 為 120
+- RPC 參數預設仍為 `p_days=7`；一般 loader 呼叫預設仍為 30，Monitor card 明確請求 120
+- Monitor 查詢：`p_days=120`、`p_region_key='twmain_12nm'`、`p_tier_mode='confirmed_plus_dual_use'`
+- UI 預設 30D，可切換 30D／90D／120D；切換只篩已取得資料，不重新呼叫 RPC
 - tier modes：`confirmed_only` / `confirmed_plus_dual_use` / `all_non_excluded`
 
 ## 前端接線位置
@@ -38,6 +40,8 @@
 
 缺少的 calendar day 不由前端補列，也不補 0。
 圖表只保留 `target_day <= latest_valid_day`；`latest_valid_day` 之後的未完成日不呈現。
+期間以 `latest_valid_day` 為終點往前算 30／90／120 個日曆日，不使用最後 N 筆資料；UI 顯示可呈現日 X/window。
+期間 median 只納入可呈現的非 null `pass_count`，合法 0 納入，偶數筆取兩中央值平均；最新日與 median 顯示高／低／相等及絕對差。
 
 `coverage_complete=false` 可能仍回 partial registry 計數，前端會保留數字並搭配固定範圍警示；卡片不得將這種情況當成無資料。卡片固定顯示「v1 YAOGAN／GAOFEN／JILIN 範圍，非全中國 ISR census」。
 
@@ -59,6 +63,7 @@ RPC 暫不直接回 `freshness`，前端依以下條件推導：
 | 日界改動 | 更新日期標籤、freshness 推導與 tooltip |
 | coverage 定義改動 | 重新驗證 scoped true-zero 與 partial China-wide census 的顯示規則 |
 | tier enum 改動 | 更新 TypeScript union 與預設模式 |
+| `p_days` 上限低於 120 | 90D／120D 不可發布；先擴約並完成 RPC contract 驗證 |
 
 ## 已知不對稱
 

--- a/src/components/intel/monitor/IsrSatellitePassCard.tsx
+++ b/src/components/intel/monitor/IsrSatellitePassCard.tsx
@@ -5,9 +5,12 @@ import { SectionLabel } from "./PressureRing";
 import { HazardTrendBars, type HazardBar } from "./HazardTrendBars";
 import {
   fetchIsrSatellitePassesDaily,
-  ISR_PASSES_DEFAULT_DAYS,
+  ISR_PASSES_DEFAULT_WINDOW_DAYS,
   ISR_PASSES_DEFAULT_REGION,
   ISR_PASSES_DEFAULT_TIER_MODE,
+  ISR_PASSES_FETCH_DAYS,
+  ISR_PASSES_WINDOW_OPTIONS,
+  type IsrPassWindowDays,
   type IsrSatellitePassReport,
 } from "../../../data/isrSatellitePassesLoader";
 
@@ -27,6 +30,13 @@ export interface IsrLatestDisplay {
   passCount: number | null;
   uniqueSatelliteCount: number | null;
   day: string | null;
+}
+
+export type IsrMedianDirection = "higher" | "lower" | "equal" | "unknown";
+
+export interface IsrMedianComparison {
+  direction: IsrMedianDirection;
+  difference: number | null;
 }
 
 /** 頭部只讀 latest_valid_day；全中國 census 不完整不會擋住 v1 scope 內計數。 */
@@ -61,17 +71,62 @@ export function buildIsrPassBars(
   latestValidDay: string | null,
 ): HazardBar[] {
   if (!latestValidDay) return [];
-  return rows.filter((row) => row.day <= latestValidDay).map((row) => ({
-    label: `${row.day.slice(5, 7)}/${row.day.slice(8, 10)}`,
-    key: row.day,
-    value: row.passCount !== null && (row.passCount !== 0 || scopeCoverageComplete === true)
-      ? row.passCount
-      : null,
-    level: 0,
-    note: row.passCount !== null && row.uniqueSatelliteCount !== null
-      ? `不重複衛星 ${row.uniqueSatelliteCount} 顆`
-      : "計數缺失，非 0",
-  }));
+  return rows.filter((row) => row.day <= latestValidDay).map((row) => {
+    const countIsDisplayable = row.passCount !== null
+      && (row.passCount !== 0 || scopeCoverageComplete === true);
+    return {
+      label: `${row.day.slice(5, 7)}/${row.day.slice(8, 10)}`,
+      key: row.day,
+      value: countIsDisplayable ? row.passCount : null,
+      level: 0,
+      note: countIsDisplayable
+        ? row.uniqueSatelliteCount !== null
+          ? `不重複衛星 ${row.uniqueSatelliteCount} 顆`
+          : "過境次數可呈現；不重複衛星數缺失"
+        : "過境計數缺失或 scope 不完整，非 0",
+    };
+  });
+}
+
+/**
+ * 以 latest_valid_day 為日曆窗終點，而不是取最後 N 筆；缺日不合成列。
+ */
+export function selectIsrPassWindow(
+  rows: IsrSatellitePassReport["rows"],
+  latestValidDay: string | null,
+  windowDays: IsrPassWindowDays,
+): IsrSatellitePassReport["rows"] {
+  if (!latestValidDay) return [];
+  const anchorMs = Date.parse(`${latestValidDay}T00:00:00Z`);
+  if (!Number.isFinite(anchorMs)) return [];
+  const firstDay = new Date(anchorMs - (windowDays - 1) * 86_400_000)
+    .toISOString()
+    .slice(0, 10);
+  return rows.filter((row) => row.day >= firstDay && row.day <= latestValidDay);
+}
+
+/** null 不納入；0 是合法觀測值；偶數筆取兩個中央值平均。 */
+export function medianOfIsrPassCounts(values: ReadonlyArray<number | null>): number | null {
+  const valid = values
+    .filter((value): value is number => value !== null)
+    .sort((a, b) => a - b);
+  if (!valid.length) return null;
+  const midpoint = Math.floor(valid.length / 2);
+  return valid.length % 2 === 1
+    ? valid[midpoint]!
+    : (valid[midpoint - 1]! + valid[midpoint]!) / 2;
+}
+
+export function compareLatestToMedian(
+  latest: number | null,
+  median: number | null,
+): IsrMedianComparison {
+  if (latest === null || median === null) return { direction: "unknown", difference: null };
+  if (latest === median) return { direction: "equal", difference: 0 };
+  return {
+    direction: latest > median ? "higher" : "lower",
+    difference: Math.abs(latest - median),
+  };
 }
 
 const DISPLAY_LABEL: Record<Exclude<IsrLatestDisplayKind, "ready">, string> = {
@@ -99,16 +154,37 @@ function formatTimestamp(value: string | null): string {
   }).format(parsed);
 }
 
+function formatMetric(value: number | null): string {
+  if (value === null) return "—";
+  return Number.isInteger(value) ? String(value) : value.toFixed(1);
+}
+
+const MEDIAN_DIRECTION_LABEL: Record<Exclude<IsrMedianDirection, "unknown">, string> = {
+  higher: "↑ 高於中位數",
+  lower: "↓ 低於中位數",
+  equal: "＝ 等於中位數",
+};
+
+const MEDIAN_DIRECTION_COLOR: Record<IsrMedianDirection, string> = {
+  higher: "#c4b5fd",
+  lower: "#93c5fd",
+  equal: COLORS.textMuted,
+  unknown: COLORS.textFaint,
+};
+
 export function IsrSatellitePassCard({ open = true }: { open?: boolean }) {
   const [report, setReport] = useState<IsrSatellitePassReport | null>(null);
   const [state, setState] = useState<LoadState>("loading");
+  const [windowDays, setWindowDays] = useState<IsrPassWindowDays>(
+    ISR_PASSES_DEFAULT_WINDOW_DAYS,
+  );
 
   useEffect(() => {
     if (!open) return;
     let cancelled = false;
     const tick = () => {
       setState((current) => (current === "ready" ? current : "loading"));
-      fetchIsrSatellitePassesDaily()
+      fetchIsrSatellitePassesDaily(ISR_PASSES_FETCH_DAYS)
         .then((next) => {
           if (cancelled) return;
           setReport(next);
@@ -126,19 +202,35 @@ export function IsrSatellitePassCard({ open = true }: { open?: boolean }) {
   }, [open]);
 
   const latest = deriveIsrLatestDisplay(report, state);
+  const windowRows = useMemo(
+    () => selectIsrPassWindow(
+      report?.rows ?? [],
+      report?.latestValidDay ?? null,
+      windowDays,
+    ),
+    [report, windowDays],
+  );
   const bars = useMemo(
     () => buildIsrPassBars(
-      report?.rows ?? [],
+      windowRows,
       report?.scopeCoverageComplete ?? null,
       report?.latestValidDay ?? null,
     ),
-    [report],
+    [report?.latestValidDay, report?.scopeCoverageComplete, windowRows],
   );
   const countedBars = useMemo(
     () => bars.filter((bar): bar is HazardBar & { value: number } => bar.value !== null),
     [bars],
   );
   const peak = countedBars.length ? Math.max(...countedBars.map((bar) => bar.value)) : null;
+  const medianPassCount = useMemo(
+    () => medianOfIsrPassCounts(bars.map((bar) => bar.value)),
+    [bars],
+  );
+  const medianComparison = compareLatestToMedian(
+    latest.kind === "ready" ? latest.passCount : null,
+    medianPassCount,
+  );
 
   return (
     <div style={{ display: "flex", flexDirection: "column", gap: 8, fontFamily: FONT_CJK }}>
@@ -170,14 +262,60 @@ export function IsrSatellitePassCard({ open = true }: { open?: boolean }) {
           )}
         </div>
 
+        <div
+          role="group"
+          aria-label="過境統計期間"
+          style={{ display: "flex", gap: 4 }}
+        >
+          {ISR_PASSES_WINDOW_OPTIONS.map((option) => {
+            const selected = option === windowDays;
+            return (
+              <button
+                key={option}
+                type="button"
+                onClick={() => setWindowDays(option)}
+                aria-pressed={selected}
+                title={`顯示 latest_valid_day 往前 ${option} 個日曆日`}
+                style={{
+                  fontSize: 9,
+                  padding: "2px 7px",
+                  borderRadius: RADIUS.sm,
+                  cursor: "pointer",
+                  fontFamily: FONT_DATA,
+                  background: selected ? COLORS.accentFaint : "transparent",
+                  color: selected ? COLORS.textStrong : COLORS.textDim,
+                  border: `1px solid ${selected ? COLORS.borderStrong : COLORS.borderSoft}`,
+                }}
+              >
+                {option}D
+              </button>
+            );
+          })}
+        </div>
+
+        <div
+          style={{
+            display: "flex", alignItems: "center", gap: "4px 10px", flexWrap: "wrap",
+            fontFamily: FONT_DATA, fontSize: 9, color: COLORS.textDim,
+          }}
+        >
+          <span>{windowDays}D 中位數 {formatMetric(medianPassCount)} 次／日</span>
+          <span>可呈現日 {countedBars.length}/{windowDays} · 缺日不補 0</span>
+          <span style={{ color: MEDIAN_DIRECTION_COLOR[medianComparison.direction] }}>
+            {medianComparison.direction === "unknown"
+              ? "最新日比較 —"
+              : `最新 ${MEDIAN_DIRECTION_LABEL[medianComparison.direction]} · 差 ${formatMetric(medianComparison.difference)} 次`}
+          </span>
+        </div>
+
         {bars.length > 0 && (
           <HazardTrendBars
             bars={bars}
             levelColors={["#8b5cf6"]}
             height={74}
             unit="次"
-            caption={`${ISR_PASSES_DEFAULT_DAYS}D · 過境事件（柱）／不重複衛星（tooltip）`}
-            footer={peak === null ? undefined : `可呈現日 ${countedBars.length}/${bars.length} · 單日最高 ${peak} 次`}
+            caption={`${windowDays}D · 過境事件（柱）／不重複衛星（tooltip）`}
+            footer={`可呈現日 ${countedBars.length}/${windowDays} · 缺日不補 0${peak === null ? "" : ` · 單日最高 ${peak} 次`}`}
           />
         )}
 

--- a/src/components/intel/monitor/IsrSatellitePassCard.tsx
+++ b/src/components/intel/monitor/IsrSatellitePassCard.tsx
@@ -239,7 +239,7 @@ export function IsrSatellitePassCard({ open = true }: { open?: boolean }) {
         style={{
           borderRadius: RADIUS.xl,
           border: `1px solid ${COLORS.panelBorder}`,
-          background: "linear-gradient(160deg, rgba(139,92,246,0.08), rgba(255,255,255,0.012))",
+          background: "rgba(255,255,255,0.02)",
           padding: "11px 13px",
           display: "flex", flexDirection: "column", gap: 9,
         }}

--- a/src/components/intel/monitor/__tests__/isrSatellitePassCard.test.ts
+++ b/src/components/intel/monitor/__tests__/isrSatellitePassCard.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { buildIsrPassBars, deriveIsrLatestDisplay } from "../IsrSatellitePassCard";
+import {
+  buildIsrPassBars,
+  compareLatestToMedian,
+  deriveIsrLatestDisplay,
+  medianOfIsrPassCounts,
+  selectIsrPassWindow,
+} from "../IsrSatellitePassCard";
 import type { IsrSatellitePassReport } from "../../../../data/isrSatellitePassesLoader";
 
 function report(overrides: Partial<IsrSatellitePassReport> = {}): IsrSatellitePassReport {
@@ -62,5 +68,69 @@ describe("ISR pass card zero/null semantics", () => {
       { day: "2026-08-30", passCount: 1, uniqueSatelliteCount: 1, coverageComplete: false },
     ], true, "2026-08-29");
     expect(bars.map((bar) => bar.key)).toEqual(["2026-08-29"]);
+  });
+});
+
+describe("ISR pass card calendar windows", () => {
+  it("anchors the 30D window at latest_valid_day without synthesizing missing days", () => {
+    const rows: IsrSatellitePassReport["rows"] = [
+      { day: "2026-07-31", passCount: 1, uniqueSatelliteCount: 1, coverageComplete: true },
+      { day: "2026-08-01", passCount: 2, uniqueSatelliteCount: 2, coverageComplete: true },
+      { day: "2026-08-15", passCount: null, uniqueSatelliteCount: null, coverageComplete: false },
+      { day: "2026-08-30", passCount: 4, uniqueSatelliteCount: 3, coverageComplete: true },
+      { day: "2026-08-31", passCount: 5, uniqueSatelliteCount: 4, coverageComplete: true },
+    ];
+
+    expect(selectIsrPassWindow(rows, "2026-08-30", 30).map((row) => row.day)).toEqual([
+      "2026-08-01",
+      "2026-08-15",
+      "2026-08-30",
+    ]);
+  });
+
+  it("returns no window when latest_valid_day is unavailable", () => {
+    expect(selectIsrPassWindow(report().rows, null, 120)).toEqual([]);
+  });
+
+  it("uses inclusive calendar boundaries for the 90D and 120D windows", () => {
+    const rows: IsrSatellitePassReport["rows"] = [
+      { day: "2026-05-02", passCount: 1, uniqueSatelliteCount: 1, coverageComplete: true },
+      { day: "2026-05-03", passCount: 2, uniqueSatelliteCount: 2, coverageComplete: true },
+      { day: "2026-06-01", passCount: 3, uniqueSatelliteCount: 3, coverageComplete: true },
+      { day: "2026-06-02", passCount: 4, uniqueSatelliteCount: 4, coverageComplete: true },
+      { day: "2026-08-30", passCount: 5, uniqueSatelliteCount: 5, coverageComplete: true },
+    ];
+
+    expect(selectIsrPassWindow(rows, "2026-08-30", 90).map((row) => row.day)).toEqual([
+      "2026-06-02",
+      "2026-08-30",
+    ]);
+    expect(selectIsrPassWindow(rows, "2026-08-30", 120).map((row) => row.day)).toEqual([
+      "2026-05-03",
+      "2026-06-01",
+      "2026-06-02",
+      "2026-08-30",
+    ]);
+  });
+});
+
+describe("ISR pass card median comparison", () => {
+  it("excludes null but includes a legitimate zero in an odd-sized median", () => {
+    expect(medianOfIsrPassCounts([0, null, 4, 2])).toBe(2);
+  });
+
+  it("averages the two central values for an even-sized median", () => {
+    expect(medianOfIsrPassCounts([0, 2, null, 8, 10])).toBe(5);
+  });
+
+  it("keeps an all-missing window unknown instead of turning it into zero", () => {
+    expect(medianOfIsrPassCounts([null, null])).toBeNull();
+  });
+
+  it("reports higher, lower and equal with an absolute difference", () => {
+    expect(compareLatestToMedian(8, 5.5)).toEqual({ direction: "higher", difference: 2.5 });
+    expect(compareLatestToMedian(3, 5.5)).toEqual({ direction: "lower", difference: 2.5 });
+    expect(compareLatestToMedian(5.5, 5.5)).toEqual({ direction: "equal", difference: 0 });
+    expect(compareLatestToMedian(null, 5.5)).toEqual({ direction: "unknown", difference: null });
   });
 });

--- a/src/components/intel/monitor/__tests__/monitorPacking.test.ts
+++ b/src/components/intel/monitor/__tests__/monitorPacking.test.ts
@@ -139,9 +139,9 @@ describe("monitorPacking · split dock（右半邊窄版）", () => {
     expect(head.children.map(nodeWidth)).toEqual([6, 6]);
   });
 
-  it("軍事態勢尾段依序為 PLA、ISR、特殊船舶、台鐵", () => {
+  it("軍事態勢尾段依序為 PLA、特殊船舶、ISR、台鐵", () => {
     expect(
       items.filter((item) => item.y >= 92).map((item) => item.i),
-    ).toEqual(["plaBoard", "isrSatellitePasses", "vesselZone", "traDelay"]);
+    ).toEqual(["plaBoard", "vesselZone", "isrSatellitePasses", "traDelay"]);
   });
 });

--- a/src/components/intel/monitor/monitorLayout.ts
+++ b/src/components/intel/monitor/monitorLayout.ts
@@ -114,6 +114,8 @@ export const MONITOR_GRID_GAP = 10;
  *   維持左右欄同止 y68。⚠ 本版座標為接線時暫定、非沙盒匯出，定稿請回沙盒重拖。
  * - 2026-08-30 十二版 — 上半事件區與下半雙欄之間插入全寬 internetHealth 狀態卡；
  *   下半整體 +4，左右欄同止改為 y72。
+ * - 2026-08-30 十三版 — 軍事態勢尾段改為特殊船舶 → ISR 衛星 → 台鐵；
+ *   左右欄仍同止於 y80。
  */
 export const MONITOR_LAYOUT: MonitorGridItem[] = [
   { i: "newsFeed", x: 0, y: 0, w: 4, h: 12 },
@@ -160,27 +162,21 @@ export const MONITOR_LAYOUT: MonitorGridItem[] = [
   // 迷你走勢圖會擠到看不出形狀；w7 每格約 280px 才讀得出趨勢。
   // h 9→12（2026-08-10）：多出的高度全部灌進四張卡的走勢圖（SPARK_H 34→52 + flex:1）。
   // y 48→56（同上，跟著 powerCard 下移）
-  // h 12→20：fit:"content" 不改實際高度，只讓右欄跨過 y72、與新增的 ISR 卡同止 y80，
+  // h 12→20：fit:"content" 不改實際高度，只讓右欄跨過軍事態勢尾段、同止 y80，
   // 維持頂層「下方左右兩欄（5+7）」而不切出第三個全寬段。
   { i: "foodPriceBoard", x: 5, y: 60, w: 7, h: 20, fit: "content" },
   // 特殊船舶接近帶（2026-08-20，VZ-4）：左欄收尾，與共機卡同寬 w5。
-  // ⚠️ y61→72 是刻意算過的：原本左欄止於 y61（airportPax）、右欄止於 y72
-  // （foodPriceBoard），兩欄不同止。本格補滿左欄到 y72 後**左右欄同時結束**，
-  // 頂層才維持「上方三欄 + 下方左右兩欄(5+7)」的兩段結構
-  // （monitorPacking.test.ts 有斷言；第一版放最底部全寬 w12 會多切出第三段）。
+  // ⚠️ y61 起的三張左欄卡與 foodPriceBoard 同止 y80，頂層才維持
+  // 「上方三欄 + 下方左右兩欄(5+7)」的兩段結構（packing test 有斷言）。
   // 也刻意不用 w12：全寬約 1200px，柱狀圖會被拉到看不出形狀，w5 與 plaBoard 一致。
-  // h 11→6（2026-08-22）：純粹讓出左欄尾段給 traDelay。兩格都是 fit:"content"，
+  // h 11→6（2026-08-22）：純粹讓出左欄尾段給後續卡片。三格都是 fit:"content"，
   // h 不是實際高度、只決定欄內順序與拆解，所以縮 h 不會壓縮畫面上的船舶卡。
   { i: "vesselZone", x: 0, y: 61, w: 5, h: 6, fit: "content" },
-  // 台鐵誤點（2026-08-22，migration 369）。
-  // ⚠️ 為什麼卡在 y67–72 而不是接在最底部：左右兩欄必須**同時結束**於 y72。
-  // 先前試過接在同止點（左欄再向下延伸），其下只剩左欄 → guillotine 在那裡切出
-  // 貫穿全寬的第三段，monitorPacking「頂層拆成上方三欄 + 下方左右兩欄」直接紅。
-  // 版面要正式定稿請回沙盒拖完重新匯出整份 MONITOR_LAYOUT。
-  { i: "traDelay", x: 0, y: 67, w: 5, h: 5, fit: "content" },
-  // 中國 ISR 衛星領海過境頻率：左欄軍事態勢尾段；右欄由 foodPriceBoard 的排序佔位
-  // 跨過 y72，兩欄同止 y80（fit h 只影響 packing，不改卡片實際高度）。
-  { i: "isrSatellitePasses", x: 0, y: 72, w: 5, h: 8, fit: "content" },
+  // 中國 ISR 衛星領海過境頻率：接在特殊船舶後，形成海域 → 太空的態勢順序。
+  { i: "isrSatellitePasses", x: 0, y: 67, w: 5, h: 8, fit: "content" },
+  // 台鐵誤點收尾；右欄由 foodPriceBoard 跨過同一排序範圍，左右同止 y80。
+  // fit h 只影響 packing，不改卡片實際高度。
+  { i: "traDelay", x: 0, y: 75, w: 5, h: 5, fit: "content" },
 ];
 
 /** 沙盒 hidden 清單 — 列在這裡的 widget 不渲染（histogram 與時間軸新聞密度重複，2026-07-26 移除） */

--- a/src/components/intel/monitor/monitorSplitLayout.ts
+++ b/src/components/intel/monitor/monitorSplitLayout.ts
@@ -126,10 +126,10 @@ export const MONITOR_LAYOUT_SPLIT: MonitorGridItem[] = [
   { i: "erCongestion", x: 0, y: 77, w: 12, h: 11, fit: "content" },
   { i: "situationOverview", x: 0, y: 88, w: 12, h: 4, fit: "content" },
   { i: "plaBoard", x: 0, y: 92, w: 12, h: 12, fit: "content" },
-  // 中國 ISR 衛星過境：與共機／特殊船舶同屬軍事態勢，窄版用全寬保留日柱可讀性。
-  { i: "isrSatellitePasses", x: 0, y: 104, w: 12, h: 8, fit: "content" },
-  // 接在共機卡之後 —— 兩者同屬「軍事態勢」，一個看空域一個看海域
-  { i: "vesselZone", x: 0, y: 112, w: 12, h: 10, fit: "content" },
+  // 接在共機卡之後 —— 兩者同屬「軍事態勢」，一個看空域一個看海域。
+  { i: "vesselZone", x: 0, y: 104, w: 12, h: 10, fit: "content" },
+  // 中國 ISR 衛星過境接在特殊船舶後；窄版用全寬保留日柱可讀性。
+  { i: "isrSatellitePasses", x: 0, y: 114, w: 12, h: 8, fit: "content" },
   // 台鐵誤點（2026-08-22）：窄版底部沿用全寬堆疊，不影響「兩欄同止」規則。
   { i: "traDelay", x: 0, y: 122, w: 12, h: 8, fit: "content" },
 ];

--- a/src/data/__tests__/isrSatellitePassesLoader.test.ts
+++ b/src/data/__tests__/isrSatellitePassesLoader.test.ts
@@ -2,6 +2,9 @@ import { describe, expect, it } from "vitest";
 import {
   deriveIsrPassFreshness,
   hasIsrPassCounts,
+  ISR_PASSES_DEFAULT_DAYS,
+  ISR_PASSES_DEFAULT_WINDOW_DAYS,
+  ISR_PASSES_FETCH_DAYS,
   normalizeIsrPassDays,
   parseIsrSatellitePassReport,
 } from "../isrSatellitePassesLoader";
@@ -72,10 +75,18 @@ describe("ISR satellite daily pass RPC contract", () => {
     expect(report.rows.map((row) => row.day)).toEqual(["2026-08-27", "2026-08-29"]);
   });
 
-  it("normalizes p_days to the RPC's 1..31 contract", () => {
+  it("loads 120 days once while keeping the default UI window at 30 days", () => {
+    expect(ISR_PASSES_FETCH_DAYS).toBe(120);
+    expect(ISR_PASSES_DEFAULT_DAYS).toBe(30);
+    expect(ISR_PASSES_DEFAULT_WINDOW_DAYS).toBe(30);
+  });
+
+  it("normalizes p_days to the RPC's 1..120 contract", () => {
     expect(normalizeIsrPassDays(1)).toBe(1);
     expect(normalizeIsrPassDays(31)).toBe(31);
-    expect(normalizeIsrPassDays(90)).toBe(31);
+    expect(normalizeIsrPassDays(90)).toBe(90);
+    expect(normalizeIsrPassDays(120)).toBe(120);
+    expect(normalizeIsrPassDays(121)).toBe(120);
     expect(normalizeIsrPassDays(0)).toBe(30);
     expect(normalizeIsrPassDays(1.5)).toBe(30);
   });

--- a/src/data/isrSatellitePassesLoader.ts
+++ b/src/data/isrSatellitePassesLoader.ts
@@ -2,8 +2,14 @@ import { supabase, supabaseConfigured } from "../lib/supabase";
 import { withLoading } from "../lib/loadingRegistry";
 import { keyedThunkCache } from "../lib/loaderCache";
 
+export const ISR_PASSES_WINDOW_OPTIONS = [30, 90, 120] as const;
+export type IsrPassWindowDays = typeof ISR_PASSES_WINDOW_OPTIONS[number];
+export const ISR_PASSES_DEFAULT_WINDOW_DAYS: IsrPassWindowDays = 30;
+/** 一次取足所有 UI 日曆窗；切窗不重新呼叫 RPC。 */
+export const ISR_PASSES_FETCH_DAYS = 120;
+/** 保留 loader 的既有呼叫預設；需要完整切窗的 card 會明確傳 120。 */
 export const ISR_PASSES_DEFAULT_DAYS = 30;
-export const ISR_PASSES_MAX_DAYS = 31;
+export const ISR_PASSES_MAX_DAYS = ISR_PASSES_FETCH_DAYS;
 export const ISR_PASSES_DEFAULT_REGION = "twmain_12nm";
 export const ISR_PASSES_DEFAULT_TIER_MODE = "confirmed_plus_dual_use";
 


### PR DESCRIPTION
## Summary
- add 30D / 90D / 120D controls, defaulting to 30D while fetching 120 days once
- calculate the selected-window median from non-null daily pass counts, preserving legitimate zero; show whether the latest complete day is higher, lower, or equal
- anchor windows at latest_valid_day, expose visible-day coverage, and never synthesize missing days
- place the ISR card after Special Vessel Approach in dock and split layouts
- use the neutral gray Monitor card background instead of the purple gradient

## Validation
- 98 test files passed: 953 tests passed, 1 skipped
- production build passed
- upstream gis-platform PR #73 merged and production RPC verified: 120 rows, no null/incomplete days, HTTP 200 in ~0.41s
- production medians for acceptance: 30D 94, 90D 94.5, 120D 95.5; latest complete day 72

## Semantics
Ground-track crossings are a public-orbit proxy and do not prove payload activation, tasking, or actual intelligence collection.