### PR TITLE
feat(monitor): show RIPE measurement values

### DIFF
--- a/docs/features/internet-health/handoff.md
+++ b/docs/features/internet-health/handoff.md
@@ -39,15 +39,18 @@ is_stale, active_incident_id, incident_status, metadata
 8. active incident 只列 entity name/id、類型與時間。
 9. 不新增 LayerVisibility、Mapbox source、overlay、popup 或 ASN geometry。
 
-## RIPE 擴充契約（2026-08-31）
+## RIPE 擴充契約（2026-09-01）
 
 - `source = ripe_atlas`、`evidence_family = ripe_atlas`：active probing evidence。
 - `source = ripe_ris_live`、`evidence_family = ripe_ris`：BGP routing evidence。
 - detector 維持 `source = internet_health_detector_v1`、`evidence_family = composite`、
   `signal = internet_health`。
-- IODA、RIPE Atlas 與 RIPE RIS provider rows 初期皆為 internal-only；public RPC 不回傳其
-  normalized/raw 明細。前端以 LIMITED 呈現；只有 composite metadata 明示時才標 fresh／stale，
-  metadata 缺欄則顯示 freshness 未知，不把缺 row 說成來源故障。
+- IODA 維持 internal-only。RIPE Atlas／RIS 只接受 platform public RPC 回傳的 allowlisted normalized
+  measurements；前端不得繞過 RPC 連 provider realtime，也不得保留 observation ID 或 provider metadata。
+- Atlas allowlist：`probe_connectivity_ratio_ipv4/ipv6`、`ping_success_ratio_ipv4/ipv6`、
+  `median_rtt_ms_ipv4/ipv6`、`reachable_asn_ratio_ipv4/ipv6`。
+- RIS allowlist：`prefix_visibility_ratio_ipv4/ipv6`、`withdrawn_prefix_ratio_ipv4/ipv6`、
+  `origin_change_count_ipv4/ipv6`。其他 signal 即使因上游 policy regression 出現在 RPC 也整列丟棄。
 - Public-safe composite metadata 可包含：`detector_version`、`normal_quorum_met`、
   `fresh_evidence_families`、`stale_evidence_families`、`restricted_evidence_families`、
   `dependency_groups`、`evidence_class_count`、`coverage_gate_met`、`decision_reasons`。
@@ -55,9 +58,25 @@ is_stale, active_incident_id, incident_status, metadata
 - `normal` 只接受 fresh composite detector 且 `metadata.normal_quorum_met = true`；不再要求
   永遠不公開的 IODA provider row。Provider-only normal、stale composite 或缺 quorum metadata
   都必須顯示「資料不足」。
-- 來源列區分 `fresh / stale / missing / restricted`，公開 evidence 才顯示 signal、value、
-  sample count、資料年齡與 confidence。受限來源只顯示 detector metadata 揭露的 family freshness，
-  不推測或洩露 raw metrics。
+- Atlas／RIS 以兩張主要量測卡顯示 allowlisted value、sample count、confidence、資料時間與 freshness；
+  Cloudflare／IODA／NCDR 是旁證。Freshness 與 judgment 分開：fresh unknown 只代表資料剛更新，總體仍可為
+  `UNKNOWN · BASELINE BUILDING`。null 顯示 `—`；RIS visibility null 額外顯示「RIB 基準建立中」。
+- 100% Ping、0 Origin change 或 0 Withdrawal 都只是單一量測值，不能推導 `normal`。Atlas 與 RIS 同屬
+  `ripe_ncc` dependency group，不當成兩個獨立 quorum。
+- Browser model 的 RIPE rows 不進 `summary.evidence`；只輸出 allowlisted `summary.measurements`，固定單位為
+  ratio／milliseconds／count，並移除 source observation ID、baseline/change ratio、incident 與 metadata。
+- Provider metadata 只保留 `measurement_state`（暫定 allowlist：`ready / baseline_building / partial /
+  unavailable`；相同 enum 的 `quality_state` 可正規化為此欄）。`stream_gap`／empty window、缺
+  `source_updated_at`、`sample_count = 0`、partial 或 unavailable 都不可標為 CURRENT；provider 時間不以
+  `observed_at` fallback 冒充更新時間。
+- 非 partial row 若缺 `source_updated_at` 或 `sample_count <= 0`，value 同時 fail-closed 為 null、state 為
+  unavailable；visibility 維持 baseline building。Partial row 可保留值，但必須同時標示 PARTIAL 與
+  non-current freshness。
+- Ratio 必須在 0–1、milliseconds 必須 `>= 0`、count 與 sample count 必須是 `>= 0` 的整數；invalid
+  value fail-closed 為 null。`prefix_visibility_ratio_*` 即使非 null，也只有明示
+  `measurement_state = ready` 才可公開，否則維持 `— / RIB 基準建立中`。
+- Sample count 依 metric 標示其母體：Atlas probe connectivity／Ping 使用 `probes`、median RTT 使用
+  `RTT samples`、ASN reachability 使用 `ASNs`、RIS 使用 `BGP messages`，不使用語意模糊的統一 `n=`。
 
 既有 `ripeAtlasProbes` 是 3,000 點全球靜態 connected-probe metadata 概覽，座標經模糊化且有
 志願者偏差；本卡不以 country／ASN／BGP 狀態替探針染色。RIPE RIS prefix／ASN 也不建立 geometry。
@@ -85,16 +104,20 @@ overlay registry、legend、popup、click registry 與既有 `ripeAtlasProbes` a
 ## Browser live gate
 
 1. 確認 migration 已 apply，且 RPC 用 anonymous session 呼叫 country/TW 能回 fresh detector；只有
-   `public_rpc_enabled=true` 的 provider rows 會回傳，IODA 與兩個 RIPE provider rows 缺席是預期政策。
+   `public_rpc_enabled=true` 且 signal 在 public allowlist 的 provider rows 才能回傳，IODA 缺席是預期政策。
 2. 啟動前端並開啟 Monitor；`電信與網路 · CONNECTIVITY` 應位於事件區下方、全寬、不壓到下方雙欄卡片。
 3. 在 browser Network 面板確認 request 是 `get_internet_health_status`，參數為 country、`[TW]`、include evidence、limit 500。
-4. 逐列對照 Cloudflare／IODA／RIPE Atlas／RIPE RIS Live／NCDR；公開來源顯示狀態、metric、
-   sample、confidence 與資料年齡，受限來源顯示 LIMITED 與 detector family freshness；null 必須是 `—`，
-   NCDR 缺 row 必須是「未通報／無資料」。
+4. 逐列對照兩張 RIPE 主卡與 Cloudflare／IODA／NCDR 旁證；RIPE 公開量測顯示 value、sample、confidence、
+   freshness 與資料時間，IODA 顯示 LIMITED；null 必須是 `—`，RIS visibility null 同時顯示
+   「RIB 基準建立中」，NCDR 缺 row 必須是「未通報／無資料」。
 5. 用 stale 或空資料 fixture 驗證總體為「資料不足」且 fresh sources 為 0；用 RPC 失敗驗證舊 normal 不會繼續亮綠。
 6. 用 fresh detector + `normal_quorum_met=true` fixture 驗證 normal；缺 metadata／false 必須 unknown；
    加入 active NCDR official evidence 時驗證 outage 與 incident 摘要。
 7. 縮窄視窗檢查來源列換行、卡片內容不裁切；Mapbox sources/layers 數量不應因本卡增加。
+8. 用 100% Ping + 0 Withdrawal + 0 Origin change fixture 驗證頁面仍為 `UNKNOWN / 建立基準中`；
+   Network response 若混入非 allowlisted RIPE signal 或 provider metadata，頁面與前端 summary 都不得出現。
+9. 用 stream gap、sample count 0、缺 `source_updated_at` 與 visibility 非 null 但缺 `ready` fixture，驗證
+   不顯示 CURRENT、不 fallback `observed_at`，且 visibility 仍為 `— / RIB 基準建立中`。
 
 ## Production truth（2026-08-31）
 

--- a/src/components/intel/monitor/TelecomStatusCard.tsx
+++ b/src/components/intel/monitor/TelecomStatusCard.tsx
@@ -12,6 +12,8 @@ import {
   fetchInternetHealthStatus,
   invalidateInternetHealthStatus,
   type InternetHealthIncident,
+  type InternetHealthMeasurement,
+  type InternetHealthMeasurementSignal,
   type InternetHealthSourceSummary,
   type InternetHealthStatus,
   type InternetHealthSummary,
@@ -64,6 +66,134 @@ function ageLabel(ageSeconds: number | null): string {
 function confidenceLabel(source: InternetHealthSourceSummary): string {
   const score = source.confidence_score == null ? "" : ` ${(source.confidence_score * 100).toFixed(0)}%`;
   return `${source.confidence}${score}`;
+}
+
+const MEASUREMENT_LABELS: Record<InternetHealthMeasurementSignal, string> = {
+  probe_connectivity_ratio_ipv4: "Probe 回報率",
+  probe_connectivity_ratio_ipv6: "Probe 回報率",
+  ping_success_ratio_ipv4: "Ping 成功率",
+  ping_success_ratio_ipv6: "Ping 成功率",
+  median_rtt_ms_ipv4: "中位 RTT",
+  median_rtt_ms_ipv6: "中位 RTT",
+  reachable_asn_ratio_ipv4: "可達 ASN 比率",
+  reachable_asn_ratio_ipv6: "可達 ASN 比率",
+  prefix_visibility_ratio_ipv4: "Prefix 可見度",
+  prefix_visibility_ratio_ipv6: "Prefix 可見度",
+  withdrawn_prefix_ratio_ipv4: "撤回 Prefix 比率",
+  withdrawn_prefix_ratio_ipv6: "撤回 Prefix 比率",
+  origin_change_count_ipv4: "Origin 變更",
+  origin_change_count_ipv6: "Origin 變更",
+};
+
+const ATLAS_SIGNALS: InternetHealthMeasurementSignal[] = [
+  "ping_success_ratio_ipv4", "ping_success_ratio_ipv6",
+  "median_rtt_ms_ipv4", "median_rtt_ms_ipv6",
+  "probe_connectivity_ratio_ipv4", "probe_connectivity_ratio_ipv6",
+  "reachable_asn_ratio_ipv4", "reachable_asn_ratio_ipv6",
+];
+
+const RIS_SIGNALS: InternetHealthMeasurementSignal[] = [
+  "prefix_visibility_ratio_ipv4", "prefix_visibility_ratio_ipv6",
+  "withdrawn_prefix_ratio_ipv4", "withdrawn_prefix_ratio_ipv6",
+  "origin_change_count_ipv4", "origin_change_count_ipv6",
+];
+
+function measurementValue(measurement: InternetHealthMeasurement | undefined): string {
+  if (!measurement || measurement.value == null) return "—";
+  if (measurement.unit === "ratio") return `${(measurement.value * 100).toFixed(1)}%`;
+  if (measurement.unit === "milliseconds") return `${measurement.value.toFixed(1)} ms`;
+  return measurement.value.toLocaleString("zh-TW", { maximumFractionDigits: 0 });
+}
+
+function measurementSampleLabel(measurement: InternetHealthMeasurement): string {
+  const count = measurement.sample_count?.toLocaleString("zh-TW") ?? "—";
+  if (measurement.source_key === "ripe_ris") return `BGP messages=${count}`;
+  if (measurement.signal.startsWith("reachable_asn_ratio_")) return `ASNs=${count}`;
+  if (measurement.signal.startsWith("median_rtt_ms_")) return `RTT samples=${count}`;
+  return `probes=${count}`;
+}
+
+function measurementStateLabel(measurement: InternetHealthMeasurement | undefined): string | null {
+  if (!measurement) return null;
+  if (measurement.state === "baseline_building") return "RIB 基準建立中";
+  if (measurement.state === "partial") return "PARTIAL";
+  if (measurement.state === "unavailable" || measurement.state === "missing") return "UNAVAILABLE";
+  return null;
+}
+
+function MeasurementCard({
+  title, subtitle, source, measurements, signals, nowTs,
+}: {
+  title: string;
+  subtitle: string;
+  source: InternetHealthSourceSummary | undefined;
+  measurements: InternetHealthMeasurement[];
+  signals: InternetHealthMeasurementSignal[];
+  nowTs: number;
+}) {
+  const current = measurements.filter((item) => item.freshness === "fresh").length;
+  const hasPartial = measurements.some((item) => item.state === "partial");
+  const hasBaseline = measurements.some((item) => item.state === "baseline_building");
+  const hasStale = measurements.some((item) => item.freshness === "stale");
+  const freshness = source?.availability === "restricted" ? "LIMITED"
+    : current > 0 ? "CURRENT"
+      : hasPartial ? "PARTIAL"
+        : hasBaseline ? "BASELINE"
+          : hasStale ? "STALE"
+            : measurements.length > 0 ? "UNAVAILABLE" : "NO DATA";
+  const freshnessColor = current > 0 ? "#22d3ee" : COLORS.textDim;
+  const pairs = signals.filter((_, index) => index % 2 === 0);
+  return (
+    <div
+      data-testid={`internet-health-measurements-${source?.key ?? "missing"}`}
+      style={{
+        minWidth: 0, padding: "11px 12px", borderRadius: RADIUS.xl,
+        border: `1px solid ${COLORS.borderMid}`, background: "rgba(2,8,23,0.32)",
+      }}
+    >
+      <div style={{ display: "flex", justifyContent: "space-between", gap: 10, alignItems: "flex-start" }}>
+        <span>
+          <b style={{ display: "block", fontFamily: FONT_DATA, fontSize: FONT_SIZE.base, color: COLORS.textDefault }}>{title}</b>
+          <span style={{ display: "block", marginTop: 2, fontFamily: FONT_CJK, fontSize: FONT_SIZE.xs, color: COLORS.textFaint }}>{subtitle}</span>
+        </span>
+        <span style={{ fontFamily: FONT_DATA, fontSize: FONT_SIZE.xs, color: freshnessColor, letterSpacing: "0.8px" }}>{freshness}</span>
+      </div>
+      <div style={{ display: "grid", gridTemplateColumns: "minmax(94px, 1.2fr) repeat(2, minmax(70px, 1fr))", gap: "5px 8px", marginTop: 10 }}>
+        <span />
+        {([4, 6] as const).map((family) => (
+          <span key={family} style={{ fontFamily: FONT_DATA, fontSize: FONT_SIZE.xs, color: COLORS.textDim }}>IPv{family}</span>
+        ))}
+        {pairs.map((signal) => {
+          const base = signal.replace(/_ipv4$/, "");
+          const ipv4 = measurements.find((item) => item.signal === `${base}_ipv4`);
+          const ipv6 = measurements.find((item) => item.signal === `${base}_ipv6`);
+          return [
+            <span key={`${base}-label`} style={{ fontFamily: FONT_CJK, fontSize: FONT_SIZE.xs, color: COLORS.textMuted }}>{MEASUREMENT_LABELS[signal]}</span>,
+            ...([ipv4, ipv6] as const).map((measurement, index) => (
+              <span key={`${base}-${index}`} style={{ minWidth: 0 }}>
+                <b style={{ display: "block", fontFamily: FONT_DATA, fontSize: FONT_SIZE.sm, color: measurement?.freshness === "stale" ? COLORS.textFaint : COLORS.textDefault }}>
+                  {measurementValue(measurement)}
+                </b>
+                {measurementStateLabel(measurement) && (
+                  <span style={{ display: "block", fontFamily: FONT_CJK, fontSize: FONT_SIZE.xs, color: COLORS.statusWarn }}>
+                    {measurementStateLabel(measurement)}
+                  </span>
+                )}
+                <span style={{ display: "block", fontFamily: FONT_DATA, fontSize: FONT_SIZE.xs, color: COLORS.textFaint }}>
+                  {measurement ? `${measurement.freshness.toUpperCase()} · ${measurementSampleLabel(measurement)}` : "—"}
+                </span>
+                {measurement && (
+                  <span style={{ display: "block", fontFamily: FONT_DATA, fontSize: FONT_SIZE.xs, color: COLORS.textFaint }}>
+                    {timeLabel(measurement.source_updated_at, nowTs)} · confidence {measurement.confidence}
+                  </span>
+                )}
+              </span>
+            )),
+          ];
+        })}
+      </div>
+    </div>
+  );
 }
 
 function SourceEvidenceRow({ source, nowTs }: { source: InternetHealthSourceSummary; nowTs: number }) {
@@ -186,6 +316,9 @@ export function TelecomStatusCardView({
     ? "unknown"
     : (summary?.overall_status ?? "unknown");
   const meta = STATUS_META[effectiveStatus];
+  const baselineBuilding = phase === "ready" && summary?.assessment_phase === "baseline_building";
+  const statusLabel = baselineBuilding ? "建立基準中" : meta.label;
+  const statusEn = baselineBuilding ? "UNKNOWN · BASELINE BUILDING" : meta.en;
   const description = phase === "loading"
     ? "正在取得多來源觀測…"
     : phase === "error"
@@ -205,6 +338,12 @@ export function TelecomStatusCardView({
   const confidence = phase === "error" ? "unknown" : (summary?.confidence ?? "unknown");
   const confidenceScore = phase === "error" ? null : (summary?.confidence_score ?? null);
   const freshSourceCount = phase === "error" ? 0 : (summary?.fresh_source_count ?? 0);
+  const measurements = phase === "error" ? [] : (summary?.measurements ?? []);
+  const atlasSource = sources.find((source) => source.key === "ripe_atlas");
+  const risSource = sources.find((source) => source.key === "ripe_ris");
+  const supportingSources = sources.filter((source) => (
+    source.key === "cloudflare" || source.key === "ioda" || source.key === "ncdr"
+  ));
   const quorumLabel = phase === "error" || summary?.normal_quorum_met == null
     ? "—"
     : summary.normal_quorum_met ? "PASS" : "NO";
@@ -221,7 +360,7 @@ export function TelecomStatusCardView({
           gap: 14, alignItems: "stretch",
         }}
       >
-        <div style={{ display: "flex", flexDirection: "column", justifyContent: "space-between", gap: 10 }}>
+        <div style={{ display: "flex", flexDirection: "column", justifyContent: "space-between", gap: 10, gridColumn: "1 / -1" }}>
           <div>
             <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
               <span
@@ -235,11 +374,11 @@ export function TelecomStatusCardView({
                 data-testid="internet-health-status-label"
                 style={{ fontFamily: FONT_CJK, fontSize: FONT_SIZE.lg, fontWeight: 700, color: meta.color }}
               >
-                {meta.label}
+                {statusLabel}
               </span>
             </div>
             <div style={{ marginTop: 4, fontFamily: FONT_DATA, fontSize: FONT_SIZE.xs, letterSpacing: "1.6px", color: COLORS.textFaint }}>
-              {meta.en} · confidence {confidence}{confidenceScore == null ? "" : ` ${(confidenceScore * 100).toFixed(0)}%`}
+              {statusEn} · confidence {confidence}{confidenceScore == null ? "" : ` ${(confidenceScore * 100).toFixed(0)}%`}
             </div>
           </div>
           <div style={{ fontFamily: FONT_CJK, fontSize: FONT_SIZE.sm, lineHeight: 1.45, color: COLORS.textMuted }}>
@@ -267,13 +406,31 @@ export function TelecomStatusCardView({
           </div>
         </div>
 
+        <div
+          style={{
+            gridColumn: "1 / -1", display: "grid",
+            gridTemplateColumns: "repeat(auto-fit, minmax(min(100%, 300px), 1fr))", gap: 10,
+          }}
+        >
+          <MeasurementCard
+            title="RIPE Atlas" subtitle="端到端主動量測 · RIPE NCC"
+            source={atlasSource} measurements={measurements.filter((item) => item.source_key === "ripe_atlas")}
+            signals={ATLAS_SIGNALS} nowTs={nowTs}
+          />
+          <MeasurementCard
+            title="RIPE RIS Live" subtitle="BGP 路由觀測 · RIPE NCC"
+            source={risSource} measurements={measurements.filter((item) => item.source_key === "ripe_ris")}
+            signals={RIS_SIGNALS} nowTs={nowTs}
+          />
+        </div>
+
         <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
           <span style={{ fontFamily: FONT_DATA, fontSize: FONT_SIZE.xs, letterSpacing: "1.2px", color: COLORS.textDim }}>
-            SOURCE EVIDENCE
+            SUPPORTING EVIDENCE
           </span>
-          {sources.length > 0
-            ? sources.map((source) => <SourceEvidenceRow key={source.key} source={source} nowTs={nowTs} />)
-            : (["Cloudflare Radar", "IODA", "RIPE Atlas", "RIPE RIS Live", "NCDR"] as const).map((label) => (
+          {supportingSources.length > 0
+            ? supportingSources.map((source) => <SourceEvidenceRow key={source.key} source={source} nowTs={nowTs} />)
+            : (["Cloudflare Radar", "IODA", "NCDR"] as const).map((label) => (
               <div key={label} style={{ padding: "7px 9px", borderRadius: RADIUS.lg, border: `1px solid ${COLORS.borderSoft}`, color: COLORS.textFaint, fontFamily: FONT_DATA, fontSize: FONT_SIZE.sm }}>
                 {label} · —
               </div>
@@ -298,7 +455,7 @@ export function TelecomStatusCardView({
               </div>
             )}
           <span style={{ marginTop: "auto", fontFamily: FONT_CJK, fontSize: FONT_SIZE.xs, lineHeight: 1.4, color: COLORS.textFaint }}>
-            Cloudflare Radar + IODA + RIPE Atlas + RIPE RIS Live + NCDR；受限來源僅依綜合判定揭露 freshness，不公開明細。ASN／prefix 僅列文字，不推測服務範圍。
+            Atlas 與 RIS 同屬 RIPE NCC，不視為兩個獨立 quorum。量測 freshness 與狀態判讀分離；100% Ping、0 Origin 變更或 0 Withdrawal 都不能單獨推導為正常。ASN／prefix 僅列文字，不推測服務範圍。
           </span>
         </div>
       </div>

--- a/src/components/intel/monitor/__tests__/TelecomStatusCard.test.ts
+++ b/src/components/intel/monitor/__tests__/TelecomStatusCard.test.ts
@@ -76,11 +76,79 @@ describe("TelecomStatusCardView", () => {
     expect(html).toContain("confidence high 91%");
     expect(html).toContain("1/2");
     expect(html).toContain("PASS");
-    expect(html).toContain("判定來源新鮮 · 明細不公開");
+    expect(html).toContain("LIMITED");
     expect(html).toContain("n=24");
     expect(html).toContain("confidence high 86%");
     expect(html).toContain("NCDR");
     expect(html).toContain("未通報／無資料");
+  });
+
+  it("renders RIPE measurements as primary cards without promoting perfect or zero values to normal", () => {
+    const summary = aggregateInternetHealthRows([
+      {
+        ...freshNormal("ripe_atlas"), evidence_family: "ripe_atlas",
+        signal: "ping_success_ratio_ipv4", effective_status: "unknown",
+        reported_status: "unknown", value: 1, unit: "ratio", sample_count: 18,
+      },
+      {
+        ...freshNormal("ripe_atlas"), evidence_family: "ripe_atlas",
+        signal: "median_rtt_ms_ipv4", effective_status: "unknown",
+        reported_status: "unknown", value: 23.4, unit: "milliseconds", sample_count: 17,
+      },
+      {
+        ...freshNormal("ripe_atlas"), evidence_family: "ripe_atlas",
+        signal: "reachable_asn_ratio_ipv4", effective_status: "unknown",
+        reported_status: "unknown", value: 0.8, unit: "ratio", sample_count: 4,
+      },
+      {
+        ...freshNormal("ripe_ris_live"), evidence_family: "ripe_ris",
+        signal: "prefix_visibility_ratio_ipv4", effective_status: "unknown",
+        reported_status: "unknown", value: null, unit: "ratio", sample_count: 1292,
+      },
+      {
+        ...freshNormal("ripe_ris_live"), evidence_family: "ripe_ris",
+        signal: "withdrawn_prefix_ratio_ipv4", effective_status: "unknown",
+        reported_status: "unknown", value: 0, unit: "ratio", sample_count: 1292,
+      },
+      {
+        ...freshNormal("ripe_ris_live"), evidence_family: "ripe_ris",
+        signal: "origin_change_count_ipv4", effective_status: "unknown",
+        reported_status: "unknown", value: 0, unit: "count", sample_count: 1292,
+      },
+    ]);
+    const html = renderCard(summary, "ready");
+    expect(html).toContain("建立基準中");
+    expect(html).toContain("UNKNOWN · BASELINE BUILDING");
+    expect(html).toContain("internet-health-measurements-ripe_atlas");
+    expect(html).toContain("internet-health-measurements-ripe_ris");
+    expect(html).toContain("Ping 成功率");
+    expect(html).toContain("100.0%");
+    expect(html).toContain("23.4 ms");
+    expect(html).toContain("RIB 基準建立中");
+    expect(html).toContain("0.0%");
+    expect(html).toContain("probes=18");
+    expect(html).toContain("RTT samples=17");
+    expect(html).toContain("ASNs=4");
+    expect(html).toContain("BGP messages=1,292");
+    expect(html).not.toContain("n=1292");
+    expect(html).toContain("Atlas 與 RIS 同屬 RIPE NCC");
+    expect(html).not.toContain("目前正常");
+  });
+
+  it("shows partial or untimed RIPE rows as unavailable instead of current", () => {
+    const summary = aggregateInternetHealthRows([
+      {
+        ...freshNormal("ripe_ris_live"), evidence_family: "ripe_ris",
+        signal: "origin_change_count_ipv4", effective_status: "unknown",
+        reported_status: "unknown", value: 0, sample_count: 0,
+        source_updated_at: null, metadata: { measurement_state: "partial" },
+      },
+    ]);
+    const html = renderCard(summary, "ready");
+    expect(html).toContain("PARTIAL");
+    expect(html).toContain("UNAVAILABLE · BGP messages=0");
+    expect(html).toContain("— · confidence high");
+    expect(html).not.toContain("CURRENT");
   });
 
   it("labels watch as suspected and distinguishes stale public evidence", () => {
@@ -96,7 +164,7 @@ describe("TelecomStatusCardView", () => {
     const html = renderCard(summary, "ready");
     expect(html).toContain("疑似異常");
     expect(html).toContain("資料逾時");
-    expect(html).toContain("判定來源逾時 · 明細不公開");
+    expect(html).toContain("LIMITED");
   });
 
   it("a refresh error overrides a previous normal snapshot", () => {

--- a/src/data/__tests__/internetHealthLoader.test.ts
+++ b/src/data/__tests__/internetHealthLoader.test.ts
@@ -142,6 +142,190 @@ describe("internet health RPC contract", () => {
     expect(publicModel).not.toContain("2026-08-30T03:43:02Z");
   });
 
+  it("exposes only allowlisted RIPE measurements while keeping the assessment unknown", () => {
+    const summary = aggregateInternetHealthRows([
+      row({
+        source_observation_id: "atlas-private-id",
+        source: "ripe_atlas",
+        evidence_family: "ripe_atlas",
+        signal: "ping_success_ratio_ipv4",
+        effective_status: "unknown",
+        reported_status: "unknown",
+        value: 1,
+        unit: "provider_ratio",
+        sample_count: 18,
+        confidence: 0.82,
+        metadata: { measurement_ids: [1234], target_groups: ["secret-target"] },
+      }),
+      row({
+        source_observation_id: "ris-private-id",
+        source: "ripe_ris_live",
+        evidence_family: "ripe_ris",
+        signal: "withdrawn_prefix_ratio_ipv4",
+        effective_status: "unknown",
+        reported_status: "unknown",
+        value: 0,
+        unit: "provider_ratio",
+        sample_count: 1292,
+        metadata: { subscription_sha256: "private-sha", raw_archive_prefix: "private-path" },
+      }),
+      row({
+        source: "ripe_atlas",
+        evidence_family: "ripe_atlas",
+        signal: "not_public_probe_identifier",
+        value: 999,
+        metadata: { secret: "must-not-leak" },
+      }),
+    ]);
+
+    expect(summary.overall_status).toBe("unknown");
+    expect(summary.assessment_phase).toBe("baseline_building");
+    expect(summary.summary).toContain("基準建立中");
+    expect(summary.fresh_source_count).toBe(2);
+    expect(summary.public_source_total).toBe(4);
+    expect(summary.measurements).toEqual([
+      expect.objectContaining({
+        source_key: "ripe_atlas", dependency_group: "ripe_ncc",
+        signal: "ping_success_ratio_ipv4", value: 1, unit: "ratio",
+        address_family: 4, freshness: "fresh", state: "available", sample_count: 18,
+      }),
+      expect.objectContaining({
+        source_key: "ripe_ris", dependency_group: "ripe_ncc",
+        signal: "withdrawn_prefix_ratio_ipv4", value: 0, unit: "ratio",
+        address_family: 4, freshness: "fresh", state: "available", sample_count: 1292,
+      }),
+    ]);
+    expect(summary.evidence).toHaveLength(0);
+    expect(summary.sources.find((source) => source.key === "ripe_atlas")).toMatchObject({
+      availability: "fresh", fresh: true, status: "unknown", dependency_group: "ripe_ncc",
+    });
+    const publicModel = JSON.stringify(summary);
+    for (const forbidden of [
+      "atlas-private-id", "ris-private-id", "measurement_ids", "secret-target",
+      "subscription_sha256", "private-sha", "private-path", "must-not-leak",
+      "not_public_probe_identifier", "999", "provider_ratio",
+    ]) expect(publicModel).not.toContain(forbidden);
+  });
+
+  it("keeps null RIS visibility as a baseline-building null and stale measurements stale", () => {
+    const summary = aggregateInternetHealthRows([
+      row({
+        source: "ripe_ris_live", evidence_family: "ripe_ris",
+        signal: "prefix_visibility_ratio_ipv6", effective_status: "unknown",
+        value: null, unit: "ratio", is_stale: false,
+      }),
+      row({
+        source: "ripe_atlas", evidence_family: "ripe_atlas",
+        signal: "median_rtt_ms_ipv6", effective_status: "unknown",
+        value: 37.5, unit: "milliseconds", is_stale: true,
+      }),
+    ]);
+    expect(summary.overall_status).toBe("unknown");
+    expect(summary.measurements).toEqual([
+      expect.objectContaining({
+        signal: "prefix_visibility_ratio_ipv6", value: null,
+        freshness: "unavailable", state: "baseline_building",
+      }),
+      expect.objectContaining({
+        signal: "median_rtt_ms_ipv6", value: 37.5,
+        freshness: "stale", state: "available",
+      }),
+    ]);
+    expect(summary.sources.find((source) => source.key === "ripe_atlas")).toMatchObject({
+      availability: "stale", fresh: false,
+    });
+  });
+
+  it("requires an explicit ready state before exposing non-null prefix visibility", () => {
+    const summary = aggregateInternetHealthRows([
+      row({
+        source: "ripe_ris_live", evidence_family: "ripe_ris",
+        signal: "prefix_visibility_ratio_ipv4", effective_status: "unknown",
+        value: 0.97, sample_count: 300, metadata: {},
+      }),
+      row({
+        source: "ripe_ris_live", evidence_family: "ripe_ris",
+        signal: "prefix_visibility_ratio_ipv6", effective_status: "unknown",
+        value: 0.91, sample_count: 240,
+        metadata: { measurement_state: "ready", subscription_sha256: "must-not-leak" },
+      }),
+    ]);
+    expect(summary.measurements).toEqual([
+      expect.objectContaining({
+        signal: "prefix_visibility_ratio_ipv4", value: null,
+        quality_state: null, state: "baseline_building", freshness: "unavailable",
+      }),
+      expect.objectContaining({
+        signal: "prefix_visibility_ratio_ipv6", value: 0.91,
+        quality_state: "ready", state: "available", freshness: "fresh",
+      }),
+    ]);
+    expect(JSON.stringify(summary)).not.toContain("subscription_sha256");
+    expect(JSON.stringify(summary)).not.toContain("must-not-leak");
+  });
+
+  it("does not call stream gaps, empty samples, or missing provider timestamps current", () => {
+    const summary = aggregateInternetHealthRows([
+      row({
+        source: "ripe_ris_live", evidence_family: "ripe_ris",
+        signal: "origin_change_count_ipv4", effective_status: "unknown",
+        value: 0, sample_count: 0, source_updated_at: null,
+        observed_at: "2026-08-30T04:00:00Z",
+        metadata: { quality_state: "stream_gap" },
+      }),
+      row({
+        source: "ripe_atlas", evidence_family: "ripe_atlas",
+        signal: "ping_success_ratio_ipv4", effective_status: "unknown",
+        value: 1, sample_count: 12, source_updated_at: null,
+        observed_at: "2026-08-30T04:00:00Z",
+        metadata: { quality_state: "ready" },
+      }),
+    ]);
+    expect(summary.measurements).toEqual([
+      expect.objectContaining({
+        signal: "origin_change_count_ipv4", value: null, freshness: "unavailable",
+        state: "unavailable", quality_state: "unavailable", sample_count: 0,
+      }),
+      expect.objectContaining({
+        signal: "ping_success_ratio_ipv4", value: null, freshness: "unavailable",
+        state: "unavailable", quality_state: "ready", source_updated_at: null,
+      }),
+    ]);
+    expect(summary.fresh_source_count).toBe(0);
+    expect(summary.last_updated_at).toBeNull();
+  });
+
+  it("fails closed on invalid values and non-integer or negative sample counts", () => {
+    const summary = aggregateInternetHealthRows([
+      row({
+        source: "ripe_atlas", evidence_family: "ripe_atlas",
+        signal: "ping_success_ratio_ipv4", effective_status: "unknown",
+        value: 1.01, sample_count: 2.5,
+      }),
+      row({
+        source: "ripe_atlas", evidence_family: "ripe_atlas",
+        signal: "median_rtt_ms_ipv4", effective_status: "unknown",
+        value: -0.1, sample_count: -1,
+      }),
+      row({
+        source: "ripe_ris_live", evidence_family: "ripe_ris",
+        signal: "origin_change_count_ipv6", effective_status: "unknown",
+        value: 1.5, sample_count: 20,
+      }),
+      row({
+        source: "ripe_ris_live", evidence_family: "ripe_ris",
+        signal: "withdrawn_prefix_ratio_ipv4", effective_status: "unknown",
+        value: 0, sample_count: 0,
+      }),
+    ]);
+    expect(summary.measurements).toEqual([
+      expect.objectContaining({ value: null, sample_count: null, freshness: "unavailable", state: "unavailable" }),
+      expect.objectContaining({ value: null, sample_count: null, freshness: "unavailable", state: "unavailable" }),
+      expect.objectContaining({ value: null, sample_count: 20, freshness: "unavailable", state: "missing" }),
+      expect.objectContaining({ value: null, sample_count: 0, freshness: "unavailable", state: "unavailable" }),
+    ]);
+  });
+
   it("does not treat NCDR no-alert row as proof of normal internet", () => {
     const summary = aggregateInternetHealthRows([
       row({ source: "ncdr", signal: "mobile_outage_alerts", value: 0, unit: "alerts" }),

--- a/src/data/internetHealthLoader.ts
+++ b/src/data/internetHealthLoader.ts
@@ -19,6 +19,36 @@ export type InternetHealthConfidence = "low" | "medium" | "high" | "unknown";
 export type InternetHealthSourceKey = "cloudflare" | "ioda" | "ripe_atlas" | "ripe_ris" | "ncdr";
 export type InternetHealthSourceAvailability = "fresh" | "stale" | "missing" | "restricted";
 export type InternetHealthRowType = "detector" | "evidence" | "official" | "unknown";
+export type InternetHealthAssessmentPhase = "assessed" | "baseline_building" | "insufficient_data";
+export type InternetHealthMeasurementFreshness = "fresh" | "stale" | "unavailable";
+export type InternetHealthMeasurementState = "available" | "baseline_building" | "partial" | "unavailable" | "missing";
+export type InternetHealthMeasurementQualityState = "ready" | "baseline_building" | "partial" | "unavailable";
+export type InternetHealthMeasurementSignal =
+  | "probe_connectivity_ratio_ipv4" | "probe_connectivity_ratio_ipv6"
+  | "ping_success_ratio_ipv4" | "ping_success_ratio_ipv6"
+  | "median_rtt_ms_ipv4" | "median_rtt_ms_ipv6"
+  | "reachable_asn_ratio_ipv4" | "reachable_asn_ratio_ipv6"
+  | "prefix_visibility_ratio_ipv4" | "prefix_visibility_ratio_ipv6"
+  | "withdrawn_prefix_ratio_ipv4" | "withdrawn_prefix_ratio_ipv6"
+  | "origin_change_count_ipv4" | "origin_change_count_ipv6";
+
+export interface InternetHealthMeasurement {
+  source_key: "ripe_atlas" | "ripe_ris";
+  dependency_group: "ripe_ncc";
+  signal: InternetHealthMeasurementSignal;
+  address_family: 4 | 6;
+  value: number | null;
+  unit: "ratio" | "milliseconds" | "count";
+  sample_count: number | null;
+  confidence: InternetHealthConfidence;
+  confidence_score: number | null;
+  observed_at: string | null;
+  source_updated_at: string | null;
+  age_seconds: number | null;
+  freshness: InternetHealthMeasurementFreshness;
+  state: InternetHealthMeasurementState;
+  quality_state: InternetHealthMeasurementQualityState | null;
+}
 
 export interface InternetHealthEvidence {
   row_type: InternetHealthRowType;
@@ -69,6 +99,7 @@ export interface InternetHealthSourceSummary {
   confidence_score: number | null;
   sample_count: number | null;
   evidence_count: number;
+  dependency_group: "ripe_ncc" | null;
 }
 
 export interface InternetHealthIncident {
@@ -89,6 +120,7 @@ export interface InternetHealthSummary {
   confidence: InternetHealthConfidence;
   confidence_score: number | null;
   summary: string;
+  assessment_phase: InternetHealthAssessmentPhase;
   last_updated_at: string | null;
   fresh_source_count: number;
   public_source_total: number;
@@ -99,6 +131,7 @@ export interface InternetHealthSummary {
   restricted_evidence_families: string[];
   sources: InternetHealthSourceSummary[];
   incidents: InternetHealthIncident[];
+  measurements: InternetHealthMeasurement[];
   evidence: InternetHealthEvidence[];
 }
 
@@ -115,12 +148,42 @@ const SOURCE_KEYS: readonly InternetHealthSourceKey[] = [
 ];
 
 /**
- * Production public RPC policy (2026-08-31): IODA and both RIPE provider rows
- * stay internal-only. The detector may disclose family names/freshness in its
- * public-safe metadata, but the UI must not infer or reveal provider metrics.
+ * IODA remains internal-only. RIPE rows may be returned by the public RPC only
+ * after the platform allowlist approves their exact signal; this loader repeats
+ * that allowlist so a policy regression cannot expose arbitrary provider data.
  */
 const RESTRICTED_SOURCE_KEYS = new Set<InternetHealthSourceKey>([
-  "ioda", "ripe_atlas", "ripe_ris",
+  "ioda",
+]);
+
+const RIPE_SIGNAL_UNITS: Record<InternetHealthMeasurementSignal, InternetHealthMeasurement["unit"]> = {
+  probe_connectivity_ratio_ipv4: "ratio",
+  probe_connectivity_ratio_ipv6: "ratio",
+  ping_success_ratio_ipv4: "ratio",
+  ping_success_ratio_ipv6: "ratio",
+  median_rtt_ms_ipv4: "milliseconds",
+  median_rtt_ms_ipv6: "milliseconds",
+  reachable_asn_ratio_ipv4: "ratio",
+  reachable_asn_ratio_ipv6: "ratio",
+  prefix_visibility_ratio_ipv4: "ratio",
+  prefix_visibility_ratio_ipv6: "ratio",
+  withdrawn_prefix_ratio_ipv4: "ratio",
+  withdrawn_prefix_ratio_ipv6: "ratio",
+  origin_change_count_ipv4: "count",
+  origin_change_count_ipv6: "count",
+};
+
+const RIPE_ATLAS_SIGNALS = new Set<InternetHealthMeasurementSignal>([
+  "probe_connectivity_ratio_ipv4", "probe_connectivity_ratio_ipv6",
+  "ping_success_ratio_ipv4", "ping_success_ratio_ipv6",
+  "median_rtt_ms_ipv4", "median_rtt_ms_ipv6",
+  "reachable_asn_ratio_ipv4", "reachable_asn_ratio_ipv6",
+]);
+
+const RIPE_RIS_SIGNALS = new Set<InternetHealthMeasurementSignal>([
+  "prefix_visibility_ratio_ipv4", "prefix_visibility_ratio_ipv6",
+  "withdrawn_prefix_ratio_ipv4", "withdrawn_prefix_ratio_ipv6",
+  "origin_change_count_ipv4", "origin_change_count_ipv6",
 ]);
 
 const SOURCE_FAMILIES: Record<InternetHealthSourceKey, readonly string[]> = {
@@ -224,6 +287,45 @@ function rowTypeOf(value: unknown, evidenceFamily: string | null): InternetHealt
   return "unknown";
 }
 
+function normalizeMeasurementQualityState(value: unknown): InternetHealthMeasurementQualityState | null {
+  const state = text(value)?.toLowerCase();
+  if (state === "stream_gap" || state === "empty") return "unavailable";
+  return state === "ready" || state === "baseline_building" || state === "partial" || state === "unavailable"
+    ? state
+    : null;
+}
+
+function safeMetadata(
+  raw: Record<string, unknown>,
+  rowType: InternetHealthRowType,
+  sourceKey: InternetHealthSourceKey | "other",
+): Record<string, unknown> {
+  const metadata = isRecord(raw.metadata) ? raw.metadata : {};
+  if (sourceKey === "ripe_atlas" || sourceKey === "ripe_ris") {
+    const rawMeasurementState = metadata.measurement_state ?? metadata.quality_state;
+    const measurementState = normalizeMeasurementQualityState(rawMeasurementState);
+    if (measurementState) return { measurement_state: measurementState };
+    // A present but unknown quality state is not equivalent to no state: fail closed.
+    return rawMeasurementState == null ? {} : { measurement_state: "unavailable" };
+  }
+  if (rowType !== "detector") return {};
+  const out: Record<string, unknown> = {};
+  if (typeof metadata.normal_quorum_met === "boolean") out.normal_quorum_met = metadata.normal_quorum_met;
+  for (const key of [
+    "fresh_evidence_families", "stale_evidence_families", "restricted_evidence_families",
+    "dependency_groups", "decision_reasons",
+  ] as const) {
+    const values = stringArray(metadata[key]);
+    if (values.length) out[key] = values;
+  }
+  const detectorVersion = text(metadata.detector_version);
+  const evidenceClassCount = num(metadata.evidence_class_count);
+  if (detectorVersion !== null) out.detector_version = detectorVersion;
+  if (evidenceClassCount !== null) out.evidence_class_count = evidenceClassCount;
+  if (typeof metadata.coverage_gate_met === "boolean") out.coverage_gate_met = metadata.coverage_gate_met;
+  return out;
+}
+
 /** 單列 parser；欄位缺失時保守保留 null，不補 0。 */
 export function parseInternetHealthEvidence(raw: unknown): InternetHealthEvidence | null {
   if (!isRecord(raw)) return null;
@@ -237,15 +339,17 @@ export function parseInternetHealthEvidence(raw: unknown): InternetHealthEvidenc
   const effective = normalizeInternetHealthStatus(raw.effective_status);
   const status = isStale ? "unknown" : effective;
   const evidenceFamily = text(raw.evidence_family);
+  const rowType = rowTypeOf(raw.row_type, evidenceFamily);
+  const sourceKey = sourceKeyOf(source);
 
   return {
-    row_type: rowTypeOf(raw.row_type, evidenceFamily),
+    row_type: rowType,
     source_observation_id: text(raw.source_observation_id),
     entity_type: entityType,
     entity_id: entityId,
     entity_name: text(raw.entity_name),
     source,
-    source_key: sourceKeyOf(source),
+    source_key: sourceKey,
     evidence_family: evidenceFamily,
     signal: text(raw.signal),
     reported_status: text(raw.reported_status),
@@ -265,7 +369,7 @@ export function parseInternetHealthEvidence(raw: unknown): InternetHealthEvidenc
     is_stale: isStale,
     active_incident_id: text(raw.active_incident_id),
     incident_status: text(raw.incident_status),
-    metadata: isRecord(raw.metadata) ? raw.metadata : {},
+    metadata: safeMetadata(raw, rowType, sourceKey),
   };
 }
 
@@ -342,8 +446,11 @@ function sourceSummary(
   metadata: DetectorMetadataSummary,
 ): InternetHealthSourceSummary {
   const sourceRows = rows.filter((row) => row.source_key === key);
-  const freshRows = sourceRows.filter((row) => !row.is_stale && row.status !== "unknown");
-  const restricted = RESTRICTED_SOURCE_KEYS.has(key) || familyListed(key, metadata.restrictedFamilies);
+  // Freshness is transport recency, not a judgment. Fresh RIPE rows commonly
+  // have effective_status=unknown while a baseline is still being built.
+  const freshRows = sourceRows.filter((row) => !row.is_stale);
+  const restricted = RESTRICTED_SOURCE_KEYS.has(key)
+    || (sourceRows.length === 0 && familyListed(key, metadata.restrictedFamilies));
   const status = restricted ? "unknown" : worstStatus(freshRows);
   const candidates = freshRows.filter((row) => row.status === status);
   const notable = [...(candidates.length ? candidates : sourceRows)].sort((a, b) => {
@@ -377,6 +484,102 @@ function sourceSummary(
     confidence_score: restricted ? null : conservativeConfidenceScore(candidates),
     sample_count: restricted ? null : (notable?.sample_count ?? null),
     evidence_count: sourceRows.length,
+    dependency_group: key === "ripe_atlas" || key === "ripe_ris" ? "ripe_ncc" : null,
+  };
+}
+
+function ripeSignal(row: InternetHealthEvidence): InternetHealthMeasurementSignal | null {
+  const signal = row.signal as InternetHealthMeasurementSignal | null;
+  if (!signal) return null;
+  if (row.source_key === "ripe_atlas" && RIPE_ATLAS_SIGNALS.has(signal)) return signal;
+  if (row.source_key === "ripe_ris" && RIPE_RIS_SIGNALS.has(signal)) return signal;
+  return null;
+}
+
+function validSampleCount(value: number | null): number | null {
+  return value !== null && Number.isInteger(value) && value >= 0 ? value : null;
+}
+
+function validMeasurementValue(
+  value: number | null,
+  unit: InternetHealthMeasurement["unit"],
+): number | null {
+  if (value === null) return null;
+  if (unit === "ratio") return value >= 0 && value <= 1 ? value : null;
+  if (unit === "milliseconds") return value >= 0 ? value : null;
+  return Number.isInteger(value) && value >= 0 ? value : null;
+}
+
+function toRipeMeasurement(row: InternetHealthEvidence): InternetHealthMeasurement | null {
+  const signal = ripeSignal(row);
+  if (!signal || (row.source_key !== "ripe_atlas" && row.source_key !== "ripe_ris")) return null;
+  const isVisibility = signal.startsWith("prefix_visibility_ratio_");
+  const unit = RIPE_SIGNAL_UNITS[signal];
+  const qualityState = normalizeMeasurementQualityState(row.metadata.measurement_state);
+  const sampleCount = validSampleCount(row.sample_count);
+  const validatedValue = validMeasurementValue(row.value, unit);
+  const hasUsableWindow = row.source_updated_at !== null && sampleCount !== null && sampleCount > 0;
+  let value: number | null = validatedValue;
+  let state: InternetHealthMeasurementState;
+  if (isVisibility && (qualityState !== "ready" || !hasUsableWindow || validatedValue === null)) {
+    value = null;
+    state = "baseline_building";
+  } else if (qualityState === "partial") {
+    // A partial window may retain a clearly labelled value, but is never CURRENT.
+    state = "partial";
+  } else if (qualityState === "baseline_building") {
+    value = null;
+    state = "baseline_building";
+  } else if (qualityState === "unavailable" || !hasUsableWindow) {
+    value = null;
+    state = "unavailable";
+  } else if (validatedValue === null) {
+    state = "missing";
+  } else {
+    state = "available";
+  }
+  const freshness: InternetHealthMeasurementFreshness = row.is_stale
+    ? "stale"
+    : state !== "available"
+      ? "unavailable"
+      : "fresh";
+  return {
+    source_key: row.source_key,
+    dependency_group: "ripe_ncc",
+    signal,
+    address_family: signal.endsWith("_ipv6") ? 6 : 4,
+    value,
+    unit,
+    sample_count: sampleCount,
+    confidence: row.confidence,
+    confidence_score: row.confidence_score,
+    observed_at: row.observed_at,
+    source_updated_at: row.source_updated_at,
+    age_seconds: row.age_seconds,
+    freshness,
+    state,
+    quality_state: qualityState,
+  };
+}
+
+function safeRipeEvidence(row: InternetHealthEvidence): InternetHealthEvidence | null {
+  const measurement = toRipeMeasurement(row);
+  if (!measurement) return null;
+  return {
+    ...row,
+    source_observation_id: null,
+    signal: measurement.signal,
+    value: measurement.value,
+    unit: measurement.unit,
+    sample_count: measurement.sample_count,
+    source_updated_at: measurement.source_updated_at,
+    is_stale: measurement.freshness !== "fresh",
+    baseline_value: null,
+    change_ratio: null,
+    active_incident_id: null,
+    incident_status: null,
+    incident_kind: null,
+    metadata: measurement.quality_state ? { measurement_state: measurement.quality_state } : {},
   };
 }
 
@@ -386,7 +589,10 @@ function sourceSummary(
  * restricted provider rows (or an unknown future provider) into page memory.
  */
 function isPublicEvidence(row: InternetHealthEvidence): boolean {
-  if (row.row_type === "detector" || row.row_type === "official") return true;
+  // Provider identity wins over a forged/misclassified row_type.
+  if (row.source_key === "ioda" || row.source_key === "ripe_atlas" || row.source_key === "ripe_ris") return false;
+  if (row.row_type === "detector") return row.evidence_family === "composite";
+  if (row.row_type === "official") return row.source_key === "ncdr";
   return row.source_key === "cloudflare" || row.source_key === "ncdr";
 }
 
@@ -417,11 +623,12 @@ function activeIncidents(rows: InternetHealthEvidence[]): InternetHealthIncident
   return [...byId.values()].sort((a, b) => STATUS_RANK[b.severity] - STATUS_RANK[a.severity]);
 }
 
-function summaryText(status: InternetHealthStatus): string {
+function summaryText(status: InternetHealthStatus, phase: InternetHealthAssessmentPhase): string {
   if (status === "normal") return "多來源未見明顯網路異常";
   if (status === "watch") return "部分訊號需要持續觀察";
   if (status === "degraded") return "偵測到局部或服務品質下降";
   if (status === "outage") return "偵測到網路中斷訊號";
+  if (phase === "baseline_building") return "量測持續收集中，判定基準建立中";
   return "核心來源不足，暫時無法判斷";
 }
 
@@ -430,12 +637,19 @@ export function aggregateInternetHealthRows(rawRows: unknown): InternetHealthSum
   const parsedEvidence = Array.isArray(rawRows)
     ? rawRows.map(parseInternetHealthEvidence).filter((row): row is InternetHealthEvidence => row !== null)
     : [];
+  const measurements = parsedEvidence
+    .map(toRipeMeasurement)
+    .filter((measurement): measurement is InternetHealthMeasurement => measurement !== null);
+  const safeRipeRows = parsedEvidence
+    .map(safeRipeEvidence)
+    .filter((row): row is InternetHealthEvidence => row !== null);
   const evidence = parsedEvidence.filter(isPublicEvidence);
+  const publicRows = [...evidence, ...safeRipeRows];
   const freshEvidence = evidence.filter((row) => !row.is_stale && row.status !== "unknown");
   const freshDetectors = freshEvidence.filter((row) => row.row_type === "detector");
   const freshOfficial = freshEvidence.filter((row) => row.row_type === "official");
   const detectorMeta = detectorMetadata(freshDetectors);
-  const sources = SOURCE_KEYS.map((key) => sourceSummary(key, evidence, detectorMeta));
+  const sources = SOURCE_KEYS.map((key) => sourceSummary(key, publicRows, detectorMeta));
   // Provider evidence 是 detector 的輸入，不可蓋過 composite；NCDR active official evidence
   // 則保留為獨立正向中斷證據。
   const primaryRows = freshDetectors.length ? [...freshDetectors, ...freshOfficial] : freshEvidence;
@@ -453,13 +667,27 @@ export function aggregateInternetHealthRows(rawRows: unknown): InternetHealthSum
   }
   if (!primaryRows.length) overall = "unknown";
 
+  const assessmentPhase: InternetHealthAssessmentPhase = overall !== "unknown"
+    ? "assessed"
+    : measurements.some((measurement) => (
+        measurement.freshness === "fresh"
+        || measurement.state === "baseline_building"
+        || measurement.state === "partial"
+      ))
+      ? "baseline_building"
+      : "insufficient_data";
+
   const contributing = primaryRows.filter((row) => row.status === overall);
   return {
     overall_status: overall,
     confidence: conservativeConfidence(contributing),
     confidence_score: conservativeConfidenceScore(contributing),
-    summary: summaryText(overall),
-    last_updated_at: latestTimestamp(evidence),
+    summary: summaryText(overall, assessmentPhase),
+    assessment_phase: assessmentPhase,
+    last_updated_at: latestTimestamp([
+      ...evidence,
+      ...safeRipeRows.filter((row) => row.source_updated_at !== null),
+    ]),
     fresh_source_count: sources.filter((source) => source.fresh).length,
     public_source_total: sources.filter((source) => source.availability !== "restricted").length,
     source_total: sources.length,
@@ -469,6 +697,7 @@ export function aggregateInternetHealthRows(rawRows: unknown): InternetHealthSum
     restricted_evidence_families: detectorMeta.restrictedFamilies,
     sources,
     incidents: activeIncidents(evidence),
+    measurements,
     evidence,
   };
 }


### PR DESCRIPTION
## Summary
- promote RIPE Atlas/RIS aggregate measurements to primary Monitor cards
- keep overall assessment UNKNOWN while the baseline is building
- fail closed on stale, partial, empty, invalid, or non-allowlisted provider data

## Verification
- targeted tests: 21/21
- full tests: 970 passed, 1 skipped
- npx tsc -b
- npm run build
- git diff --check

## Rollout
Deploy only after gis-platform migration 384 is applied and public RPC fixtures pass.