### PR TITLE
feat(monitor): add RIPE observation timeline

### DIFF
--- a/docs/features/internet-health/handoff.md
+++ b/docs/features/internet-health/handoff.md
@@ -1,10 +1,13 @@
-# Handoff — 臺灣電信與網路狀態 MVP
+# Handoff — 臺灣 RIPE NCC 網路觀察
 
 ## 產品目的
 
-在 Monitor 顯示臺灣目前的電信與網路狀態。這是多來源狀態卡，不是地圖圖層：
-Cloudflare Radar、IODA、RIPE Atlas、RIPE RIS Live 與 NCDR evidence 只顯示文字／數值，
-不替 ASN、prefix、國家狀態或缺資料區域製造 geometry。
+在 Monitor 顯示臺灣目前的 RIPE NCC 網路量測與歷史趨勢。畫面只使用 RIPE Atlas 與
+RIPE RIS Live；Cloudflare Radar、IODA、NCDR 不再出現在這張卡，但既有 collector、資料與
+後端判讀契約都不停止或刪除。這不是地圖圖層，不替 ASN、prefix、國家狀態或缺資料區域製造 geometry。
+
+此畫面是 `OBSERVATION ONLY`：先呈現數值、freshness、coverage 與缺口，不把 RIPE 單一
+dependency group 直接判成「臺灣正常／斷網」。異常判讀待歷史基準與 detector 成熟後再加入。
 
 ## 上游契約
 
@@ -59,8 +62,9 @@ is_stale, active_incident_id, incident_status, metadata
   永遠不公開的 IODA provider row。Provider-only normal、stale composite 或缺 quorum metadata
   都必須顯示「資料不足」。
 - Atlas／RIS 以兩張主要量測卡顯示 allowlisted value、sample count、confidence、資料時間與 freshness；
-  Cloudflare／IODA／NCDR 是旁證。Freshness 與 judgment 分開：fresh unknown 只代表資料剛更新，總體仍可為
-  `UNKNOWN · BASELINE BUILDING`。null 顯示 `—`；RIS visibility null 額外顯示「RIB 基準建立中」。
+  Monitor 不顯示 Cloudflare／IODA／NCDR。Freshness 與 judgment 分開：fresh 只代表資料剛更新，
+  header 顯示 `OBSERVATION ONLY · BASELINE BUILDING`。null 顯示 `—`；RIS visibility null 額外顯示
+  「RIB 基準建立中」。
 - 100% Ping、0 Origin change 或 0 Withdrawal 都只是單一量測值，不能推導 `normal`。Atlas 與 RIS 同屬
   `ripe_ncc` dependency group，不當成兩個獨立 quorum。
 - Browser model 的 RIPE rows 不進 `summary.evidence`；只輸出 allowlisted `summary.measurements`，固定單位為
@@ -78,6 +82,21 @@ is_stale, active_incident_id, incident_status, metadata
 - Sample count 依 metric 標示其母體：Atlas probe connectivity／Ping 使用 `probes`、median RTT 使用
   `RTT samples`、ASN reachability 使用 `ASNs`、RIS 使用 `BGP messages`，不使用語意模糊的統一 `n=`。
 
+## RIPE 時間軸契約（2026-09-01）
+
+- RPC：`public.get_internet_health_timeseries`；固定 `country / TW`，只請求目前選定 metric 的
+  IPv4／IPv6 兩個 allowlisted signals，前端不直讀 `realtime.*`。
+- 範圍：`24H` 保留 5 分鐘 bucket、`7D` 聚合為 30 分鐘、`30D` 聚合為 2 小時。
+- 30D 拆成連續 half-open chunks 查詢並在前端去除重複邊界；任一 response 達 5,000 rows 即標為
+  truncated／partial，不冒充完整歷史。
+- Ratio 用 `sample_count` 加權平均；RTT 使用 median-of-medians；Origin change count 加總；
+  prefix visibility 取 bucket 內最後一筆 ready 值。
+- 缺資料、partial、unavailable、無 provider timestamp、`sample_count <= 0` 都維持 null／圖表斷線，
+  不補 0。coverage 是 ready 5 分鐘 observation ÷ expected 5 分鐘 observation，IPv4／IPv6 分開顯示；
+  7D／30D aggregate bucket 少任一底層 subslot 即標 partial，不冒充完整 bucket。
+- 所有 RPC 包在 `loadingRegistry`；range／source／metric keyed cache 4 分鐘，畫面每 5 分鐘重抓；
+  切換 Atlas／RIS 時只保留該來源合法 metric。
+
 既有 `ripeAtlasProbes` 是 3,000 點全球靜態 connected-probe metadata 概覽，座標經模糊化且有
 志願者偏差；本卡不以 country／ASN／BGP 狀態替探針染色。RIPE RIS prefix／ASN 也不建立 geometry。
 
@@ -89,35 +108,48 @@ is_stale, active_incident_id, incident_status, metadata
 - `src/components/intel/monitor/monitorLayout.ts`：dock/wall 全寬位置。
 - `src/components/intel/monitor/monitorSplitLayout.ts`：split 全寬位置。
 
-RIPE 擴充只修改 loader、卡片、tests 與本文件。`MonitorPanel`／兩份 layout、layer manifest、
-overlay registry、legend、popup、click registry 與既有 `ripeAtlasProbes` asset 均維持不變。
+RIPE-only 時間軸修改 loader、卡片、共用 sparkline 的 opt-in 明示時間範圍、tests 與本文件。
+`MonitorPanel`／兩份 layout、layer manifest、overlay registry、legend、popup、click registry 與既有
+`ripeAtlasProbes` asset 均維持不變。
 
 既有 `lifelineAlerts` 仍負責 NCDR CAP 地圖：只有上游真的提供 geometry 才渲染；本卡不複製或推測其範圍。
 
 ## 驗收邊界
 
-- RPC migration 未 apply 前，卡片應誠實顯示「資料不足」，不代表前端壞掉。
+- RPC migration 未 apply 前，卡片應誠實顯示「等待 RIPE 量測」或載入失敗，不代表前端壞掉。
 - Browser live gate 必須把卡片與實際 RPC rows、`source_updated_at`、`is_stale` 逐項對照。
-- 單元測試覆蓋 stale、空資料、NCDR-only normal、composite quorum、受限來源、incident 與 null 語意。
+- 單元測試覆蓋 stale／partial／空資料、RIPE allowlist、時間窗聚合、缺口斷線、source 切換與 null 語意。
 - 正式上線仍需 migration apply、collector fresh data、RPC anonymous grant、browser QA 與 deploy 分別確認。
 
 ## Browser live gate
 
 1. 確認 migration 已 apply，且 RPC 用 anonymous session 呼叫 country/TW 能回 fresh detector；只有
    `public_rpc_enabled=true` 且 signal 在 public allowlist 的 provider rows 才能回傳，IODA 缺席是預期政策。
-2. 啟動前端並開啟 Monitor；`電信與網路 · CONNECTIVITY` 應位於事件區下方、全寬、不壓到下方雙欄卡片。
-3. 在 browser Network 面板確認 request 是 `get_internet_health_status`，參數為 country、`[TW]`、include evidence、limit 500。
-4. 逐列對照兩張 RIPE 主卡與 Cloudflare／IODA／NCDR 旁證；RIPE 公開量測顯示 value、sample、confidence、
-   freshness 與資料時間，IODA 顯示 LIMITED；null 必須是 `—`，RIS visibility null 同時顯示
-   「RIB 基準建立中」，NCDR 缺 row 必須是「未通報／無資料」。
-5. 用 stale 或空資料 fixture 驗證總體為「資料不足」且 fresh sources 為 0；用 RPC 失敗驗證舊 normal 不會繼續亮綠。
-6. 用 fresh detector + `normal_quorum_met=true` fixture 驗證 normal；缺 metadata／false 必須 unknown；
-   加入 active NCDR official evidence 時驗證 outage 與 incident 摘要。
-7. 縮窄視窗檢查來源列換行、卡片內容不裁切；Mapbox sources/layers 數量不應因本卡增加。
-8. 用 100% Ping + 0 Withdrawal + 0 Origin change fixture 驗證頁面仍為 `UNKNOWN / 建立基準中`；
-   Network response 若混入非 allowlisted RIPE signal 或 provider metadata，頁面與前端 summary 都不得出現。
+2. 啟動前端並開啟 Monitor；`RIPE NCC 網路觀察 · NETWORK OBSERVATION` 應位於事件區下方、全寬，
+   且卡片內不得出現 Cloudflare／IODA／NCDR／supporting evidence／active incidents。
+3. 在 browser Network 面板確認 current request 是 `get_internet_health_status`；timeline request 是
+   `get_internet_health_timeseries`，固定 country/TW 且只含選定的 RIPE IPv4／IPv6 signals。
+4. 逐列對照兩張 RIPE 主卡；公開量測顯示 value、sample、confidence、freshness 與資料時間；null 必須是
+   `—`，RIS visibility null 同時顯示「RIB 基準建立中」。
+5. 用 stale／partial／空資料 fixture 驗證 header 不顯示舊值或 normal；RPC 失敗時不得沿用上一個
+   range／source／metric 的 coverage 或最後回報。
+6. 用 100% Ping + 0 Withdrawal + 0 Origin change fixture 驗證頁面仍只有 `OBSERVATION ONLY /
+   BASELINE BUILDING`，沒有 normal／outage 判讀。
+7. 逐一切換 24H／7D／30D、Atlas／RIS 與各指標；確認 IPv4／IPv6、coverage、最後回報與缺口可見，
+   partial／empty 不連線也不補 0。縮窄視窗確認控制列換行、卡片內容不裁切；Mapbox sources/layers
+   數量不應因本卡增加。
+8. Network response 若混入 Cloudflare／IODA／NCDR、非 allowlisted RIPE signal 或 provider metadata，
+   Monitor 卡片不得渲染；前端 timeline summary 不得保留 provider metadata。
 9. 用 stream gap、sample count 0、缺 `source_updated_at` 與 visibility 非 null 但缺 `ready` fixture，驗證
    不顯示 CURRENT、不 fallback `observed_at`，且 visibility 仍為 `— / RIB 基準建立中`。
+
+## Target release（RIPE-only timeline）
+
+- Branch：`codex/ripe-observation-timeline`。
+- 目標：Monitor 只顯示 RIPE Atlas／RIS current measurements 與 24H／7D／30D timeline；既有其他來源
+  仍在後端收集，但不構成此畫面。
+- 下方 Production truth 是上一版已部署證據；本段功能必須在 merge、Zeabur deploy 與 browser gate
+  完成後才能改寫為 production truth。
 
 ## Production truth（2026-09-01）
 

--- a/src/components/TimeseriesSparkline.tsx
+++ b/src/components/TimeseriesSparkline.tsx
@@ -15,6 +15,11 @@ export interface SparklinePoint {
 
 export interface TimeseriesSparklineProps {
   data: SparklinePoint[];
+  /**
+   * X 軸明示的 half-open 時間範圍 [from, to)（unix seconds）。
+   * 僅在 from/to 皆為 finite 且 from < to 時生效；無效值回退到既有 data 首尾範圍。
+   */
+  timeDomain?: { from: number; to: number };
   /** value 單位（例：m / cm / mm） */
   unit?: string;
   /** 警戒值（畫紅色水平虛線）；不傳則不畫 */
@@ -71,6 +76,25 @@ export function computeCombinedYRange(
     vMax = Math.max(vMax, warningValue);
   }
   return { vMin, vMax };
+}
+
+/**
+ * X 軸值域（純函式，可獨立測試）。不傳或傳入無效 domain 時，逐位元沿用既有 data 首尾算法。
+ */
+export function computeTimeRange(
+  data: SparklinePoint[],
+  timeDomain?: { from: number; to: number },
+): { tMin: number; tMax: number } | null {
+  if (data.length === 0) return null;
+  if (
+    timeDomain
+    && Number.isFinite(timeDomain.from)
+    && Number.isFinite(timeDomain.to)
+    && timeDomain.from < timeDomain.to
+  ) {
+    return { tMin: timeDomain.from, tMax: timeDomain.to };
+  }
+  return { tMin: data[0]!.t, tMax: data[data.length - 1]!.t };
 }
 
 /** 缺口分段（沿用主線舊邏輯，抽出後主線與 extraSeries 共用） */
@@ -172,6 +196,7 @@ function fmtTooltipValue(v: number, unit: string): string {
 
 export function TimeseriesSparkline({
   data,
+  timeDomain,
   unit = "",
   warningValue = null,
   warningLabel = "警戒",
@@ -208,8 +233,7 @@ export function TimeseriesSparkline({
 
   const view = useMemo(() => {
     if (data.length === 0) return null;
-    const tMin = data[0]!.t;
-    const tMax = data[data.length - 1]!.t;
+    const { tMin, tMax } = computeTimeRange(data, timeDomain)!;
     // Y 值域把 extraSeries（如有）與警戒線一起納入，否則第二條線／警戒線可能跑出畫面
     const { vMin, vMax } = computeCombinedYRange(data, extraSeries?.data, warningValue)!;
     // 給 vMax 留 10% 空間，避免最高點貼頂
@@ -274,7 +298,7 @@ export function TimeseriesSparkline({
     }
 
     return { tMin, tMax, yLo, yHi, ticks, tickStep, xScale, yScale, segViews, extraSegViews, extraByT, timeTicks };
-  }, [data, warningValue, height, w, gapSec, extraSeries]);
+  }, [data, timeDomain, warningValue, height, w, gapSec, extraSeries]);
 
   function handleMouseMove(e: ReactMouseEvent<SVGSVGElement>) {
     if (!showTooltip || !view || data.length === 0) return;

--- a/src/components/__tests__/TimeseriesSparkline.test.ts
+++ b/src/components/__tests__/TimeseriesSparkline.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { computeCombinedYRange, type SparklinePoint } from "../TimeseriesSparkline";
+import { computeCombinedYRange, computeTimeRange, type SparklinePoint } from "../TimeseriesSparkline";
 
 /**
  * TimeseriesSparkline 的 Y 值域計算是 view useMemo 內唯一被抽成純函式的部分
@@ -63,5 +63,44 @@ describe("computeCombinedYRange", () => {
     const extra: SparklinePoint[] = [{ t: 1, v: 200 }];
     const result = computeCombinedYRange(data, extra, -50);
     expect(result).toEqual({ vMin: -50, vMax: 200 });
+  });
+});
+
+describe("computeTimeRange", () => {
+  const day = 24 * 60 * 60;
+  const from = 1_700_000_000;
+  const data: SparklinePoint[] = [
+    { t: from + 10 * day, v: 10 },
+    { t: from + 20 * day, v: 20 },
+  ];
+
+  it("不傳 timeDomain 時沿用既有 data 首尾範圍", () => {
+    expect(computeTimeRange(data)).toEqual({
+      tMin: data[0]!.t,
+      tMax: data[data.length - 1]!.t,
+    });
+  });
+
+  it("明示 30d half-open domain 時使用完整 [from, to) 範圍", () => {
+    expect(computeTimeRange(data, { from, to: from + 30 * day })).toEqual({
+      tMin: from,
+      tMax: from + 30 * day,
+    });
+  });
+
+  it.each([
+    { from: 10, to: 10 },
+    { from: 11, to: 10 },
+    { from: Number.NaN, to: 10 },
+    { from: 0, to: Number.POSITIVE_INFINITY },
+  ])("無效 domain $from..$to 安全回退到既有範圍", (timeDomain) => {
+    expect(computeTimeRange(data, timeDomain)).toEqual({
+      tMin: data[0]!.t,
+      tMax: data[data.length - 1]!.t,
+    });
+  });
+
+  it("空資料維持 null，即使有明示 domain 也不渲染空圖", () => {
+    expect(computeTimeRange([], { from, to: from + 30 * day })).toBeNull();
   });
 });

--- a/src/components/intel/monitor/TelecomStatusCard.tsx
+++ b/src/components/intel/monitor/TelecomStatusCard.tsx
@@ -1,33 +1,33 @@
 /**
- * 台灣電信與網路狀態卡。
+ * RIPE NCC 臺灣網路觀察卡。
  *
- * 這是 Monitor widget，不是地圖 layer：ASN / country 狀態只顯示文字證據，
- * 不建立 Mapbox source，也不推測 coverage geometry。
+ * Atlas / RIS 都屬同一個 RIPE NCC dependency group；這裡只呈現量測與歷史，
+ * 不把單一來源的漂亮數字推導成「臺灣網路正常」，也不建立任何推測 geometry。
  */
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState, type ReactNode } from "react";
+import { TimeseriesSparkline, type SparklinePoint } from "../../TimeseriesSparkline";
 import { COLORS, FONT_CJK, FONT_DATA, relTime } from "../intelTokens";
 import { RADIUS, FONT_SIZE } from "../../../styles/designTokens";
 import { SectionLabel } from "./PressureRing";
 import {
   fetchInternetHealthStatus,
+  fetchInternetHealthTimeline,
   invalidateInternetHealthStatus,
-  type InternetHealthIncident,
+  invalidateInternetHealthTimelineCache,
   type InternetHealthMeasurement,
   type InternetHealthMeasurementSignal,
-  type InternetHealthSourceSummary,
-  type InternetHealthStatus,
   type InternetHealthSummary,
+  type InternetHealthTimelineMetric,
+  type InternetHealthTimelineRange,
+  type InternetHealthTimelineSource,
+  type InternetHealthTimelineSummary,
 } from "../../../data/internetHealthLoader";
 
 export type InternetHealthPhase = "loading" | "ready" | "error";
+type TimelinePhase = "loading" | "ready" | "error";
 
-const STATUS_META: Record<InternetHealthStatus, { label: string; en: string; color: string; tint: string }> = {
-  normal: { label: "目前正常", en: "NORMAL", color: COLORS.statusLive, tint: "rgba(34,197,94,0.07)" },
-  watch: { label: "疑似異常", en: "WATCH", color: COLORS.statusWarn, tint: "rgba(250,204,21,0.07)" },
-  degraded: { label: "局部異常", en: "DEGRADED", color: "#fb923c", tint: "rgba(251,146,60,0.08)" },
-  outage: { label: "中斷訊號", en: "OUTAGE", color: COLORS.statusErr, tint: "rgba(239,68,68,0.09)" },
-  unknown: { label: "資料不足", en: "UNKNOWN", color: COLORS.textDim, tint: "rgba(148,163,184,0.05)" },
-};
+const RIPE_CYAN = "#22d3ee";
+const IPV6_VIOLET = "#a78bfa";
 
 function timeLabel(iso: string | null, nowTs: number): string {
   if (!iso) return "—";
@@ -35,37 +35,16 @@ function timeLabel(iso: string | null, nowTs: number): string {
   return Number.isFinite(ts) ? relTime(ts, nowTs) : "—";
 }
 
-function metricLabel(source: InternetHealthSourceSummary): string {
-  if (source.change_ratio != null) {
-    const pct = source.change_ratio * 100;
-    return `${pct > 0 ? "+" : ""}${pct.toFixed(Math.abs(pct) < 10 ? 1 : 0)}%`;
-  }
-  if (source.value == null) return "—";
-  return `${source.value.toLocaleString("zh-TW", { maximumFractionDigits: 2 })}${source.unit ? ` ${source.unit}` : ""}`;
+function unixTimeLabel(ts: number | null, nowTs: number): string {
+  return ts == null ? "—" : relTime(ts, nowTs);
 }
 
-function sourceStatusLabel(source: InternetHealthSourceSummary): string {
-  if (source.availability === "restricted") {
-    if (source.detector_fresh) return "判定來源新鮮 · 明細不公開";
-    if (source.detector_stale) return "判定來源逾時 · 明細不公開";
-    return "明細不公開 · freshness 未知";
-  }
-  if (source.availability === "stale") return "資料逾時";
-  if (source.availability === "missing") return source.key === "ncdr" ? "未通報／無資料" : "無資料";
-  return STATUS_META[source.status].label;
-}
-
-function ageLabel(ageSeconds: number | null): string {
-  if (ageSeconds == null || ageSeconds < 0) return "—";
-  if (ageSeconds < 60) return `${Math.round(ageSeconds)}s`;
-  if (ageSeconds < 3600) return `${Math.round(ageSeconds / 60)}m`;
-  if (ageSeconds < 86400) return `${(ageSeconds / 3600).toFixed(ageSeconds < 36_000 ? 1 : 0)}h`;
-  return `${(ageSeconds / 86400).toFixed(ageSeconds < 864_000 ? 1 : 0)}d`;
-}
-
-function confidenceLabel(source: InternetHealthSourceSummary): string {
-  const score = source.confidence_score == null ? "" : ` ${(source.confidence_score * 100).toFixed(0)}%`;
-  return `${source.confidence}${score}`;
+function newestMeasurementAt(measurements: InternetHealthMeasurement[]): string | null {
+  const timestamps = measurements
+    .map((item) => item.source_updated_at)
+    .filter((value): value is string => value != null && Number.isFinite(Date.parse(value)))
+    .sort((a, b) => Date.parse(b) - Date.parse(a));
+  return timestamps[0] ?? null;
 }
 
 const MEASUREMENT_LABELS: Record<InternetHealthMeasurementSignal, string> = {
@@ -122,11 +101,11 @@ function measurementStateLabel(measurement: InternetHealthMeasurement | undefine
 }
 
 function MeasurementCard({
-  title, subtitle, source, measurements, signals, nowTs,
+  title, subtitle, sourceKey, measurements, signals, nowTs,
 }: {
   title: string;
   subtitle: string;
-  source: InternetHealthSourceSummary | undefined;
+  sourceKey: "ripe_atlas" | "ripe_ris";
   measurements: InternetHealthMeasurement[];
   signals: InternetHealthMeasurementSignal[];
   nowTs: number;
@@ -135,17 +114,16 @@ function MeasurementCard({
   const hasPartial = measurements.some((item) => item.state === "partial");
   const hasBaseline = measurements.some((item) => item.state === "baseline_building");
   const hasStale = measurements.some((item) => item.freshness === "stale");
-  const freshness = source?.availability === "restricted" ? "LIMITED"
-    : current > 0 ? "CURRENT"
-      : hasPartial ? "PARTIAL"
-        : hasBaseline ? "BASELINE"
-          : hasStale ? "STALE"
-            : measurements.length > 0 ? "UNAVAILABLE" : "NO DATA";
-  const freshnessColor = current > 0 ? "#22d3ee" : COLORS.textDim;
+  const freshness = current > 0 ? "CURRENT"
+    : hasPartial ? "PARTIAL"
+      : hasBaseline ? "BASELINE"
+        : hasStale ? "STALE"
+          : measurements.length > 0 ? "UNAVAILABLE" : "NO DATA";
   const pairs = signals.filter((_, index) => index % 2 === 0);
+
   return (
     <div
-      data-testid={`internet-health-measurements-${source?.key ?? "missing"}`}
+      data-testid={`internet-health-measurements-${sourceKey}`}
       style={{
         minWidth: 0, padding: "11px 12px", borderRadius: RADIUS.xl,
         border: `1px solid ${COLORS.borderMid}`, background: "rgba(2,8,23,0.32)",
@@ -156,7 +134,7 @@ function MeasurementCard({
           <b style={{ display: "block", fontFamily: FONT_DATA, fontSize: FONT_SIZE.base, color: COLORS.textDefault }}>{title}</b>
           <span style={{ display: "block", marginTop: 2, fontFamily: FONT_CJK, fontSize: FONT_SIZE.xs, color: COLORS.textFaint }}>{subtitle}</span>
         </span>
-        <span style={{ fontFamily: FONT_DATA, fontSize: FONT_SIZE.xs, color: freshnessColor, letterSpacing: "0.8px" }}>{freshness}</span>
+        <span style={{ fontFamily: FONT_DATA, fontSize: FONT_SIZE.xs, color: current > 0 ? RIPE_CYAN : COLORS.textDim, letterSpacing: "0.8px" }}>{freshness}</span>
       </div>
       <div style={{ display: "grid", gridTemplateColumns: "minmax(94px, 1.2fr) repeat(2, minmax(70px, 1fr))", gap: "5px 8px", marginTop: 10 }}>
         <span />
@@ -196,267 +174,235 @@ function MeasurementCard({
   );
 }
 
-function SourceEvidenceRow({ source, nowTs }: { source: InternetHealthSourceSummary; nowTs: number }) {
-  const meta = STATUS_META[source.fresh ? source.status : "unknown"];
-  const restricted = source.availability === "restricted";
-  const timestamp = source.source_updated_at ?? source.observed_at;
+const RANGE_LABELS: Record<InternetHealthTimelineRange, string> = { "24h": "24H", "7d": "7D", "30d": "30D" };
+
+const SOURCE_LABELS: Record<InternetHealthTimelineSource, string> = {
+  ripe_atlas: "RIPE Atlas",
+  ripe_ris: "RIPE RIS Live",
+};
+
+const METRIC_OPTIONS: Record<InternetHealthTimelineSource, { value: InternetHealthTimelineMetric; label: string }[]> = {
+  ripe_atlas: [
+    { value: "ping_success_ratio", label: "Ping 成功率" },
+    { value: "median_rtt_ms", label: "中位 RTT" },
+    { value: "probe_connectivity_ratio", label: "Probe 回報率" },
+    { value: "reachable_asn_ratio", label: "可達 ASN 比率" },
+  ],
+  ripe_ris: [
+    { value: "prefix_visibility_ratio", label: "Prefix 可見度" },
+    { value: "withdrawn_prefix_ratio", label: "撤回 Prefix 比率" },
+    { value: "origin_change_count", label: "Origin 變更" },
+  ],
+};
+
+function chartUnit(summary: InternetHealthTimelineSummary): string {
+  if (summary.unit === "ratio") return "%";
+  if (summary.unit === "milliseconds") return "ms";
+  return "次";
+}
+
+function toSparkline(summary: InternetHealthTimelineSummary, family: 4 | 6): SparklinePoint[] {
+  const series = family === 4 ? summary.ipv4 : summary.ipv6;
+  const ratio = summary.unit === "ratio";
+  return series.points.flatMap((point) => (
+    point.state === "ready" && point.value != null
+      ? [{ t: point.at, v: ratio ? point.value * 100 : point.value }]
+      : []
+  ));
+}
+
+function coverageLabel(value: number): string {
+  return `${(value * 100).toFixed(value < 0.1 ? 1 : 0)}%`;
+}
+
+export function RipeTimelineView({
+  summary, phase, range, source, metric, nowTs,
+  onRangeChange, onSourceChange, onMetricChange,
+}: {
+  summary: InternetHealthTimelineSummary | null;
+  phase: TimelinePhase;
+  range: InternetHealthTimelineRange;
+  source: InternetHealthTimelineSource;
+  metric: InternetHealthTimelineMetric;
+  nowTs: number;
+  onRangeChange?: (range: InternetHealthTimelineRange) => void;
+  onSourceChange?: (source: InternetHealthTimelineSource) => void;
+  onMetricChange?: (metric: InternetHealthTimelineMetric) => void;
+}) {
+  const displayedSummary = summary?.range === range && summary.source === source && summary.metric === metric
+    ? summary
+    : null;
+  const ipv4 = displayedSummary ? toSparkline(displayedSummary, 4) : [];
+  const ipv6 = displayedSummary ? toSparkline(displayedSummary, 6) : [];
+  const hasIPv4 = ipv4.length > 0;
+  const primary = hasIPv4 ? ipv4 : ipv6;
+  const secondary = hasIPv4 ? ipv6 : [];
+  const primaryFamily = hasIPv4 ? 4 : 6;
+  const metricLabel = METRIC_OPTIONS[source].find((item) => item.value === metric)?.label ?? metric;
+  // 兩個 ready 點中間只缺一格時相距 2 buckets；門檻必須 < 2 才會誠實斷線。
+  const gapSec = displayedSummary ? displayedSummary.bucketSeconds * 1.5 : undefined;
+
   return (
-    <div
-      data-testid={`internet-health-source-${source.key}`}
-      style={{
-        display: "grid", gridTemplateColumns: "minmax(110px, 1fr) auto",
-        alignItems: "center", columnGap: 9, rowGap: 2, padding: "7px 9px", borderRadius: RADIUS.lg,
-        background: "rgba(255,255,255,0.025)", border: `1px solid ${COLORS.borderSoft}`,
-      }}
-    >
-      <span style={{ display: "flex", alignItems: "center", gap: 7, minWidth: 0 }}>
-        <span
-          style={{
-            width: 7, height: 7, borderRadius: RADIUS.full, background: meta.color,
-            boxShadow: source.fresh ? `0 0 5px ${meta.color}` : "none", flexShrink: 0,
-          }}
-        />
-        <span
-          style={{
-            fontFamily: FONT_DATA, fontSize: FONT_SIZE.sm, fontWeight: 700,
-            color: COLORS.textDefault, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap",
-          }}
-        >
-          {source.label}
+    <div data-testid="ripe-internet-health-timeline" style={{ gridColumn: "1 / -1", padding: "12px", borderRadius: RADIUS.xl, border: `1px solid ${COLORS.borderMid}`, background: "rgba(2,8,23,0.42)", minWidth: 0 }}>
+      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start", gap: 10, flexWrap: "wrap" }}>
+        <span>
+          <b style={{ display: "block", fontFamily: FONT_DATA, fontSize: FONT_SIZE.base, color: COLORS.textDefault }}>RIPE 歷史量測</b>
+          <span style={{ display: "block", marginTop: 2, fontFamily: FONT_CJK, fontSize: FONT_SIZE.xs, color: COLORS.textFaint }}>觀察趨勢與資料缺口 · 不單獨判定全臺正常或斷網</span>
         </span>
-        {restricted && (
-          <span
-            style={{
-              padding: "1px 5px", borderRadius: RADIUS.full, border: `1px solid ${COLORS.borderMid}`,
-              color: COLORS.textDim, fontFamily: FONT_DATA, fontSize: FONT_SIZE.xs,
-              letterSpacing: "0.6px", flexShrink: 0,
-            }}
-          >
-            LIMITED
-          </span>
+        <span style={{ display: "flex", gap: 4 }}>
+          {(Object.keys(RANGE_LABELS) as InternetHealthTimelineRange[]).map((item) => {
+            const selected = item === range;
+            return (
+              <button key={item} type="button" aria-pressed={selected} onClick={() => onRangeChange?.(item)} style={{ border: `1px solid ${selected ? RIPE_CYAN : COLORS.borderMid}`, borderRadius: RADIUS.md, padding: "4px 8px", cursor: "pointer", background: selected ? "rgba(34,211,238,0.12)" : "rgba(255,255,255,0.02)", color: selected ? RIPE_CYAN : COLORS.textDim, fontFamily: FONT_DATA, fontSize: FONT_SIZE.xs }}>
+                {RANGE_LABELS[item]}
+              </button>
+            );
+          })}
+        </span>
+      </div>
+
+      <div style={{ display: "flex", gap: 8, alignItems: "center", flexWrap: "wrap", marginTop: 10 }}>
+        <span style={{ display: "flex", gap: 4 }}>
+          {(Object.keys(SOURCE_LABELS) as InternetHealthTimelineSource[]).map((item) => {
+            const selected = item === source;
+            return (
+              <button key={item} type="button" aria-pressed={selected} onClick={() => onSourceChange?.(item)} style={{ border: 0, borderBottom: `1px solid ${selected ? RIPE_CYAN : "transparent"}`, padding: "4px 5px", cursor: "pointer", background: "transparent", color: selected ? COLORS.textDefault : COLORS.textDim, fontFamily: FONT_DATA, fontSize: FONT_SIZE.xs }}>
+                {SOURCE_LABELS[item]}
+              </button>
+            );
+          })}
+        </span>
+        <label style={{ marginLeft: "auto", fontFamily: FONT_CJK, fontSize: FONT_SIZE.xs, color: COLORS.textFaint }}>
+          指標{" "}
+          <select aria-label="RIPE 時間軸指標" value={metric} onChange={(event) => onMetricChange?.(event.target.value as InternetHealthTimelineMetric)} style={{ marginLeft: 4, minHeight: 27, padding: "3px 24px 3px 7px", borderRadius: RADIUS.md, border: `1px solid ${COLORS.borderMid}`, background: "#09101d", color: COLORS.textDefault, fontFamily: FONT_CJK, fontSize: FONT_SIZE.xs }}>
+            {METRIC_OPTIONS[source].map((item) => <option key={item.value} value={item.value}>{item.label}</option>)}
+          </select>
+        </label>
+      </div>
+
+      <div style={{ minHeight: 148, marginTop: 8 }}>
+        {phase === "loading" && <div style={{ height: 138, display: "grid", placeItems: "center", color: COLORS.textFaint, fontFamily: FONT_CJK, fontSize: FONT_SIZE.sm }}>正在載入 {SOURCE_LABELS[source]} {RANGE_LABELS[range]} 歷史量測…</div>}
+        {phase === "error" && <div style={{ height: 138, display: "grid", placeItems: "center", color: COLORS.statusWarn, fontFamily: FONT_CJK, fontSize: FONT_SIZE.sm }}>歷史量測暫時無法更新；目前數值仍可繼續查看</div>}
+        {phase === "ready" && (!displayedSummary || displayedSummary.empty || primary.length === 0) && <div style={{ height: 138, display: "grid", placeItems: "center", color: COLORS.textFaint, fontFamily: FONT_CJK, fontSize: FONT_SIZE.sm, textAlign: "center" }}>這段期間尚無可畫的 {metricLabel}；空白不是 0，也不代表異常</div>}
+        {phase === "ready" && displayedSummary && primary.length > 0 && (
+          <TimeseriesSparkline
+            data={primary}
+            timeDomain={{ from: displayedSummary.from, to: displayedSummary.to }}
+            unit={chartUnit(displayedSummary)}
+            height={142}
+            gapSec={gapSec}
+            fillArea
+            lineColor={primaryFamily === 4 ? RIPE_CYAN : IPV6_VIOLET}
+            seriesLabel={`IPv${primaryFamily}`}
+            extraSeries={secondary.length > 0 ? { data: secondary, color: IPV6_VIOLET, label: "IPv6" } : undefined}
+            showTooltip
+          />
         )}
-      </span>
-      <span style={{ minWidth: 0, gridColumn: "1 / -1", gridRow: 2 }}>
-        <span style={{ fontFamily: FONT_CJK, fontSize: FONT_SIZE.sm, color: meta.color }}>
-          {sourceStatusLabel(source)}
-        </span>
-        <span
-          style={{
-            display: "block", marginTop: 1, fontFamily: FONT_DATA, fontSize: FONT_SIZE.xs,
-            color: COLORS.textFaint, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap",
-          }}
-          title={source.signal ?? undefined}
-        >
-          {restricted ? "detector evidence" : (source.signal ?? "—")} · {timestamp ? timeLabel(timestamp, nowTs) : "—"}
-        </span>
-        <span
-          style={{
-            display: "block", marginTop: 1, fontFamily: FONT_DATA, fontSize: FONT_SIZE.xs,
-            color: COLORS.textFaint, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap",
-          }}
-        >
-          age {ageLabel(source.age_seconds)} · n={source.sample_count?.toLocaleString("zh-TW") ?? "—"} · confidence {confidenceLabel(source)}
-        </span>
-      </span>
-      <span
-        style={{
-          gridColumn: 2, gridRow: 1,
-          fontFamily: FONT_DATA, fontSize: FONT_SIZE.base, fontWeight: 700,
-          color: source.fresh ? meta.color : COLORS.textFaint, whiteSpace: "nowrap",
-        }}
-      >
-        {restricted ? "—" : metricLabel(source)}
-      </span>
+      </div>
+
+      <div style={{ display: "flex", gap: "6px 14px", flexWrap: "wrap", alignItems: "center", marginTop: 4, fontFamily: FONT_DATA, fontSize: FONT_SIZE.xs, color: COLORS.textFaint }}>
+        <span><i style={{ display: "inline-block", width: 9, height: 2, marginRight: 5, verticalAlign: "middle", background: RIPE_CYAN }} />IPv4</span>
+        <span><i style={{ display: "inline-block", width: 9, height: 2, marginRight: 5, verticalAlign: "middle", background: IPV6_VIOLET }} />IPv6</span>
+        <span>IPv4 coverage {displayedSummary ? coverageLabel(displayedSummary.ipv4.coverage) : "—"}</span>
+        <span>IPv6 coverage {displayedSummary ? coverageLabel(displayedSummary.ipv6.coverage) : "—"}</span>
+        <span>最後回報 {displayedSummary ? unixTimeLabel(displayedSummary.latestAt, nowTs) : "—"}</span>
+        {displayedSummary?.partial && <span style={{ color: COLORS.statusWarn }}>含缺口／部分資料</span>}
+        {displayedSummary?.truncated && <span style={{ color: COLORS.statusErr }}>回傳達上限，圖表不完整</span>}
+      </div>
     </div>
   );
 }
 
-const INCIDENT_KIND_LABELS: Record<string, string> = {
-  single_asn_outage: "單一電信商異常",
-  multi_asn_partial_outage: "多家電信商局部異常",
-  national_outage: "全臺大規模中斷",
-  international_path_degradation: "國際路徑異常",
-  selective_service_blocking: "特定服務異常",
-};
+function RipeTimelinePanel({ open, nowTs }: { open: boolean; nowTs: number }) {
+  const [range, setRange] = useState<InternetHealthTimelineRange>("24h");
+  const [source, setSource] = useState<InternetHealthTimelineSource>("ripe_atlas");
+  const [metric, setMetric] = useState<InternetHealthTimelineMetric>("ping_success_ratio");
+  const [summary, setSummary] = useState<InternetHealthTimelineSummary | null>(null);
+  const [phase, setPhase] = useState<TimelinePhase>("loading");
 
-function IncidentRow({ incident, nowTs }: { incident: InternetHealthIncident; nowTs: number }) {
-  const meta = STATUS_META[incident.severity];
-  const kind = incident.kind ? (INCIDENT_KIND_LABELS[incident.kind] ?? incident.kind.replace(/_/g, " ")) : "網路異常";
-  const entity = incident.entity_name ?? incident.entity_id;
-  return (
-    <div
-      data-testid="internet-health-incident"
-      style={{
-        display: "flex", gap: 8, alignItems: "flex-start", padding: "6px 8px",
-        borderRadius: RADIUS.lg, background: meta.tint, border: `1px solid ${meta.color}44`,
-      }}
-    >
-      <span style={{ width: 7, height: 7, marginTop: 4, borderRadius: RADIUS.full, background: meta.color, flexShrink: 0 }} />
-      <span style={{ minWidth: 0, flex: 1 }}>
-        <span style={{ display: "block", fontFamily: FONT_CJK, fontSize: FONT_SIZE.sm, color: COLORS.textDefault }}>
-          {entity} · {kind}
-        </span>
-        <span style={{ display: "block", marginTop: 1, fontFamily: FONT_DATA, fontSize: FONT_SIZE.xs, color: COLORS.textFaint }}>
-          {incident.source} · {timeLabel(incident.observed_at, nowTs)} · confidence {incident.confidence}
-        </span>
-      </span>
-    </div>
-  );
+  useEffect(() => {
+    if (!open) return;
+    let cancelled = false;
+    let latestRequest = 0;
+    const tick = (force = false) => {
+      const requestId = ++latestRequest;
+      if (force) invalidateInternetHealthTimelineCache();
+      setSummary(null);
+      setPhase("loading");
+      fetchInternetHealthTimeline({ range, source, metric })
+        .then((next) => {
+          if (cancelled || requestId !== latestRequest) return;
+          setSummary(next);
+          setPhase("ready");
+        })
+        .catch((error) => {
+          console.warn("[TelecomStatusCard] get_internet_health_timeseries failed", error);
+          if (!cancelled && requestId === latestRequest) setPhase("error");
+        });
+    };
+    tick();
+    const id = window.setInterval(() => tick(true), 5 * 60_000);
+    return () => {
+      cancelled = true;
+      window.clearInterval(id);
+    };
+  }, [metric, open, range, source]);
+
+  const handleSourceChange = (next: InternetHealthTimelineSource) => {
+    setSource(next);
+    setMetric(METRIC_OPTIONS[next][0]!.value);
+  };
+
+  return <RipeTimelineView summary={summary} phase={phase} range={range} source={source} metric={metric} nowTs={nowTs} onRangeChange={setRange} onSourceChange={handleSourceChange} onMetricChange={setMetric} />;
 }
 
 export function TelecomStatusCardView({
-  summary, phase, nowTs,
+  summary, phase, nowTs, timeline,
 }: {
   summary: InternetHealthSummary | null;
   phase: InternetHealthPhase;
   nowTs: number;
+  timeline?: ReactNode;
 }) {
-  // 載入失敗時即使留有上次成功資料，也不能繼續亮 normal。
-  const effectiveStatus: InternetHealthStatus = phase === "error"
-    ? "unknown"
-    : (summary?.overall_status ?? "unknown");
-  const meta = STATUS_META[effectiveStatus];
-  const baselineBuilding = phase === "ready" && summary?.assessment_phase === "baseline_building";
-  const statusLabel = baselineBuilding ? "建立基準中" : meta.label;
-  const statusEn = baselineBuilding ? "UNKNOWN · BASELINE BUILDING" : meta.en;
-  const description = phase === "loading"
-    ? "正在取得多來源觀測…"
-    : phase === "error"
-      ? "本次更新失敗，暫時無法判斷"
-      : (summary?.summary ?? "核心來源不足，暫時無法判斷");
-  const sources = (summary?.sources ?? []).map((source) => phase === "error"
-    ? {
-        ...source,
-        status: "unknown" as const,
-        fresh: false,
-        availability: source.availability === "restricted" ? "restricted" as const : "missing" as const,
-        detector_fresh: false,
-        detector_stale: false,
-      }
-    : source);
-  const incidents = summary?.incidents ?? [];
-  const confidence = phase === "error" ? "unknown" : (summary?.confidence ?? "unknown");
-  const confidenceScore = phase === "error" ? null : (summary?.confidence_score ?? null);
-  const freshSourceCount = phase === "error" ? 0 : (summary?.fresh_source_count ?? 0);
   const measurements = phase === "error" ? [] : (summary?.measurements ?? []);
-  const atlasSource = sources.find((source) => source.key === "ripe_atlas");
-  const risSource = sources.find((source) => source.key === "ripe_ris");
-  const supportingSources = sources.filter((source) => (
-    source.key === "cloudflare" || source.key === "ioda" || source.key === "ncdr"
-  ));
-  const quorumLabel = phase === "error" || summary?.normal_quorum_met == null
-    ? "—"
-    : summary.normal_quorum_met ? "PASS" : "NO";
+  const atlasMeasurements = measurements.filter((item) => item.source_key === "ripe_atlas");
+  const risMeasurements = measurements.filter((item) => item.source_key === "ripe_ris");
+  const freshMetricCount = measurements.filter((item) => item.freshness === "fresh").length;
+  const reportingFeeds = Number(atlasMeasurements.some((item) => item.freshness === "fresh")) + Number(risMeasurements.some((item) => item.freshness === "fresh"));
+  const latestAt = newestMeasurementAt(measurements);
+  const statusLabel = phase === "loading" ? "正在讀取 RIPE 量測" : phase === "error" ? "RIPE 量測暫時無法更新" : freshMetricCount > 0 ? "RIPE 量測中" : "等待 RIPE 量測";
+  const statusColor = freshMetricCount > 0 && phase === "ready" ? RIPE_CYAN : COLORS.textDim;
+  const description = phase === "error" ? "本次更新失敗；不沿用舊資料判定網路狀態。" : "持續觀察 RIPE Atlas 端到端量測與 RIPE RIS BGP 路由更新。數值先如實呈現，異常判讀待基準累積後再加入。";
 
   return (
     <div data-testid="internet-health-card" style={{ display: "flex", flexDirection: "column", gap: 10 }}>
-      <SectionLabel color="#22d3ee">電信與網路 · CONNECTIVITY</SectionLabel>
-      <div
-        style={{
-          borderRadius: RADIUS.xl, border: `1px solid ${meta.color}55`,
-          background: `linear-gradient(145deg, ${meta.tint}, rgba(255,255,255,0.012) 48%)`,
-          padding: "12px 14px", display: "grid",
-          gridTemplateColumns: "repeat(auto-fit, minmax(min(100%, 250px), 1fr))",
-          gap: 14, alignItems: "stretch",
-        }}
-      >
+      <SectionLabel color={RIPE_CYAN}>RIPE NCC 網路觀察 · NETWORK OBSERVATION</SectionLabel>
+      <div style={{ borderRadius: RADIUS.xl, border: `1px solid ${statusColor}55`, background: "linear-gradient(145deg, rgba(34,211,238,0.055), rgba(255,255,255,0.012) 48%)", padding: "12px 14px", display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(min(100%, 250px), 1fr))", gap: 14, alignItems: "stretch" }}>
         <div style={{ display: "flex", flexDirection: "column", justifyContent: "space-between", gap: 10, gridColumn: "1 / -1" }}>
           <div>
             <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
-              <span
-                data-testid="internet-health-status-dot"
-                style={{
-                  width: 12, height: 12, borderRadius: RADIUS.full, background: meta.color,
-                  boxShadow: effectiveStatus === "unknown" ? "none" : `0 0 8px ${meta.color}`,
-                }}
-              />
-              <span
-                data-testid="internet-health-status-label"
-                style={{ fontFamily: FONT_CJK, fontSize: FONT_SIZE.lg, fontWeight: 700, color: meta.color }}
-              >
-                {statusLabel}
-              </span>
+              <span data-testid="internet-health-status-dot" style={{ width: 12, height: 12, borderRadius: RADIUS.full, background: statusColor }} />
+              <span data-testid="internet-health-status-label" style={{ fontFamily: FONT_CJK, fontSize: FONT_SIZE.lg, fontWeight: 700, color: statusColor }}>{statusLabel}</span>
             </div>
-            <div style={{ marginTop: 4, fontFamily: FONT_DATA, fontSize: FONT_SIZE.xs, letterSpacing: "1.6px", color: COLORS.textFaint }}>
-              {statusEn} · confidence {confidence}{confidenceScore == null ? "" : ` ${(confidenceScore * 100).toFixed(0)}%`}
-            </div>
+            <div style={{ marginTop: 4, fontFamily: FONT_DATA, fontSize: FONT_SIZE.xs, letterSpacing: "1.6px", color: COLORS.textFaint }}>OBSERVATION ONLY · BASELINE BUILDING</div>
           </div>
-          <div style={{ fontFamily: FONT_CJK, fontSize: FONT_SIZE.sm, lineHeight: 1.45, color: COLORS.textMuted }}>
-            {description}
-          </div>
+          <div style={{ fontFamily: FONT_CJK, fontSize: FONT_SIZE.sm, lineHeight: 1.45, color: COLORS.textMuted }}>{description}</div>
           <div style={{ display: "flex", gap: 14, flexWrap: "wrap" }}>
-            <span style={{ fontFamily: FONT_DATA, fontSize: FONT_SIZE.xs, color: COLORS.textFaint }}>
-              FRESH PUBLIC<br />
-              <b style={{ fontSize: FONT_SIZE.md, color: COLORS.textDefault }}>
-                {freshSourceCount}/{summary?.public_source_total ?? 2}
-              </b>
-            </span>
-            <span style={{ fontFamily: FONT_DATA, fontSize: FONT_SIZE.xs, color: COLORS.textFaint }}>
-              NORMAL QUORUM<br />
-              <b style={{ fontSize: FONT_SIZE.sm, color: summary?.normal_quorum_met ? COLORS.statusLive : COLORS.textDefault }}>
-                {quorumLabel}
-              </b>
-            </span>
-            <span style={{ fontFamily: FONT_DATA, fontSize: FONT_SIZE.xs, color: COLORS.textFaint }}>
-              LAST UPDATE<br />
-              <b style={{ fontSize: FONT_SIZE.sm, color: COLORS.textDefault }}>
-                {timeLabel(summary?.last_updated_at ?? null, nowTs)}
-              </b>
-            </span>
+            <span style={{ fontFamily: FONT_DATA, fontSize: FONT_SIZE.xs, color: COLORS.textFaint }}>FRESH METRICS<br /><b style={{ fontSize: FONT_SIZE.md, color: COLORS.textDefault }}>{freshMetricCount}/14</b></span>
+            <span style={{ fontFamily: FONT_DATA, fontSize: FONT_SIZE.xs, color: COLORS.textFaint }}>REPORTING FEEDS<br /><b style={{ fontSize: FONT_SIZE.md, color: COLORS.textDefault }}>{reportingFeeds}/2</b></span>
+            <span style={{ fontFamily: FONT_DATA, fontSize: FONT_SIZE.xs, color: COLORS.textFaint }}>LAST RIPE UPDATE<br /><b style={{ fontSize: FONT_SIZE.sm, color: COLORS.textDefault }}>{timeLabel(latestAt, nowTs)}</b></span>
           </div>
         </div>
 
-        <div
-          style={{
-            gridColumn: "1 / -1", display: "grid",
-            gridTemplateColumns: "repeat(auto-fit, minmax(min(100%, 300px), 1fr))", gap: 10,
-          }}
-        >
-          <MeasurementCard
-            title="RIPE Atlas" subtitle="端到端主動量測 · RIPE NCC"
-            source={atlasSource} measurements={measurements.filter((item) => item.source_key === "ripe_atlas")}
-            signals={ATLAS_SIGNALS} nowTs={nowTs}
-          />
-          <MeasurementCard
-            title="RIPE RIS Live" subtitle="BGP 路由觀測 · RIPE NCC"
-            source={risSource} measurements={measurements.filter((item) => item.source_key === "ripe_ris")}
-            signals={RIS_SIGNALS} nowTs={nowTs}
-          />
+        <div style={{ gridColumn: "1 / -1", display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(min(100%, 300px), 1fr))", gap: 10 }}>
+          <MeasurementCard title="RIPE Atlas" subtitle="端到端主動量測 · RIPE NCC" sourceKey="ripe_atlas" measurements={atlasMeasurements} signals={ATLAS_SIGNALS} nowTs={nowTs} />
+          <MeasurementCard title="RIPE RIS Live" subtitle="BGP 路由觀測 · RIPE NCC" sourceKey="ripe_ris" measurements={risMeasurements} signals={RIS_SIGNALS} nowTs={nowTs} />
         </div>
 
-        <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
-          <span style={{ fontFamily: FONT_DATA, fontSize: FONT_SIZE.xs, letterSpacing: "1.2px", color: COLORS.textDim }}>
-            SUPPORTING EVIDENCE
-          </span>
-          {supportingSources.length > 0
-            ? supportingSources.map((source) => <SourceEvidenceRow key={source.key} source={source} nowTs={nowTs} />)
-            : (["Cloudflare Radar", "IODA", "NCDR"] as const).map((label) => (
-              <div key={label} style={{ padding: "7px 9px", borderRadius: RADIUS.lg, border: `1px solid ${COLORS.borderSoft}`, color: COLORS.textFaint, fontFamily: FONT_DATA, fontSize: FONT_SIZE.sm }}>
-                {label} · —
-              </div>
-            ))}
-        </div>
+        {timeline}
 
-        <div style={{ display: "flex", flexDirection: "column", gap: 6, minWidth: 0 }}>
-          <span style={{ fontFamily: FONT_DATA, fontSize: FONT_SIZE.xs, letterSpacing: "1.2px", color: COLORS.textDim }}>
-            ACTIVE INCIDENTS
-          </span>
-          {incidents.length > 0
-            ? incidents.slice(0, 3).map((incident) => <IncidentRow key={incident.id} incident={incident} nowTs={nowTs} />)
-            : (
-              <div
-                style={{
-                  flex: 1, minHeight: 54, display: "flex", alignItems: "center", justifyContent: "center",
-                  borderRadius: RADIUS.lg, border: `1px dashed ${COLORS.borderMid}`,
-                  fontFamily: FONT_CJK, fontSize: FONT_SIZE.sm, color: COLORS.textFaint, textAlign: "center",
-                }}
-              >
-                {effectiveStatus === "normal" ? "目前沒有 active incident" : "沒有可確認的 incident 資料"}
-              </div>
-            )}
-          <span style={{ marginTop: "auto", fontFamily: FONT_CJK, fontSize: FONT_SIZE.xs, lineHeight: 1.4, color: COLORS.textFaint }}>
-            Atlas 與 RIS 同屬 RIPE NCC，不視為兩個獨立 quorum。量測 freshness 與狀態判讀分離；100% Ping、0 Origin 變更或 0 Withdrawal 都不能單獨推導為正常。ASN／prefix 僅列文字，不推測服務範圍。
-          </span>
+        <div style={{ gridColumn: "1 / -1", fontFamily: FONT_CJK, fontSize: FONT_SIZE.xs, lineHeight: 1.5, color: COLORS.textFaint }}>
+          Atlas 與 RIS 同屬 RIPE NCC，只算一個來源群組。CURRENT 只表示至少一項量測新鮮；100% Ping、0 Origin 變更或 0 Withdrawal 都不能單獨推導為正常。圖表缺口維持空白，不補成 0。
         </div>
       </div>
     </div>
@@ -491,5 +437,6 @@ export function TelecomStatusCard({ open, nowTs }: { open: boolean; nowTs: numbe
     };
   }, [open]);
 
-  return <TelecomStatusCardView summary={summary} phase={phase} nowTs={nowTs} />;
+  const timeline = useMemo(() => <RipeTimelinePanel open={open} nowTs={nowTs} />, [nowTs, open]);
+  return <TelecomStatusCardView summary={summary} phase={phase} nowTs={nowTs} timeline={timeline} />;
 }

--- a/src/components/intel/monitor/__tests__/TelecomStatusCard.test.ts
+++ b/src/components/intel/monitor/__tests__/TelecomStatusCard.test.ts
@@ -1,10 +1,13 @@
 import { createElement } from "react";
 import { describe, expect, it } from "vitest";
 import { renderToStaticMarkup } from "react-dom/server";
-import { aggregateInternetHealthRows } from "../../../../data/internetHealthLoader";
-import { TelecomStatusCardView } from "../TelecomStatusCard";
+import {
+  aggregateInternetHealthRows,
+  type InternetHealthTimelineSummary,
+} from "../../../../data/internetHealthLoader";
+import { RipeTimelineView, TelecomStatusCardView } from "../TelecomStatusCard";
 
-const freshNormal = (source: string) => ({
+const freshRow = (source: string) => ({
   row_type: "status",
   source_observation_id: `${source}-1`,
   entity_type: "country",
@@ -13,8 +16,8 @@ const freshNormal = (source: string) => ({
   source,
   evidence_family: "network",
   signal: "reachability",
-  reported_status: "normal",
-  effective_status: "normal",
+  reported_status: "unknown",
+  effective_status: "unknown",
   incident_kind: null,
   value: null,
   unit: null,
@@ -32,8 +35,6 @@ const freshNormal = (source: string) => ({
   metadata: {},
 });
 
-const normalDetector = () => freshNormal("internet_health_detector_v1") satisfies Record<string, unknown>;
-
 const renderCard = (
   summary: ReturnType<typeof aggregateInternetHealthRows>,
   phase: "loading" | "ready" | "error",
@@ -41,87 +42,110 @@ const renderCard = (
   summary, phase, nowTs: 1_788_060_000,
 }));
 
+const timelineSummary: InternetHealthTimelineSummary = {
+  range: "24h",
+  source: "ripe_atlas",
+  metric: "ping_success_ratio",
+  unit: "ratio",
+  from: 1_787_973_600,
+  to: 1_788_060_000,
+  bucketSeconds: 300,
+  ipv4: {
+    addressFamily: 4,
+    signal: "ping_success_ratio_ipv4",
+    points: [
+      { at: 1_788_055_200, value: 0.99, state: "ready", sampleCount: 10 },
+      { at: 1_788_055_500, value: null, state: "partial", sampleCount: 0 },
+      { at: 1_788_055_800, value: 1, state: "ready", sampleCount: 12 },
+    ],
+    coverage: 2 / 3,
+    readyBuckets: 2,
+    totalBuckets: 3,
+  },
+  ipv6: {
+    addressFamily: 6,
+    signal: "ping_success_ratio_ipv6",
+    points: [
+      { at: 1_788_055_200, value: 0.96, state: "ready", sampleCount: 20 },
+      { at: 1_788_055_500, value: 0.97, state: "ready", sampleCount: 22 },
+      { at: 1_788_055_800, value: 0.98, state: "ready", sampleCount: 25 },
+    ],
+    coverage: 1,
+    readyBuckets: 3,
+    totalBuckets: 3,
+  },
+  coverage: 5 / 6,
+  latestAt: 1_788_055_800,
+  truncated: false,
+  partial: true,
+  empty: false,
+};
+
 describe("TelecomStatusCardView", () => {
-  it("renders missing data as unknown, not a green normal state", () => {
+  it("is RIPE-only and keeps missing measurements as observation wait state", () => {
     const html = renderCard(aggregateInternetHealthRows([]), "ready");
-    expect(html).toContain("資料不足");
-    expect(html).toContain("Cloudflare Radar");
-    expect(html).toContain("internet-health-source-cloudflare");
+    expect(html).toContain("RIPE NCC 網路觀察");
+    expect(html).toContain("等待 RIPE 量測");
+    expect(html).toContain("OBSERVATION ONLY · BASELINE BUILDING");
     expect(html).toContain("RIPE Atlas");
     expect(html).toContain("RIPE RIS Live");
-    expect(html).toContain("LIMITED");
+    expect(html).not.toContain("Cloudflare Radar");
+    expect(html).not.toContain("IODA");
+    expect(html).not.toContain("NCDR");
+    expect(html).not.toContain("SUPPORTING EVIDENCE");
+    expect(html).not.toContain("ACTIVE INCIDENTS");
     expect(html).not.toContain("目前正常");
   });
 
-  it("shows normal only with a fresh detector quorum and exposes restricted freshness", () => {
-    const detector = normalDetector();
-    const html = renderCard(
-      aggregateInternetHealthRows([
-        {
-          ...detector,
-          evidence_family: "composite",
-          signal: "internet_health",
-          confidence: 0.91,
-          metadata: {
-            normal_quorum_met: true,
-            fresh_evidence_families: ["cloudflare", "ioda", "ripe_atlas", "ripe_ris"],
-            restricted_evidence_families: ["ioda", "ripe_atlas", "ripe_ris"],
-          },
-        },
-        { ...freshNormal("cloudflare_radar"), confidence: 0.86, sample_count: 24 },
-      ]),
-      "ready",
-    );
-    expect(html).toContain("目前正常");
-    expect(html).toContain("confidence high 91%");
-    expect(html).toContain("1/2");
-    expect(html).toContain("PASS");
-    expect(html).toContain("LIMITED");
-    expect(html).toContain("n=24");
-    expect(html).toContain("confidence high 86%");
-    expect(html).toContain("NCDR");
-    expect(html).toContain("未通報／無資料");
-  });
-
-  it("renders RIPE measurements as primary cards without promoting perfect or zero values to normal", () => {
+  it("does not render non-RIPE evidence even when the status RPC returns it", () => {
     const summary = aggregateInternetHealthRows([
+      { ...freshRow("cloudflare_radar"), evidence_family: "cloudflare", effective_status: "normal" },
+      { ...freshRow("ncdr_cap"), evidence_family: "official", effective_status: "outage", active_incident_id: "ncdr-1" },
       {
-        ...freshNormal("ripe_atlas"), evidence_family: "ripe_atlas",
-        signal: "ping_success_ratio_ipv4", effective_status: "unknown",
-        reported_status: "unknown", value: 1, unit: "ratio", sample_count: 18,
-      },
-      {
-        ...freshNormal("ripe_atlas"), evidence_family: "ripe_atlas",
-        signal: "median_rtt_ms_ipv4", effective_status: "unknown",
-        reported_status: "unknown", value: 23.4, unit: "milliseconds", sample_count: 17,
-      },
-      {
-        ...freshNormal("ripe_atlas"), evidence_family: "ripe_atlas",
-        signal: "reachable_asn_ratio_ipv4", effective_status: "unknown",
-        reported_status: "unknown", value: 0.8, unit: "ratio", sample_count: 4,
-      },
-      {
-        ...freshNormal("ripe_ris_live"), evidence_family: "ripe_ris",
-        signal: "prefix_visibility_ratio_ipv4", effective_status: "unknown",
-        reported_status: "unknown", value: null, unit: "ratio", sample_count: 1292,
-      },
-      {
-        ...freshNormal("ripe_ris_live"), evidence_family: "ripe_ris",
-        signal: "withdrawn_prefix_ratio_ipv4", effective_status: "unknown",
-        reported_status: "unknown", value: 0, unit: "ratio", sample_count: 1292,
-      },
-      {
-        ...freshNormal("ripe_ris_live"), evidence_family: "ripe_ris",
-        signal: "origin_change_count_ipv4", effective_status: "unknown",
-        reported_status: "unknown", value: 0, unit: "count", sample_count: 1292,
+        ...freshRow("ripe_atlas"), evidence_family: "ripe_atlas",
+        signal: "ping_success_ratio_ipv4", value: 1, unit: "ratio", sample_count: 18,
       },
     ]);
     const html = renderCard(summary, "ready");
-    expect(html).toContain("建立基準中");
-    expect(html).toContain("UNKNOWN · BASELINE BUILDING");
-    expect(html).toContain("internet-health-measurements-ripe_atlas");
-    expect(html).toContain("internet-health-measurements-ripe_ris");
-    expect(html).toContain("Ping 成功率");
+    expect(html).toContain("RIPE Atlas");
+    expect(html).not.toContain("Cloudflare Radar");
+    expect(html).not.toContain("NCDR");
+    expect(html).not.toContain("ncdr-1");
+    expect(html).not.toContain("ACTIVE INCIDENTS");
+    expect(html).not.toContain("中斷訊號");
+  });
+
+  it("renders fresh RIPE values without promoting perfect or zero values to normal", () => {
+    const summary = aggregateInternetHealthRows([
+      {
+        ...freshRow("ripe_atlas"), evidence_family: "ripe_atlas",
+        signal: "ping_success_ratio_ipv4", value: 1, unit: "ratio", sample_count: 18,
+      },
+      {
+        ...freshRow("ripe_atlas"), evidence_family: "ripe_atlas",
+        signal: "median_rtt_ms_ipv4", value: 23.4, unit: "milliseconds", sample_count: 17,
+      },
+      {
+        ...freshRow("ripe_atlas"), evidence_family: "ripe_atlas",
+        signal: "reachable_asn_ratio_ipv4", value: 0.8, unit: "ratio", sample_count: 4,
+      },
+      {
+        ...freshRow("ripe_ris_live"), evidence_family: "ripe_ris",
+        signal: "prefix_visibility_ratio_ipv4", value: null, unit: "ratio", sample_count: 1292,
+      },
+      {
+        ...freshRow("ripe_ris_live"), evidence_family: "ripe_ris",
+        signal: "withdrawn_prefix_ratio_ipv4", value: 0, unit: "ratio", sample_count: 1292,
+      },
+      {
+        ...freshRow("ripe_ris_live"), evidence_family: "ripe_ris",
+        signal: "origin_change_count_ipv4", value: 0, unit: "count", sample_count: 1292,
+      },
+    ]);
+    const html = renderCard(summary, "ready");
+    expect(html).toContain("RIPE 量測中");
+    expect(html).toContain("5/14");
+    expect(html).toContain("2/2");
     expect(html).toContain("100.0%");
     expect(html).toContain("23.4 ms");
     expect(html).toContain("RIB 基準建立中");
@@ -130,53 +154,95 @@ describe("TelecomStatusCardView", () => {
     expect(html).toContain("RTT samples=17");
     expect(html).toContain("ASNs=4");
     expect(html).toContain("BGP messages=1,292");
-    expect(html).not.toContain("n=1292");
-    expect(html).toContain("Atlas 與 RIS 同屬 RIPE NCC");
+    expect(html).toContain("只算一個來源群組");
     expect(html).not.toContain("目前正常");
   });
 
   it("shows partial or untimed RIPE rows as unavailable instead of current", () => {
-    const summary = aggregateInternetHealthRows([
-      {
-        ...freshNormal("ripe_ris_live"), evidence_family: "ripe_ris",
-        signal: "origin_change_count_ipv4", effective_status: "unknown",
-        reported_status: "unknown", value: 0, sample_count: 0,
-        source_updated_at: null, metadata: { measurement_state: "partial" },
-      },
-    ]);
+    const summary = aggregateInternetHealthRows([{
+      ...freshRow("ripe_ris_live"), evidence_family: "ripe_ris",
+      signal: "origin_change_count_ipv4", value: 0, sample_count: 0,
+      source_updated_at: null, metadata: { measurement_state: "partial" },
+    }]);
     const html = renderCard(summary, "ready");
     expect(html).toContain("PARTIAL");
     expect(html).toContain("UNAVAILABLE · BGP messages=0");
-    expect(html).toContain("— · confidence high");
-    expect(html).not.toContain("CURRENT");
+    expect(html).toContain("0/14");
+    expect(html).toContain(">PARTIAL</span>");
   });
 
-  it("labels watch as suspected and distinguishes stale public evidence", () => {
-    const summary = aggregateInternetHealthRows([
-      {
-        ...freshNormal("internet_health_detector_v1"),
-        evidence_family: "composite",
-        effective_status: "watch",
-        metadata: { normal_quorum_met: false, stale_evidence_families: ["ripe_ris"] },
-      },
-      { ...freshNormal("cloudflare_radar"), is_stale: true },
-    ]);
-    const html = renderCard(summary, "ready");
-    expect(html).toContain("疑似異常");
-    expect(html).toContain("資料逾時");
-    expect(html).toContain("LIMITED");
-  });
-
-  it("a refresh error overrides a previous normal snapshot", () => {
-    const detector = normalDetector();
+  it("does not keep a previous snapshot current after refresh error", () => {
     const summary = aggregateInternetHealthRows([{
-      ...detector,
-      evidence_family: "composite",
-      metadata: { normal_quorum_met: true },
+      ...freshRow("ripe_atlas"), evidence_family: "ripe_atlas",
+      signal: "ping_success_ratio_ipv4", value: 1, unit: "ratio", sample_count: 18,
     }]);
     const html = renderCard(summary, "error");
-    expect(html).toContain("資料不足");
-    expect(html).toContain("本次更新失敗");
-    expect(html).not.toContain("目前正常");
+    expect(html).toContain("RIPE 量測暫時無法更新");
+    expect(html).toContain("不沿用舊資料");
+    expect(html).toContain("0/14");
+    expect(html).not.toContain("100.0%");
+  });
+});
+
+describe("RipeTimelineView", () => {
+  it("renders 24H, 7D and 30D controls with IPv4/IPv6 history and coverage", () => {
+    const html = renderToStaticMarkup(createElement(RipeTimelineView, {
+      summary: timelineSummary,
+      phase: "ready",
+      range: "24h",
+      source: "ripe_atlas",
+      metric: "ping_success_ratio",
+      nowTs: 1_788_060_000,
+    }));
+    expect(html).toContain("RIPE 歷史量測");
+    expect(html).toContain("24H");
+    expect(html).toContain("7D");
+    expect(html).toContain("30D");
+    expect(html).toContain("RIPE Atlas");
+    expect(html).toContain("RIPE RIS Live");
+    expect(html).toContain("IPv4 coverage 67%");
+    expect(html).toContain("IPv6 coverage 100%");
+    expect(html).toContain("含缺口／部分資料");
+    expect(html).toContain("<svg");
+    // IPv4 ready → partial → ready 會成為兩個單點 circle，不得跨缺口連成 polyline。
+    expect(html.match(/<circle/g)?.length ?? 0).toBeGreaterThanOrEqual(2);
+  });
+
+  it("keeps an empty history explicit instead of drawing zero", () => {
+    const empty = {
+      ...timelineSummary,
+      ipv4: { ...timelineSummary.ipv4, points: [], coverage: 0, readyBuckets: 0, totalBuckets: 288 },
+      ipv6: { ...timelineSummary.ipv6, points: [], coverage: 0, readyBuckets: 0, totalBuckets: 288 },
+      coverage: 0,
+      latestAt: null,
+      partial: false,
+      empty: true,
+    } satisfies InternetHealthTimelineSummary;
+    const html = renderToStaticMarkup(createElement(RipeTimelineView, {
+      summary: empty,
+      phase: "ready",
+      range: "24h",
+      source: "ripe_atlas",
+      metric: "ping_success_ratio",
+      nowTs: 1_788_060_000,
+    }));
+    expect(html).toContain("空白不是 0，也不代表異常");
+    expect(html).not.toContain("<svg");
+  });
+
+  it("does not show a previous source summary under newly selected controls", () => {
+    const html = renderToStaticMarkup(createElement(RipeTimelineView, {
+      summary: timelineSummary,
+      phase: "error",
+      range: "24h",
+      source: "ripe_ris",
+      metric: "prefix_visibility_ratio",
+      nowTs: 1_788_060_000,
+    }));
+    expect(html).toContain("歷史量測暫時無法更新");
+    expect(html).toContain("IPv4 coverage —");
+    expect(html).toContain("IPv6 coverage —");
+    expect(html).not.toContain("coverage 67%");
+    expect(html).not.toContain("coverage 100%");
   });
 });

--- a/src/data/__tests__/internetHealthLoader.test.ts
+++ b/src/data/__tests__/internetHealthLoader.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "vitest";
 import {
   aggregateInternetHealthRows,
+  aggregateInternetHealthTimelineRows,
   parseInternetHealthEvidence,
+  planInternetHealthTimelineChunks,
 } from "../internetHealthLoader";
 
 const row = (overrides: Record<string, unknown> = {}) => ({
@@ -30,6 +32,32 @@ const row = (overrides: Record<string, unknown> = {}) => ({
   active_incident_id: null,
   incident_status: null,
   metadata: {},
+  ...overrides,
+});
+
+const timelineRow = (overrides: Record<string, unknown> = {}) => ({
+  observation_id: null,
+  source: "ripe_atlas",
+  evidence_family: "ripe_atlas",
+  entity_type: "country",
+  entity_id: "TW",
+  entity_name: "Taiwan",
+  signal: "ping_success_ratio_ipv4",
+  observed_at: "2026-08-31T23:35:00Z",
+  window_start: "2026-08-31T23:30:00Z",
+  window_end: "2026-08-31T23:35:00Z",
+  value: 0.9,
+  unit: "ratio",
+  baseline_value: null,
+  change_ratio: null,
+  reported_status: "unknown",
+  incident_kind: null,
+  confidence: null,
+  sample_count: 10,
+  source_updated_at: "2026-08-31T23:36:00Z",
+  collected_at: "2026-08-31T23:36:30Z",
+  quality_flags: {},
+  metadata: { address_family: 4, measurement_state: "ready" },
   ...overrides,
 });
 
@@ -454,5 +482,215 @@ describe("internet health RPC contract", () => {
       sample_count: null,
       observed_at: null,
     });
+  });
+});
+
+describe("internet health RIPE timeline", () => {
+  const to = "2026-09-01T00:00:00Z";
+
+  it("plans continuous half-open chunks and splits 30d below the RPC cap", () => {
+    const chunks = planInternetHealthTimelineChunks({
+      range: "30d", source: "ripe_atlas", metric: "ping_success_ratio", to,
+    });
+    expect(chunks).toHaveLength(5);
+    expect(chunks[0]?.from).toBe("2026-08-02T00:00:00.000Z");
+    expect(chunks[chunks.length - 1]?.to).toBe("2026-09-01T00:00:00.000Z");
+    for (let index = 1; index < chunks.length; index++) {
+      expect(chunks[index]?.from).toBe(chunks[index - 1]?.to);
+    }
+    expect(planInternetHealthTimelineChunks({
+      range: "7d", source: "ripe_atlas", metric: "median_rtt_ms", to,
+    })).toHaveLength(1);
+  });
+
+  it("builds IPv4 and IPv6 series and sample-weights ratio buckets", () => {
+    const summary = aggregateInternetHealthTimelineRows([{ rows: [
+      timelineRow({ value: 0.4, sample_count: 10 }),
+      timelineRow({ observed_at: "2026-08-31T23:40:00Z", value: 1, sample_count: 30 }),
+      timelineRow({
+        signal: "ping_success_ratio_ipv6",
+        observed_at: "2026-08-31T23:40:00Z",
+        value: 0.5,
+        sample_count: 20,
+        metadata: { address_family: 6, measurement_state: "ready" },
+      }),
+    ] }], { range: "7d", source: "ripe_atlas", metric: "ping_success_ratio", to });
+
+    expect(summary.bucketSeconds).toBe(1800);
+    expect(summary.ipv4.points).toHaveLength(336);
+    expect(summary.ipv6.points).toHaveLength(336);
+    expect(summary.ipv4.points.find((point) => point.value !== null)).toMatchObject({
+      value: 0.85, state: "partial", sampleCount: 40,
+    });
+    expect(summary.ipv6.points.find((point) => point.value !== null)).toMatchObject({
+      value: 0.5, state: "partial", sampleCount: 20,
+    });
+    expect(summary.coverage).toBeCloseTo(3 / 4032);
+    expect(summary.latestAt).toBe(Date.parse("2026-08-31T23:36:00Z") / 1000);
+    expect(summary.empty).toBe(false);
+    expect(summary.partial).toBe(true);
+  });
+
+  it("uses median-of-medians for RTT and preserves null buckets", () => {
+    const summary = aggregateInternetHealthTimelineRows([{ rows: [
+      timelineRow({
+        signal: "median_rtt_ms_ipv4", value: 10, unit: "milliseconds", sample_count: 2,
+      }),
+      timelineRow({
+        signal: "median_rtt_ms_ipv4", observed_at: "2026-08-31T23:40:00Z",
+        value: 100, unit: "milliseconds", sample_count: 2,
+      }),
+      timelineRow({
+        signal: "median_rtt_ms_ipv4", observed_at: "2026-08-31T23:45:00Z",
+        value: 20, unit: "milliseconds", sample_count: 2,
+      }),
+    ] }], { range: "30d", source: "ripe_atlas", metric: "median_rtt_ms", to });
+
+    expect(summary.bucketSeconds).toBe(7200);
+    expect(summary.ipv4.points.find((point) => point.value !== null)).toMatchObject({
+      value: 20, state: "partial", sampleCount: 6,
+    });
+    expect(summary.ipv6.points.every((point) => point.value === null && point.state === "empty")).toBe(true);
+  });
+
+  it("sums count buckets but uses the latest ready visibility value", () => {
+    const countSummary = aggregateInternetHealthTimelineRows([{ rows: [
+      timelineRow({
+        source: "ripe_ris_live", evidence_family: "ripe_ris",
+        signal: "origin_change_count_ipv4", value: 2, unit: "count",
+      }),
+      timelineRow({
+        source: "ripe_ris_live", evidence_family: "ripe_ris",
+        signal: "origin_change_count_ipv4", observed_at: "2026-08-31T23:40:00Z",
+        value: 3, unit: "count",
+      }),
+    ] }], { range: "7d", source: "ripe_ris", metric: "origin_change_count", to });
+    expect(countSummary.ipv4.points.find((point) => point.value !== null)?.value).toBe(5);
+
+    const visibilitySummary = aggregateInternetHealthTimelineRows([{ rows: [
+      timelineRow({
+        source: "ripe_ris_live", evidence_family: "ripe_ris",
+        signal: "prefix_visibility_ratio_ipv4", value: 0.9,
+      }),
+      timelineRow({
+        source: "ripe_ris_live", evidence_family: "ripe_ris",
+        signal: "prefix_visibility_ratio_ipv4", observed_at: "2026-08-31T23:40:00Z", value: 0.7,
+      }),
+    ] }], { range: "7d", source: "ripe_ris", metric: "prefix_visibility_ratio", to });
+    expect(visibilitySummary.ipv4.points.find((point) => point.value !== null)?.value).toBe(0.7);
+  });
+
+  it("keeps partial, missing timestamps and zero samples null instead of zero/current", () => {
+    const summary = aggregateInternetHealthTimelineRows([{ rows: [
+      timelineRow({
+        value: 1,
+        metadata: { address_family: 4, measurement_state: "partial" },
+      }),
+      timelineRow({
+        signal: "ping_success_ratio_ipv6",
+        observed_at: "2026-08-31T23:40:00Z",
+        value: 1,
+        sample_count: 0,
+        source_updated_at: null,
+        metadata: { address_family: 6, measurement_state: "ready" },
+      }),
+    ] }], { range: "24h", source: "ripe_atlas", metric: "ping_success_ratio", to });
+
+    expect(summary.ipv4.points.find((point) => point.state === "partial")).toMatchObject({
+      value: null, sampleCount: null,
+    });
+    expect(summary.ipv6.points.find((point) => point.state === "unavailable")).toMatchObject({
+      value: null, sampleCount: null,
+    });
+    expect(summary.ipv4.points.some((point) => point.value === 0)).toBe(false);
+    expect(summary.latestAt).toBe(Date.parse("2026-08-31T23:36:00Z") / 1000);
+  });
+
+  it("strictly allows country/TW RIPE rows and never retains unknown metadata", () => {
+    const summary = aggregateInternetHealthTimelineRows([{ rows: [
+      timelineRow({ entity_id: "US", value: 0.1 }),
+      timelineRow({ source: "cloudflare_radar", value: 0.2 }),
+      timelineRow({ signal: "private_probe_id", value: 999 }),
+      timelineRow({ metadata: { address_family: 6, measurement_state: "ready" }, value: 0.3 }),
+      timelineRow({
+        metadata: {
+          address_family: 4,
+          measurement_state: "ready",
+          probe_ids: [1234],
+          archive_path: "private/archive.json",
+        },
+      }),
+    ] }], { range: "24h", source: "ripe_atlas", metric: "ping_success_ratio", to });
+
+    expect(summary.ipv4.readyBuckets).toBe(1);
+    const serialized = JSON.stringify(summary);
+    for (const forbidden of [
+      "private_probe_id", "999", "probe_ids", "1234", "archive_path", "private/archive.json",
+      "cloudflare_radar",
+    ]) expect(serialized).not.toContain(forbidden);
+  });
+
+  it("fails timeline values and unknown quality states closed", () => {
+    const summary = aggregateInternetHealthTimelineRows([{ rows: [
+      timelineRow({ value: 1.2 }),
+      timelineRow({
+        signal: "ping_success_ratio_ipv6",
+        value: 0.9,
+        metadata: { address_family: 6, measurement_state: "future_state" },
+      }),
+    ] }], { range: "24h", source: "ripe_atlas", metric: "ping_success_ratio", to });
+
+    expect(summary.ipv4.points.find((point) => point.state === "unavailable")).toMatchObject({ value: null });
+    expect(summary.ipv6.points.find((point) => point.state === "unavailable")).toMatchObject({ value: null });
+    expect(summary.coverage).toBe(0);
+    expect(summary.ipv4.points.some((point) => point.value === 1.2)).toBe(false);
+    expect(JSON.stringify(summary)).not.toContain("future_state");
+  });
+
+  it("deduplicates chunk boundaries and excludes the half-open upper boundary", () => {
+    const duplicate = timelineRow({
+      source: "ripe_ris_live", evidence_family: "ripe_ris",
+      signal: "origin_change_count_ipv4", value: 2, unit: "count",
+    });
+    const upperBoundary = timelineRow({
+      source: "ripe_ris_live", evidence_family: "ripe_ris",
+      signal: "origin_change_count_ipv4", observed_at: to, value: 9, unit: "count",
+    });
+    const summary = aggregateInternetHealthTimelineRows([
+      { rows: [duplicate] },
+      { rows: [duplicate, upperBoundary] },
+    ], { range: "24h", source: "ripe_ris", metric: "origin_change_count", to });
+
+    expect(summary.ipv4.points.filter((point) => point.value !== null)).toHaveLength(1);
+    expect(summary.ipv4.points.find((point) => point.value !== null)?.value).toBe(2);
+  });
+
+  it("marks a 5,000-row RPC response truncated without inventing complete coverage", () => {
+    const from = Date.parse("2026-08-02T00:00:00Z");
+    const rows = Array.from({ length: 5000 }, (_, index) => {
+      const observedAt = new Date(from + index * 5 * 60_000).toISOString();
+      return timelineRow({ observed_at: observedAt, source_updated_at: observedAt });
+    });
+    const summary = aggregateInternetHealthTimelineRows(
+      [{ rows }],
+      { range: "30d", source: "ripe_atlas", metric: "ping_success_ratio", to },
+    );
+    expect(summary.truncated).toBe(true);
+    expect(summary.partial).toBe(true);
+    expect(summary.coverage).toBeLessThan(1);
+  });
+
+  it("returns explicit empty dual series and rejects a mismatched source/metric", () => {
+    const summary = aggregateInternetHealthTimelineRows(
+      [{ rows: [] }],
+      { range: "24h", source: "ripe_atlas", metric: "ping_success_ratio", to },
+    );
+    expect(summary).toMatchObject({ empty: true, partial: false, truncated: false, latestAt: null });
+    expect(summary.ipv4.points).toHaveLength(288);
+    expect(summary.ipv6.points).toHaveLength(288);
+    expect(summary.ipv4.points.every((point) => point.value === null)).toBe(true);
+    expect(() => planInternetHealthTimelineChunks({
+      range: "24h", source: "ripe_ris", metric: "ping_success_ratio", to,
+    })).toThrow(/source\/metric/);
   });
 });

--- a/src/data/internetHealthLoader.ts
+++ b/src/data/internetHealthLoader.ts
@@ -1,8 +1,8 @@
 /**
  * 台灣電信與網路狀態 loader。
  *
- * 資料只走 public.get_internet_health_status RPC；前端不直打各 provider，
- * 也不把 ASN 或 country status 轉成地圖 geometry。
+ * Current 與 history 只走 public.get_internet_health_status / get_internet_health_timeseries RPC；
+ * 前端不直打各 provider，也不把 ASN 或 country status 轉成地圖 geometry。
  *
  * 保守語意：
  * - effective_status 是 UI 狀態真相，reported_status 只留作溯源。
@@ -12,7 +12,7 @@
  */
 import { supabase, supabaseConfigured } from "../lib/supabase";
 import { withLoading } from "../lib/loadingRegistry";
-import { cachedOnce } from "../lib/loaderCache";
+import { cachedOnce, keyedThunkCache } from "../lib/loaderCache";
 
 export type InternetHealthStatus = "normal" | "watch" | "degraded" | "outage" | "unknown";
 export type InternetHealthConfidence = "low" | "medium" | "high" | "unknown";
@@ -31,6 +31,71 @@ export type InternetHealthMeasurementSignal =
   | "prefix_visibility_ratio_ipv4" | "prefix_visibility_ratio_ipv6"
   | "withdrawn_prefix_ratio_ipv4" | "withdrawn_prefix_ratio_ipv6"
   | "origin_change_count_ipv4" | "origin_change_count_ipv6";
+
+export type InternetHealthTimelineRange = "24h" | "7d" | "30d";
+export type InternetHealthTimelineSource = "ripe_atlas" | "ripe_ris";
+export type InternetHealthTimelineMetric =
+  | "probe_connectivity_ratio"
+  | "ping_success_ratio"
+  | "median_rtt_ms"
+  | "reachable_asn_ratio"
+  | "prefix_visibility_ratio"
+  | "withdrawn_prefix_ratio"
+  | "origin_change_count";
+export type InternetHealthTimelinePointState = "ready" | "partial" | "unavailable" | "empty";
+
+export interface InternetHealthTimelineRequest {
+  range: InternetHealthTimelineRange;
+  source: InternetHealthTimelineSource;
+  metric: InternetHealthTimelineMetric;
+  /** ISO timestamp. Omitted requests are anchored to the latest five-minute boundary. */
+  to?: string;
+}
+
+export interface InternetHealthTimelinePoint {
+  at: number;
+  value: number | null;
+  state: InternetHealthTimelinePointState;
+  sampleCount: number | null;
+}
+
+export interface InternetHealthTimelineSeries {
+  addressFamily: 4 | 6;
+  signal: InternetHealthMeasurementSignal;
+  points: InternetHealthTimelinePoint[];
+  coverage: number;
+  readyBuckets: number;
+  totalBuckets: number;
+}
+
+export interface InternetHealthTimelineSummary {
+  range: InternetHealthTimelineRange;
+  source: InternetHealthTimelineSource;
+  metric: InternetHealthTimelineMetric;
+  unit: InternetHealthMeasurement["unit"];
+  from: number;
+  to: number;
+  bucketSeconds: number;
+  ipv4: InternetHealthTimelineSeries;
+  ipv6: InternetHealthTimelineSeries;
+  coverage: number;
+  /** Latest provider timestamp; never falls back to observed_at. */
+  latestAt: number | null;
+  truncated: boolean;
+  partial: boolean;
+  empty: boolean;
+}
+
+export interface InternetHealthTimelineChunk {
+  from: string;
+  to: string;
+}
+
+export interface InternetHealthTimelineChunkResult {
+  rows: unknown;
+  /** Set by the transport when the RPC returns its hard 5,000-row limit. */
+  hitLimit?: boolean;
+}
 
 export interface InternetHealthMeasurement {
   source_key: "ripe_atlas" | "ripe_ris";
@@ -185,6 +250,43 @@ const RIPE_RIS_SIGNALS = new Set<InternetHealthMeasurementSignal>([
   "withdrawn_prefix_ratio_ipv4", "withdrawn_prefix_ratio_ipv6",
   "origin_change_count_ipv4", "origin_change_count_ipv6",
 ]);
+
+const TIMELINE_RANGE_SECONDS: Record<InternetHealthTimelineRange, number> = {
+  "24h": 24 * 60 * 60,
+  "7d": 7 * 24 * 60 * 60,
+  "30d": 30 * 24 * 60 * 60,
+};
+
+const TIMELINE_BUCKET_SECONDS: Record<InternetHealthTimelineRange, number> = {
+  "24h": 5 * 60,
+  "7d": 30 * 60,
+  "30d": 2 * 60 * 60,
+};
+
+const TIMELINE_METRICS: Record<InternetHealthTimelineMetric, {
+  source: InternetHealthTimelineSource;
+  unit: InternetHealthMeasurement["unit"];
+  aggregation: "weighted_average" | "median" | "sum" | "latest";
+}> = {
+  probe_connectivity_ratio: { source: "ripe_atlas", unit: "ratio", aggregation: "weighted_average" },
+  ping_success_ratio: { source: "ripe_atlas", unit: "ratio", aggregation: "weighted_average" },
+  median_rtt_ms: { source: "ripe_atlas", unit: "milliseconds", aggregation: "median" },
+  reachable_asn_ratio: { source: "ripe_atlas", unit: "ratio", aggregation: "weighted_average" },
+  prefix_visibility_ratio: { source: "ripe_ris", unit: "ratio", aggregation: "latest" },
+  withdrawn_prefix_ratio: { source: "ripe_ris", unit: "ratio", aggregation: "weighted_average" },
+  origin_change_count: { source: "ripe_ris", unit: "count", aggregation: "sum" },
+};
+
+const TIMELINE_RPC_SOURCES: Record<InternetHealthTimelineSource, "ripe_atlas" | "ripe_ris_live"> = {
+  ripe_atlas: "ripe_atlas",
+  ripe_ris: "ripe_ris_live",
+};
+
+const TIMELINE_RPC_LIMIT = 5000;
+const TIMELINE_CACHE_TTL_MS = 4 * 60_000;
+const TIMELINE_DEFAULT_ANCHOR_MS = 5 * 60_000;
+const TIMELINE_SOURCE_BUCKET_SECONDS = 5 * 60;
+const TIMELINE_30D_CHUNK_SECONDS = 6 * 24 * 60 * 60;
 
 const SOURCE_FAMILIES: Record<InternetHealthSourceKey, readonly string[]> = {
   cloudflare: ["cloudflare", "cloudflare_radar"],
@@ -700,6 +802,327 @@ export function aggregateInternetHealthRows(rawRows: unknown): InternetHealthSum
     measurements,
     evidence,
   };
+}
+
+interface NormalizedTimelineRequest extends InternetHealthTimelineRequest {
+  to: string;
+  fromMs: number;
+  toMs: number;
+  bucketSeconds: number;
+  unit: InternetHealthMeasurement["unit"];
+}
+
+interface ParsedTimelineRow {
+  signal: InternetHealthMeasurementSignal;
+  addressFamily: 4 | 6;
+  observedAt: number;
+  sourceUpdatedAt: number | null;
+  value: number | null;
+  sampleCount: number | null;
+  state: InternetHealthMeasurementQualityState;
+}
+
+function normalizeTimelineRequest(request: InternetHealthTimelineRequest): NormalizedTimelineRequest {
+  const metric = TIMELINE_METRICS[request.metric];
+  if (!metric || metric.source !== request.source) {
+    throw new Error(`Invalid internet health timeline source/metric: ${request.source}/${request.metric}`);
+  }
+  const parsedTo = request.to === undefined
+    ? Math.floor(Date.now() / TIMELINE_DEFAULT_ANCHOR_MS) * TIMELINE_DEFAULT_ANCHOR_MS
+    : Date.parse(request.to);
+  if (!Number.isFinite(parsedTo)) throw new Error("Invalid internet health timeline to timestamp");
+  const toMs = Math.floor(parsedTo / 1000) * 1000;
+  const fromMs = toMs - TIMELINE_RANGE_SECONDS[request.range] * 1000;
+  return {
+    ...request,
+    to: new Date(toMs).toISOString(),
+    fromMs,
+    toMs,
+    bucketSeconds: TIMELINE_BUCKET_SECONDS[request.range],
+    unit: metric.unit,
+  };
+}
+
+/** Build continuous half-open RPC windows. Only 30d needs chunking for the 5,000-row cap. */
+export function planInternetHealthTimelineChunks(
+  request: InternetHealthTimelineRequest,
+): InternetHealthTimelineChunk[] {
+  const normalized = normalizeTimelineRequest(request);
+  const chunkSeconds = request.range === "30d"
+    ? TIMELINE_30D_CHUNK_SECONDS
+    : TIMELINE_RANGE_SECONDS[request.range];
+  const chunks: InternetHealthTimelineChunk[] = [];
+  for (let fromMs = normalized.fromMs; fromMs < normalized.toMs;) {
+    const toMs = Math.min(fromMs + chunkSeconds * 1000, normalized.toMs);
+    chunks.push({ from: new Date(fromMs).toISOString(), to: new Date(toMs).toISOString() });
+    fromMs = toMs;
+  }
+  return chunks;
+}
+
+function expectedTimelineSignals(
+  metric: InternetHealthTimelineMetric,
+): readonly [InternetHealthMeasurementSignal, InternetHealthMeasurementSignal] {
+  return [`${metric}_ipv4`, `${metric}_ipv6`] as readonly [
+    InternetHealthMeasurementSignal,
+    InternetHealthMeasurementSignal,
+  ];
+}
+
+function parseTimelineRow(
+  raw: unknown,
+  request: NormalizedTimelineRequest,
+): ParsedTimelineRow | null {
+  if (!isRecord(raw)) return null;
+  const rpcSource = TIMELINE_RPC_SOURCES[request.source];
+  const expectedFamily = request.source === "ripe_atlas" ? "ripe_atlas" : "ripe_ris";
+  if (
+    raw.entity_type !== "country"
+    || raw.entity_id !== "TW"
+    || raw.source !== rpcSource
+    || raw.evidence_family !== expectedFamily
+  ) return null;
+
+  const [ipv4Signal, ipv6Signal] = expectedTimelineSignals(request.metric);
+  const signal = raw.signal;
+  if (signal !== ipv4Signal && signal !== ipv6Signal) return null;
+  const safeSignal = signal as InternetHealthMeasurementSignal;
+  const addressFamily: 4 | 6 = signal === ipv4Signal ? 4 : 6;
+  const metadata = isRecord(raw.metadata) ? raw.metadata : {};
+  if (metadata.address_family !== addressFamily) return null;
+  const rawState = metadata.measurement_state;
+  const state = normalizeMeasurementQualityState(rawState) ?? "unavailable";
+
+  const observedAtText = timestamp(raw.observed_at);
+  if (observedAtText === null) return null;
+  const observedAt = Date.parse(observedAtText) / 1000;
+  if (observedAt < request.fromMs / 1000 || observedAt >= request.toMs / 1000) return null;
+  const sourceUpdatedText = timestamp(raw.source_updated_at);
+  const sourceUpdatedAt = sourceUpdatedText === null ? null : Date.parse(sourceUpdatedText) / 1000;
+  const sampleCount = typeof raw.sample_count === "number"
+    && Number.isInteger(raw.sample_count)
+    && raw.sample_count >= 0
+    ? raw.sample_count
+    : null;
+  const rawValue = typeof raw.value === "number" && Number.isFinite(raw.value) ? raw.value : null;
+  const value = validMeasurementValue(rawValue, request.unit);
+  const qualityFlags = isRecord(raw.quality_flags) ? raw.quality_flags : null;
+  const qualityFailure = qualityFlags === null || [
+    "missing_value", "stream_gap", "state_uninitialized",
+  ].some((key) => qualityFlags[key] !== undefined && qualityFlags[key] !== false);
+  const ready = state === "ready"
+    && sourceUpdatedAt !== null
+    && sampleCount !== null
+    && sampleCount > 0
+    && value !== null
+    && !qualityFailure;
+  return {
+    signal: safeSignal,
+    addressFamily,
+    observedAt,
+    sourceUpdatedAt,
+    value: ready ? value : null,
+    sampleCount,
+    state: ready
+      ? "ready"
+      : state === "partial" || qualityFailure
+        ? "partial"
+        : state === "baseline_building" ? "baseline_building" : "unavailable",
+  };
+}
+
+function median(values: number[]): number | null {
+  if (!values.length) return null;
+  const sorted = [...values].sort((a, b) => a - b);
+  const middle = Math.floor(sorted.length / 2);
+  if (sorted.length % 2 === 1) return sorted[middle] ?? null;
+  const left = sorted[middle - 1];
+  const right = sorted[middle];
+  return left === undefined || right === undefined ? null : (left + right) / 2;
+}
+
+function aggregateTimelineValue(
+  rows: ParsedTimelineRow[],
+  metric: InternetHealthTimelineMetric,
+): number | null {
+  const ready = rows.filter((row) => row.state === "ready" && row.value !== null);
+  if (!ready.length) return null;
+  const aggregation = TIMELINE_METRICS[metric].aggregation;
+  if (aggregation === "weighted_average") {
+    const weight = ready.reduce((sum, row) => sum + (row.sampleCount ?? 0), 0);
+    return weight > 0
+      ? ready.reduce((sum, row) => sum + row.value! * (row.sampleCount ?? 0), 0) / weight
+      : null;
+  }
+  if (aggregation === "median") return median(ready.map((row) => row.value!));
+  if (aggregation === "sum") return ready.reduce((sum, row) => sum + row.value!, 0);
+  return [...ready].sort((a, b) => b.observedAt - a.observedAt)[0]?.value ?? null;
+}
+
+function buildTimelineSeries(
+  rows: ParsedTimelineRow[],
+  request: NormalizedTimelineRequest,
+  addressFamily: 4 | 6,
+): InternetHealthTimelineSeries {
+  const totalBuckets = TIMELINE_RANGE_SECONDS[request.range] / request.bucketSeconds;
+  const expectedSubslotsPerBucket = request.bucketSeconds / TIMELINE_SOURCE_BUCKET_SECONDS;
+  const expectedSubslots = totalBuckets * expectedSubslotsPerBucket;
+  const buckets = new Map<number, ParsedTimelineRow[]>();
+  for (const row of rows) {
+    if (row.addressFamily !== addressFamily) continue;
+    const index = Math.floor((row.observedAt - request.fromMs / 1000) / request.bucketSeconds);
+    if (index < 0 || index >= totalBuckets) continue;
+    const bucket = buckets.get(index) ?? [];
+    bucket.push(row);
+    buckets.set(index, bucket);
+  }
+
+  const points: InternetHealthTimelinePoint[] = [];
+  let readyBuckets = 0;
+  let readySubslots = 0;
+  for (let index = 0; index < totalBuckets; index++) {
+    const bucketRows = buckets.get(index) ?? [];
+    const readyRows = bucketRows.filter((row) => row.state === "ready" && row.value !== null);
+    readySubslots += Math.min(readyRows.length, expectedSubslotsPerBucket);
+    const value = aggregateTimelineValue(bucketRows, request.metric);
+    const hasNonReady = bucketRows.some((row) => row.state !== "ready");
+    const complete = readyRows.length === expectedSubslotsPerBucket && !hasNonReady;
+    const state: InternetHealthTimelinePointState = bucketRows.length === 0
+      ? "empty"
+      : complete
+        ? "ready"
+        : readyRows.length > 0
+          ? "partial"
+        : bucketRows.some((row) => row.state === "partial") ? "partial" : "unavailable";
+    if (state === "ready") readyBuckets++;
+    const sampleCount = readyRows.length > 0
+      ? readyRows.reduce((sum, row) => sum + (row.sampleCount ?? 0), 0)
+      : null;
+    points.push({
+      at: request.fromMs / 1000 + index * request.bucketSeconds,
+      value,
+      state,
+      sampleCount,
+    });
+  }
+  return {
+    addressFamily,
+    signal: expectedTimelineSignals(request.metric)[addressFamily === 4 ? 0 : 1],
+    points,
+    // Coverage counts the underlying expected five-minute observations, not merely
+    // aggregate buckets containing at least one value.
+    coverage: expectedSubslots > 0 ? readySubslots / expectedSubslots : 0,
+    readyBuckets,
+    totalBuckets,
+  };
+}
+
+/**
+ * Parse, de-duplicate and aggregate RPC chunks without retaining raw rows or metadata.
+ * This helper is exported so the security and cap behavior stay directly testable.
+ */
+export function aggregateInternetHealthTimelineRows(
+  rawChunks: readonly InternetHealthTimelineChunkResult[],
+  request: InternetHealthTimelineRequest,
+): InternetHealthTimelineSummary {
+  const normalized = normalizeTimelineRequest(request);
+  const truncated = rawChunks.some((chunk) => (
+    chunk.hitLimit === true || (Array.isArray(chunk.rows) && chunk.rows.length >= TIMELINE_RPC_LIMIT)
+  ));
+  const deduped = new Map<string, ParsedTimelineRow>();
+  for (const chunk of rawChunks) {
+    if (!Array.isArray(chunk.rows)) continue;
+    for (const raw of chunk.rows) {
+      const parsed = parseTimelineRow(raw, normalized);
+      if (!parsed) continue;
+      const key = `${parsed.signal}|${parsed.observedAt}`;
+      if (!deduped.has(key)) deduped.set(key, parsed);
+    }
+  }
+  const rows = [...deduped.values()].sort((a, b) => a.observedAt - b.observedAt);
+  const ipv4 = buildTimelineSeries(rows, normalized, 4);
+  const ipv6 = buildTimelineSeries(rows, normalized, 6);
+  const totalBuckets = ipv4.totalBuckets + ipv6.totalBuckets;
+  const readyBuckets = ipv4.readyBuckets + ipv6.readyBuckets;
+  const coverage = totalBuckets > 0 ? readyBuckets / totalBuckets : 0;
+  const latestAt = rows.reduce<number | null>((latest, row) => (
+    row.sourceUpdatedAt !== null && (latest === null || row.sourceUpdatedAt > latest)
+      ? row.sourceUpdatedAt
+      : latest
+  ), null);
+  const empty = rows.length === 0;
+  return {
+    range: normalized.range,
+    source: normalized.source,
+    metric: normalized.metric,
+    unit: normalized.unit,
+    from: normalized.fromMs / 1000,
+    to: normalized.toMs / 1000,
+    bucketSeconds: normalized.bucketSeconds,
+    ipv4,
+    ipv6,
+    coverage,
+    latestAt,
+    truncated,
+    partial: truncated || (!empty && coverage < 1),
+    empty,
+  };
+}
+
+async function fetchInternetHealthTimelineUncached(
+  request: InternetHealthTimelineRequest,
+): Promise<InternetHealthTimelineSummary> {
+  if (!supabaseConfigured) throw new Error("Supabase not configured");
+  const chunks = planInternetHealthTimelineChunks(request);
+  const rpcSource = TIMELINE_RPC_SOURCES[request.source];
+  const signals = [...expectedTimelineSignals(request.metric)];
+  const settled = await withLoading(
+    `internet-health:timeline:${request.range}:${request.source}:${request.metric}`,
+    `網路量測歷史 ${request.range}`,
+    Promise.allSettled(chunks.map(async (chunk): Promise<InternetHealthTimelineChunkResult> => {
+      const { data, error } = await supabase.rpc("get_internet_health_timeseries", {
+        p_entity_type: "country",
+        p_entity_id: "TW",
+        p_from: chunk.from,
+        p_to: chunk.to,
+        p_sources: [rpcSource],
+        p_signals: signals,
+        p_limit: TIMELINE_RPC_LIMIT,
+      });
+      if (error) throw new Error(`get_internet_health_timeseries: ${error.message}`);
+      return {
+        rows: data,
+        hitLimit: Array.isArray(data) && data.length >= TIMELINE_RPC_LIMIT,
+      };
+    })),
+  );
+  const rejected = settled.find((result): result is PromiseRejectedResult => result.status === "rejected");
+  if (rejected) throw rejected.reason;
+  const results = settled.map((result) => (result as PromiseFulfilledResult<InternetHealthTimelineChunkResult>).value);
+  return aggregateInternetHealthTimelineRows(results, request);
+}
+
+const internetHealthTimelineCache = keyedThunkCache<InternetHealthTimelineSummary>(
+  TIMELINE_CACHE_TTL_MS,
+  18,
+);
+
+export function fetchInternetHealthTimeline(
+  request: InternetHealthTimelineRequest,
+): Promise<InternetHealthTimelineSummary> {
+  const normalized = normalizeTimelineRequest(request);
+  const stableRequest: InternetHealthTimelineRequest = {
+    range: normalized.range,
+    source: normalized.source,
+    metric: normalized.metric,
+    to: normalized.to,
+  };
+  const key = `${stableRequest.range}|${stableRequest.source}|${stableRequest.metric}|${stableRequest.to}`;
+  return internetHealthTimelineCache(key, () => fetchInternetHealthTimelineUncached(stableRequest));
+}
+
+export function invalidateInternetHealthTimelineCache(): void {
+  internetHealthTimelineCache.invalidate();
 }
 
 async function fetchInternetHealthStatusUncached(): Promise<InternetHealthSummary> {


### PR DESCRIPTION
## Summary

將 Monitor 收斂成 RIPE NCC-only 網路觀察，保留 Atlas／RIS current measurements，新增 24H／7D／30D 歷史時間軸，並以缺口與底層 5 分鐘 coverage 誠實呈現資料累積狀況。

## Changes

- 移除卡片內 Cloudflare／IODA／NCDR supporting evidence 與 active incidents，只顯示 RIPE Atlas／RIS。
- 新增 public get_internet_health_timeseries loader：RIPE allowlist、30D half-open chunks、metric-specific aggregation、null/partial fail-closed、loading/cache/race protection。
- 共用 sparkline 新增 opt-in full time domain，完整顯示 7D／30D 空白期間，不把缺資料壓縮掉。
- 新增 24H／7D／30D、source、metric controls；IPv4／IPv6、coverage、最後回報與缺口提示。

## Test

- [x] npx tsc -b 通過
- [x] npm test 通過：98 files，989 passed，1 skipped
- [x] npm run build 通過
- [x] Browser：live RPC、24H／7D／30D、Atlas／RIS、RIPE-only、console error 0
- [x] RPC migration 384 已在前次 release 套用與 verify，本 PR 無 DB 變更

## Risk / Rollback

- 只改 Monitor UI 與 public RPC client；collectors、DB、其他來源資料不停止或刪除。
- 回滾此 PR 即恢復上一版多來源卡片。

## Related

- Feature: docs/features/internet-health/handoff.md
- Upstream: gis-platform migration 384

## Checklist

- [x] Branch 使用 Codex worktree 慣例 codex/ripe-observation-timeline
- [x] Commit 使用 Conventional Commits
- [x] 無 layer／geometry／registry 變更
- [x] 資料契約與 browser gate 已更新於 handoff
- [x] changelog 檔不存在；變更記錄併入既有 handoff