### PR TITLE
fix(global-events): simplify popup and enlarge event title

### DIFF
--- a/docs/features/global-events/backlog.md
+++ b/docs/features/global-events/backlog.md
@@ -9,6 +9,9 @@
 - [x] Production browser／部署驗收（PR #205／#206；def3dc6 RUNNING，真實資料與時間軸驗收）
 - [x] 同位置避讓改為 native screen-space offset，所有 geometry 固定；tsc／完整 tests
 - [x] 固定錨點 hotfix 本地 browser：平移／旋轉／縮放、並排點選、opacity／off、console
-- [ ] 固定錨點 hotfix PR／正式部署驗收
+- [x] 固定錨點 hotfix PR #207／正式部署 RUNNING（78c90aa）
+- [ ] 固定錨點／popup瘦身正式視覺驗收（由使用者執行，不由agent自驗）
+- [x] Popup 瘦身與18px標題；資料、位置與其他圖層不變
+- [ ] Popup 瘦身 CI／正式部署
 
 後續：重要性判準持續校準；本次不引入新的分數體系。

--- a/docs/features/global-events/changelog.md
+++ b/docs/features/global-events/changelog.md
@@ -1,12 +1,18 @@
 # Changelog
 
-## 2026-09-03 — 固定地理錨點 hotfix（待發布）
+## 2026-09-03 — Popup 摘要瘦身（待發布）
+
+僅 Global Events popup 保留：18px 事件標題、查證狀態、摘要、同列分類／嚴重度、臺灣影響、判斷理由、地點、落點語意、來源收集時間及可點位置來源。隱藏信心／Qwen分類／關聯代碼／座標／避讓／時間軸／lineage等內部細節，底層資料與其他圖層不變。來源用網域標籤、原http(s) URL，拒絕不安全或帶帳密連結；正式事件沒有來源收集時間時顯示—，不挪用事件時間。
+
+依使用者要求，不做browser、截圖或devserver視覺驗收；只跑focused tests、tsc與既有CI。視覺驗收由使用者。
+
+## 2026-09-03 — PR #207 固定地理錨點 hotfix
 
 修正同位置避讓先 `project` 再 `unproject`，導致移動地球後顯示座標重算、點位跳動。事件與群組的 GeoJSON geometry 現在始終保留原國家／城市座標；並排改用 native symbol `icon-offset`，以 viewport 對齊並反向補償 severity 的 icon-size。移除 moveend 資料重送，原避讓短線改為固定位置小錨點；跨國關聯弧線仍用真實 endpoints。
 
 保留 category 分色、severity 大小、AI／選取外框、群組展開、popup、opacity 與原錨點 pulse。同步 SDF image 在 style reload／missing 時補回，layer off 隱藏所有相關圖層並解除 listener。本地 tsc-b、23 focused tests、完整 1031 tests（1 skipped）通過。
 
-本地 browser 通過：加拿大7件群組展開後可分別點出亞伯達特別投票與工會事件；平移、bearing15、zoom2.2→3後錨點保持Canada 60,-96，無moveend重排。分色／大小／popup、opacity0、AllOff／再ON皆正常，console error=[]；style reload 以 regression 驗證，未宣稱 browser 已切換底圖。正式部署仍待完成。
+本地 browser 通過：加拿大7件群組展開後可分別點出亞伯達特別投票與工會事件；平移、bearing15、zoom2.2→3後錨點保持Canada 60,-96，無moveend重排。分色／大小／popup、opacity0、AllOff／再ON皆正常，console error=[]；style reload 以 regression 驗證，未宣稱 browser 已切換底圖。PR #207 merge 78c90aa，deployment 6a99545bc3fffb61baebd662 於11:10:02Z RUNNING；正式視覺驗收依使用者後續指示交由使用者，不宣稱已驗。
 
 ## 2026-09-03 — PR #205
 

--- a/docs/features/global-events/handoff.md
+++ b/docs/features/global-events/handoff.md
@@ -16,7 +16,9 @@
 
 ## Release
 
-固定錨點 hotfix 目前本地完成（base def3dc6）：tsc-b、23 focused／1031 full tests（1 skipped）通過。本地 browser 驗證加拿大7件群組分別點選、平移／旋轉／縮放後錨點不變、opacity0／off／on與console皆通過；style reload 僅以 regression 驗證。新 deployment 尚待驗收，以下 PR #205／#206 是前次發布紀錄，不代表此修正已上線。
+固定錨點 hotfix PR #207 merge 78c90aa 已部署，Zeabur 6a99545bc3fffb61baebd662 於11:10:02Z RUNNING；tsc-b、23 focused／1031 full tests（1 skipped）與CI通過。本地 browser 驗證加拿大7件群組分別點選、平移／旋轉／縮放後錨點不變、opacity0／off／on與console皆通過；style reload 僅以 regression 驗證。
+
+後續popup瘦身只改顯示，底層欄位及位置不變。依使用者最新指示，不再做browser／截圖／devserver視覺驗收；固定錨點與popup正式視覺確認均交使用者。Popup發布證據待本次CI／deployment完成，不能以測試代稱視覺已驗。
 
 實作基線：frontend e16dc2354c74d7563d6b7525120c935f43e64f2b；platform 1f4f7e352ef4292ce1615474cf400716dffb4ba3；collector 48250361d1d459d1590d1f228f2e4cd4e51390fc。
 

--- a/src/components/featureInfo/__tests__/GlobalEventPanel.test.ts
+++ b/src/components/featureInfo/__tests__/GlobalEventPanel.test.ts
@@ -1,0 +1,66 @@
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { GlobalEventPanel } from "../globalClimatePanels";
+import { DARK_FEATURE, FeatureThemeProvider, LIGHT_FEATURE } from "../featureTheme";
+
+const props = Object.freeze({
+  title_zh_tw: "來源提供的事件標題", summary_zh_tw: "來源提供的摘要，不改写內容。",
+  research_status: "ai_assessed", assessment_status: "assessed", category: "policy", severity: 2,
+  taiwan_impact_zh_tw: "暫無已知直接影響", reason_zh_tw: "依據來源內容判斷",
+  place_name: "來源地點", location_kind: "country_center", source_kind: "gdelt_metadata_mention",
+  valid_from: "2026-09-02T08:30:00Z", location_source: "https://news.example.org/long/path?article=123&ref=source",
+  confidence: 0.97, decision: "drop_noise", taiwan_relationship: "unrelated", original_lng: 12.34567, original_lat: 45.67891,
+  display_offset: true, display_from: "2026-09-03T08:30:00Z", display_to: "2026-09-04T08:30:00Z",
+  relation_kind: "association", location_lineage: "internal-lineage", publication_no: 3, lifecycle_state: "published",
+  candidate_assessments: JSON.stringify([{ title: "內部候選甲" }, { title: "內部候選乙" }]),
+});
+const render = (values: Record<string, unknown> = props) => renderToStaticMarkup(createElement(GlobalEventPanel, { props: values }));
+
+describe("Global Events concise popup", () => {
+  it("shows only the requested fields in order, with 18px title and unchanged event content", () => {
+    const markup = render();
+    const labels = ["事件", "查證狀態", "摘要", "分類／嚴重度", "臺灣影響", "判斷理由", "地點", "落點語意", "來源收集時間", "位置來源"];
+    const positions = labels.map((label) => markup.indexOf(`>${label}<`));
+    expect(positions.every((position) => position >= 0)).toBe(true);
+    expect([...positions].sort((a, b) => a - b)).toEqual(positions);
+    expect(markup).toMatch(/<h3[^>]*font-size:18px[^>]*>來源提供的事件標題<\/h3>/);
+    expect(markup).toContain(props.summary_zh_tw);
+    expect(markup).toContain("政策 · 重大");
+    expect(markup).toContain("新聞地理提及的概略位置，未核實精確發生地");
+    for (const hidden of ["AI 判斷信心", "Qwen 分類", "臺灣關聯", "原始位置座標", "畫面避讓", "時間軸顯示", "位置依據", "關聯線", "生命週期", "發布版本", "97%", "drop_noise", "unrelated", "12.34567", "internal-lineage", "內部候選甲"]) {
+      expect(markup).not.toContain(hidden);
+    }
+    expect(props.confidence).toBe(0.97);
+    expect(props.location_lineage).toBe("internal-lineage");
+  });
+
+  it("labels source by hostname while preserving the exact URL and safe external-link attributes", () => {
+    const markup = render();
+    expect(markup).toContain('href="https://news.example.org/long/path?article=123&amp;ref=source"');
+    expect(markup).toContain('target="_blank" rel="noopener noreferrer"');
+    expect(markup).toContain(">news.example.org</a>");
+    for (const location_source of ["javascript:alert(1)", "data:text/html,unsafe", "https://user:password@news.example.org", "internal/path.json#/places/0", null]) {
+      expect(render({ ...props, location_source })).not.toContain("<a ");
+    }
+  });
+
+  it("retains pending/researched status and never presents formal event time as collection time", () => {
+    expect(render({ ...props, assessment_status: "pending" })).toContain("待 AI 判斷（尚未研究確認）");
+    const formal = render({ ...props, research_status: "published" });
+    expect(formal).toContain("已研究並正式發布");
+    expect(formal).toMatch(/>來源收集時間<\/span><span[^>]*>—<\/span>/);
+    const candidate = render();
+    expect(candidate).not.toMatch(/>來源收集時間<\/span><span[^>]*>—<\/span>/);
+    expect(render({ ...props, research_status: "published", observed_at: props.valid_from })).not.toMatch(/>來源收集時間<\/span><span[^>]*>—<\/span>/);
+  });
+
+  it("uses the existing dark/light theme palette without changing other panels", () => {
+    for (const palette of [DARK_FEATURE, LIGHT_FEATURE]) {
+      const markup = renderToStaticMarkup(createElement(FeatureThemeProvider, { palette, children: createElement(GlobalEventPanel, { props }) }));
+      expect(markup).toContain(`color:${palette.textStrong};font-size:18px`);
+      expect(markup).toContain(`color:${palette.link}`);
+      expect(markup).not.toContain("color:inherit");
+    }
+  });
+});

--- a/src/components/featureInfo/globalClimatePanels.tsx
+++ b/src/components/featureInfo/globalClimatePanels.tsx
@@ -2,6 +2,7 @@ import { Row } from "./shared";
 import { useFeatureTheme } from "./featureTheme";
 import { parseGfwHourlyGridVessels, type GfwHourlyGridVessel } from "../../data/gfwHourlyGridTypes";
 import { globalEventCategoryLabel, globalEventSeverityLabel } from "../../data/globalEventsTypes";
+import { FONT_SIZE } from "../../styles/designTokens";
 
 function fmtAge(ts: unknown): string {
   if (typeof ts !== "number" || !Number.isFinite(ts)) return "—";
@@ -146,64 +147,44 @@ export function globalEventLocationLabel(props: Record<string, unknown>): string
 }
 
 export function GlobalEventPanel({ props }: { props: Record<string, unknown> }) {
-  let assessments: Record<string, unknown>[] = [];
-  try {
-    const parsed: unknown = typeof props.candidate_assessments === "string" ? JSON.parse(props.candidate_assessments) : [];
-    if (Array.isArray(parsed)) assessments = parsed.filter((item): item is Record<string, unknown> => item !== null && typeof item === "object" && !Array.isArray(item));
-  } catch { /* Malformed optional details must not break the popup. */ }
-  const confidence = typeof props.confidence === "number" && Number.isFinite(props.confidence)
-    ? `${Math.round(props.confidence * 100)}%`
-    : "—";
+  const t = useFeatureTheme();
+  const isInitial = props.research_status === "ai_assessed";
+  let locationUrl: URL | null = null;
+  if (typeof props.location_source === "string") {
+    try {
+      const parsed = new URL(props.location_source);
+      if (["https:", "http:"].includes(parsed.protocol) && !parsed.username && !parsed.password) locationUrl = parsed;
+    } catch { /* Missing/invalid evidence links are not replaced with invented sources. */ }
+  }
   const placeParts = [...new Set(
     [props.place_name, props.admin2, props.admin1, props.country_code]
       .filter((value): value is string => typeof value === "string" && value.length > 0),
   )];
-  const publicationNo = typeof props.publication_no === "number" && Number.isInteger(props.publication_no)
-    ? props.publication_no
-    : null;
   return (
-    <div data-testid="global-event-popup">
-      <Row label="事件" value={String(props.title_zh_tw ?? "—")} />
-      {props.relation_kind === "association" && <Row label="關聯線" value="同一事件涉及多國；不是移動軌跡、方向或發生順序" />}
-      <Row label="查證狀態" value={props.research_status === "ai_assessed" ? (props.assessment_status === "pending" ? "待 AI 判斷（尚未研究確認）" : "AI 初判（尚未研究確認）") : "已研究並正式發布"} />
-      <Row label="摘要" value={String(props.summary_zh_tw ?? "—")} />
-      <Row label="分類" value={globalEventCategoryLabel(props.category)} />
-      <Row label="嚴重度" value={globalEventSeverityLabel(props.severity)} />
-      <Row label={props.research_status === "ai_assessed" ? "AI 判斷信心（非定位精度）" : "信心"} value={confidence} />
-      {typeof props.decision === "string" && <Row label="Qwen 分類" value={props.decision} />}
-      {typeof props.taiwan_relationship === "string" && <Row label="臺灣關聯" value={props.taiwan_relationship} />}
-      {typeof props.taiwan_impact_zh_tw === "string" && <Row label="臺灣影響" value={props.taiwan_impact_zh_tw} />}
-      {typeof props.reason_zh_tw === "string" && <Row label="判斷理由" value={props.reason_zh_tw} />}
+    <div data-testid="global-event-popup" style={{ color: t.textDefault }}>
+      <div style={{ color: t.textMuted, fontSize: FONT_SIZE.base, marginBottom: 3 }}>事件</div>
+      <h3 style={{ color: t.textStrong, fontSize: FONT_SIZE.xl, fontWeight: 600, lineHeight: 1.45, margin: "0 0 10px", overflowWrap: "anywhere" }}>
+        {String(props.title_zh_tw ?? "—")}
+      </h3>
+      <Row label="查證狀態" value={isInitial ? (props.assessment_status === "pending" ? "待 AI 判斷（尚未研究確認）" : "AI 初判（尚未研究確認）") : "已研究並正式發布"} />
+      <div style={{ marginTop: 10 }}>
+        <div style={{ color: t.textMuted, fontSize: FONT_SIZE.base }}>摘要</div>
+        <p style={{ color: t.textStrong, fontSize: FONT_SIZE.md, lineHeight: 1.65, margin: "3px 0 10px", overflowWrap: "anywhere" }}>
+          {String(props.summary_zh_tw ?? "—")}
+        </p>
+      </div>
+      <Row label="分類／嚴重度" value={`${globalEventCategoryLabel(props.category)} · ${globalEventSeverityLabel(props.severity)}`} />
+      <Row label="臺灣影響" value={String(props.taiwan_impact_zh_tw ?? "—")} />
+      <Row label="判斷理由" value={String(props.reason_zh_tw ?? "—")} />
       <Row label="地點" value={placeParts.length > 0 ? placeParts.join(" · ") : "—"} />
       <Row label="落點語意" value={globalEventLocationLabel(props)} />
-      {typeof props.original_lng === "number" && typeof props.original_lat === "number" && (
-        <Row label="原始位置座標" value={`${props.original_lat.toFixed(5)}, ${props.original_lng.toFixed(5)}`} />
-      )}
-      {props.display_offset === true && <Row label="畫面避讓" value="小錨點固定原位置；事件圖示僅在畫面上並排，座標不變" />}
-      <Row label={props.research_status === "ai_assessed" ? "來源收集時間" : "事件時間"} value={fmtGlobalEventTime(props.valid_from)} />
-      {props.research_status !== "ai_assessed" && <Row label="發布時間" value={fmtGlobalEventTime(props.published_at)} />}
-      {publicationNo !== null && <Row label="發布版本" value={`#${publicationNo}`} />}
-      {typeof props.lifecycle_state === "string" && <Row label="生命週期" value={props.lifecycle_state} />}
-      {typeof props.display_from === "string" && <Row label="時間軸顯示起點" value={fmtGlobalEventTime(props.display_from)} />}
-      {typeof props.display_from === "string" && (
-        <Row
-          label="時間軸顯示終點"
-          value={typeof props.display_to === "string" ? fmtGlobalEventTime(props.display_to) : "未有真實結束時間"}
-        />
-      )}
-      <Row label="位置來源" value={String(props.location_source ?? "—")} />
-      {props.source_kind === "gdelt_metadata_mention" && <Row label="位置依據" value="新聞 metadata 提及地點，尚待研究確認事件與地點的關係" />}
-      {props.source_kind === "headline_gazetteer" && <Row label="位置依據" value="新聞標題地名＋固定地名表，非精確事件座標" />}
-      {assessments.length > 1 && <details>
-        <summary>同組 {assessments.length} 筆候選原始判斷</summary>
-        {assessments.map((assessment, index) => <div key={String(assessment.candidateId ?? index)}>
-          <Row label="候選" value={String(assessment.title ?? "—")} />
-          <Row label="Qwen 分類" value={String(assessment.decision ?? "待判斷")} />
-          <Row label="臺灣關聯" value={String(assessment.taiwanRelationship ?? "未知")} />
-          <Row label="臺灣影響" value={String(assessment.taiwanImpact ?? "—")} />
-          <Row label="判斷理由" value={String(assessment.reason ?? "—")} />
-        </div>)}
-      </details>}
+      {/* Candidate valid_from carries observed_at; formal valid_from is not a collection time. */}
+      <Row label="來源收集時間" value={fmtGlobalEventTime(props.observed_at ?? (isInitial ? props.valid_from : null))} />
+      <div style={{ display: "flex", gap: 8, marginTop: 8, fontSize: FONT_SIZE.base, lineHeight: 1.5 }}>
+        <span style={{ color: t.textMuted, flexShrink: 0 }}>位置來源</span>
+        {locationUrl ? <a href={String(props.location_source)} target="_blank" rel="noopener noreferrer"
+          style={{ color: t.link, overflowWrap: "anywhere" }}>{locationUrl.hostname}</a> : <span style={{ color: t.textStrong }}>—</span>}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Make only the Global Events popup a concise news summary with a larger title. Data, source content, geographic anchors, RPCs and other layers are unchanged.

## Changes

- Keep the requested order: 18px title, verification status, summary, category/severity on one line, Taiwan impact, reasoning, place, location semantics, source collection time, linked location source.
- Hide confidence, Qwen category, relationship codes, raw coordinates, offset details, timeline/version/lifecycle/internal lineage and grouped raw assessments from the popup; preserve underlying fields.
- Use existing theme tokens, safe http(s) source hostname labels, original href and `noopener noreferrer`; reject URLs containing credentials.
- Do not mislabel formal event valid_from as source collection time; show — when absent.
- Record prior PR207 RUNNING and explicitly defer visual acceptance to the user.

## Test

- [x] `npx tsc -b`
- [x] Focused tests: 17 passed (4 popup + 13 existing Global Events hook tests)
- [x] Field order/content/hidden internals, 18px theme title, safe original URL links, pending/researched status and truthful time semantics
- Existing full suite runs in CI; not redundantly rerun locally for this small popup-only change.
- **No browser, screenshot or devserver visual verification was performed. The user explicitly requested to do visual acceptance themselves.** This also applies to production visual acceptance of the preceding fixed-anchor release.
- No backend/RPC/location/config changes.

## Risk / Rollback

- Scope: Global Events panel only. Revert this PR to restore previous verbose display; no data migration or position change.
- Normal CI must pass before exact-head squash merge and deployment.

## Related

- Feature: `docs/features/global-events/`
- Related PRs: #205, #206, #207

## Checklist

- [x] New isolated `codex/` branch, shared checkout untouched
- [x] Conventional commit
- [x] Existing theme, minimal panel-only change
- [x] Feature docs updated; visual acceptance explicitly assigned to user
