### PR TITLE
fix(global-events): clamp replay pulse opacity

### DIFF
--- a/src/hooks/__tests__/useGlobalEventsLayer.test.ts
+++ b/src/hooks/__tests__/useGlobalEventsLayer.test.ts
@@ -282,6 +282,32 @@ describe("useGlobalEventsLayer timeline", () => {
     expect(globalEventsViewStore.getSnapshot().status).toBe("partial");
     expect(globalEventsViewStore.getSnapshot().message).toContain("載入失敗");
   });
+
+  it("clamps pulse phase when RAF frame time precedes performance.now at animation start", async () => {
+    const frames: FrameRequestCallback[] = [];
+    vi.stubGlobal("requestAnimationFrame", vi.fn((callback: FrameRequestCallback) => {
+      frames.push(callback);
+      return frames.length;
+    }));
+    vi.spyOn(performance, "now").mockReturnValue(1000);
+    clock.current = Date.parse("2026-09-03T09:59:00Z") / 1000;
+    loader.window.mockResolvedValue([point()]);
+    const state = createMap();
+    useGlobalEventsLayer({ current: state.map } as RefObject<MapboxMap | null>, true, 0.8, "replay");
+    await flush();
+    harness.tick(Date.parse("2026-09-03T10:01:00Z") / 1000);
+    expect(frames).toHaveLength(1);
+    frames.shift()!(990); // The browser's current frame began before this animation was started.
+    frames.shift()!(1900);
+    frames.shift()!(4000); // Late frame must also remain within the end bound.
+    const calls = vi.mocked(state.map.setPaintProperty).mock.calls;
+    const opacities = calls.filter(([id, property]) => id === GLOBAL_EVENTS_PULSE_LAYER_ID && property === "circle-stroke-opacity").map((call) => Number(call[2]));
+    const radii = calls.filter(([id, property]) => id === GLOBAL_EVENTS_PULSE_LAYER_ID && property === "circle-radius").map((call) => Number(call[2]));
+    expect(opacities.every((value) => Number.isFinite(value) && value >= 0 && value <= 0.8)).toBe(true);
+    expect(radii).toEqual([8, 19, 30]);
+    expect(opacities[opacities.length - 1]).toBe(0);
+    expect(frames).toHaveLength(0);
+  });
 });
 
 describe("Global Events pulse and location semantics", () => {

--- a/src/hooks/useGlobalEventsLayer.ts
+++ b/src/hooks/useGlobalEventsLayer.ts
@@ -229,7 +229,9 @@ export function useGlobalEventsLayer(
         rafRef.current = 0;
         return;
       }
-      const phase = Math.min(1, (now - startedAt) / PULSE_DURATION_MS);
+      // RAF timestamps mark the frame start and can precede performance.now() sampled
+      // later in that same frame. Clamp both ends before deriving Mapbox paint values.
+      const phase = Math.max(0, Math.min(1, (now - startedAt) / PULSE_DURATION_MS));
       map.setPaintProperty(GLOBAL_EVENTS_PULSE_LAYER_ID, "circle-radius", 8 + phase * 22);
       map.setPaintProperty(
         GLOBAL_EVENTS_PULSE_LAYER_ID,


### PR DESCRIPTION
## Summary

修正 Global Events 回放 pulse 偶發將負數 `circle-stroke-opacity` 傳入 Mapbox 的 production 錯誤。

## Changes

- RAF timestamp 是目前 frame 的起始時間，可能早於同 frame 內取得的 `performance.now()`。
- Pulse phase 原本只 clamp 上限，現在 clamp 至 `[0, 1]`，確保 opacity 非負且半徑介於 8–30。
- 僅修改 `useGlobalEventsLayer.ts` 與其 regression test，不改資料、時間語意、文件或其他功能。

## Test

- [x] 新 regression 在舊碼確實失敗（負 opacity）。
- [x] `npx tsc -b`
- [x] Focused `useGlobalEventsLayer.test.ts`：11 passed；包含 frame 早於開始時間、中間 frame、過晚結束 frame。
- [ ] CI
- [ ] Production console regression：主 agent 驗收。

## Risk / Rollback

- 必要 production bugfix；無 DB／schema／publisher 變更。
- 回滾此 PR 即還原原本 phase 計算，但會恢復已確認的負 opacity 錯誤。

## Related

- Global Events release: #205
- Feature: `docs/features/global-events/`（本次依主 agent 分工不修改文件）

## Checklist

- [x] `codex/` isolated branch；未動 shared master
- [x] Conventional Commit
- [x] 最小 pulse 修正；保留原 loading／popup／legend／opacity 行為
