### PR TITLE
feat(monitor): reposition network stability card

### DIFF
--- a/docs/features/internet-health/handoff.md
+++ b/docs/features/internet-health/handoff.md
@@ -125,7 +125,7 @@ RIPE-only 時間軸修改 loader、卡片、共用 sparkline 的 opt-in 明示�
 
 1. 確認 migration 已 apply，且 RPC 用 anonymous session 呼叫 country/TW 能回 fresh detector；只有
    `public_rpc_enabled=true` 且 signal 在 public allowlist 的 provider rows 才能回傳，IODA 缺席是預期政策。
-2. 啟動前端並開啟 Monitor；`RIPE NCC 網路觀察 · NETWORK OBSERVATION` 應位於事件區下方、全寬，
+2. 啟動前端並開啟 Monitor；`RIPE NCC 網路觀察 · NETWORK OBSERVATION` 應位於 TRA DELAY 後方、Monitor 尾端全寬，
    且卡片內不得出現 Cloudflare／IODA／NCDR／supporting evidence／active incidents。
 3. 在 browser Network 面板確認 current request 是 `get_internet_health_status`；timeline request 是
    `get_internet_health_timeseries`，固定 country/TW 且只含選定的 RIPE IPv4／IPv6 signals。

--- a/src/components/intel/monitor/TelecomStatusCard.tsx
+++ b/src/components/intel/monitor/TelecomStatusCard.tsx
@@ -370,7 +370,7 @@ export function TelecomStatusCardView({
   const freshMetricCount = measurements.filter((item) => item.freshness === "fresh").length;
   const reportingFeeds = Number(atlasMeasurements.some((item) => item.freshness === "fresh")) + Number(risMeasurements.some((item) => item.freshness === "fresh"));
   const latestAt = newestMeasurementAt(measurements);
-  const statusLabel = phase === "loading" ? "正在讀取 RIPE 量測" : phase === "error" ? "RIPE 量測暫時無法更新" : freshMetricCount > 0 ? "RIPE 量測中" : "等待 RIPE 量測";
+  const statusLabel = phase === "loading" ? "正在讀取 RIPE 量測" : phase === "error" ? "RIPE 量測暫時無法更新" : freshMetricCount > 0 ? "網路穩定度" : "等待 RIPE 量測";
   const statusColor = freshMetricCount > 0 && phase === "ready" ? RIPE_CYAN : COLORS.textDim;
   const description = phase === "error" ? "本次更新失敗；不沿用舊資料判定網路狀態。" : "持續觀察 RIPE Atlas 端到端量測與 RIPE RIS BGP 路由更新。數值先如實呈現，異常判讀待基準累積後再加入。";
 

--- a/src/components/intel/monitor/__tests__/TelecomStatusCard.test.ts
+++ b/src/components/intel/monitor/__tests__/TelecomStatusCard.test.ts
@@ -143,7 +143,8 @@ describe("TelecomStatusCardView", () => {
       },
     ]);
     const html = renderCard(summary, "ready");
-    expect(html).toContain("RIPE 量測中");
+    expect(html).toContain("網路穩定度");
+    expect(html).not.toContain("RIPE 量測中");
     expect(html).toContain("5/14");
     expect(html).toContain("2/2");
     expect(html).toContain("100.0%");

--- a/src/components/intel/monitor/__tests__/monitorPacking.test.ts
+++ b/src/components/intel/monitor/__tests__/monitorPacking.test.ts
@@ -39,13 +39,13 @@ describe("monitorPacking", () => {
   // guillotine 會先在那裡把版面切成上下兩段 —— 右欄底部那塊於是從「右欄」變成
   // 撐滿 12 欄的獨立區塊（寬度爆掉、與上方右欄對不齊）。
   // 新 widget 要接在右欄下方時，左欄必須有格子跨過那條線，或改插進右欄中段。
-  it("頂層拆成「上方三欄」+「全寬網路狀態」+「下方左右兩欄（5 + 7）」", () => {
+  it("頂層拆成「上方三欄」+「下方左右兩欄（5 + 7）」+「全寬網路狀態」", () => {
     const tree = buildMonitorTree(MONITOR_VISIBLE_LAYOUT);
     expect(tree.t).toBe("rows");
     if (tree.t !== "rows") return;
     expect(tree.children).toHaveLength(3);
-    expect(flattenNode(tree.children[1]!).map((it) => it.i)).toEqual(["internetHealth"]);
-    const bottom = tree.children[2]!;
+    expect(flattenNode(tree.children[2]!).map((it) => it.i)).toEqual(["internetHealth"]);
+    const bottom = tree.children[1]!;
     expect(bottom.t).toBe("cols");
     if (bottom.t !== "cols") return;
     expect(bottom.children.map(nodeWidth)).toEqual([5, 7]);
@@ -53,16 +53,23 @@ describe("monitorPacking", () => {
 
   it("ISR 插入後 dock 左右兩欄同止於 y80", () => {
     const leftEnd = Math.max(
-      ...MONITOR_VISIBLE_LAYOUT.filter((item) => item.x < 5 && item.y >= 55)
+      ...MONITOR_VISIBLE_LAYOUT.filter((item) => item.w < 12 && item.x < 5 && item.y >= 55)
         .map((item) => item.y + item.h),
     );
     const rightEnd = Math.max(
-      ...MONITOR_VISIBLE_LAYOUT.filter((item) => item.x >= 5 && item.y >= 55)
+      ...MONITOR_VISIBLE_LAYOUT.filter((item) => item.w < 12 && item.x >= 5 && item.y >= 55)
         .map((item) => item.y + item.h),
     );
 
     expect(leftEnd).toBe(80);
     expect(rightEnd).toBe(80);
+  });
+
+  it("RIPE 網路觀察在 dock 與 split 都位於 TRA DELAY 後方", () => {
+    for (const layout of [MONITOR_VISIBLE_LAYOUT, MONITOR_SPLIT_VISIBLE_LAYOUT]) {
+      const ids = flattenNode(buildMonitorTree(layout)).map((item) => item.i);
+      expect(ids.indexOf("internetHealth")).toBeGreaterThan(ids.indexOf("traDelay"));
+    }
   });
 
   it("互卡佈局（風車形）退回固定網格而不是掉 widget", () => {
@@ -139,9 +146,9 @@ describe("monitorPacking · split dock（右半邊窄版）", () => {
     expect(head.children.map(nodeWidth)).toEqual([6, 6]);
   });
 
-  it("軍事態勢尾段依序為 PLA、特殊船舶、ISR、台鐵", () => {
+  it("尾段依序為 PLA、特殊船舶、ISR、台鐵、RIPE 網路觀察", () => {
     expect(
       items.filter((item) => item.y >= 92).map((item) => item.i),
-    ).toEqual(["plaBoard", "vesselZone", "isrSatellitePasses", "traDelay"]);
+    ).toEqual(["plaBoard", "vesselZone", "isrSatellitePasses", "traDelay", "internetHealth"]);
   });
 });

--- a/src/components/intel/monitor/monitorLayout.ts
+++ b/src/components/intel/monitor/monitorLayout.ts
@@ -116,6 +116,7 @@ export const MONITOR_GRID_GAP = 10;
  *   下半整體 +4，左右欄同止改為 y72。
  * - 2026-08-30 十三版 — 軍事態勢尾段改為特殊船舶 → ISR 衛星 → 台鐵；
  *   左右欄仍同止於 y80。
+ * - 2026-09-01 十四版 — internetHealth 移到台鐵誤點後方，作為 Monitor 尾端全寬觀察卡。
  */
 export const MONITOR_LAYOUT: MonitorGridItem[] = [
   { i: "newsFeed", x: 0, y: 0, w: 4, h: 12 },
@@ -123,8 +124,6 @@ export const MONITOR_LAYOUT: MonitorGridItem[] = [
   { i: "timeline", x: 7, y: 0, w: 5, h: 9 },
   { i: "hotZones", x: 4, y: 7, w: 3, h: 5 },
   { i: "triage", x: 7, y: 9, w: 5, h: 3 },
-  // 電信／網路狀態是 country/ASN 文字證據，不建立 map geometry。
-  { i: "internetHealth", x: 0, y: 12, w: 12, h: 4, fit: "content" },
   { i: "situationOverview", x: 0, y: 16, w: 5, h: 5, fit: "content" },
   { i: "liveWall", x: 5, y: 16, w: 7, h: 14, fit: "content" },
   // TAIEX 從 situationOverview 右側拆出成獨立 widget（2026-08-10）：
@@ -177,6 +176,8 @@ export const MONITOR_LAYOUT: MonitorGridItem[] = [
   // 台鐵誤點收尾；右欄由 foodPriceBoard 跨過同一排序範圍，左右同止 y80。
   // fit h 只影響 packing，不改卡片實際高度。
   { i: "traDelay", x: 0, y: 75, w: 5, h: 5, fit: "content" },
+  // RIPE country/ASN 網路觀察接在 TRA DELAY 後方，不建立 map geometry。
+  { i: "internetHealth", x: 0, y: 80, w: 12, h: 4, fit: "content" },
 ];
 
 /** 沙盒 hidden 清單 — 列在這裡的 widget 不渲染（histogram 與時間軸新聞密度重複，2026-07-26 移除） */

--- a/src/components/intel/monitor/monitorSplitLayout.ts
+++ b/src/components/intel/monitor/monitorSplitLayout.ts
@@ -83,9 +83,10 @@ export const MONITOR_SPLIT_CAMERA = {
  * 結構：**上半 2 欄（兩欄同止於 y17）＋ 下半以全寬為主的縱向流**
  *   y0–16   newsFeed(w6)     | timeline → alertBoard → hotZones（右欄三段）
  *           triage(w6, y14)  |
- *   y17–    internetHealth → liveWall → hazardStrip → 颱風（全寬）→ 其餘三卡（一列 w4）→ foodPriceBoard
+ *   y17–    liveWall → hazardStrip → 颱風（全寬）→ 其餘三卡（一列 w4）→ foodPriceBoard
  *           → taiex|situationCards → prison|airportPax → powerCard
  *           → erCongestion → situationOverview → plaBoard
+ *           → 特殊船舶 → ISR → 台鐵 → internetHealth
  *
  * 下半刻意走全寬：窄欄（~415px）放不下影像牆與趨勢圖，全寬（~835px）才讀得出來。
  * 全寬區塊之間都是乾淨的水平切線，guillotine 拆解不會有互卡。
@@ -106,7 +107,6 @@ export const MONITOR_LAYOUT_SPLIT: MonitorGridItem[] = [
   { i: "triage", x: 0, y: 14, w: 6, h: 3 },
 
   // ── 下半：全寬縱向流 ──
-  { i: "internetHealth", x: 0, y: 17, w: 12, h: 4, fit: "content" },
   { i: "liveWall", x: 0, y: 21, w: 12, h: 13, fit: "content" },
   { i: "hazardStrip", x: 0, y: 34, w: 12, h: 7, fit: "content" },
   // 颱風卡獨立一列全寬（2026-08-16）：它有上下兩排趨勢圖（接近程度 + 1000km 內顆數），
@@ -132,6 +132,8 @@ export const MONITOR_LAYOUT_SPLIT: MonitorGridItem[] = [
   { i: "isrSatellitePasses", x: 0, y: 114, w: 12, h: 8, fit: "content" },
   // 台鐵誤點（2026-08-22）：窄版底部沿用全寬堆疊，不影響「兩欄同止」規則。
   { i: "traDelay", x: 0, y: 122, w: 12, h: 8, fit: "content" },
+  // RIPE 網路觀察接在 TRA DELAY 後方，維持尾端全寬。
+  { i: "internetHealth", x: 0, y: 130, w: 12, h: 4, fit: "content" },
 ];
 
 /**


### PR DESCRIPTION
## Summary
- rename the fresh RIPE status label to 網路穩定度
- move the RIPE observation card after TRA DELAY in dock and split layouts
- add packing order guards and update browser handoff

## Verification
- targeted tests: 23 passed
- full suite: 990 passed, 1 skipped
- npx tsc -b
- npm run build
- local browser: dock and split order verified, console errors 0