### PR TITLE
feat(monitor): surface RIPE internet health evidence

### DIFF
--- a/docs/features/internet-health/handoff.md
+++ b/docs/features/internet-health/handoff.md
@@ -3,7 +3,8 @@
 ## 產品目的
 
 在 Monitor 顯示臺灣目前的電信與網路狀態。這是多來源狀態卡，不是地圖圖層：
-Cloudflare Radar、IODA 與 NCDR evidence 只顯示文字／數值，不替 ASN、國家狀態或缺資料區域製造 geometry。
+Cloudflare Radar、IODA、RIPE Atlas、RIPE RIS Live 與 NCDR evidence 只顯示文字／數值，
+不替 ASN、prefix、國家狀態或缺資料區域製造 geometry。
 
 ## 上游契約
 
@@ -33,10 +34,33 @@ is_stale, active_incident_id, incident_status, metadata
 3. RPC 的 `row_type = status` 中，`evidence_family = composite` 才正規化為 detector；其他 status rows 是 provider evidence，`official_evidence` 是 NCDR 正向證據。
 4. 有 fresh detector 時，以 detector composite 加 active official evidence 的 `effective_status` 為總體真相；沒有 detector 時才保守退回 fresh rows。
 5. `confidence` 的 RPC 值為 0–1；前端以 `<0.5 / 0.5–<0.8 / ≥0.8` 顯示 low / medium / high。
-6. `normal` 仍至少需要 Cloudflare Radar 與 IODA 兩個 fresh evidence 都是 normal。
+6. `normal` 只接受 fresh composite detector 且 `metadata.normal_quorum_met = true`；metadata 缺欄或 false 都回到 unknown。
 7. NCDR 無 row 或 0 alerts 只能顯示「未通報／無資料」，不可單獨證明正常。
 8. active incident 只列 entity name/id、類型與時間。
 9. 不新增 LayerVisibility、Mapbox source、overlay、popup 或 ASN geometry。
+
+## RIPE 擴充契約（2026-08-31）
+
+- `source = ripe_atlas`、`evidence_family = ripe_atlas`：active probing evidence。
+- `source = ripe_ris_live`、`evidence_family = ripe_ris`：BGP routing evidence。
+- detector 維持 `source = internet_health_detector_v1`、`evidence_family = composite`、
+  `signal = internet_health`。
+- IODA、RIPE Atlas 與 RIPE RIS provider rows 初期皆為 internal-only；public RPC 不回傳其
+  normalized/raw 明細。前端以 LIMITED 呈現；只有 composite metadata 明示時才標 fresh／stale，
+  metadata 缺欄則顯示 freshness 未知，不把缺 row 說成來源故障。
+- Public-safe composite metadata 可包含：`detector_version`、`normal_quorum_met`、
+  `fresh_evidence_families`、`stale_evidence_families`、`restricted_evidence_families`、
+  `dependency_groups`、`evidence_class_count`、`coverage_gate_met`、`decision_reasons`。
+  前端只讀取已知欄位，缺欄保持 unknown。
+- `normal` 只接受 fresh composite detector 且 `metadata.normal_quorum_met = true`；不再要求
+  永遠不公開的 IODA provider row。Provider-only normal、stale composite 或缺 quorum metadata
+  都必須顯示「資料不足」。
+- 來源列區分 `fresh / stale / missing / restricted`，公開 evidence 才顯示 signal、value、
+  sample count、資料年齡與 confidence。受限來源只顯示 detector metadata 揭露的 family freshness，
+  不推測或洩露 raw metrics。
+
+既有 `ripeAtlasProbes` 是 3,000 點全球靜態 connected-probe metadata 概覽，座標經模糊化且有
+志願者偏差；本卡不以 country／ASN／BGP 狀態替探針染色。RIPE RIS prefix／ASN 也不建立 geometry。
 
 ## 前端觸點
 
@@ -46,23 +70,30 @@ is_stale, active_incident_id, incident_status, metadata
 - `src/components/intel/monitor/monitorLayout.ts`：dock/wall 全寬位置。
 - `src/components/intel/monitor/monitorSplitLayout.ts`：split 全寬位置。
 
+RIPE 擴充只修改 loader、卡片、tests 與本文件。`MonitorPanel`／兩份 layout、layer manifest、
+overlay registry、legend、popup、click registry 與既有 `ripeAtlasProbes` asset 均維持不變。
+
 既有 `lifelineAlerts` 仍負責 NCDR CAP 地圖：只有上游真的提供 geometry 才渲染；本卡不複製或推測其範圍。
 
 ## 驗收邊界
 
 - RPC migration 未 apply 前，卡片應誠實顯示「資料不足」，不代表前端壞掉。
 - Browser live gate 必須把卡片與實際 RPC rows、`source_updated_at`、`is_stale` 逐項對照。
-- 單元測試覆蓋 stale、空資料、NCDR-only normal、雙來源 normal、incident 與 null 語意。
+- 單元測試覆蓋 stale、空資料、NCDR-only normal、composite quorum、受限來源、incident 與 null 語意。
 - 正式上線仍需 migration apply、collector fresh data、RPC anonymous grant、browser QA 與 deploy 分別確認。
 
 ## Browser live gate
 
-1. 確認 migration 已 apply，且 RPC 用 anonymous session 呼叫 country/TW 能回 fresh detector 與 provider rows。
+1. 確認 migration 已 apply，且 RPC 用 anonymous session 呼叫 country/TW 能回 fresh detector；只有
+   `public_rpc_enabled=true` 的 provider rows 會回傳，IODA 與兩個 RIPE provider rows 缺席是預期政策。
 2. 啟動前端並開啟 Monitor；`電信與網路 · CONNECTIVITY` 應位於事件區下方、全寬、不壓到下方雙欄卡片。
 3. 在 browser Network 面板確認 request 是 `get_internet_health_status`，參數為 country、`[TW]`、include evidence、limit 500。
-4. 逐列對照 Cloudflare／IODA／NCDR 的狀態、metric、最後資料時間；null 必須是 `—`，NCDR 缺 row 必須是「未通報／無資料」。
+4. 逐列對照 Cloudflare／IODA／RIPE Atlas／RIPE RIS Live／NCDR；公開來源顯示狀態、metric、
+   sample、confidence 與資料年齡，受限來源顯示 LIMITED 與 detector family freshness；null 必須是 `—`，
+   NCDR 缺 row 必須是「未通報／無資料」。
 5. 用 stale 或空資料 fixture 驗證總體為「資料不足」且 fresh sources 為 0；用 RPC 失敗驗證舊 normal 不會繼續亮綠。
-6. 用 fresh detector + Cloudflare + IODA fixture 驗證 normal quorum；加入 active NCDR official evidence 時驗證 outage 與 incident 摘要。
+6. 用 fresh detector + `normal_quorum_met=true` fixture 驗證 normal；缺 metadata／false 必須 unknown；
+   加入 active NCDR official evidence 時驗證 outage 與 incident 摘要。
 7. 縮窄視窗檢查來源列換行、卡片內容不裁切；Mapbox sources/layers 數量不應因本卡增加。
 
 ## Production truth（2026-08-31）

--- a/src/components/intel/monitor/TelecomStatusCard.tsx
+++ b/src/components/intel/monitor/TelecomStatusCard.tsx
@@ -21,7 +21,7 @@ export type InternetHealthPhase = "loading" | "ready" | "error";
 
 const STATUS_META: Record<InternetHealthStatus, { label: string; en: string; color: string; tint: string }> = {
   normal: { label: "目前正常", en: "NORMAL", color: COLORS.statusLive, tint: "rgba(34,197,94,0.07)" },
-  watch: { label: "需要留意", en: "WATCH", color: COLORS.statusWarn, tint: "rgba(250,204,21,0.07)" },
+  watch: { label: "疑似異常", en: "WATCH", color: COLORS.statusWarn, tint: "rgba(250,204,21,0.07)" },
   degraded: { label: "局部異常", en: "DEGRADED", color: "#fb923c", tint: "rgba(251,146,60,0.08)" },
   outage: { label: "中斷訊號", en: "OUTAGE", color: COLORS.statusErr, tint: "rgba(239,68,68,0.09)" },
   unknown: { label: "資料不足", en: "UNKNOWN", color: COLORS.textDim, tint: "rgba(148,163,184,0.05)" },
@@ -43,18 +43,39 @@ function metricLabel(source: InternetHealthSourceSummary): string {
 }
 
 function sourceStatusLabel(source: InternetHealthSourceSummary): string {
-  if (!source.fresh) return source.key === "ncdr" ? "未通報／無資料" : "無資料";
+  if (source.availability === "restricted") {
+    if (source.detector_fresh) return "判定來源新鮮 · 明細不公開";
+    if (source.detector_stale) return "判定來源逾時 · 明細不公開";
+    return "明細不公開 · freshness 未知";
+  }
+  if (source.availability === "stale") return "資料逾時";
+  if (source.availability === "missing") return source.key === "ncdr" ? "未通報／無資料" : "無資料";
   return STATUS_META[source.status].label;
+}
+
+function ageLabel(ageSeconds: number | null): string {
+  if (ageSeconds == null || ageSeconds < 0) return "—";
+  if (ageSeconds < 60) return `${Math.round(ageSeconds)}s`;
+  if (ageSeconds < 3600) return `${Math.round(ageSeconds / 60)}m`;
+  if (ageSeconds < 86400) return `${(ageSeconds / 3600).toFixed(ageSeconds < 36_000 ? 1 : 0)}h`;
+  return `${(ageSeconds / 86400).toFixed(ageSeconds < 864_000 ? 1 : 0)}d`;
+}
+
+function confidenceLabel(source: InternetHealthSourceSummary): string {
+  const score = source.confidence_score == null ? "" : ` ${(source.confidence_score * 100).toFixed(0)}%`;
+  return `${source.confidence}${score}`;
 }
 
 function SourceEvidenceRow({ source, nowTs }: { source: InternetHealthSourceSummary; nowTs: number }) {
   const meta = STATUS_META[source.fresh ? source.status : "unknown"];
+  const restricted = source.availability === "restricted";
+  const timestamp = source.source_updated_at ?? source.observed_at;
   return (
     <div
       data-testid={`internet-health-source-${source.key}`}
       style={{
         display: "grid", gridTemplateColumns: "minmax(110px, 1fr) auto",
-        alignItems: "center", gap: 9, padding: "7px 9px", borderRadius: RADIUS.lg,
+        alignItems: "center", columnGap: 9, rowGap: 2, padding: "7px 9px", borderRadius: RADIUS.lg,
         background: "rgba(255,255,255,0.025)", border: `1px solid ${COLORS.borderSoft}`,
       }}
     >
@@ -73,6 +94,17 @@ function SourceEvidenceRow({ source, nowTs }: { source: InternetHealthSourceSumm
         >
           {source.label}
         </span>
+        {restricted && (
+          <span
+            style={{
+              padding: "1px 5px", borderRadius: RADIUS.full, border: `1px solid ${COLORS.borderMid}`,
+              color: COLORS.textDim, fontFamily: FONT_DATA, fontSize: FONT_SIZE.xs,
+              letterSpacing: "0.6px", flexShrink: 0,
+            }}
+          >
+            LIMITED
+          </span>
+        )}
       </span>
       <span style={{ minWidth: 0, gridColumn: "1 / -1", gridRow: 2 }}>
         <span style={{ fontFamily: FONT_CJK, fontSize: FONT_SIZE.sm, color: meta.color }}>
@@ -85,7 +117,15 @@ function SourceEvidenceRow({ source, nowTs }: { source: InternetHealthSourceSumm
           }}
           title={source.signal ?? undefined}
         >
-          {source.signal ?? "—"} · {timeLabel(source.source_updated_at ?? source.observed_at, nowTs)}
+          {restricted ? "detector evidence" : (source.signal ?? "—")} · {timestamp ? timeLabel(timestamp, nowTs) : "—"}
+        </span>
+        <span
+          style={{
+            display: "block", marginTop: 1, fontFamily: FONT_DATA, fontSize: FONT_SIZE.xs,
+            color: COLORS.textFaint, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap",
+          }}
+        >
+          age {ageLabel(source.age_seconds)} · n={source.sample_count?.toLocaleString("zh-TW") ?? "—"} · confidence {confidenceLabel(source)}
         </span>
       </span>
       <span
@@ -95,7 +135,7 @@ function SourceEvidenceRow({ source, nowTs }: { source: InternetHealthSourceSumm
           color: source.fresh ? meta.color : COLORS.textFaint, whiteSpace: "nowrap",
         }}
       >
-        {metricLabel(source)}
+        {restricted ? "—" : metricLabel(source)}
       </span>
     </div>
   );
@@ -152,11 +192,22 @@ export function TelecomStatusCardView({
       ? "本次更新失敗，暫時無法判斷"
       : (summary?.summary ?? "核心來源不足，暫時無法判斷");
   const sources = (summary?.sources ?? []).map((source) => phase === "error"
-    ? { ...source, status: "unknown" as const, fresh: false }
+    ? {
+        ...source,
+        status: "unknown" as const,
+        fresh: false,
+        availability: source.availability === "restricted" ? "restricted" as const : "missing" as const,
+        detector_fresh: false,
+        detector_stale: false,
+      }
     : source);
   const incidents = summary?.incidents ?? [];
   const confidence = phase === "error" ? "unknown" : (summary?.confidence ?? "unknown");
+  const confidenceScore = phase === "error" ? null : (summary?.confidence_score ?? null);
   const freshSourceCount = phase === "error" ? 0 : (summary?.fresh_source_count ?? 0);
+  const quorumLabel = phase === "error" || summary?.normal_quorum_met == null
+    ? "—"
+    : summary.normal_quorum_met ? "PASS" : "NO";
 
   return (
     <div data-testid="internet-health-card" style={{ display: "flex", flexDirection: "column", gap: 10 }}>
@@ -188,7 +239,7 @@ export function TelecomStatusCardView({
               </span>
             </div>
             <div style={{ marginTop: 4, fontFamily: FONT_DATA, fontSize: FONT_SIZE.xs, letterSpacing: "1.6px", color: COLORS.textFaint }}>
-              {meta.en} · confidence {confidence}
+              {meta.en} · confidence {confidence}{confidenceScore == null ? "" : ` ${(confidenceScore * 100).toFixed(0)}%`}
             </div>
           </div>
           <div style={{ fontFamily: FONT_CJK, fontSize: FONT_SIZE.sm, lineHeight: 1.45, color: COLORS.textMuted }}>
@@ -196,9 +247,15 @@ export function TelecomStatusCardView({
           </div>
           <div style={{ display: "flex", gap: 14, flexWrap: "wrap" }}>
             <span style={{ fontFamily: FONT_DATA, fontSize: FONT_SIZE.xs, color: COLORS.textFaint }}>
-              FRESH SOURCES<br />
+              FRESH PUBLIC<br />
               <b style={{ fontSize: FONT_SIZE.md, color: COLORS.textDefault }}>
-                {freshSourceCount}/{summary?.source_total ?? 3}
+                {freshSourceCount}/{summary?.public_source_total ?? 2}
+              </b>
+            </span>
+            <span style={{ fontFamily: FONT_DATA, fontSize: FONT_SIZE.xs, color: COLORS.textFaint }}>
+              NORMAL QUORUM<br />
+              <b style={{ fontSize: FONT_SIZE.sm, color: summary?.normal_quorum_met ? COLORS.statusLive : COLORS.textDefault }}>
+                {quorumLabel}
               </b>
             </span>
             <span style={{ fontFamily: FONT_DATA, fontSize: FONT_SIZE.xs, color: COLORS.textFaint }}>
@@ -216,7 +273,7 @@ export function TelecomStatusCardView({
           </span>
           {sources.length > 0
             ? sources.map((source) => <SourceEvidenceRow key={source.key} source={source} nowTs={nowTs} />)
-            : (["Cloudflare Radar", "IODA", "NCDR"] as const).map((label) => (
+            : (["Cloudflare Radar", "IODA", "RIPE Atlas", "RIPE RIS Live", "NCDR"] as const).map((label) => (
               <div key={label} style={{ padding: "7px 9px", borderRadius: RADIUS.lg, border: `1px solid ${COLORS.borderSoft}`, color: COLORS.textFaint, fontFamily: FONT_DATA, fontSize: FONT_SIZE.sm }}>
                 {label} · —
               </div>
@@ -241,7 +298,7 @@ export function TelecomStatusCardView({
               </div>
             )}
           <span style={{ marginTop: "auto", fontFamily: FONT_CJK, fontSize: FONT_SIZE.xs, lineHeight: 1.4, color: COLORS.textFaint }}>
-            Cloudflare Radar + IODA + NCDR；多來源觀測，不代表完整臺灣網路普查。ASN 僅列文字，不推測服務範圍。
+            Cloudflare Radar + IODA + RIPE Atlas + RIPE RIS Live + NCDR；受限來源僅依綜合判定揭露 freshness，不公開明細。ASN／prefix 僅列文字，不推測服務範圍。
           </span>
         </div>
       </div>

--- a/src/components/intel/monitor/__tests__/TelecomStatusCard.test.ts
+++ b/src/components/intel/monitor/__tests__/TelecomStatusCard.test.ts
@@ -32,6 +32,8 @@ const freshNormal = (source: string) => ({
   metadata: {},
 });
 
+const normalDetector = () => freshNormal("internet_health_detector_v1") satisfies Record<string, unknown>;
+
 const renderCard = (
   summary: ReturnType<typeof aggregateInternetHealthRows>,
   phase: "loading" | "ready" | "error",
@@ -45,22 +47,65 @@ describe("TelecomStatusCardView", () => {
     expect(html).toContain("資料不足");
     expect(html).toContain("Cloudflare Radar");
     expect(html).toContain("internet-health-source-cloudflare");
+    expect(html).toContain("RIPE Atlas");
+    expect(html).toContain("RIPE RIS Live");
+    expect(html).toContain("LIMITED");
     expect(html).not.toContain("目前正常");
   });
 
-  it("shows normal only with two fresh independent network sources", () => {
+  it("shows normal only with a fresh detector quorum and exposes restricted freshness", () => {
+    const detector = normalDetector();
     const html = renderCard(
-      aggregateInternetHealthRows([freshNormal("cloudflare_radar"), freshNormal("ioda")]),
+      aggregateInternetHealthRows([
+        {
+          ...detector,
+          evidence_family: "composite",
+          signal: "internet_health",
+          confidence: 0.91,
+          metadata: {
+            normal_quorum_met: true,
+            fresh_evidence_families: ["cloudflare", "ioda", "ripe_atlas", "ripe_ris"],
+            restricted_evidence_families: ["ioda", "ripe_atlas", "ripe_ris"],
+          },
+        },
+        { ...freshNormal("cloudflare_radar"), confidence: 0.86, sample_count: 24 },
+      ]),
       "ready",
     );
     expect(html).toContain("目前正常");
-    expect(html).toContain("2/3");
+    expect(html).toContain("confidence high 91%");
+    expect(html).toContain("1/2");
+    expect(html).toContain("PASS");
+    expect(html).toContain("判定來源新鮮 · 明細不公開");
+    expect(html).toContain("n=24");
+    expect(html).toContain("confidence high 86%");
     expect(html).toContain("NCDR");
     expect(html).toContain("未通報／無資料");
   });
 
+  it("labels watch as suspected and distinguishes stale public evidence", () => {
+    const summary = aggregateInternetHealthRows([
+      {
+        ...freshNormal("internet_health_detector_v1"),
+        evidence_family: "composite",
+        effective_status: "watch",
+        metadata: { normal_quorum_met: false, stale_evidence_families: ["ripe_ris"] },
+      },
+      { ...freshNormal("cloudflare_radar"), is_stale: true },
+    ]);
+    const html = renderCard(summary, "ready");
+    expect(html).toContain("疑似異常");
+    expect(html).toContain("資料逾時");
+    expect(html).toContain("判定來源逾時 · 明細不公開");
+  });
+
   it("a refresh error overrides a previous normal snapshot", () => {
-    const summary = aggregateInternetHealthRows([freshNormal("cloudflare_radar"), freshNormal("ioda")]);
+    const detector = normalDetector();
+    const summary = aggregateInternetHealthRows([{
+      ...detector,
+      evidence_family: "composite",
+      metadata: { normal_quorum_met: true },
+    }]);
     const html = renderCard(summary, "error");
     expect(html).toContain("資料不足");
     expect(html).toContain("本次更新失敗");

--- a/src/data/__tests__/internetHealthLoader.test.ts
+++ b/src/data/__tests__/internetHealthLoader.test.ts
@@ -34,17 +34,112 @@ const row = (overrides: Record<string, unknown> = {}) => ({
 });
 
 describe("internet health RPC contract", () => {
-  it("requires Cloudflare + IODA fresh normal evidence before overall normal", () => {
+  it("requires a fresh composite with explicit quorum before overall normal", () => {
     const summary = aggregateInternetHealthRows([
-      row(),
-      row({ source: "ioda", evidence_family: "active_probing", signal: "reachability" }),
+      row({
+        source: "internet_health_detector_v1",
+        evidence_family: "composite",
+        signal: "internet_health",
+        confidence: 0.91,
+        metadata: {
+          normal_quorum_met: true,
+          fresh_evidence_families: ["cloudflare", "ioda", "ripe_atlas", "ripe_ris"],
+          restricted_evidence_families: ["ioda", "ripe_atlas", "ripe_ris"],
+        },
+      }),
+      row({ source: "cloudflare_radar" }),
     ]);
     expect(summary.overall_status).toBe("normal");
-    expect(summary.fresh_source_count).toBe(2);
-    expect(summary.source_total).toBe(3);
-    expect(summary.sources.find((source) => source.key === "ncdr")).toMatchObject({
-      status: "unknown", fresh: false, value: null,
+    expect(summary.confidence_score).toBe(0.91);
+    expect(summary.normal_quorum_met).toBe(true);
+    expect(summary.fresh_source_count).toBe(1);
+    expect(summary.public_source_total).toBe(2);
+    expect(summary.source_total).toBe(5);
+    expect(summary.sources.find((source) => source.key === "ripe_atlas")).toMatchObject({
+      availability: "restricted", detector_fresh: true, fresh: false,
     });
+    expect(summary.sources.find((source) => source.key === "ripe_ris")).toMatchObject({
+      availability: "restricted", detector_fresh: true, fresh: false,
+    });
+    expect(summary.sources.find((source) => source.key === "ncdr")).toMatchObject({
+      status: "unknown", fresh: false, availability: "missing", value: null,
+    });
+  });
+
+  it("does not accept provider-only normal or a composite without quorum metadata", () => {
+    expect(aggregateInternetHealthRows([row()]).overall_status).toBe("unknown");
+    expect(aggregateInternetHealthRows([
+      row({ source: "internet_health_detector_v1", evidence_family: "composite" }),
+    ]).overall_status).toBe("unknown");
+    expect(aggregateInternetHealthRows([
+      row({
+        source: "internet_health_detector_v1",
+        evidence_family: "composite",
+        metadata: { normal_quorum_met: false },
+      }),
+    ]).overall_status).toBe("unknown");
+  });
+
+  it("recognizes RIPE source aliases but protects restricted provider detail", () => {
+    const summary = aggregateInternetHealthRows([
+      row({
+        source: "internet_health_detector_v1",
+        evidence_family: "composite",
+        effective_status: "watch",
+        metadata: {
+          normal_quorum_met: false,
+          fresh_evidence_families: ["ripe_atlas"],
+          stale_evidence_families: ["ripe_ris"],
+          restricted_evidence_families: ["ripe_atlas", "ripe_ris"],
+        },
+      }),
+      row({
+        source_observation_id: "private-atlas-observation",
+        source: "ripe_atlas",
+        evidence_family: "ripe_atlas",
+        signal: "private_probe_success_ratio",
+        value: 0.123456,
+        unit: "private_ratio",
+        sample_count: 42,
+        observed_at: "2026-08-30T03:42:01Z",
+        source_updated_at: "2026-08-30T03:42:02Z",
+      }),
+      row({
+        source_observation_id: "private-ris-observation",
+        source: "ripe_ris_live",
+        evidence_family: "ripe_ris",
+        signal: "private_prefix_visibility",
+        value: 0.654321,
+        confidence: 0.74,
+        observed_at: "2026-08-30T03:43:01Z",
+        source_updated_at: "2026-08-30T03:43:02Z",
+      }),
+    ]);
+    expect(summary.overall_status).toBe("watch");
+    expect(summary.evidence).toHaveLength(1);
+    expect(summary.evidence[0]).toMatchObject({ row_type: "detector", signal: "http_requests" });
+    expect(summary.evidence.some((item) => item.source_key === "ripe_atlas" || item.source_key === "ripe_ris")).toBe(false);
+    expect(summary.sources.find((source) => source.key === "ripe_atlas")).toMatchObject({
+      availability: "restricted", detector_fresh: true, signal: null, value: null,
+      sample_count: null, observed_at: null, source_updated_at: null,
+      confidence: "unknown", confidence_score: null, evidence_count: 0,
+    });
+    expect(summary.sources.find((source) => source.key === "ripe_ris")).toMatchObject({
+      availability: "restricted", detector_stale: true, signal: null, value: null,
+      sample_count: null, observed_at: null, source_updated_at: null,
+      confidence: "unknown", confidence_score: null, evidence_count: 0,
+    });
+    const publicModel = JSON.stringify(summary);
+    expect(publicModel).not.toContain("private-atlas-observation");
+    expect(publicModel).not.toContain("private-ris-observation");
+    expect(publicModel).not.toContain("private_probe_success_ratio");
+    expect(publicModel).not.toContain("private_prefix_visibility");
+    expect(publicModel).not.toContain("private_ratio");
+    expect(publicModel).not.toContain("0.123456");
+    expect(publicModel).not.toContain("0.654321");
+    expect(publicModel).not.toContain("0.74");
+    expect(publicModel).not.toContain("2026-08-30T03:42:01Z");
+    expect(publicModel).not.toContain("2026-08-30T03:43:02Z");
   });
 
   it("does not treat NCDR no-alert row as proof of normal internet", () => {
@@ -78,7 +173,7 @@ describe("internet health RPC contract", () => {
   it("uses effective_status rather than reported_status and preserves active incident scope as text", () => {
     const summary = aggregateInternetHealthRows([
       row({
-        source: "ioda",
+        source: "cloudflare_radar",
         entity_type: "asn",
         entity_id: "AS3462",
         entity_name: "HiNet",
@@ -132,6 +227,7 @@ describe("internet health RPC contract", () => {
         evidence_family: "composite",
         effective_status: "normal",
         confidence: 0.9,
+        metadata: { normal_quorum_met: true },
       }),
       row({
         row_type: "official_evidence",

--- a/src/data/internetHealthLoader.ts
+++ b/src/data/internetHealthLoader.ts
@@ -1,14 +1,14 @@
 /**
  * 台灣電信與網路狀態 loader。
  *
- * 資料只走 public.get_internet_health_status RPC；前端不直打 Cloudflare / IODA，
+ * 資料只走 public.get_internet_health_status RPC；前端不直打各 provider，
  * 也不把 ASN 或 country status 轉成地圖 geometry。
  *
  * 保守語意：
  * - effective_status 是 UI 狀態真相，reported_status 只留作溯源。
  * - stale / unavailable / 缺列都只能是 unknown，不能安靜變成 normal 或 0。
- * - normal 至少需要 Cloudflare Radar + IODA 兩個 fresh network evidence 都是 normal；
- *   NCDR 無通報只能表示「未通報」，不能單獨證明網路正常。
+ * - normal 只接受 fresh detector composite 且 metadata 明示 normal quorum；
+ *   provider 明細缺席／受限或 NCDR 無通報都不能單獨證明網路正常。
  */
 import { supabase, supabaseConfigured } from "../lib/supabase";
 import { withLoading } from "../lib/loadingRegistry";
@@ -16,7 +16,8 @@ import { cachedOnce } from "../lib/loaderCache";
 
 export type InternetHealthStatus = "normal" | "watch" | "degraded" | "outage" | "unknown";
 export type InternetHealthConfidence = "low" | "medium" | "high" | "unknown";
-export type InternetHealthSourceKey = "cloudflare" | "ioda" | "ncdr";
+export type InternetHealthSourceKey = "cloudflare" | "ioda" | "ripe_atlas" | "ripe_ris" | "ncdr";
+export type InternetHealthSourceAvailability = "fresh" | "stale" | "missing" | "restricted";
 export type InternetHealthRowType = "detector" | "evidence" | "official" | "unknown";
 
 export interface InternetHealthEvidence {
@@ -37,6 +38,7 @@ export interface InternetHealthEvidence {
   baseline_value: number | null;
   change_ratio: number | null;
   confidence: InternetHealthConfidence;
+  confidence_score: number | null;
   sample_count: number | null;
   observed_at: string | null;
   source_updated_at: string | null;
@@ -53,13 +55,19 @@ export interface InternetHealthSourceSummary {
   label: string;
   status: InternetHealthStatus;
   fresh: boolean;
+  availability: InternetHealthSourceAvailability;
+  detector_fresh: boolean;
+  detector_stale: boolean;
   observed_at: string | null;
   source_updated_at: string | null;
+  age_seconds: number | null;
   signal: string | null;
   value: number | null;
   unit: string | null;
   change_ratio: number | null;
   confidence: InternetHealthConfidence;
+  confidence_score: number | null;
+  sample_count: number | null;
   evidence_count: number;
 }
 
@@ -79,10 +87,16 @@ export interface InternetHealthIncident {
 export interface InternetHealthSummary {
   overall_status: InternetHealthStatus;
   confidence: InternetHealthConfidence;
+  confidence_score: number | null;
   summary: string;
   last_updated_at: string | null;
   fresh_source_count: number;
+  public_source_total: number;
   source_total: number;
+  normal_quorum_met: boolean | null;
+  fresh_evidence_families: string[];
+  stale_evidence_families: string[];
+  restricted_evidence_families: string[];
   sources: InternetHealthSourceSummary[];
   incidents: InternetHealthIncident[];
   evidence: InternetHealthEvidence[];
@@ -91,7 +105,30 @@ export interface InternetHealthSummary {
 const SOURCE_LABELS: Record<InternetHealthSourceKey, string> = {
   cloudflare: "Cloudflare Radar",
   ioda: "IODA",
+  ripe_atlas: "RIPE Atlas",
+  ripe_ris: "RIPE RIS Live",
   ncdr: "NCDR",
+};
+
+const SOURCE_KEYS: readonly InternetHealthSourceKey[] = [
+  "cloudflare", "ioda", "ripe_atlas", "ripe_ris", "ncdr",
+];
+
+/**
+ * Production public RPC policy (2026-08-31): IODA and both RIPE provider rows
+ * stay internal-only. The detector may disclose family names/freshness in its
+ * public-safe metadata, but the UI must not infer or reveal provider metrics.
+ */
+const RESTRICTED_SOURCE_KEYS = new Set<InternetHealthSourceKey>([
+  "ioda", "ripe_atlas", "ripe_ris",
+]);
+
+const SOURCE_FAMILIES: Record<InternetHealthSourceKey, readonly string[]> = {
+  cloudflare: ["cloudflare", "cloudflare_radar"],
+  ioda: ["ioda"],
+  ripe_atlas: ["ripe_atlas"],
+  ripe_ris: ["ripe_ris", "ripe_ris_live"],
+  ncdr: ["ncdr", "official"],
 };
 
 const STATUS_RANK: Record<InternetHealthStatus, number> = {
@@ -134,6 +171,11 @@ function timestamp(value: unknown): string | null {
   return out;
 }
 
+function stringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return [...new Set(value.map(text).filter((item): item is string => item !== null))];
+}
+
 export function normalizeInternetHealthStatus(value: unknown): InternetHealthStatus {
   const raw = text(value)?.toLowerCase().replace(/[\s-]+/g, "_") ?? "";
   if (["normal", "ok", "healthy", "clear"].includes(raw)) return "normal";
@@ -158,10 +200,17 @@ function normalizeConfidence(value: unknown): InternetHealthConfidence {
   return "unknown";
 }
 
+function confidenceScore(value: unknown): number | null {
+  const numeric = num(value);
+  return numeric !== null && numeric >= 0 && numeric <= 1 ? numeric : null;
+}
+
 function sourceKeyOf(value: unknown): InternetHealthSourceKey | "other" {
   const raw = text(value)?.toLowerCase() ?? "";
   if (raw.includes("cloudflare") || raw.includes("radar")) return "cloudflare";
   if (raw.includes("ioda")) return "ioda";
+  if (raw.includes("ripe_atlas") || raw.includes("ripe atlas")) return "ripe_atlas";
+  if (raw.includes("ripe_ris") || raw.includes("ris_live") || raw.includes("ris live")) return "ripe_ris";
   if (raw.includes("ncdr")) return "ncdr";
   return "other";
 }
@@ -207,6 +256,7 @@ export function parseInternetHealthEvidence(raw: unknown): InternetHealthEvidenc
     baseline_value: num(raw.baseline_value),
     change_ratio: num(raw.change_ratio),
     confidence: normalizeConfidence(raw.confidence),
+    confidence_score: confidenceScore(raw.confidence),
     sample_count: num(raw.sample_count),
     observed_at: timestamp(raw.observed_at),
     source_updated_at: timestamp(raw.source_updated_at),
@@ -248,30 +298,96 @@ function conservativeConfidence(rows: InternetHealthEvidence[]): InternetHealthC
   return known.reduce((a, b) => CONFIDENCE_RANK[a] <= CONFIDENCE_RANK[b] ? a : b);
 }
 
-function sourceSummary(key: InternetHealthSourceKey, rows: InternetHealthEvidence[]): InternetHealthSourceSummary {
+function conservativeConfidenceScore(rows: InternetHealthEvidence[]): number | null {
+  const known = rows
+    .map((row) => row.confidence_score)
+    .filter((score): score is number => score !== null);
+  return known.length ? Math.min(...known) : null;
+}
+
+interface DetectorMetadataSummary {
+  normalQuorumMet: boolean | null;
+  freshFamilies: string[];
+  staleFamilies: string[];
+  restrictedFamilies: string[];
+}
+
+function detectorMetadata(rows: InternetHealthEvidence[]): DetectorMetadataSummary {
+  const sorted = [...rows].sort((a, b) => {
+    const ta = Date.parse(a.source_updated_at ?? a.observed_at ?? "") || 0;
+    const tb = Date.parse(b.source_updated_at ?? b.observed_at ?? "") || 0;
+    return tb - ta;
+  });
+  const latest = sorted[0];
+  if (!latest) {
+    return { normalQuorumMet: null, freshFamilies: [], staleFamilies: [], restrictedFamilies: [] };
+  }
+  return {
+    normalQuorumMet: typeof latest.metadata.normal_quorum_met === "boolean"
+      ? latest.metadata.normal_quorum_met
+      : null,
+    freshFamilies: stringArray(latest.metadata.fresh_evidence_families),
+    staleFamilies: stringArray(latest.metadata.stale_evidence_families),
+    restrictedFamilies: stringArray(latest.metadata.restricted_evidence_families),
+  };
+}
+
+function familyListed(key: InternetHealthSourceKey, families: string[]): boolean {
+  return SOURCE_FAMILIES[key].some((family) => families.includes(family));
+}
+
+function sourceSummary(
+  key: InternetHealthSourceKey,
+  rows: InternetHealthEvidence[],
+  metadata: DetectorMetadataSummary,
+): InternetHealthSourceSummary {
   const sourceRows = rows.filter((row) => row.source_key === key);
   const freshRows = sourceRows.filter((row) => !row.is_stale && row.status !== "unknown");
-  const status = worstStatus(freshRows);
+  const restricted = RESTRICTED_SOURCE_KEYS.has(key) || familyListed(key, metadata.restrictedFamilies);
+  const status = restricted ? "unknown" : worstStatus(freshRows);
   const candidates = freshRows.filter((row) => row.status === status);
   const notable = [...(candidates.length ? candidates : sourceRows)].sort((a, b) => {
     const ta = Date.parse(a.source_updated_at ?? a.observed_at ?? "") || 0;
     const tb = Date.parse(b.source_updated_at ?? b.observed_at ?? "") || 0;
     return tb - ta;
   })[0] ?? null;
+  const availability: InternetHealthSourceAvailability = restricted
+    ? "restricted"
+    : freshRows.length > 0
+      ? "fresh"
+      : sourceRows.length > 0
+        ? "stale"
+        : "missing";
   return {
     key,
     label: SOURCE_LABELS[key],
     status,
-    fresh: freshRows.length > 0,
-    observed_at: notable?.observed_at ?? null,
-    source_updated_at: notable?.source_updated_at ?? null,
-    signal: notable?.signal ?? null,
-    value: notable?.value ?? null,
-    unit: notable?.unit ?? null,
-    change_ratio: notable?.change_ratio ?? null,
-    confidence: conservativeConfidence(candidates),
+    fresh: !restricted && freshRows.length > 0,
+    availability,
+    detector_fresh: familyListed(key, metadata.freshFamilies),
+    detector_stale: familyListed(key, metadata.staleFamilies),
+    observed_at: restricted ? null : (notable?.observed_at ?? null),
+    source_updated_at: restricted ? null : (notable?.source_updated_at ?? null),
+    age_seconds: restricted ? null : (notable?.age_seconds ?? null),
+    signal: restricted ? null : (notable?.signal ?? null),
+    value: restricted ? null : (notable?.value ?? null),
+    unit: restricted ? null : (notable?.unit ?? null),
+    change_ratio: restricted ? null : (notable?.change_ratio ?? null),
+    confidence: restricted ? "unknown" : conservativeConfidence(candidates),
+    confidence_score: restricted ? null : conservativeConfidenceScore(candidates),
+    sample_count: restricted ? null : (notable?.sample_count ?? null),
     evidence_count: sourceRows.length,
   };
+}
+
+/**
+ * Defense in depth for the browser model. The production RPC already applies
+ * a migration-owned allowlist, but an upstream policy regression must not put
+ * restricted provider rows (or an unknown future provider) into page memory.
+ */
+function isPublicEvidence(row: InternetHealthEvidence): boolean {
+  if (row.row_type === "detector" || row.row_type === "official") return true;
+  return row.source_key === "cloudflare" || row.source_key === "ncdr";
 }
 
 function activeIncidents(rows: InternetHealthEvidence[]): InternetHealthIncident[] {
@@ -311,23 +427,27 @@ function summaryText(status: InternetHealthStatus): string {
 
 /** 將 RPC evidence rows 彙整成 Monitor 卡片模型。 */
 export function aggregateInternetHealthRows(rawRows: unknown): InternetHealthSummary {
-  const evidence = Array.isArray(rawRows)
+  const parsedEvidence = Array.isArray(rawRows)
     ? rawRows.map(parseInternetHealthEvidence).filter((row): row is InternetHealthEvidence => row !== null)
     : [];
-  const sources = (["cloudflare", "ioda", "ncdr"] as const).map((key) => sourceSummary(key, evidence));
+  const evidence = parsedEvidence.filter(isPublicEvidence);
   const freshEvidence = evidence.filter((row) => !row.is_stale && row.status !== "unknown");
   const freshDetectors = freshEvidence.filter((row) => row.row_type === "detector");
   const freshOfficial = freshEvidence.filter((row) => row.row_type === "official");
+  const detectorMeta = detectorMetadata(freshDetectors);
+  const sources = SOURCE_KEYS.map((key) => sourceSummary(key, evidence, detectorMeta));
   // Provider evidence 是 detector 的輸入，不可蓋過 composite；NCDR active official evidence
   // 則保留為獨立正向中斷證據。
   const primaryRows = freshDetectors.length ? [...freshDetectors, ...freshOfficial] : freshEvidence;
   let overall = worstStatus(primaryRows);
 
-  // normal 是唯一需要 quorum 的狀態：NCDR 無通報不能單獨證明正常。
+  // normal 只接受 fresh composite 明示 quorum。IODA／RIPE provider 明細受限，
+  // 因此不能再靠公開 provider rows 重算 normal；metadata 缺欄一律 unknown。
   if (overall === "normal") {
-    const cloudflare = sources.find((source) => source.key === "cloudflare");
-    const ioda = sources.find((source) => source.key === "ioda");
-    if (!cloudflare?.fresh || cloudflare.status !== "normal" || !ioda?.fresh || ioda.status !== "normal") {
+    const hasQuorumDetector = freshDetectors.some((row) => (
+      row.status === "normal" && row.metadata.normal_quorum_met === true
+    ));
+    if (!hasQuorumDetector) {
       overall = "unknown";
     }
   }
@@ -337,10 +457,16 @@ export function aggregateInternetHealthRows(rawRows: unknown): InternetHealthSum
   return {
     overall_status: overall,
     confidence: conservativeConfidence(contributing),
+    confidence_score: conservativeConfidenceScore(contributing),
     summary: summaryText(overall),
     last_updated_at: latestTimestamp(evidence),
     fresh_source_count: sources.filter((source) => source.fresh).length,
+    public_source_total: sources.filter((source) => source.availability !== "restricted").length,
     source_total: sources.length,
+    normal_quorum_met: detectorMeta.normalQuorumMet,
+    fresh_evidence_families: detectorMeta.freshFamilies,
+    stale_evidence_families: detectorMeta.staleFamilies,
+    restricted_evidence_families: detectorMeta.restrictedFamilies,
     sources,
     incidents: activeIncidents(evidence),
     evidence,


### PR DESCRIPTION
## Summary
- recognize RIPE Atlas and RIPE RIS Live in the telecom status card
- require fresh composite plus normal_quorum_met=true for normal
- keep IODA/RIPE provider detail restricted and filter it from the browser model
- show stale/missing/restricted states without adding map geometry

## Verification
- full Vitest: 963 passed, 1 skipped
- targeted after defense-in-depth fix: 14 passed
- TypeScript build and production build pass
- git diff check pass