### PR TITLE
feat: add global events map layer

### DIFF
--- a/src/components/LegendPanel.tsx
+++ b/src/components/LegendPanel.tsx
@@ -14,6 +14,7 @@ import { ALERT_GROUPS, ALERT_GROUP_KEYS } from "../data/disasterAlertTypes";
 import { NEWS_CATEGORIES } from "../data/newsEventTypes";
 import { PLA_KIND_COLORS, PLA_KIND_LABELS } from "../data/plaTracksLoader";
 import { VESSEL_CLASSES } from "../data/vesselWatchTypes";
+import { GLOBAL_EVENT_CATEGORIES, GLOBAL_EVENT_SEVERITIES } from "../data/globalEventsTypes";
 // 船種色票／航班識別色 —— 皆為 three-free 出處（見 ShipsLegend / FlightsLegend 註解）
 import { SHIP_TYPE_LEGEND, SHIP_TYPE_COLORS_DARK } from "../data/shipTrails";
 import { GFW_HOURLY_GRID_V4_COLOR_BANDS } from "../data/gfwHourlyGridTypes";
@@ -311,6 +312,7 @@ export const LEGEND_REGISTRY: LegendEntry[] = [
   { id: "earthquakeReplay", render: () => <EarthquakeReplayLegend /> },
   { id: "earthquakesGlobal", render: () => <EarthquakeGlobalLegend /> },
   { id: "worldTrashDebris", render: () => <WorldTrashDebrisLegend /> },
+  { id: "globalEvents", render: () => <GlobalEventsLegend /> },
   { id: "jpReligion", render: ({ visibility }) => <JpReligionLegend visibility={visibility} /> },
   { id: "jpStations", render: ({ overlayParams }) => <JpStationsLegend modeIdx={overlayParams.jpStationsColorModeIdx ?? 0} /> },
   { id: "typhoonTracks", render: () => <TyphoonTrackLegend /> },
@@ -4586,6 +4588,36 @@ function WorldTrashDebrisLegend() {
       </div>
       <div style={{ fontSize: FONT_SIZE.xs, color: t.textDim, marginTop: 2, lineHeight: 1.3 }}>
         資料：Outerview (CC-BY-4.0)
+      </div>
+    </div>
+  );
+}
+
+function GlobalEventsLegend() {
+  const t = useLegendTheme();
+  return (
+    <div>
+      <div style={{ fontSize: FONT_SIZE.xs, color: t.textDim, letterSpacing: 1, marginBottom: 4 }}>
+        全球重要事件 GLOBAL EVENTS
+      </div>
+      <FireCatRows cats={GLOBAL_EVENT_CATEGORIES.map(({ color, label }) => ({ color, label }))} />
+      <div style={{ display: "flex", alignItems: "center", gap: 8, marginTop: 5 }}>
+        {GLOBAL_EVENT_SEVERITIES.map((item) => (
+          <div key={item.value} style={{ display: "flex", alignItems: "center", gap: 3 }}>
+            <div style={{
+              width: item.radius * 2,
+              height: item.radius * 2,
+              borderRadius: RADIUS.full,
+              background: "#94a3b8",
+              border: "1px solid rgba(15,23,42,0.8)",
+              flexShrink: 0,
+            }} />
+            <span style={{ fontSize: FONT_SIZE.xs, color: t.textDim }}>{item.value}</span>
+          </div>
+        ))}
+      </div>
+      <div style={{ fontSize: FONT_SIZE.xs, color: t.textDim, marginTop: 4 }}>
+        大小 = 嚴重度 0–3；無可靠位置的事件不顯示
       </div>
     </div>
   );

--- a/src/components/featureInfo/globalClimatePanels.tsx
+++ b/src/components/featureInfo/globalClimatePanels.tsx
@@ -1,6 +1,7 @@
 import { Row } from "./shared";
 import { useFeatureTheme } from "./featureTheme";
 import { parseGfwHourlyGridVessels, type GfwHourlyGridVessel } from "../../data/gfwHourlyGridTypes";
+import { globalEventCategoryLabel, globalEventSeverityLabel } from "../../data/globalEventsTypes";
 
 function fmtAge(ts: unknown): string {
   if (typeof ts !== "number" || !Number.isFinite(ts)) return "—";
@@ -113,6 +114,36 @@ export function WorldTrashDebrisPanel({ props }: { props: Record<string, unknown
       <Row label="ID" value={String(props.id ?? "—")} />
       <Row label="資料" value="Outerview（CC-BY-4.0）" />
       <Row label="說明" value="點密度反映 Mapillary 街景覆蓋，非真實垃圾分佈" />
+    </div>
+  );
+}
+
+function fmtGlobalEventTime(value: unknown): string {
+  if (typeof value !== "string" || !value) return "—";
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? value : date.toLocaleString("zh-TW", {
+    year: "numeric", month: "2-digit", day: "2-digit",
+    hour: "2-digit", minute: "2-digit", hour12: false,
+  });
+}
+
+export function GlobalEventPanel({ props }: { props: Record<string, unknown> }) {
+  const confidence = typeof props.confidence === "number" && Number.isFinite(props.confidence)
+    ? `${Math.round(props.confidence * 100)}%`
+    : "—";
+  const placeParts = [props.place_name, props.admin2, props.admin1, props.country_code]
+    .filter((value) => typeof value === "string" && value.length > 0);
+  return (
+    <div>
+      <Row label="事件" value={String(props.title_zh_tw ?? "—")} />
+      <Row label="摘要" value={String(props.summary_zh_tw ?? "—")} />
+      <Row label="分類" value={globalEventCategoryLabel(props.category)} />
+      <Row label="嚴重度" value={globalEventSeverityLabel(props.severity)} />
+      <Row label="信心" value={confidence} />
+      <Row label="地點" value={placeParts.length > 0 ? placeParts.join(" · ") : "—"} />
+      <Row label="事件時間" value={fmtGlobalEventTime(props.valid_from)} />
+      <Row label="發布時間" value={fmtGlobalEventTime(props.published_at)} />
+      <Row label="位置精度" value={String(props.precision ?? "—")} />
     </div>
   );
 }

--- a/src/components/featureInfo/registry.tsx
+++ b/src/components/featureInfo/registry.tsx
@@ -112,7 +112,7 @@ import {
   EarthquakeReplayStationPanel, EarthquakeReplayTownPanel, MountainRescuePanel,
 } from "./hazardPanels";
 import {
-  EarthquakeGlobalPanel, TyphoonTrackPanel, ClimateFieldPanel, WorldTrashDebrisPanel,
+  EarthquakeGlobalPanel, TyphoonTrackPanel, ClimateFieldPanel, WorldTrashDebrisPanel, GlobalEventPanel,
   AisstreamVesselPanel, GfwVesselPresencePanel, GfwHourlyGridPanel, GfwHourlyTrackPanel, GfwFishingEffortPanel, GfwDarkVesselPanel,
 } from "./globalClimatePanels";
 import {
@@ -324,6 +324,7 @@ export const PANEL_REGISTRY: Partial<Record<FeatureInfo["layerType"], FC<PanelPr
   earthquakeReplayStation: EarthquakeReplayStationPanel,
   earthquakeReplayTown: EarthquakeReplayTownPanel,
   earthquakeGlobal: EarthquakeGlobalPanel,
+  globalEvent: GlobalEventPanel,
   typhoonTrack: TyphoonTrackPanel,
   climateField: ClimateFieldPanel,
   rasterProbe: RasterProbePanel,
@@ -686,6 +687,7 @@ export const HEADER_LABELS: Record<FeatureInfo["layerType"], string> = {
   earthquakeReplayStation: "地震回放 強震測站",
   earthquakeReplayTown: "地震回放 鄉鎮震度",
   earthquakeGlobal: "全球地震 USGS",
+  globalEvent: "全球重要事件",
   typhoonTrack: "颱風軌跡",
   climateField: "氣候場讀值",
   rasterProbe: "圖層讀值",

--- a/src/components/sidebar/layerCatalog.ts
+++ b/src/components/sidebar/layerCatalog.ts
@@ -1415,6 +1415,12 @@ const THEME_CATALOG: ThemeDef[] = [
     defaultCollapsed: true,
     groups: [
       {
+        title: "重要事件",
+        layers: [
+          fromManifest("globalEvents"),
+        ],
+      },
+      {
         title: "環境",
         layers: [
           fromManifest("worldTrashDebris"),

--- a/src/data/__tests__/__fixtures__/layer-golden.json
+++ b/src/data/__tests__/__fixtures__/layer-golden.json
@@ -1,6 +1,6 @@
 {
   "meta": {
-    "keyCount": 392,
+    "keyCount": 393,
     "sections": [
       "gisLayers",
       "overlays",
@@ -540,6 +540,12 @@
         "earthquakes-global-circle"
       ],
       "type": "earthquakeGlobal"
+    },
+    {
+      "layers": [
+        "global-events-current-circle"
+      ],
+      "type": "globalEvent"
     },
     {
       "layers": [
@@ -50322,6 +50328,15 @@
         "min": 0,
         "step": 0.05,
         "value": 0.75
+      }
+    ],
+    "globalEvents": [
+      {
+        "label": "透明度 0.90",
+        "max": 1,
+        "min": 0,
+        "step": 0.05,
+        "value": 0.9
       }
     ],
     "govServiceOffices": [

--- a/src/data/__tests__/layerGoldenSnapshot.test.ts
+++ b/src/data/__tests__/layerGoldenSnapshot.test.ts
@@ -129,7 +129,8 @@ describe("黃金快照覆蓋度", () => {
     // 2026-08-28：+1 = gfwFishingEffort（DEV-only v4 shadow daily sample）。
     // 2026-09-01：+4 = jpAdminPrefecture / jpAdminBoundaries / jpStations / jpAirports
     // （日本 Japan Batch 2：行政區 2 層 PMTiles + 交通 2 層 GeoJSON）。
-    expect(keys.length).toBe(392);
+    // 2026-09-03：+1 = globalEvents（已發布全球重要事件的真實 Point 點位）。
+    expect(keys.length).toBe(393);
     expect(Object.keys(full.colors as object)).toHaveLength(keys.length);
     expect(Object.keys(full.icons as object)).toHaveLength(keys.length);
     expect(Object.keys(full.upstream as object)).toHaveLength(keys.length);

--- a/src/data/globalEventsLoader.ts
+++ b/src/data/globalEventsLoader.ts
@@ -1,0 +1,122 @@
+import { supabase, supabaseConfigured } from "../lib/supabase";
+import { withLoading } from "../lib/loadingRegistry";
+import { cachedOnce } from "../lib/loaderCache";
+
+export interface GlobalEventPoint {
+  eventId: string;
+  versionId: string;
+  eventPlaceId: string;
+  titleZhTw: string;
+  summaryZhTw: string | null;
+  category: string | null;
+  severity: number | null;
+  confidence: number | null;
+  validFrom: string | null;
+  publishedAt: string | null;
+  placeKey: string | null;
+  placeName: string | null;
+  countryCode: string | null;
+  admin1: string | null;
+  admin2: string | null;
+  precision: string | null;
+  locationSource: string | null;
+  coordinates: [number, number];
+}
+
+type JsonObject = Record<string, unknown>;
+
+function nullableString(value: unknown): string | null {
+  return value === null || value === undefined || value === "" ? null : String(value);
+}
+
+function nullableFiniteNumber(value: unknown): number | null {
+  if (value === null || value === undefined || value === "") return null;
+  const number = Number(value);
+  return Number.isFinite(number) ? number : null;
+}
+
+function pointCoordinates(value: unknown): [number, number] | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const geometry = value as JsonObject;
+  if (geometry.type !== "Point" || !Array.isArray(geometry.coordinates)) return null;
+  const lng = Number(geometry.coordinates[0]);
+  const lat = Number(geometry.coordinates[1]);
+  if (!Number.isFinite(lng) || !Number.isFinite(lat)) return null;
+  if (lng < -180 || lng > 180 || lat < -90 || lat > 90) return null;
+  return [lng, lat];
+}
+
+export function parseGlobalEventPoint(row: JsonObject): GlobalEventPoint | null {
+  const coordinates = pointCoordinates(row.geometry);
+  if (!coordinates) return null;
+  return {
+    eventId: String(row.event_id ?? ""),
+    versionId: String(row.version_id ?? ""),
+    eventPlaceId: String(row.event_place_id ?? ""),
+    titleZhTw: String(row.title_zh_tw ?? "未命名事件"),
+    summaryZhTw: nullableString(row.summary_zh_tw),
+    category: nullableString(row.category),
+    severity: nullableFiniteNumber(row.severity),
+    confidence: nullableFiniteNumber(row.confidence),
+    validFrom: nullableString(row.valid_from),
+    publishedAt: nullableString(row.published_at),
+    placeKey: nullableString(row.place_key),
+    placeName: nullableString(row.name),
+    countryCode: nullableString(row.country_code),
+    admin1: nullableString(row.admin1),
+    admin2: nullableString(row.admin2),
+    precision: nullableString(row.precision),
+    locationSource: nullableString(row.location_source),
+    coordinates,
+  };
+}
+
+async function fetchGlobalEventsUncached(): Promise<GlobalEventPoint[]> {
+  if (!supabaseConfigured) return [];
+  const { data, error } = await withLoading(
+    "global-events:current",
+    "全球重要事件",
+    supabase.rpc("get_global_event_places_current", {
+      p_category: null,
+      p_before_published_at: null,
+      p_limit: 100,
+    }),
+  );
+  if (error) throw new Error(`Supabase get_global_event_places_current: ${error.message}`);
+  return ((data ?? []) as JsonObject[])
+    .map(parseGlobalEventPoint)
+    .filter((event): event is GlobalEventPoint => event !== null);
+}
+
+export const fetchGlobalEvents = cachedOnce(fetchGlobalEventsUncached, 5 * 60_000);
+
+export function globalEventsToGeoJSON(
+  events: readonly GlobalEventPoint[],
+): GeoJSON.FeatureCollection<GeoJSON.Point> {
+  return {
+    type: "FeatureCollection",
+    features: events.map((event) => ({
+      type: "Feature",
+      geometry: { type: "Point", coordinates: event.coordinates },
+      properties: {
+        event_id: event.eventId,
+        version_id: event.versionId,
+        event_place_id: event.eventPlaceId,
+        title_zh_tw: event.titleZhTw,
+        summary_zh_tw: event.summaryZhTw,
+        category: event.category,
+        severity: event.severity,
+        confidence: event.confidence,
+        valid_from: event.validFrom,
+        published_at: event.publishedAt,
+        place_key: event.placeKey,
+        place_name: event.placeName,
+        country_code: event.countryCode,
+        admin1: event.admin1,
+        admin2: event.admin2,
+        precision: event.precision,
+        location_source: event.locationSource,
+      },
+    })),
+  };
+}

--- a/src/data/globalEventsTypes.ts
+++ b/src/data/globalEventsTypes.ts
@@ -1,0 +1,41 @@
+import type { ExpressionSpecification } from "mapbox-gl";
+
+export const GLOBAL_EVENT_CATEGORIES = [
+  { value: "disaster", label: "災害", color: "#ef4444" },
+  { value: "accident", label: "事故", color: "#f97316" },
+  { value: "health", label: "健康", color: "#eab308" },
+  { value: "crime", label: "治安", color: "#a855f7" },
+  { value: "traffic", label: "交通", color: "#06b6d4" },
+  { value: "policy", label: "政策", color: "#3b82f6" },
+  { value: "other", label: "其他", color: "#94a3b8" },
+] as const;
+
+export const GLOBAL_EVENT_SEVERITIES = [
+  { value: 0, label: "一般", radius: 4 },
+  { value: 1, label: "關注", radius: 5.5 },
+  { value: 2, label: "重大", radius: 7 },
+  { value: 3, label: "嚴重", radius: 9 },
+] as const;
+
+export function globalEventCategoryLabel(category: unknown): string {
+  const key = typeof category === "string" ? category : "";
+  return GLOBAL_EVENT_CATEGORIES.find((item) => item.value === key)?.label ?? "未分類";
+}
+
+export function globalEventSeverityLabel(severity: unknown): string {
+  return GLOBAL_EVENT_SEVERITIES.find((item) => item.value === severity)?.label ?? "未知";
+}
+
+export const GLOBAL_EVENT_CATEGORY_COLOR_EXPR = [
+  "match",
+  ["get", "category"],
+  ...GLOBAL_EVENT_CATEGORIES.flatMap((item) => [item.value, item.color]),
+  "#64748b",
+] as unknown as ExpressionSpecification;
+
+export const GLOBAL_EVENT_SEVERITY_RADIUS_EXPR = [
+  "match",
+  ["get", "severity"],
+  ...GLOBAL_EVENT_SEVERITIES.flatMap((item) => [item.value, item.radius]),
+  4.5,
+] as unknown as ExpressionSpecification;

--- a/src/data/layerManifest.ts
+++ b/src/data/layerManifest.ts
@@ -1061,6 +1061,32 @@ export const LAYER_MANIFEST = {
     topics: ["世界", "環境", "垃圾"],
   },
 
+  globalEvents: {
+    key: "globalEvents",
+    section: { theme: "世界 World", group: "重要事件" },
+    label: "全球重要事件 Global Events",
+    labelMobile: "全球重要事件",
+    expandable: true,
+    color: "#f97316",
+    icon: MapPinned,
+    upstream: {
+      status: "catalog_missing",
+      datasets: [],
+      processing: "Collector + Qwen 大量初篩，Codex cloud 深度研究；GitHub 為研究 SSOT，publisher 發布 current version 到 Supabase",
+      note: "前端只讀 anon-safe public.get_global_event_places_current RPC；unknown geometry 不顯示也不補代理座標",
+    },
+    dataClass: "D",
+    source: {
+      kind: "custom",
+      note: "useGlobalEventsLayer 自建 global-events-current GeoJSON source/circle；RPC 最多取最新 100 筆，僅接受非 null Point geometry",
+    },
+    legend: "globalEvents",
+    popup: "globalEvent",
+    params: { count: 1, kinds: ["slider"] },
+    description: "已發布的全球重要事件；顏色表示分類、大小表示嚴重度，無可靠位置者不畫上地圖",
+    topics: ["世界", "重要事件", "情報"],
+  },
+
   aisstreamVessels: {
     key: "aisstreamVessels",
     section: { theme: "全球海事 Global Maritime", group: "船舶" },

--- a/src/data/layerParamsSpec.ts
+++ b/src/data/layerParamsSpec.ts
@@ -1297,6 +1297,9 @@ export const LAYER_PARAMS_SPEC = {
   worldTrashDebris: [
     { kind: "slider", name: "worldTrashDebrisOpacity", labelPrefix: "透明度", digits: 2, default: 0.85, min: 0, max: 1, step: 0.05 },
   ],
+  globalEvents: [
+    { kind: "slider", name: "globalEventsOpacity", labelPrefix: "透明度", digits: 2, default: 0.9, min: 0, max: 1, step: 0.05 },
+  ],
   aisstreamVessels: [
     { kind: "slider", name: "aisstreamVesselsOpacity", labelPrefix: "透明度", digits: 2, default: 0.9, min: 0, max: 1, step: 0.05 },
   ],

--- a/src/hooks/useGlobalEventsLayer.ts
+++ b/src/hooks/useGlobalEventsLayer.ts
@@ -1,0 +1,75 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { CircleLayer, GeoJSONSource, Map as MapboxMap } from "mapbox-gl";
+import { fetchGlobalEvents, globalEventsToGeoJSON } from "../data/globalEventsLoader";
+import {
+  GLOBAL_EVENT_CATEGORY_COLOR_EXPR,
+  GLOBAL_EVENT_SEVERITY_RADIUS_EXPR,
+} from "../data/globalEventsTypes";
+import { keepLoadingUntilMapIdle } from "../lib/loadingRegistry";
+import { useMapReadyTick } from "./useMapReadyTick";
+
+const SOURCE_ID = "global-events-current";
+export const GLOBAL_EVENTS_LAYER_ID = "global-events-current-circle";
+
+export function useGlobalEventsLayer(
+  mapRef: React.RefObject<MapboxMap | null>,
+  visible: boolean,
+  opacity = 0.9,
+) {
+  const mapTick = useMapReadyTick(mapRef, visible);
+  const dataRef = useRef<GeoJSON.FeatureCollection<GeoJSON.Point> | null>(null);
+  const [dataTick, setDataTick] = useState(0);
+
+  const ensureLayer = useCallback((map: MapboxMap) => {
+    if (!dataRef.current) return false;
+    if (!map.getSource(SOURCE_ID)) {
+      map.addSource(SOURCE_ID, { type: "geojson", data: dataRef.current });
+    }
+    if (!map.getLayer(GLOBAL_EVENTS_LAYER_ID)) {
+      map.addLayer({
+        id: GLOBAL_EVENTS_LAYER_ID,
+        type: "circle",
+        source: SOURCE_ID,
+        paint: {
+          "circle-radius": GLOBAL_EVENT_SEVERITY_RADIUS_EXPR,
+          "circle-color": GLOBAL_EVENT_CATEGORY_COLOR_EXPR,
+          "circle-opacity": 0.9,
+          "circle-stroke-color": "rgba(15, 23, 42, 0.8)",
+          "circle-stroke-width": ["match", ["get", "severity"], 3, 2, 2, 1.5, 1],
+          "circle-stroke-opacity": 0.85,
+        },
+      } as CircleLayer);
+    }
+    return true;
+  }, []);
+
+  useEffect(() => {
+    if (!visible || dataRef.current) return;
+    let cancelled = false;
+    fetchGlobalEvents()
+      .then((events) => {
+        if (cancelled) return;
+        const collection = globalEventsToGeoJSON(events);
+        dataRef.current = collection;
+        const map = mapRef.current;
+        if (map?.isStyleLoaded()) {
+          const source = map.getSource(SOURCE_ID) as GeoJSONSource | undefined;
+          if (source) source.setData(collection);
+          else ensureLayer(map);
+          keepLoadingUntilMapIdle(map, "global-events:render", "全球重要事件 渲染中", SOURCE_ID);
+        }
+        setDataTick((tick) => tick + 1);
+      })
+      .catch((error) => console.warn("[GlobalEvents] load failed:", error));
+    return () => { cancelled = true; };
+  }, [ensureLayer, mapRef, mapTick, visible]);
+
+  useEffect(() => {
+    const map = mapRef.current;
+    if (!map || !ensureLayer(map)) return;
+    map.setLayoutProperty(GLOBAL_EVENTS_LAYER_ID, "visibility", visible ? "visible" : "none");
+    const safeOpacity = Math.max(0, Math.min(1, opacity));
+    map.setPaintProperty(GLOBAL_EVENTS_LAYER_ID, "circle-opacity", safeOpacity);
+    map.setPaintProperty(GLOBAL_EVENTS_LAYER_ID, "circle-stroke-opacity", safeOpacity * 0.9);
+  }, [dataTick, ensureLayer, mapRef, mapTick, opacity, visible]);
+}

--- a/src/layers/hosts/climateHosts.tsx
+++ b/src/layers/hosts/climateHosts.tsx
@@ -4,6 +4,7 @@
 import { useEarthquakesGlobalLayer } from "../../hooks/useEarthquakesGlobalLayer";
 import { useTyphoonTracksLayer, type TyphoonSource } from "../../hooks/useTyphoonTracksLayer";
 import { useWorldTrashDebrisLayer } from "../../hooks/useWorldTrashDebrisLayer";
+import { useGlobalEventsLayer } from "../../hooks/useGlobalEventsLayer";
 import { useJpReligionLayers } from "../../hooks/useJpReligionLayers";
 import { useClimateParticleLineLayer } from "../../hooks/useClimateParticleLineLayer";
 import { useDustForecastLayer } from "../../hooks/useDustForecastLayer";
@@ -55,6 +56,18 @@ export const WorldTrashDebrisHost: LayerHostComponent = ({ deps }) => {
     deps.mapRef,
     deps.layerVisibility.worldTrashDebris,
     p.worldTrashDebrisOpacity ?? 0.85,
+  );
+  return null;
+};
+
+/** 🌍 世界 WORLD：已發布的全球重要事件（僅有真實 Point 者）。 */
+export const GlobalEventsHost: LayerHostComponent = ({ deps }) => {
+  bumpHostRender("useGlobalEventsLayer");
+  const p = useKeyOverlayParams("globalEvents");
+  useGlobalEventsLayer(
+    deps.mapRef,
+    deps.layerVisibility.globalEvents,
+    p.globalEventsOpacity ?? 0.9,
   );
   return null;
 };

--- a/src/layers/layerHookRegistry.tsx
+++ b/src/layers/layerHookRegistry.tsx
@@ -50,6 +50,7 @@ import {
 } from "./hosts/hazardHosts";
 import {
   EarthquakesGlobalHost, TyphoonTracksHost, WorldTrashDebrisHost, JpReligionHost,
+  GlobalEventsHost,
   WindFieldHost, OceanCurrentsHost, DustForecastHost,
   DisasterAlertHost, PlaActivityHost, VesselWatchHost,
 } from "./hosts/climateHosts";
@@ -205,6 +206,7 @@ export const LAYER_HOOK_REGISTRY: readonly LayerHookEntry[] = [
   { id: "useEarthquakesGlobalLayer", keys: ["earthquakesGlobal"], Host: EarthquakesGlobalHost },
   { id: "useTyphoonTracksLayer", keys: ["typhoonTracks"], Host: TyphoonTracksHost },
   { id: "useWorldTrashDebrisLayer", keys: ["worldTrashDebris"], Host: WorldTrashDebrisHost },
+  { id: "useGlobalEventsLayer", keys: ["globalEvents"], Host: GlobalEventsHost },
   {
     id: "useJpReligionLayers",
     keys: ["jpReligionGsi", "jpReligionOsm", "jpReligionWikidata"],

--- a/src/map/gisClickRegistry.ts
+++ b/src/map/gisClickRegistry.ts
@@ -153,6 +153,7 @@ export const GIS_LAYERS: { layers: string[]; type: FeatureInfo["layerType"] }[] 
   // 全球氣候 GLOBAL CLIMATE
   { layers: ["earthquakes-global-circle"], type: "earthquakeGlobal" },
   // 🌍 世界 WORLD
+  { layers: ["global-events-current-circle"], type: "globalEvent" },
   { layers: ["global-maritime-aisstream-circle"], type: "aisstreamVessel" },
   { layers: ["global-maritime-gfw-circle"], type: "gfwVesselPresence" },
   // grid hook 會把 alpha dominant 的 H 或 H+1 複製到專用 hit source；此處只查它，

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -690,7 +690,7 @@ export interface FeatureInfo {
     | "publicLibrary" | "welfareCenter" | "retailMarket" | "publicToilet"
     | "weatherStation" | "bikeStation" | "busStation" | "lighthouse" | "railStation"
     | "port" | "airport" | "ship" | "cctv" | "etcGantry" | "serviceArea" | "serviceAreaPolygon" | "taxiStand"
-    | "activeFault" | "newsEvent" | "disasterAlert" | "plaActivity" | "vesselWatch"
+    | "activeFault" | "newsEvent" | "globalEvent" | "disasterAlert" | "plaActivity" | "vesselWatch"
     | "aisstreamVessel" | "gfwVesselPresence" | "gfwHourlyGrid" | "gfwHourlyTrack" | "gfwFishingEffort" | "gfwDarkVessel"
     | "roadEvent" | "roadCongestion" | "freewayCongestion"
     | "provincialRoad" | "highway" | "cyclingRoute"
@@ -894,6 +894,8 @@ export interface LayerVisibility {
   ooklaFixedTaiwan: boolean;
   activeFaults: boolean;
   newsEvents: boolean;
+  /** GitHub append-only 研究經 publisher 發布的全球重要事件；僅顯示有真實 Point 的位置 */
+  globalEvents: boolean;
   /** 共機活動區（國防部每日航跡示意圖向量化，spatial.pla_tracks · 依日期回放） */
   plaActivity: boolean;
   /**


### PR DESCRIPTION
## Outcome
- add a World / Global Events toggle backed by the anon-safe published-current map RPC
- render only source-bound Point geometry; null, unknown and non-Point locations remain absent
- add category color, severity size, opacity, legend and click details

## Verification
- TypeScript project build passed
- 52 related layer contract tests passed

## Production dependency
- gis-platform migration 394 is merged and applied to production