### PR TITLE
fix(global-events): sync historical timeline cursor

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,7 +7,7 @@ import { MapView } from "./map/MapView";
 import { useAirspaceData } from "./hooks/useAirspaceData";
 import { useShipData } from "./hooks/useShipData";
 import { useRailData } from "./hooks/useRailData";
-import { useTimeline } from "./hooks/useTimeline";
+import { historicalPeriodSnapshot, useTimeline } from "./hooks/useTimeline";
 import { timeStore } from "./state/timeStore";
 import { useIsMobile } from "./hooks/useIsMobile";
 // AR-22 P4：`useLayerParamsRuntime` 已整支退役。參數的消費端各自 per-key 訂閱
@@ -593,9 +593,11 @@ export default function App() {
   );
   // 火災資料覆蓋範圍（民國 111~113）— 月/日推進的上限
   const FIRE_MAX_YEAR = 113;
-  // 共機活動區已向量化到 115 年（2026）。開著它時月/日推進要能走到 115，
-  // 沒開就維持火災的 113 上限，不改變既有行為。
-  const monthDayMaxYear = layerVisibility.plaActivity ? 115 : FIRE_MAX_YEAR;
+  // 共機活動區與 Global Events 都有 115 年（2026）資料。開著任一時，
+  // 月/日推進要能走到 115；只有火災時仍維持原本的 113 上限。
+  const monthDayMaxYear = layerVisibility.plaActivity || layerVisibility.globalEvents
+    ? 115
+    : FIRE_MAX_YEAR;
 
   // 歷史模式自動播放：依粒度推進年/月/日，到頂暫停
   // （房地產的播放交給 useRealEstateTimeline 的 RAF 引擎，這裡略過）
@@ -667,7 +669,12 @@ export default function App() {
       for (const k of Object.keys(allOff) as (keyof LayerVisibility)[]) {
         allOff[k] = false;
       }
-      setLayerVisibility({ ...allOff, popCount: true, plaActivity: current.plaActivity });
+      setLayerVisibility({
+        ...allOff,
+        popCount: true,
+        plaActivity: current.plaActivity,
+        globalEvents: current.globalEvents,
+      });
     } else {
       const snapshot = layerVisBeforeHistoricalRef.current;
       if (snapshot) {
@@ -772,6 +779,30 @@ export default function App() {
       `${end.getFullYear()}-${pad(end.getMonth() + 1)}-${pad(end.getDate())}`,
     );
   }, [appMode, historicalYear, historicalMonth, historicalDay, historicalGranularity]);
+
+  // Global Events 沿用共用 timeStore。HistoricalTimeline 本身只管理年/月/日，
+  // 因此僅在該圖層開啟時，把所選期間結束前的 snapshot 同步給 useTimeline；
+  // 火災仍直接使用既有 historical state，不改其語意。
+  const globalEventsHistoricalSnapshot = useMemo(() => {
+    if (appMode !== "historical" || !layerVisibility.globalEvents) return null;
+    return historicalPeriodSnapshot(
+      historicalYear,
+      historicalMonth,
+      historicalDay,
+      historicalGranularity,
+    );
+  }, [
+    appMode,
+    layerVisibility.globalEvents,
+    historicalYear,
+    historicalMonth,
+    historicalDay,
+    historicalGranularity,
+  ]);
+  useEffect(() => {
+    if (!globalEventsHistoricalSnapshot) return;
+    timeline.jumpToTime(globalEventsHistoricalSnapshot.cursorTime);
+  }, [globalEventsHistoricalSnapshot, timeline.jumpToTime]);
 
   // 共機活動區 / 衛星 / 路況 / 火災 / 清潔隊 / 地形 raster / 坡度坡向 /
   // 氣象空品影像 / 壅塞 / 殯葬密度 / 溫度網格的 hook 全部搬進 LayerHost
@@ -1759,6 +1790,7 @@ export default function App() {
               onDayChange={setHistoricalDay}
               onGranularityChange={setHistoricalGranularity}
               plaActive={layerVisibility.plaActivity}
+              globalEventsActive={layerVisibility.globalEvents}
               reActive={realEstateActive}
               reGran={reGran}
               onReGranChange={(g) => { setReGran(g); if (g === "quarter") setReCursorTs((t) => snapQuarterStart(t)); }}
@@ -2191,6 +2223,7 @@ export default function App() {
                 onDayChange={setHistoricalDay}
                 onGranularityChange={setHistoricalGranularity}
                 plaActive={layerVisibility.plaActivity}
+                globalEventsActive={layerVisibility.globalEvents}
               />
             )}
           </div>

--- a/src/components/HistoricalTimeline.tsx
+++ b/src/components/HistoricalTimeline.tsx
@@ -17,6 +17,8 @@ interface Props {
   onTogglePlay: () => void;
   /** 共機活動區是否開著（決定資料範圍提示） */
   plaActive?: boolean;
+  /** 全球事件是否開著（依已發布 immutable versions 回放）。 */
+  globalEventsActive?: boolean;
   onSpeedChange: (s: number) => void;
   onYearChange: (y: number) => void;
   onMonthChange: (m: number) => void;
@@ -97,6 +99,7 @@ export function HistoricalTimeline({
   leftOffset = 16,
   onTogglePlay,
   plaActive = false,
+  globalEventsActive = false,
   onSpeedChange,
   onYearChange,
   onMonthChange,
@@ -122,7 +125,9 @@ export function HistoricalTimeline({
   // 提示該模式下「現在開著的圖層」實際有資料的區間，避免使用者在空年份亂撥
   const dataNote = reActive
     ? "房地產：2024Q3~2026Q1"
-    : plaActive
+    : globalEventsActive
+      ? "全球重要事件：依已發布版本回放"
+      : plaActive
       ? "共機活動區：115/01~115/07"
       : "火災資料：111~113";
   const playStepLabel = reActive ? reGranLabel[reGran] : granLabel[granularity];
@@ -207,7 +212,7 @@ export function HistoricalTimeline({
   );
 
   return (
-    <div style={wrapStyle}>
+    <div style={wrapStyle} data-testid="historical-timeline">
       {/* Row 1: 粒度 + Label */}
       <div style={{ display: "flex", gap: 6, alignItems: "center", marginBottom: 4 }}>
         {reActive ? (

--- a/src/hooks/__tests__/useGlobalEventsLayer.test.ts
+++ b/src/hooks/__tests__/useGlobalEventsLayer.test.ts
@@ -171,6 +171,30 @@ describe("useGlobalEventsLayer timeline", () => {
     expect(loader.window).toHaveBeenCalledTimes(2);
   });
 
+  it("跨日換 window 仍保留舊 cursor，9/2→9/3 跨發布時間會 pulse", async () => {
+    clock.current = Date.parse("2026-09-02T15:59:59Z") / 1000;
+    const published = point({
+      displayFrom: "2026-09-03T05:41:00Z",
+      publishedAt: "2026-09-03T05:41:00Z",
+    });
+    loader.window.mockResolvedValueOnce([]).mockResolvedValueOnce([published]);
+    const state = createMap();
+    useGlobalEventsLayer({ current: state.map } as RefObject<MapboxMap | null>, true, 0.8, "replay");
+    await flush();
+
+    harness.changeWindow(["2026-09-03"]);
+    clock.current = Date.parse("2026-09-03T15:59:59.999Z") / 1000;
+    harness.tick(clock.current);
+    await flush();
+
+    const calls = state.sources.get("global-events-current")?.setData.mock.calls ?? [];
+    const fc = calls[calls.length - 1]?.[0] as GeoJSON.FeatureCollection;
+    expect(fc.features[0]?.properties).toMatchObject({
+      event_id: "event-1",
+      transition_kind: "new_event",
+    });
+  });
+
   it("Live 只使用 current RPC，仍保留 proxy metadata 給 popup", async () => {
     loader.current.mockResolvedValue([point({
       locationKind: "country_center",

--- a/src/hooks/useGlobalEventsLayer.ts
+++ b/src/hooks/useGlobalEventsLayer.ts
@@ -210,11 +210,15 @@ export function useGlobalEventsLayer(
       feed(events, transitions);
     };
 
-    const acceptRows = (events: GlobalEventPoint[], loadingKey: string) => {
+    const acceptRows = (
+      events: GlobalEventPoint[],
+      loadingKey: string,
+      transitionFromTime = timeStore.getTime(),
+    ) => {
       if (cancelled) return;
       allEventsRef.current = events;
       signatureRef.current = "";
-      previousTimeRef.current = timeStore.getTime();
+      previousTimeRef.current = transitionFromTime;
       renderAt(timeStore.getTime());
       keepLoadingUntilMapIdle(map, `global-events:render:${loadingKey}`, "全球重要事件 渲染中", SOURCE_ID);
     };
@@ -231,6 +235,9 @@ export function useGlobalEventsLayer(
 
     const loadWindow = (dateKeys: readonly string[]) => {
       const bounds = globalEventWindowBounds(dateKeys);
+      // 跨日 scrub 會換 RPC window。保留換窗前的 cursor，等新 rows 回來後仍可
+      // 判斷是否向前跨過 display_from；不可在 fetch 完成時重設成新 cursor。
+      const transitionFromTime = previousTimeRef.current ?? timeStore.getTime();
       const request = ++requestRef.current;
       allEventsRef.current = [];
       signatureRef.current = "";
@@ -239,7 +246,7 @@ export function useGlobalEventsLayer(
       fetchGlobalEventsWindow(bounds.start, bounds.end)
         .then((events) => {
           if (request !== requestRef.current) return;
-          acceptRows(events, `${bounds.start}/${bounds.end}`);
+          acceptRows(events, `${bounds.start}/${bounds.end}`, transitionFromTime);
         })
         .catch((error) => console.warn("[GlobalEvents] window load failed:", error));
     };

--- a/src/hooks/useTimeline.test.ts
+++ b/src/hooks/useTimeline.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { advanceReplayFrame, dayEndUnix, dayStartUnix, taiwanDateParts } from "./useTimeline";
+import {
+  advanceReplayFrame,
+  dayEndUnix,
+  dayStartUnix,
+  historicalPeriodSnapshot,
+  taiwanDateParts,
+} from "./useTimeline";
 
 describe("useTimeline 時間契約", () => {
   it("以 Asia/Taipei 日曆日切窗，UTC 跨日不改成 UTC 日", () => {
@@ -12,5 +18,22 @@ describe("useTimeline 時間契約", () => {
   it("播放抵達 windowEnd 時停止在尾端，不跳回 windowStart", () => {
     expect(advanceReplayFrame(100, 0.5, 60, 120)).toEqual({ time: 120, reachedEnd: true });
     expect(advanceReplayFrame(100, 0.1, 60, 120)).toEqual({ time: 106, reachedEnd: false });
+  });
+
+  it("民國 115/9/3 使用該日結束前 snapshot，window 精確覆蓋該台北日", () => {
+    const snapshot = historicalPeriodSnapshot(115, 9, 3, "day");
+
+    expect(new Date(snapshot.cursorTime * 1000).toISOString()).toBe("2026-09-03T15:59:59.999Z");
+    expect(snapshot.cursorTime).toBeLessThan(Date.parse("2026-09-04T00:00:00+08:00") / 1000);
+    expect(snapshot.dateKey).toBe("2026-09-03");
+    expect(snapshot.windowStart).toBe("2026-09-02T16:00:00.000Z");
+    expect(snapshot.windowEnd).toBe("2026-09-03T16:00:00.000Z");
+  });
+
+  it("年／月粒度同樣取期間結束前，而不是日初", () => {
+    expect(new Date(historicalPeriodSnapshot(115, 9, 1, "month").cursorTime * 1000).toISOString())
+      .toBe("2026-09-30T15:59:59.999Z");
+    expect(new Date(historicalPeriodSnapshot(115, 1, 1, "year").cursorTime * 1000).toISOString())
+      .toBe("2026-12-31T15:59:59.999Z");
   });
 });

--- a/src/hooks/useTimeline.ts
+++ b/src/hooks/useTimeline.ts
@@ -22,9 +22,58 @@ export function dayEndUnix(d: Date): number {
   return Date.UTC(y, m, day, 23, 59, 59) / 1000 - 8 * 3600;
 }
 
+export interface HistoricalPeriodSnapshot {
+  /** 所選期間結束前 1ms；只代表回放游標，不是事件的結束時間。 */
+  cursorTime: number;
+  /** 游標所在的台北日曆日。 */
+  dateKey: string;
+  /** RPC 查詢用的單日 half-open window。 */
+  windowStart: string;
+  windowEnd: string;
+}
+
+/**
+ * HistoricalTimeline 的年／月／日都是「該期間結束前的快照」。
+ * 台灣沒有 DST，因此可安全用固定 +08:00 日界；不替事件製造 valid_to。
+ */
+export function historicalPeriodSnapshot(
+  rocYear: number,
+  month: number,
+  day: number,
+  granularity: "year" | "month" | "day",
+): HistoricalPeriodSnapshot {
+  const adYear = Math.trunc(rocYear) + 1911;
+  const safeMonth = Math.max(1, Math.min(12, Math.trunc(month)));
+  const daysInSelectedMonth = new Date(Date.UTC(adYear, safeMonth, 0)).getUTCDate();
+  const safeDay = Math.max(1, Math.min(daysInSelectedMonth, Math.trunc(day)));
+  const taipeiOffsetMs = 8 * 3_600_000;
+  const nextBoundaryMs = granularity === "year"
+    ? Date.UTC(adYear + 1, 0, 1) - taipeiOffsetMs
+    : granularity === "month"
+      ? Date.UTC(adYear, safeMonth, 1) - taipeiOffsetMs
+      : Date.UTC(adYear, safeMonth - 1, safeDay + 1) - taipeiOffsetMs;
+  const cursorMs = nextBoundaryMs - 1;
+  const dateKey = new Date(cursorMs).toLocaleDateString("sv-SE", { timeZone: "Asia/Taipei" });
+  const windowStartMs = new Date(`${dateKey}T00:00:00+08:00`).getTime();
+  return {
+    cursorTime: cursorMs / 1000,
+    dateKey,
+    windowStart: new Date(windowStartMs).toISOString(),
+    windowEnd: new Date(windowStartMs + 86_400_000).toISOString(),
+  };
+}
+
 /** 加減天數（台灣無 DST，直接加 86400 秒） */
 function addDays(d: Date, n: number): Date {
   return new Date(d.getTime() + n * 86400 * 1000);
+}
+
+function windowDateKeysFor(selectedDate: Date, rangeDays: number): string[] {
+  const keys: string[] = [];
+  for (let i = 0; i < rangeDays; i++) {
+    keys.push(addDays(selectedDate, i).toLocaleDateString("sv-SE", { timeZone: "Asia/Taipei" }));
+  }
+  return keys;
 }
 
 interface UseTimelineOptions {
@@ -115,11 +164,7 @@ export function useTimeline({
   // 視窗內每一天的 dateKey（YYYY-MM-DD, Asia/Taipei）→ 寫入 timeStore SSOT，
   // time-aware loader 訂閱 subscribeWindowDateKeys 後嚴格只預載這份；視窗外不打 RPC。
   useEffect(() => {
-    const keys: string[] = [];
-    for (let i = 0; i < rangeDays; i++) {
-      keys.push(addDays(selectedDate, i).toLocaleDateString("sv-SE", { timeZone: "Asia/Taipei" }));
-    }
-    timeStore.setWindowDateKeys(keys);
+    timeStore.setWindowDateKeys(windowDateKeysFor(selectedDate, rangeDays));
   }, [selectedDate, rangeDays]);
 
   // 首次掛載寫入 timeStore 初始值（從「現在 - 1 小時」開始；過去日期從午夜開始）。
@@ -238,11 +283,15 @@ export function useTimeline({
   const jumpToTime = useCallback((time: number) => {
     if (!Number.isFinite(time)) return;
     // Date 保留絕對時間；dayStartUnix 會從中取 Asia/Taipei 日曆日。
-    setSelectedDateRaw(new Date(time * 1000));
+    const selected = new Date(time * 1000);
+    setSelectedDateRaw(selected);
     setTimeMode("replay");
     setPlaying(false);
+    // 先同步 window，再推進 cursor：跨日 loader 才能保留舊 cursor，判斷向前
+    // 跨過 display_from 的 new_event / version_update pulse。
+    timeStore.setWindowDateKeys(windowDateKeysFor(selected, rangeDays));
     timeStore.setTime(time);
-  }, []);
+  }, [rangeDays]);
 
   const seekByProgress = useCallback(
     (p: number) => {

--- a/src/layers/hosts/climateHosts.tsx
+++ b/src/layers/hosts/climateHosts.tsx
@@ -68,7 +68,7 @@ export const GlobalEventsHost: LayerHostComponent = ({ deps }) => {
     deps.mapRef,
     deps.layerVisibility.globalEvents,
     p.globalEventsOpacity ?? 0.9,
-    deps.timeMode,
+    deps.appMode === "historical" ? "replay" : deps.timeMode,
   );
   return null;
 };


### PR DESCRIPTION
## Why
Production browser acceptance found that HistoricalTimeline year/month/day state did not write to the shared timeStore, so Global Events replay could not actually follow the visible historical controls.

## Fix
- keep Global Events enabled when entering historical mode
- expose ROC 115 when Global Events is active
- sync the selected historical period end snapshot into useTimeline/timeStore only for this layer
- force Global Events host to replay in historical app mode
- preserve the prior cursor across window reload so a forward cross-day scrub can pulse
- keep fire-only historical behavior unchanged

## Semantics
- selected period means the final millisecond before the real period boundary
- this is only a replay cursor, never a synthetic event end time
- 115/9/3 resolves to 2026-09-03T15:59:59.999Z with a Taipei-day window

## Validation
- focused tests: 16 passed
- npx tsc -b
- full npm test: 1004 passed, 1 skipped
- git diff --check