### PR TITLE
fix(global-events): keep country anchors fixed while moving globe

### DIFF
--- a/docs/features/global-events/backlog.md
+++ b/docs/features/global-events/backlog.md
@@ -7,5 +7,8 @@
 - [x] 同事件多國關聯弧線toggle與選取強調
 - [x] tsc-b、focused/full tests、RPC readback
 - [x] Production browser／部署驗收（PR #205／#206；def3dc6 RUNNING，真實資料與時間軸驗收）
+- [x] 同位置避讓改為 native screen-space offset，所有 geometry 固定；tsc／完整 tests
+- [x] 固定錨點 hotfix 本地 browser：平移／旋轉／縮放、並排點選、opacity／off、console
+- [ ] 固定錨點 hotfix PR／正式部署驗收
 
 後續：重要性判準持續校準；本次不引入新的分數體系。

--- a/docs/features/global-events/backlog.md
+++ b/docs/features/global-events/backlog.md
@@ -6,6 +6,6 @@
 - [x] 同位置不同事件避讓／群組展開
 - [x] 同事件多國關聯弧線toggle與選取強調
 - [x] tsc-b、focused/full tests、RPC readback
-- [ ] Production browser／部署驗收（完成證據見 PR #205）
+- [x] Production browser／部署驗收（PR #205／#206；def3dc6 RUNNING，真實資料與時間軸驗收）
 
 後續：重要性判準持續校準；本次不引入新的分數體系。

--- a/docs/features/global-events/changelog.md
+++ b/docs/features/global-events/changelog.md
@@ -6,4 +6,8 @@
 
 城市／國家可先以概略代表位置上圖，不冒充精確發生地；原始座標不因畫面避讓而變動。修復深色列表黑字（改 theme token、11px）及四國代表點缺 country code 時的關聯線。
 
-本地 tsc-b、1027 tests（1 skipped）通過；production 上線進度與最後 readback 記錄於 PR #205／上游 handoff。
+本地 tsc-b、1027 tests（1 skipped）通過；PR #205 merge ab813b0 已部署。Production 實測最近七天、AI開關、來源國家點popup、同位置7件群組展開、跨國線與透明度開關。9/2尚未導入時為0，9/3可讀實際導入版本。
+
+## 2026-09-03 — PR #206 pulse hotfix
+
+修正requestAnimationFrame時間戳早於pulse起點時產生負opacity；phase限制為[0,1]。Regression先重現舊碼失敗，修後11 focused／tsc／CI通過。Merge def3dc6，Zeabur 6a994975c3fffb61baebd2b3 RUNNING，新資產main-Bblqfkou.js。Production歷史scrub後讀出163件／58件待定位（Qwen補正前快照），新版console無error；最後恢復即時／最近七天。

--- a/docs/features/global-events/changelog.md
+++ b/docs/features/global-events/changelog.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 2026-09-03 — 固定地理錨點 hotfix（待發布）
+
+修正同位置避讓先 `project` 再 `unproject`，導致移動地球後顯示座標重算、點位跳動。事件與群組的 GeoJSON geometry 現在始終保留原國家／城市座標；並排改用 native symbol `icon-offset`，以 viewport 對齊並反向補償 severity 的 icon-size。移除 moveend 資料重送，原避讓短線改為固定位置小錨點；跨國關聯弧線仍用真實 endpoints。
+
+保留 category 分色、severity 大小、AI／選取外框、群組展開、popup、opacity 與原錨點 pulse。同步 SDF image 在 style reload／missing 時補回，layer off 隱藏所有相關圖層並解除 listener。本地 tsc-b、23 focused tests、完整 1031 tests（1 skipped）通過。
+
+本地 browser 通過：加拿大7件群組展開後可分別點出亞伯達特別投票與工會事件；平移、bearing15、zoom2.2→3後錨點保持Canada 60,-96，無moveend重排。分色／大小／popup、opacity0、AllOff／再ON皆正常，console error=[]；style reload 以 regression 驗證，未宣稱 browser 已切換底圖。正式部署仍待完成。
+
 ## 2026-09-03 — PR #205
 
 完整情勢／低重要性與臺灣無關不排除、七天總覽、同位置避讓、跨國關聯弧線，沿用既有圖層與兩層判斷。包含 unknown 事件列表、candidate keyset 分頁、真實 immutable 回放與延遲導入擴窗修正。

--- a/docs/features/global-events/handoff.md
+++ b/docs/features/global-events/handoff.md
@@ -21,4 +21,12 @@ Platform [PR #90](https://github.com/ianlkl11234s/gis-platform/pull/90) 已合�
 
 Workbench [PR #29](https://github.com/ianlkl11234s/pulse-intel-workbench/pull/29) 已合併（412e20f），保留兩層判斷與原 frozen artifacts。Collector [PR #79](https://github.com/ianlkl11234s/gis-data-collectors/pull/79) 已合併（a284253），另接續來源地理提及的概略定位放寬。
 
-Frontend [PR #205](https://github.com/ianlkl11234s/mini-taiwan-pulse/pull/205) 包含本次實作；tsc-b 與 1027 tests（1 skipped）通過。正式部署 commit／最後 production browser 證據記錄於該 PR 與上游 handoff；不能只以 CI 成功代替 production 驗收。
+Frontend [PR #205](https://github.com/ianlkl11234s/mini-taiwan-pulse/pull/205) merge ab813b0；tsc-b 與 1027 tests（1 skipped）通過。[PR #206](https://github.com/ianlkl11234s/mini-taiwan-pulse/pull/206) 修正pulse負opacity，merge def3dc662b645696824e61451416288b496219cb；11 focused／tsc／CI通過。Zeabur deployment 6a994975c3fffb61baebd2b3 RUNNING，新JS main-Bblqfkou.js 已由正式browser確認。
+
+Production browser：最近七天、AI off僅3正式事件／1未知、Nigeria drop_noise／none國家代表點popup、同位置7件群組展開、跨國線ON/OFF與opacity0均通過。歷史9/2無導入資料→0，9/3讀出實際available版本；新版scrub無consoleerror。驗收時163顯示事件／58待定位是Qwen74候選補正前快照，不應當作永久總量。
+
+Platform #91／migration399與45舊候選概略位置enrichment已上線；Collector #80來源地理提及fallback、#81相容性修正已上線（43b5665）。首輪74候選已用原cache補正為74有效／0待判斷，未重跑Qwen。Workbench #30／#31已合併，舊partial與新repair紀錄均保留，open PR=[]。
+
+18:29台北最終anon讀回179候選，110有位置／69unknown、199代表點，所有core34／watch39／drop106保留。正式browser合併重複報導後155件／58待定位（97件有位置），待判斷標籤0。來源仍落後約14小時，不宣稱近七天已完整；Publisher始終0。不同筆數分母與完整證據以上游handoff及PR #205發布紀錄為準。
+
+正式網址：https://mini-taiwan-pulse.itsmigu.com/?v=1&lng=10&lat=25&z=1.8&layers=globalEvents&style=dark 。圖層會啟用，World側欄需自行展開。

--- a/docs/features/global-events/handoff.md
+++ b/docs/features/global-events/handoff.md
@@ -10,10 +10,13 @@
 - `observed_at` / `assessed_at` / `available_at` 分開，不把收集時間假裝發生時間。
 - 已發布版本依 explicit candidate reference 與candidate去重，不靠模糊標題猜事件。
 - 代表點與原始geometry在避讓時不變；弧線沒有移動、因果或先後語意。
+- 固定錨點 hotfix：顯示 GeoJSON 也不得因相機改變座標；僅 native symbol viewport icon-offset 可做並排，icon-size 需反向補償。原位置小錨點與跨國 arc endpoints 固定，無 moveend 座標重算。
 - 國家／城市可採來源地理提及或固定版本 gazetteer 的概略代表點，不要求精確發生地；Popup 需標示概略位置，Qwen 信心不代表定位精度。
 - 單日回放的候選查詢向前擴七天，再依實際 available_at 過濾；不修改正式事件窗口，不倒灌回填前的歷史。
 
 ## Release
+
+固定錨點 hotfix 目前本地完成（base def3dc6）：tsc-b、23 focused／1031 full tests（1 skipped）通過。本地 browser 驗證加拿大7件群組分別點選、平移／旋轉／縮放後錨點不變、opacity0／off／on與console皆通過；style reload 僅以 regression 驗證。新 deployment 尚待驗收，以下 PR #205／#206 是前次發布紀錄，不代表此修正已上線。
 
 實作基線：frontend e16dc2354c74d7563d6b7525120c935f43e64f2b；platform 1f4f7e352ef4292ce1615474cf400716dffb4ba3；collector 48250361d1d459d1590d1f228f2e4cd4e51390fc。
 

--- a/src/components/featureInfo/globalClimatePanels.tsx
+++ b/src/components/featureInfo/globalClimatePanels.tsx
@@ -179,7 +179,7 @@ export function GlobalEventPanel({ props }: { props: Record<string, unknown> }) 
       {typeof props.original_lng === "number" && typeof props.original_lat === "number" && (
         <Row label="原始位置座標" value={`${props.original_lat.toFixed(5)}, ${props.original_lng.toFixed(5)}`} />
       )}
-      {props.display_offset === true && <Row label="畫面避讓" value="與其他事件同位置，僅在畫面上展開；原始座標未變" />}
+      {props.display_offset === true && <Row label="畫面避讓" value="小錨點固定原位置；事件圖示僅在畫面上並排，座標不變" />}
       <Row label={props.research_status === "ai_assessed" ? "來源收集時間" : "事件時間"} value={fmtGlobalEventTime(props.valid_from)} />
       {props.research_status !== "ai_assessed" && <Row label="發布時間" value={fmtGlobalEventTime(props.published_at)} />}
       {publicationNo !== null && <Row label="發布版本" value={`#${publicationNo}`} />}

--- a/src/data/__tests__/globalEventsPresentation.test.ts
+++ b/src/data/__tests__/globalEventsPresentation.test.ts
@@ -6,8 +6,6 @@ const point = (event = "e1", country = "TW", coordinates: [number, number] = [12
   event_id: event, version_id: `${event}-v1`, event_place_id: `${event}-${country}`, display_place_id: `${event}-${country}`,
   country_code: country, publication_no: 1, lifecycle_state: "published", geometry: { type: "Point", coordinates },
 })!;
-const projection = { project: ([lng, lat]: [number, number]) => ({ x: lng * 10, y: -lat * 10 }),
-  unproject: ([x, y]: [number, number]) => ({ lng: x / 10, lat: -y / 10 }) };
 
 describe("Global Events complete situation presentation", () => {
   it("recent seven days is rolling backward from now, not a forward timeline window", () => {
@@ -36,10 +34,11 @@ describe("Global Events complete situation presentation", () => {
     const a = point("a");
     const b = point("b");
     expect(dedupeGlobalEventPlaces([a, a, b])).toEqual([a, b]);
-    const layout = layoutGlobalEventPoints([a, a, b], projection);
+    const layout = layoutGlobalEventPoints([a, a, b]);
     expect(layout.points.features).toHaveLength(2);
-    expect(layout.connectors.features).toHaveLength(2);
-    expect(layout.points.features[0]!.geometry.coordinates).not.toEqual(layout.points.features[1]!.geometry.coordinates);
+    expect(layout.anchors.features).toHaveLength(1);
+    expect(layout.points.features.map((f) => f.geometry.coordinates)).toEqual([[121, 25], [121, 25]]);
+    expect(layout.points.features[0]!.properties?.icon_offset).not.toEqual(layout.points.features[1]!.properties?.icon_offset);
     expect(a.coordinates).toEqual([121, 25]);
     expect(layout.points.features[0]!.properties).toMatchObject({ original_lng: 121, original_lat: 25, display_offset: true });
   });
@@ -50,9 +49,9 @@ describe("Global Events complete situation presentation", () => {
         { candidateId: "b", title: "事件 B", decision: "keep_watch", taiwanRelationship: "indirect", taiwanImpact: "間接影響", reason: "持續觀察" }] };
     const a = { ...point("same-ai-event"), ...provenance, placeKey: "evidence:a" };
     const b = { ...point("same-ai-event"), ...provenance, placeKey: "evidence:b" };
-    const rendered = layoutGlobalEventPoints([a, b], projection);
+    const rendered = layoutGlobalEventPoints([a, b]);
     expect(rendered.points.features).toHaveLength(1);
-    expect(rendered.connectors.features).toHaveLength(0);
+    expect(rendered.anchors.features).toHaveLength(0);
     expect(rendered.points.features[0]?.properties?.candidate_ids).toBe(JSON.stringify(["a", "b"]));
     expect(JSON.parse(String(rendered.points.features[0]?.properties?.candidate_assessments))).toHaveLength(2);
     expect(dedupeGlobalEventPlaces([a, { ...b, eventId: "different-event" }])).toHaveLength(2);
@@ -60,13 +59,31 @@ describe("Global Events complete situation presentation", () => {
 
   it("groups crowded points with a count then expands every event", () => {
     const rows = Array.from({ length: 20 }, (_, i) => point(`event-${i}`));
-    const collapsed = layoutGlobalEventPoints(rows, projection);
+    const collapsed = layoutGlobalEventPoints(rows);
     expect(collapsed.points.features).toHaveLength(0);
     expect(collapsed.clusters.features[0]!.properties?.point_count).toBe(20);
     const key = String(collapsed.clusters.features[0]!.properties?.group_key);
-    const expanded = layoutGlobalEventPoints(rows, projection, new Set([key]));
+    const expanded = layoutGlobalEventPoints(rows, new Set([key]));
     expect(expanded.points.features).toHaveLength(20);
-    expect(new Set(expanded.points.features.map((f) => f.geometry.coordinates.join(","))).size).toBe(20);
+    expect(new Set(expanded.points.features.map((f) => JSON.stringify(f.properties?.icon_offset))).size).toBe(20);
+    expect(expanded.points.features.every((f) => f.geometry.coordinates[0] === 121 && f.geometry.coordinates[1] === 25)).toBe(true);
+  });
+
+  it("native offsets compensate severity size while all anchors and relation endpoints stay geographic", () => {
+    const rows = [0, 1, 2, 3].map((severity) => ({ ...point(`event-${severity}`), severity }));
+    const layout = layoutGlobalEventPoints(rows);
+    for (const feature of layout.points.features) {
+      const props = feature.properties!;
+      const offset = props.icon_offset as number[];
+      expect(offset[0]! * Number(props.icon_scale)).toBeCloseTo(Number(props.display_offset_x));
+      expect(offset[1]! * Number(props.icon_scale)).toBeCloseTo(Number(props.display_offset_y));
+      expect(Math.hypot(Number(props.display_offset_x), Number(props.display_offset_y))).toBeCloseTo(22);
+      expect(feature.geometry.coordinates).toEqual([121, 25]);
+    }
+    expect(layout.anchors.features[0]!.geometry.coordinates).toEqual([121, 25]);
+    const relations = globalEventRelations([rows[0]!, point("event-0", "JP", [140, 35])]);
+    expect(relations.features[0]!.geometry.coordinates[0]).toEqual([140, 35]);
+    expect(relations.features[0]!.geometry.coordinates[32]).toEqual([121, 25]);
   });
 
   it("association arcs cross the dateline locally with exact endpoints and no long jumps", () => {

--- a/src/data/globalEventsPresentation.ts
+++ b/src/data/globalEventsPresentation.ts
@@ -1,11 +1,8 @@
 import { globalEventsToGeoJSON, type GlobalEventPoint, type GlobalEventRecord } from "./globalEventsLoader";
+import { GLOBAL_EVENT_SEVERITIES } from "./globalEventsTypes";
 
 export type GlobalEventsView = "recent7d" | "timeline";
-type XY = { x: number; y: number };
-export interface EventProjection {
-  project(coordinates: [number, number]): XY;
-  unproject(point: [number, number]): { lng: number; lat: number };
-}
+export const GLOBAL_EVENT_ICON_RADIUS = 8;
 
 /** Rolling seven days, never the timeline's forward-looking seven-day window. */
 export function recentGlobalEventWindow(nowMs = Date.now()): { start: string; end: string } {
@@ -57,14 +54,13 @@ function coordinateKey(coordinates: readonly number[]): string {
   return coordinates.map((value) => value.toFixed(6)).join(",");
 }
 
-/** Display-only spider offsets; source coordinates remain unchanged and travel in popup props. */
+/** Camera-independent layout. Native symbol offsets move pixels, never geographic anchors. */
 export function layoutGlobalEventPoints(
   rows: readonly GlobalEventPoint[],
-  projection: EventProjection,
   expandedGroups: ReadonlySet<string> = new Set(),
 ): {
   points: GeoJSON.FeatureCollection<GeoJSON.Point>;
-  connectors: GeoJSON.FeatureCollection<GeoJSON.LineString>;
+  anchors: GeoJSON.FeatureCollection<GeoJSON.Point>;
   clusters: GeoJSON.FeatureCollection<GeoJSON.Point>;
 } {
   const groups = new Map<string, GlobalEventPoint[]>();
@@ -75,7 +71,7 @@ export function layoutGlobalEventPoints(
     groups.set(key, group);
   }
   const points: GeoJSON.FeatureCollection<GeoJSON.Point> = { type: "FeatureCollection", features: [] };
-  const connectors: GeoJSON.FeatureCollection<GeoJSON.LineString> = { type: "FeatureCollection", features: [] };
+  const anchors: GeoJSON.FeatureCollection<GeoJSON.Point> = { type: "FeatureCollection", features: [] };
   const clusters: GeoJSON.FeatureCollection<GeoJSON.Point> = { type: "FeatureCollection", features: [] };
   for (const [groupKey, group] of groups) {
     group.sort((a, b) => a.eventId.localeCompare(b.eventId));
@@ -84,25 +80,30 @@ export function layoutGlobalEventPoints(
         properties: { group_key: groupKey, point_count: group.length } });
       continue;
     }
+    if (group.length > 1) anchors.features.push({ type: "Feature", geometry: { type: "Point", coordinates: group[0]!.coordinates },
+      properties: { group_key: groupKey, display_only: true } });
     for (const [index, row] of group.entries()) {
       const feature = globalEventsToGeoJSON([row]).features[0]!;
-      feature.properties = { ...feature.properties, original_lng: row.coordinates[0], original_lat: row.coordinates[1],
-        display_offset: group.length > 1, colocated_count: group.length };
+      const iconScale = (GLOBAL_EVENT_SEVERITIES.find((item) => item.value === row.severity)?.radius ?? 4.5) / GLOBAL_EVENT_ICON_RADIUS;
+      let offsetX = 0;
+      let offsetY = 0;
       if (group.length > 1) {
-        const origin = projection.project(row.coordinates);
         const ring = Math.floor(index / 12);
         const count = Math.min(12, group.length - ring * 12);
         const angle = (index % 12) * 2 * Math.PI / count - Math.PI / 2;
         const radius = group.length === 2 ? 13 : Math.max(22, Math.min(12, group.length) * 4) + ring * 30;
-        const offset = projection.unproject([origin.x + Math.cos(angle) * radius, origin.y + Math.sin(angle) * radius]);
-        feature.geometry = { type: "Point", coordinates: [offset.lng, offset.lat] };
-        connectors.features.push({ type: "Feature", geometry: { type: "LineString", coordinates: [row.coordinates, [offset.lng, offset.lat]] },
-          properties: { event_id: row.eventId, display_only: true } });
+        offsetX = Math.cos(angle) * radius;
+        offsetY = Math.sin(angle) * radius;
       }
+      feature.properties = { ...feature.properties, original_lng: row.coordinates[0], original_lat: row.coordinates[1],
+        display_offset: group.length > 1, colocated_count: group.length,
+        display_offset_x: offsetX, display_offset_y: offsetY, icon_scale: iconScale,
+        // Mapbox multiplies icon-offset by icon-size; normalize so severity never changes spacing.
+        icon_offset: [offsetX / iconScale, offsetY / iconScale] };
       points.features.push(feature);
     }
   }
-  return { points, connectors, clusters };
+  return { points, anchors, clusters };
 }
 
 /** Static quadratic association arc. Unwrapped longitude takes the short dateline crossing. */

--- a/src/hooks/__tests__/useGlobalEventsLayer.test.ts
+++ b/src/hooks/__tests__/useGlobalEventsLayer.test.ts
@@ -73,6 +73,7 @@ import { globalEventsViewStore } from "../../state/globalEventsViewStore";
 import {
   GLOBAL_EVENTS_LAYER_ID,
   GLOBAL_EVENTS_PULSE_LAYER_ID,
+  globalEventPointImage,
   globalEventTransitions,
   globalEventWindowBounds,
   useGlobalEventsLayer,
@@ -117,22 +118,25 @@ function point(overrides: Partial<GlobalEventPoint> = {}): GlobalEventPoint {
 function createMap() {
   const sources = new Map<string, { setData: ReturnType<typeof vi.fn> }>();
   const layers = new Map<string, unknown>();
-  const handlers = new Map<string, () => void>();
+  const handlers = new Map<string, (event?: unknown) => void>();
+  const images = new Set<string>();
   const map = {
     getSource: (id: string) => sources.get(id),
     addSource: (id: string) => sources.set(id, { setData: vi.fn() }),
     getLayer: (id: string) => layers.get(id),
     addLayer: (layer: { id: string }) => layers.set(layer.id, layer),
+    hasImage: (id: string) => images.has(id),
+    addImage: vi.fn((id: string) => images.add(id)),
     setLayoutProperty: vi.fn(),
     setPaintProperty: vi.fn(),
-    on: vi.fn((event: string, handler: () => void) => handlers.set(event, handler)),
+    on: vi.fn((event: string, handler: (event?: unknown) => void) => handlers.set(event, handler)),
     off: vi.fn((event: string) => handlers.delete(event)),
-    project: ([x, y]: [number, number]) => ({ x, y }),
-    unproject: ([lng, lat]: [number, number]) => ({ lng, lat }),
+    project: vi.fn(([x, y]: [number, number]) => ({ x, y })),
+    unproject: vi.fn(([lng, lat]: [number, number]) => ({ lng, lat })),
     queryRenderedFeatures: vi.fn(() => []),
     easeTo: vi.fn(),
   } as unknown as MapboxMap;
-  return { map, sources, layers, handlers };
+  return { map, sources, layers, handlers, images };
 }
 
 async function flush(): Promise<void> {
@@ -237,9 +241,49 @@ describe("useGlobalEventsLayer timeline", () => {
     expect(globalEventsViewStore.getSnapshot().entries).toHaveLength(2);
     expect(harness.getThrottleMs()).toBeNull();
     state.layers.clear();
+    state.images.clear();
     state.handlers.get("style.load")?.();
-    expect(state.map.setPaintProperty).toHaveBeenCalledWith(GLOBAL_EVENTS_LAYER_ID, "circle-opacity", 0.4);
+    expect(state.images.has("global-events-point-sdf")).toBe(true);
+    expect(state.map.setPaintProperty).toHaveBeenCalledWith(GLOBAL_EVENTS_LAYER_ID, "icon-opacity", 0.4);
     expect(state.map.setLayoutProperty).toHaveBeenCalledWith("global-events-relations-line", "visibility", "none");
+  });
+
+  it("pan/rotation/zoom never rewrite coordinates; native offset symbols preserve all colocated events and cleanup", async () => {
+    const rows = Array.from({ length: 8 }, (_, i) => point({ eventId: `event-${i}`, versionId: `v-${i}`, eventPlaceId: `place-${i}`, displayPlaceId: `place-${i}` }));
+    loader.current.mockResolvedValue(rows);
+    const state = createMap();
+    useGlobalEventsLayer({ current: state.map } as RefObject<MapboxMap | null>, true, 0.6, "live");
+    await flush();
+    const cluster = state.sources.get("global-events-clusters")!.setData.mock.lastCall![0].features[0];
+    vi.mocked(state.map.queryRenderedFeatures).mockReturnValue([{ properties: cluster.properties }] as never);
+    state.handlers.get("click")?.({ point: { x: 100, y: 100 } });
+    const source = state.sources.get("global-events-current")!.setData;
+    const expanded = source.mock.lastCall![0] as GeoJSON.FeatureCollection<GeoJSON.Point>;
+    expect(expanded.features).toHaveLength(8);
+    expect(new Set(expanded.features.map((f) => f.properties?.event_id)).size).toBe(8);
+    expect(new Set(expanded.features.map((f) => JSON.stringify(f.properties?.icon_offset))).size).toBe(8);
+    expect(expanded.features.every((f) => JSON.stringify(f.geometry.coordinates) === "[10,20]")).toBe(true);
+    expect(state.layers.get(GLOBAL_EVENTS_LAYER_ID)).toMatchObject({ type: "symbol", layout: {
+      "icon-pitch-alignment": "viewport", "icon-rotation-alignment": "viewport",
+      "icon-offset": ["get", "icon_offset"], "icon-allow-overlap": true, "icon-ignore-placement": true,
+    } });
+    const callCount = source.mock.calls.length;
+    for (const [scale, bearing] of [[1, 0], [4, 90], [0.1, 180]]) {
+      vi.mocked(state.map.project).mockImplementation(() => ({ x: scale, y: bearing }) as never);
+      vi.mocked(state.map.unproject).mockImplementation(() => ({ lng: bearing, lat: scale }) as never);
+      for (const event of ["move", "rotate", "zoom", "moveend", "render"]) state.handlers.get(event)?.();
+    }
+    expect(source).toHaveBeenCalledTimes(callCount);
+    expect(state.map.project).not.toHaveBeenCalled();
+    expect(state.map.unproject).not.toHaveBeenCalled();
+    expect(source.mock.lastCall![0]).toEqual(expanded);
+    state.images.clear();
+    state.handlers.get("styleimagemissing")?.({ id: "global-events-point-sdf" });
+    expect(state.images.has("global-events-point-sdf")).toBe(true);
+    harness.reset(); // Mirrors effect cleanup when layer turns off/unmounts.
+    for (const id of state.layers.keys()) expect(state.map.setLayoutProperty).toHaveBeenCalledWith(id, "visibility", "none");
+    expect(state.handlers.size).toBe(0);
+    expect(state.map.setPaintProperty).toHaveBeenCalledWith(GLOBAL_EVENTS_PULSE_LAYER_ID, "circle-stroke-opacity", 0);
   });
 
   it("unchanged cursor slices do not publish sidebar snapshots every200ms", async () => {
@@ -311,6 +355,13 @@ describe("useGlobalEventsLayer timeline", () => {
 });
 
 describe("Global Events pulse and location semantics", () => {
+  it("registers an opaque-centered SDF circle with transparent edge and no async image dependency", () => {
+    const image = globalEventPointImage();
+    expect(image.data).toBeInstanceOf(Uint8Array);
+    expect(image.data.length).toBe(image.width * image.height * 4);
+    expect(image.data[3]).toBe(0);
+    expect(image.data[(32 * image.width + 32) * 4 + 3]).toBe(255);
+  });
   it("只在時間向前跨過 display_from 時 pulse，並以 publication_no 分新事件／版本更新", () => {
     const newEvent = point({ displayFrom: "2026-09-03T10:00:00Z", publicationNo: 1 });
     const update = point({

--- a/src/hooks/useGlobalEventsLayer.ts
+++ b/src/hooks/useGlobalEventsLayer.ts
@@ -13,13 +13,12 @@ import {
 } from "../data/globalEventsLoader";
 import {
   GLOBAL_EVENT_CATEGORY_COLOR_EXPR,
-  GLOBAL_EVENT_SEVERITY_RADIUS_EXPR,
 } from "../data/globalEventsTypes";
 import { keepLoadingUntilMapIdle } from "../lib/loadingRegistry";
 import { timeStore } from "../state/timeStore";
 import type { TimeMode } from "../types";
 import { useMapReadyTick } from "./useMapReadyTick";
-import { globalEventCandidateLookbackWindow, globalEventRelations, layoutGlobalEventPoints, recentGlobalEventWindow, selectGlobalEventsOverview, type GlobalEventsView } from "../data/globalEventsPresentation";
+import { GLOBAL_EVENT_ICON_RADIUS, globalEventCandidateLookbackWindow, globalEventRelations, layoutGlobalEventPoints, recentGlobalEventWindow, selectGlobalEventsOverview, type GlobalEventsView } from "../data/globalEventsPresentation";
 import { globalEventsViewStore } from "../state/globalEventsViewStore";
 
 const SOURCE_ID = "global-events-current";
@@ -32,6 +31,7 @@ const CONNECTORS_SOURCE_ID = "global-events-connectors";
 const CLUSTERS_SOURCE_ID = "global-events-clusters";
 const CONNECTORS_LAYER_ID = "global-events-connectors-line";
 const CLUSTER_LABEL_LAYER_ID = "global-events-clusters-label";
+const POINT_IMAGE_ID = "global-events-point-sdf";
 
 const EMPTY: GeoJSON.FeatureCollection<GeoJSON.Point> = {
   type: "FeatureCollection",
@@ -86,7 +86,25 @@ function prefersReducedMotion(): boolean {
     && window.matchMedia("(prefers-reduced-motion: reduce)").matches;
 }
 
+/** Small signed-distance circle: synchronous, no image fetch or canvas/WebGL dependency. */
+export function globalEventPointImage(): { width: number; height: number; data: Uint8Array } {
+  const size = 64;
+  const data = new Uint8Array(size * size * 4);
+  for (let y = 0; y < size; y++) for (let x = 0; x < size; x++) {
+    const distance = Math.hypot(x + 0.5 - size / 2, y + 0.5 - size / 2) / 2;
+    const offset = (y * size + x) * 4;
+    data[offset] = data[offset + 1] = data[offset + 2] = 255;
+    data[offset + 3] = Math.round(255 * Math.max(0, Math.min(1, 0.75 + (GLOBAL_EVENT_ICON_RADIUS - distance) / 4)));
+  }
+  return { width: size, height: size, data };
+}
+
+function ensurePointImage(map: MapboxMap): void {
+  if (!map.hasImage(POINT_IMAGE_ID)) map.addImage(POINT_IMAGE_ID, globalEventPointImage(), { sdf: true, pixelRatio: 2 });
+}
+
 function ensureLayers(map: MapboxMap): void {
+  ensurePointImage(map);
   for (const id of [RELATIONS_SOURCE_ID, CONNECTORS_SOURCE_ID, CLUSTERS_SOURCE_ID]) {
     if (!map.getSource(id)) map.addSource(id, { type: "geojson", data: EMPTY });
   }
@@ -95,8 +113,9 @@ function ensureLayers(map: MapboxMap): void {
     paint: { "line-color": "#94a3b8", "line-width": 1, "line-opacity": 0.22 },
   });
   if (!map.getLayer(CONNECTORS_LAYER_ID)) map.addLayer({
-    id: CONNECTORS_LAYER_ID, type: "line", source: CONNECTORS_SOURCE_ID,
-    paint: { "line-color": "#94a3b8", "line-width": 0.8, "line-opacity": 0.5 },
+    // Keep legacy IDs, but render only the actual shared location, never an offset line endpoint.
+    id: CONNECTORS_LAYER_ID, type: "circle", source: CONNECTORS_SOURCE_ID,
+    paint: { "circle-color": "#94a3b8", "circle-radius": 2, "circle-opacity": 0.5 },
   });
   if (!map.getSource(SOURCE_ID)) {
     map.addSource(SOURCE_ID, { type: "geojson", data: EMPTY });
@@ -104,17 +123,25 @@ function ensureLayers(map: MapboxMap): void {
   if (!map.getLayer(GLOBAL_EVENTS_LAYER_ID)) {
     map.addLayer({
       id: GLOBAL_EVENTS_LAYER_ID,
-      type: "circle",
+      type: "symbol",
       source: SOURCE_ID,
-      paint: {
-        "circle-radius": GLOBAL_EVENT_SEVERITY_RADIUS_EXPR,
-        "circle-color": GLOBAL_EVENT_CATEGORY_COLOR_EXPR,
-        "circle-opacity": 0.9,
-        "circle-stroke-color": ["case", ["==", ["get", "research_status"], "ai_assessed"], "#e2e8f0", "#0f172a"],
-        "circle-stroke-width": ["match", ["get", "severity"], 3, 2, 2, 1.5, 1],
-        "circle-stroke-opacity": 0.85,
+      layout: {
+        "icon-image": POINT_IMAGE_ID,
+        "icon-size": ["get", "icon_scale"],
+        "icon-offset": ["get", "icon_offset"],
+        "icon-pitch-alignment": "viewport",
+        "icon-rotation-alignment": "viewport",
+        "icon-allow-overlap": true,
+        "icon-ignore-placement": true,
+        "icon-padding": 0,
       },
-    } as CircleLayer);
+      paint: {
+        "icon-color": GLOBAL_EVENT_CATEGORY_COLOR_EXPR,
+        "icon-opacity": 0.9,
+        "icon-halo-color": ["case", ["==", ["get", "research_status"], "ai_assessed"], "#e2e8f0", "#0f172a"],
+        "icon-halo-width": 1.5,
+      },
+    });
   }
   if (!map.getLayer(GLOBAL_EVENTS_PULSE_LAYER_ID)) {
     map.addLayer({
@@ -193,10 +220,9 @@ export function useGlobalEventsLayer(
     const safeOpacity = Math.max(0, Math.min(1, opacityRef.current));
     const selected = selectedRef.current ?? "";
     if (map.getLayer(GLOBAL_EVENTS_LAYER_ID)) {
-      map.setPaintProperty(GLOBAL_EVENTS_LAYER_ID, "circle-opacity", safeOpacity);
-      map.setPaintProperty(GLOBAL_EVENTS_LAYER_ID, "circle-stroke-opacity", safeOpacity * 0.9);
-      map.setPaintProperty(GLOBAL_EVENTS_LAYER_ID, "circle-stroke-width", ["case", ["==", ["get", "event_id"], selected], 3, 1.5]);
-      map.setPaintProperty(GLOBAL_EVENTS_LAYER_ID, "circle-stroke-color", ["case", ["==", ["get", "event_id"], selected], "#facc15",
+      map.setPaintProperty(GLOBAL_EVENTS_LAYER_ID, "icon-opacity", safeOpacity);
+      map.setPaintProperty(GLOBAL_EVENTS_LAYER_ID, "icon-halo-width", ["case", ["==", ["get", "event_id"], selected], 3, 1.5]);
+      map.setPaintProperty(GLOBAL_EVENTS_LAYER_ID, "icon-halo-color", ["case", ["==", ["get", "event_id"], selected], "#facc15",
         ["==", ["get", "research_status"], "ai_assessed"], "#e2e8f0", "#0f172a"]);
     }
     if (map.getLayer(GLOBAL_EVENTS_RELATIONS_LAYER_ID)) {
@@ -204,7 +230,7 @@ export function useGlobalEventsLayer(
       map.setPaintProperty(GLOBAL_EVENTS_RELATIONS_LAYER_ID, "line-opacity", ["case", ["==", ["get", "event_id"], selected], safeOpacity * 0.9, safeOpacity * 0.22]);
       map.setPaintProperty(GLOBAL_EVENTS_RELATIONS_LAYER_ID, "line-width", ["case", ["==", ["get", "event_id"], selected], 2.5, 1]);
     }
-    if (map.getLayer(CONNECTORS_LAYER_ID)) map.setPaintProperty(CONNECTORS_LAYER_ID, "line-opacity", safeOpacity * 0.5);
+    if (map.getLayer(CONNECTORS_LAYER_ID)) map.setPaintProperty(CONNECTORS_LAYER_ID, "circle-opacity", safeOpacity * 0.5);
     if (map.getLayer(GLOBAL_EVENTS_CLUSTER_LAYER_ID)) {
       map.setPaintProperty(GLOBAL_EVENTS_CLUSTER_LAYER_ID, "circle-opacity", safeOpacity);
       map.setPaintProperty(GLOBAL_EVENTS_CLUSTER_LAYER_ID, "circle-stroke-opacity", safeOpacity);
@@ -261,14 +287,14 @@ export function useGlobalEventsLayer(
 
     const feed = (events: readonly GlobalEventPoint[], transitions = new Map<string, GlobalEventTransitionKind>()) => {
       displayedRowsRef.current = [...events];
-      const layout = layoutGlobalEventPoints(events, map, expandedGroupsRef.current);
+      const layout = layoutGlobalEventPoints(events, expandedGroupsRef.current);
       const collection = layout.points;
       for (const feature of collection.features) {
         if (feature.properties) feature.properties.transition_kind = transitions.get(String(feature.properties.event_id)) ?? null;
       }
       const source = map.getSource(SOURCE_ID) as GeoJSONSource | undefined;
       source?.setData(collection);
-      (map.getSource(CONNECTORS_SOURCE_ID) as GeoJSONSource | undefined)?.setData(layout.connectors);
+      (map.getSource(CONNECTORS_SOURCE_ID) as GeoJSONSource | undefined)?.setData(layout.anchors);
       (map.getSource(CLUSTERS_SOURCE_ID) as GeoJSONSource | undefined)?.setData(layout.clusters);
       (map.getSource(RELATIONS_SOURCE_ID) as GeoJSONSource | undefined)?.setData(globalEventRelations(events));
       startPulse(map, transitions);
@@ -356,7 +382,10 @@ export function useGlobalEventsLayer(
       applyPaint(map);
     };
     map.on("style.load", onStyleLoad);
-    const onMove = () => feed(displayedRowsRef.current);
+    const onImageMissing = (event: { id: string }) => {
+      if (event.id === POINT_IMAGE_ID) ensurePointImage(map);
+    };
+    map.on("styleimagemissing", onImageMissing);
     const onClick = (event: MapMouseEvent) => {
       if (!map.getLayer(GLOBAL_EVENTS_CLUSTER_LAYER_ID)) return;
       const hit = map.queryRenderedFeatures(event.point, { layers: [GLOBAL_EVENTS_CLUSTER_LAYER_ID] })[0];
@@ -364,7 +393,6 @@ export function useGlobalEventsLayer(
       expandedGroupsRef.current.add(String(hit.properties.group_key));
       feed(displayedRowsRef.current);
     };
-    map.on("moveend", onMove);
     map.on("click", onClick);
     globalEventsViewStore.setSelectHandler((entry) => {
       const point = displayedRowsRef.current.find((row) => row.eventId === entry.eventId);
@@ -392,7 +420,7 @@ export function useGlobalEventsLayer(
       unsubscribeWindow();
       unsubscribeTime();
       map.off("style.load", onStyleLoad);
-      map.off("moveend", onMove);
+      map.off("styleimagemissing", onImageMissing);
       map.off("click", onClick);
       clearInterval(refreshTimer);
       globalEventsViewStore.setSelectHandler(null);


### PR DESCRIPTION
## Summary

Keep Global Events anchored to their real country/city coordinates while retaining separate, clickable icons for colocated events. Camera motion no longer changes display GeoJSON coordinates.

## Changes

- Replace project → pixel offset → unproject with native symbol viewport icon-offset; compensate icon-size so severity does not change spacing.
- Preserve original point/popup layer ID, category colors, severity sizes, selection halos, group expansion and geographic association arc endpoints.
- Replace geographic spider connectors with small fixed shared-location anchors; remove moveend setData/re-layout.
- Synchronous SDF icon restores on style reload/image missing; layer off hides points, anchors, groups and pulse and removes listeners.
- Carry forward the prior production acceptance docs commit and distinguish this fix's local acceptance from its pending deployment.

## Test

- [x] `npx tsc -b`
- [x] Full suite: 1031 passed, 1 skipped (103 files); focused: 23 passed
- [x] Browser: local All Off / only Global Events. Canada 7-event cluster expands; Alberta voting and Canadian union events independently selectable. Pan, bearing 15, zoom 2.2→3 keep country anchor Canada 60,-96 without moveend re-layout. Colors/sizes/popup, opacity 0, All Off and re-enable pass; console errors=[]; globe-edge rendering has no style error.
- [x] Regression: all geometry remains original, severity offset compensation, original arc endpoints, camera motion makes no source writes/project/unproject calls, every grouped event remains a distinct feature, style reload/image missing recovery and layer-off cleanup.
- Style reload is regression-tested; no claim that the browser successfully changed basemap style.
- No RPC/backend/config changes.

## Risk / Rollback

- Scope: existing Global Events rendering only. Circle markers become native SDF symbols while retaining the existing picking ID; screen offsets never create geographic locations.
- Roll back this PR if required. Published data and immutable history are unchanged.
- Production deployment and production browser acceptance are tracked separately after CI/merge.

## Related

- Feature: `docs/features/global-events/`
- Related PRs: #205, #206
- Native viewport offsets: https://docs.mapbox.com/style-spec/reference/layers/#layout-symbol-icon-offset

## Checklist

- [x] Isolated `codex/` branch; shared checkout untouched
- [x] Conventional commit
- [x] Layer onboarding: existing opacity / legend / popup / selection preserved
- [x] Feature changelog updated
- [x] No data contract changes
