### PR TITLE
feat(global-events): move situation list into Intel tab

### DIFF
--- a/docs/features/global-events/backlog.md
+++ b/docs/features/global-events/backlog.md
@@ -12,6 +12,9 @@
 - [x] 固定錨點 hotfix PR #207／正式部署 RUNNING（78c90aa）
 - [ ] 固定錨點／popup瘦身正式視覺驗收（由使用者執行，不由agent自驗）
 - [x] Popup 瘦身與18px標題；資料、位置與其他圖層不變
-- [ ] Popup 瘦身 CI／正式部署
+- [x] Popup 瘦身 CI／正式部署（PR #208／5230181 RUNNING）
+- [x] 全球情勢列表與統計移到INTEL獨立分頁；sidebar保留controls
+- [x] 圖層off不顯示舊統計，明確按鈕啟用同一圖層；不新增資料pipeline
+- [ ] INTEL全球情勢分頁 CI／正式部署（視覺由使用者確認）
 
 後續：重要性判準持續校準；本次不引入新的分數體系。

--- a/docs/features/global-events/changelog.md
+++ b/docs/features/global-events/changelog.md
@@ -1,10 +1,18 @@
 # Changelog
 
-## 2026-09-03 — Popup 摘要瘦身（待發布）
+## 2026-09-03 — 全球情勢列表移至 INTEL（待發布）
+
+將兩個sidebar的GlobalEventsList與統計搬到「即時情報 INTEL → 全球情勢」獨立第四分頁；sidebar只留原圖層controls。全球分頁不混入全部／新聞／警報總量，不顯示新聞LIVE／更新健康列、1H／6H／24H、警報篩選或IntelReplay。統計與unknown／定位展開完全沿用既有globalEventsViewStore，依原七天／時間軸窗口，不新增RPC或reader。
+
+圖層關閉時不顯示cached統計，提供「開啟全球情勢圖層以載入」按鈕，走App既有handleBulkSetVisibility；切分頁不暗中開啟圖層。沿用theme與列表資料，取消sidebar用的240px內層捲動上限。19 focused tests與tsc-b通過，正常CI另跑；依使用者要求不做browser／devserver視覺自驗，畫面由使用者確認。
+
+## 2026-09-03 — PR #208 Popup 摘要瘦身
 
 僅 Global Events popup 保留：18px 事件標題、查證狀態、摘要、同列分類／嚴重度、臺灣影響、判斷理由、地點、落點語意、來源收集時間及可點位置來源。隱藏信心／Qwen分類／關聯代碼／座標／避讓／時間軸／lineage等內部細節，底層資料與其他圖層不變。來源用網域標籤、原http(s) URL，拒絕不安全或帶帳密連結；正式事件沒有來源收集時間時顯示—，不挪用事件時間。
 
 依使用者要求，不做browser、截圖或devserver視覺驗收；只跑focused tests、tsc與既有CI。視覺驗收由使用者。
+
+PR #208 merge 5230181，Zeabur deployment 6a997433c3fffb61baebe158 於13:27:27Z RUNNING；17 focused／tsc／CI通過。沒有宣稱視覺已验。
 
 ## 2026-09-03 — PR #207 固定地理錨點 hotfix
 

--- a/docs/features/global-events/handoff.md
+++ b/docs/features/global-events/handoff.md
@@ -16,9 +16,11 @@
 
 ## Release
 
+INTEL全球情勢分頁本次僅搬UI：列表／統計仍讀globalEventsViewStore，資料載入與選取仍由原visible layer hook提供；off時顯示明確enable按鈕，不顯示舊快照。七天／時間軸由原controls決定，獨立於新聞range／警報filters／all counts。尚待本次CI與deployment，視覺由使用者確認。
+
 固定錨點 hotfix PR #207 merge 78c90aa 已部署，Zeabur 6a99545bc3fffb61baebd662 於11:10:02Z RUNNING；tsc-b、23 focused／1031 full tests（1 skipped）與CI通過。本地 browser 驗證加拿大7件群組分別點選、平移／旋轉／縮放後錨點不變、opacity0／off／on與console皆通過；style reload 僅以 regression 驗證。
 
-後續popup瘦身只改顯示，底層欄位及位置不變。依使用者最新指示，不再做browser／截圖／devserver視覺驗收；固定錨點與popup正式視覺確認均交使用者。Popup發布證據待本次CI／deployment完成，不能以測試代稱視覺已驗。
+後續popup瘦身只改顯示，底層欄位及位置不變。PR #208 merge 5230181，deployment 6a997433c3fffb61baebe158 於13:27:27Z RUNNING；17 focused／tsc／CI通過。依使用者最新指示，不再做browser／截圖／devserver視覺驗收；固定錨點與popup正式視覺確認均交使用者，不能以測試代稱視覺已驗。
 
 實作基線：frontend e16dc2354c74d7563d6b7525120c935f43e64f2b；platform 1f4f7e352ef4292ce1615474cf400716dffb4ba3；collector 48250361d1d459d1590d1f228f2e4cd4e51390fc。
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1732,6 +1732,8 @@ export default function App() {
           <IntelPanel
             open={intelOpen}
             onClose={() => setIntelOpen(false)}
+            globalEventsEnabled={layerVisibility.globalEvents}
+            onEnableGlobalEvents={() => handleBulkSetVisibility(["globalEvents"], true)}
             onSelectLocation={(lon, lat) => {
               mapRef.current?.flyTo({ center: [lon, lat], zoom: 12, speed: 1.2 });
             }}

--- a/src/components/IconRailSidebar.tsx
+++ b/src/components/IconRailSidebar.tsx
@@ -1,6 +1,5 @@
 import { useState, useEffect, useMemo, useRef, memo, createContext, useContext, type CSSProperties, type ComponentType } from "react";
 import { FONT_DATA, RADIUS, FONT_SIZE } from "../styles/designTokens";
-import { GlobalEventsList } from "./sidebar/GlobalEventsList";
 import {
   // ✅ AR-22 Phase 2 完成（批 8）：全部 layer 的 icon **全部**由 layerManifest 派生，
   //    `HANDWRITTEN_LAYER_ICONS` 已空。以下 import 沒有一顆是餵圖層的 ——
@@ -1156,7 +1155,6 @@ function ExpandedControls({
         </div>
       )}
 
-      {layerKey === "globalEvents" && <GlobalEventsList palette={{ textStrong: TEXT_STRONG, textMuted: INACTIVE_TEXT, border: CTRL_INACTIVE_BORDER, link: TEXT_STRONG, bgSubtle: CTRL_INACTIVE_BG }} />}
       {/* Controls */}
       {controls.length > 0 && (
         <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>

--- a/src/components/LayerSidebar.tsx
+++ b/src/components/LayerSidebar.tsx
@@ -1,6 +1,4 @@
 import { useState } from "react";
-import { GlobalEventsList } from "./sidebar/GlobalEventsList";
-import { DARK_FEATURE, LIGHT_FEATURE } from "./featureInfo/featureTheme";
 import { Lock } from "lucide-react";
 import type { LayerVisibility, ExpandableLayerKey, ViewMode, DisplayMode } from "../types";
 // AR-22 P4：控件不再由 App 經 4 層 props 傳下來（getControls drilling 已拆除）。
@@ -553,7 +551,6 @@ function ExpandedPanel({
         </div>
       )}
 
-      {layerKey === "globalEvents" && <GlobalEventsList palette={isDarkTheme ? DARK_FEATURE : LIGHT_FEATURE} />}
       {/* Controls: sliders + toggles */}
       {controls.length > 0 && (
         <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>

--- a/src/components/intel/IntelHeader.tsx
+++ b/src/components/intel/IntelHeader.tsx
@@ -10,6 +10,8 @@ interface Props {
   countdownSec: number;
   sourceHealth: SourceHealthSummary;
   onClose: () => void;
+  /** Global Events has its own immutable window/status; news health and LIVE badge do not apply. */
+  showFeedStatus?: boolean;
 }
 
 const STATUS_COLOR: Record<SourceStatus, string> = {
@@ -26,7 +28,7 @@ function fmtLag(sec: number | null): string {
   return `${Math.floor(sec / 3600)}h`;
 }
 
-export function IntelHeader({ totalCount, lastUpdateTs, countdownSec, sourceHealth, onClose }: Props) {
+export function IntelHeader({ totalCount, lastUpdateTs, countdownSec, sourceHealth, onClose, showFeedStatus = true }: Props) {
   const [showHealth, setShowHealth] = useState(false);
 
   const degraded = sourceHealth.degraded + sourceHealth.lagging > 0;
@@ -55,7 +57,7 @@ export function IntelHeader({ totalCount, lastUpdateTs, countdownSec, sourceHeal
             INTEL
           </span>
         </div>
-        <span
+        {showFeedStatus && <span
           style={{
             display: "inline-flex",
             alignItems: "center",
@@ -80,7 +82,7 @@ export function IntelHeader({ totalCount, lastUpdateTs, countdownSec, sourceHeal
           <span style={{ fontFamily: FONT_DATA, fontSize: FONT_SIZE.sm, fontWeight: 700, color: COLORS.statusLive }}>
             LIVE
           </span>
-        </span>
+        </span>}
         <div style={{ flex: 1 }} />
         <button
           onClick={onClose}
@@ -103,7 +105,7 @@ export function IntelHeader({ totalCount, lastUpdateTs, countdownSec, sourceHeal
       </div>
 
       {/* ── status row ── */}
-      <div
+      {showFeedStatus && <div
         style={{
           flexShrink: 0,
           padding: "8px 14px",
@@ -150,10 +152,10 @@ export function IntelHeader({ totalCount, lastUpdateTs, countdownSec, sourceHeal
         <span style={{ display: "flex", alignItems: "center", gap: 4, color: COLORS.textDim }}>
           <IntelIcon d={ICON.refresh} size={11} color={COLORS.textDim} /> {fmtCountdown(countdownSec)}
         </span>
-      </div>
+      </div>}
 
       {/* ── source health popover ── */}
-      {showHealth && (
+      {showFeedStatus && showHealth && (
         <div
           style={{
             flexShrink: 0,

--- a/src/components/intel/IntelPanel.tsx
+++ b/src/components/intel/IntelPanel.tsx
@@ -38,6 +38,7 @@ import { fetchDisasterAlertsDay } from "../../data/disasterAlertLoader";
 import type { NewsCategory } from "../../data/newsEventTypes";
 import { timeStore } from "../../state/timeStore";
 import { useNewsFilter } from "../../hooks/useNewsFilter";
+import { GlobalEventsList } from "../sidebar/GlobalEventsList";
 
 const EMPTY_HEALTH: SourceHealthSummary = {
   total: 0, ok: 0, lagging: 0, degraded: 0, unknown: 0, rows: [],
@@ -73,6 +74,8 @@ interface Props {
   onSelectLocation?: (lon: number, lat: number) => void;
   /** 來自地圖 pin click 的選取（清單應 scroll + 展開） */
   externalSelectedId?: number | null;
+  globalEventsEnabled: boolean;
+  onEnableGlobalEvents: () => void;
 }
 
 export function IntelPanel({
@@ -82,6 +85,8 @@ export function IntelPanel({
   onFilterChange: onFilterChangeProp,
   onSelectLocation,
   externalSelectedId,
+  globalEventsEnabled,
+  onEnableGlobalEvents,
 }: Props) {
   // AR-22 P4：主站不傳 filter/onFilterChange，改自己 per-key 訂閱同一個 store slot
   const { filter: storeFilter, setFilter: storeSetFilter } = useNewsFilter();
@@ -100,6 +105,7 @@ export function IntelPanel({
 
   // ── alerts state ──
   const [feedTab, setFeedTab] = useState<FeedTab>("all");
+  const isGlobalEventsTab = feedTab === "globalEvents";
   const [alertsExpanded, setAlertsExpanded] = useState(false);
   const [pickedGroups, setPickedGroups] = useState<AlertGroupShort[]>([]);
   const [severityMin, setSeverityMin] = useState<1 | 2 | 3 | 4>(1);
@@ -193,7 +199,7 @@ export function IntelPanel({
 
   // active alerts list — re-fetch when tab / filter change
   const groupKey = pickedGroups.length === 1 ? pickedGroups[0]! : null;
-  const needsAlertList = feedTab !== "news";
+  const needsAlertList = feedTab === "all" || feedTab === "alerts";
   useEffect(() => {
     if (!open || !needsAlertList) return;
     let alive = true;
@@ -410,6 +416,7 @@ export function IntelPanel({
       }}
     >
       <IntelHeader
+        showFeedStatus={!isGlobalEventsTab}
         totalCount={flatEvents.length}
         lastUpdateTs={now}
         countdownSec={countdownSec}
@@ -417,13 +424,13 @@ export function IntelPanel({
         onClose={onClose}
       />
 
-      <AlertSummaryBar
+      {!isGlobalEventsTab && <AlertSummaryBar
         tally={alertTally}
         expanded={alertsExpanded}
         onToggle={() => setAlertsExpanded((v) => !v)}
         activeGroups={pickedGroups}
         onPickGroup={onPickGroup}
-      />
+      />}
 
       <FeedTabs
         tab={feedTab}
@@ -507,7 +514,7 @@ export function IntelPanel({
             </>
           )}
         </div>
-      ) : (
+      ) : feedTab === "all" ? (
         <div
           style={{
             display: "flex", alignItems: "center", gap: 5,
@@ -543,7 +550,7 @@ export function IntelPanel({
             );
           })}
         </div>
-      )}
+      ) : null}
 
       {feedTab === "news" && (
         <IntelSituation
@@ -554,7 +561,17 @@ export function IntelPanel({
       )}
 
       <div className="mtp-scroll" style={{ flex: 1, overflowY: "auto", padding: "12px 14px 14px" }}>
-        {feedTab === "alerts" ? (
+        {isGlobalEventsTab ? (
+          globalEventsEnabled ? <GlobalEventsList fillPanel palette={{ textStrong: COLORS.textStrong, textMuted: COLORS.textMuted,
+            border: COLORS.borderMid, link: COLORS.accent, bgSubtle: COLORS.accentFaint }} /> : (
+            <div style={{ fontFamily: FONT_CJK, fontSize: FONT_SIZE.base, color: COLORS.textMuted, lineHeight: 1.6 }}>
+              <p style={{ margin: "0 0 10px" }}>全球情勢圖層目前關閉。開啟後會顯示該圖層的最近七天或時間軸資料。</p>
+              <button onClick={onEnableGlobalEvents} style={{ padding: "7px 10px", borderRadius: RADIUS.md,
+                border: `1px solid ${COLORS.accentSoft}`, background: COLORS.accentFaint, color: COLORS.textStrong,
+                fontFamily: FONT_CJK, fontSize: FONT_SIZE.base, cursor: "pointer" }}>開啟全球情勢圖層以載入</button>
+            </div>
+          )
+        ) : feedTab === "alerts" ? (
           <>
           {historyMode && (
             <div
@@ -780,7 +797,7 @@ export function IntelPanel({
         )}
       </div>
 
-      <IntelReplay
+      {!isGlobalEventsTab && <IntelReplay
         playbackTs={effectivePlayback}
         windowStartTs={windowStartTs}
         nowTs={now}
@@ -789,7 +806,7 @@ export function IntelPanel({
         onScrub={onScrub}
         onLive={goLive}
         onTogglePlay={togglePlay}
-      />
+      />}
 
       <style>{`
         @keyframes intelPanelFadeIn {

--- a/src/components/intel/__tests__/GlobalEventsTab.test.ts
+++ b/src/components/intel/__tests__/GlobalEventsTab.test.ts
@@ -1,0 +1,104 @@
+import { createElement, isValidElement, type ReactNode } from "react";
+import { readFileSync } from "node:fs";
+import { renderToStaticMarkup } from "react-dom/server";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const harness = vi.hoisted(() => ({ tab: "globalEvents" }));
+vi.mock("react", async (importOriginal) => ({
+  ...await importOriginal<typeof import("react")>(),
+  useState: (initial: unknown) => [initial === "all" ? harness.tab : typeof initial === "function" ? initial() : initial, vi.fn()],
+  useMemo: (factory: () => unknown) => factory(),
+  useRef: (current: unknown) => ({ current }),
+  useEffect: () => {},
+  useSyncExternalStore: (_subscribe: unknown, getSnapshot: () => unknown) => getSnapshot(),
+}));
+vi.mock("../../../hooks/useNewsFilter", () => ({ useNewsFilter: () => ({ filter: { minRelevance: 0, eventsOnly: false, minSeverity: 0 }, setFilter: vi.fn() }) }));
+
+import { IntelPanel } from "../IntelPanel";
+import { FeedTabs } from "../alerts/FeedTabs";
+import { GlobalEventsList } from "../../sidebar/GlobalEventsList";
+import { globalEventsViewStore } from "../../../state/globalEventsViewStore";
+import { parseGlobalEventRecord } from "../../../data/globalEventsLoader";
+
+function findButton(node: ReactNode, label: string): (() => void) | undefined {
+  if (Array.isArray(node)) {
+    for (const child of node) { const found = findButton(child, label); if (found) return found; }
+  } else if (isValidElement<{ children?: ReactNode; onClick?: () => void }>(node)) {
+    if (node.type === "button" && node.props.children === label) return node.props.onClick;
+    return findButton(node.props.children, label);
+  }
+  return undefined;
+}
+
+const located = parseGlobalEventRecord({ event_id: "located", title_zh_tw: "可定位事件", geometry: { type: "Point", coordinates: [10, 20] } });
+const unknown = parseGlobalEventRecord({ event_id: "unknown", title_zh_tw: "仍待定位事件", geometry: null });
+const panel = (globalEventsEnabled = true, onEnableGlobalEvents = vi.fn()) => IntelPanel({ open: true, onClose: vi.fn(), globalEventsEnabled, onEnableGlobalEvents });
+
+afterEach(() => {
+  harness.tab = "globalEvents";
+  globalEventsViewStore.set({ entries: [], status: "idle", message: null, windowLabel: "最近七天" });
+  globalEventsViewStore.setSelectHandler(null);
+});
+
+describe("Global Events Intel tab", () => {
+  it("removes duplicate sidebar list mounts while preserving the existing layer controls", () => {
+    for (const file of ["LayerSidebar.tsx", "IconRailSidebar.tsx"]) {
+      const source = readFileSync(new URL(`../../${file}`, import.meta.url), "utf8");
+      expect(source).not.toContain("GlobalEventsList");
+      expect(source).toContain("buildParamControls");
+    }
+  });
+
+  it("adds an independent fourth tab without changing news/alert/all counts", () => {
+    const markup = renderToStaticMarkup(createElement(FeedTabs, { tab: "globalEvents", onTab: vi.fn(), newsCount: 7, alertCount: 5, alertCountInAll: 3, alertSevere: 1 }));
+    const buttons = markup.match(/<button\b[\s\S]*?<\/button>/g)!;
+    expect(buttons).toHaveLength(4);
+    expect(buttons.map((button) => button.replace(/<[^>]+>/g, ""))).toEqual(["全部10", "新聞7", "警報5", "全球情勢"]);
+    expect(buttons[3]).toContain('aria-selected="true"');
+  });
+
+  it("shows the original store statistics, unlocated events and selection without news timing/health", () => {
+    globalEventsViewStore.set({ entries: [located, unknown], status: "ready", message: null, windowLabel: "最近七天總覽" });
+    const markup = renderToStaticMarkup(panel());
+    expect(markup).toContain("最近七天總覽 · 已載入 2 件 · 1 件待定位");
+    expect(markup).toContain("可定位事件");
+    expect(markup).toContain("仍待定位事件");
+    for (const hidden of ["更新 ", "共 0 則", ">LIVE<", "1H", "6H", "24H", "SEVERITY ≥", "REPLAY", "來源管線", "max-height:240px"]) expect(markup).not.toContain(hidden);
+    const selected = vi.fn();
+    globalEventsViewStore.setSelectHandler(selected);
+    findButton(GlobalEventsList({ fillPanel: true }), "定位並展開")!();
+    expect(selected).toHaveBeenCalledWith(located);
+    expect(located.coordinates).toEqual([10, 20]);
+  });
+
+  it("layer off hides cached statistics and requires the explicit existing-layer enable action", () => {
+    globalEventsViewStore.set({ entries: [located, unknown], status: "ready", message: null, windowLabel: "舊時間窗" });
+    const enable = vi.fn();
+    const tree = panel(false, enable);
+    const markup = renderToStaticMarkup(tree);
+    expect(markup).toContain("開啟全球情勢圖層以載入");
+    expect(markup).not.toContain("舊時間窗");
+    expect(markup).not.toContain("已載入");
+    expect(markup).not.toContain("可定位事件");
+    expect(enable).not.toHaveBeenCalled();
+    findButton(tree, "開啟全球情勢圖層以載入")!();
+    expect(enable).toHaveBeenCalledTimes(1);
+  });
+
+  it("retains history/loading/partial semantics and leaves other tab controls intact", () => {
+    globalEventsViewStore.set({ entries: [unknown], status: "partial", message: "AI 初判資料載入失敗，並非零件。", windowLabel: "跟隨時間軸" });
+    expect(renderToStaticMarkup(panel())).toContain("跟隨時間軸 · 已載入 1 件 · 1 件待定位");
+    expect(renderToStaticMarkup(panel())).toContain("並非零件");
+    globalEventsViewStore.set({ entries: [], status: "loading", message: null, windowLabel: "跟隨時間軸" });
+    expect(renderToStaticMarkup(panel())).toContain("正在載入全球情勢");
+    expect(renderToStaticMarkup(panel())).not.toContain("已載入 0");
+    harness.tab = "all";
+    const all = renderToStaticMarkup(panel());
+    expect(all).toContain("1H");
+    expect(all).toContain("REPLAY");
+    expect(all).toContain("更新 ");
+    expect(all).not.toContain('aria-label="全球情勢事件列表"');
+    harness.tab = "alerts";
+    expect(renderToStaticMarkup(panel())).toContain("SEVERITY ≥");
+  });
+});

--- a/src/components/intel/alerts/FeedTabs.tsx
+++ b/src/components/intel/alerts/FeedTabs.tsx
@@ -1,7 +1,7 @@
 import { COLORS, FONT_CJK, FONT_DATA } from "../intelTokens";
 import { RADIUS, FONT_SIZE } from "../../../styles/designTokens";
 
-export type FeedTab = "all" | "news" | "alerts";
+export type FeedTab = "all" | "news" | "alerts" | "globalEvents";
 
 interface Props {
   tab: FeedTab;
@@ -18,11 +18,14 @@ const TABS: { key: FeedTab; label: string }[] = [
   { key: "all",    label: "全部" },
   { key: "news",   label: "新聞" },
   { key: "alerts", label: "警報" },
+  { key: "globalEvents", label: "全球情勢" },
 ];
 
 export function FeedTabs({ tab, onTab, newsCount, alertCount, alertCountInAll, alertSevere }: Props) {
   return (
     <div
+      role="tablist"
+      aria-label="情報分頁"
       style={{
         flexShrink: 0,
         display: "flex", gap: 4,
@@ -35,17 +38,20 @@ export function FeedTabs({ tab, onTab, newsCount, alertCount, alertCountInAll, a
         const isAlerts = t.key === "alerts";
         const hot = isAlerts && alertSevere > 0;
         const count =
-          t.key === "news" ? newsCount
+          t.key === "globalEvents" ? null : t.key === "news" ? newsCount
             : t.key === "alerts" ? alertCount
               : newsCount + alertCountInAll;
         return (
           <button
             key={t.key}
+            role="tab"
+            aria-selected={active}
             onClick={() => onTab(t.key)}
             style={{
               flex: 1,
-              display: "flex", alignItems: "center", justifyContent: "center", gap: 5,
-              padding: "5px 8px",
+              minWidth: 0, whiteSpace: "nowrap",
+              display: "flex", alignItems: "center", justifyContent: "center", gap: 4,
+              padding: "5px 6px",
               borderRadius: RADIUS.lg,
               cursor: "pointer",
               background: active
@@ -61,7 +67,7 @@ export function FeedTabs({ tab, onTab, newsCount, alertCount, alertCountInAll, a
             }}
           >
             {t.label}
-            <span
+            {count !== null && <span
               style={{
                 fontFamily: FONT_DATA, fontSize: FONT_SIZE.sm, fontWeight: 700,
                 color: hot && active ? "#ef4444" : "inherit",
@@ -69,7 +75,7 @@ export function FeedTabs({ tab, onTab, newsCount, alertCount, alertCountInAll, a
               }}
             >
               {count}
-            </span>
+            </span>}
           </button>
         );
       })}

--- a/src/components/sidebar/GlobalEventsList.tsx
+++ b/src/components/sidebar/GlobalEventsList.tsx
@@ -4,15 +4,16 @@ import { FONT_SIZE, RADIUS } from "../../styles/designTokens";
 import { DARK_FEATURE, type FeaturePalette } from "../featureInfo/featureTheme";
 
 type ListPalette = Pick<FeaturePalette, "textStrong" | "textMuted" | "border" | "link" | "bgSubtle">;
-export function GlobalEventsList({ palette = DARK_FEATURE }: { palette?: ListPalette }) {
+export function GlobalEventsList({ palette = DARK_FEATURE, fillPanel = false }: { palette?: ListPalette; fillPanel?: boolean }) {
   const snapshot = useSyncExternalStore(globalEventsViewStore.subscribe, globalEventsViewStore.getSnapshot, globalEventsViewStore.getSnapshot);
   const events = [...new Map(snapshot.entries.map((row) => [row.eventId, row])).values()];
   const located = new Set(snapshot.entries.filter((row) => row.coordinates !== null && !row.mapSuppressed).map((row) => row.eventId));
   return <section aria-label="全球情勢事件列表" style={{ fontSize: FONT_SIZE.base, color: palette.textStrong, lineHeight: 1.5 }}>
     <div style={{ color: palette.textMuted }}>{snapshot.windowLabel}{(snapshot.status === "ready" || snapshot.status === "partial") && <> · 已載入 {events.length} 件 · {events.filter((row) => !located.has(row.eventId) && !row.mapSuppressed).length} 件待定位</>}</div>
     {snapshot.status === "loading" && <div role="status">正在載入全球情勢…</div>}
+    {snapshot.status === "idle" && <div role="status">等待全球情勢圖層載入…</div>}
     {snapshot.message && <div role="status" style={{ color: "#d97706" }}>{snapshot.message}</div>}
-    <div style={{ maxHeight: 240, overflowY: "auto", marginTop: 5 }}>
+    <div style={{ maxHeight: fillPanel ? undefined : 240, overflowY: fillPanel ? "visible" : "auto", marginTop: 5 }}>
       {events.map((event) => <details key={event.eventId} style={{ borderTop: `1px solid ${palette.border}`, padding: "5px 0" }}>
         <summary style={{ cursor: "pointer", lineHeight: 1.5 }}>
           <span style={{ color: palette.textMuted }}>{event.candidateId ? (event.assessmentStatus === "pending" ? "待判斷" : "AI 初判") : "已研究"} · {event.mapSuppressed ? "正式事件已撤回／取代，不上圖" : located.has(event.eventId) ? "可定位" : "待定位"}</span><br />


### PR DESCRIPTION
## Summary

Move the Global Events list and its real window/statistics from both sidebars into a dedicated fourth tab, 全球情勢, in the existing INTEL panel. Layer controls remain in the sidebars.

## Changes

- Reuse GlobalEventsList and globalEventsViewStore unchanged data/selection semantics, including unknown events, immutable seven-day/timeline windows and locate/expand.
- Add an independent tab without a duplicate count badge or mixing events into All/News/Alerts totals.
- Hide news LIVE/update/source-health UI, alert controls, 1H/6H/24H and IntelReplay only while Global Events is active.
- When the layer is off, hide cached statistics and show an explicit enable button wired to the existing App bulk visibility handler. Selecting the tab does not implicitly turn on the layer or create a second reader/RPC pipeline.
- Remove both sidebar list mounts, retain all layer controls, use the INTEL scroll area instead of a nested 240px list.
- Preserve existing theme/font/animation conventions; no backend/Qwen/RPC/geometry changes.

## Test

- [x] `npx tsc -b`
- [x] 19 focused tests passed: independent tab/counts, off/cache/enable action, loading/partial/history, unknown entries, original locate callback, other-tab controls and no duplicate sidebar mounts
- [x] `git diff --check`
- Existing full suite runs in CI; no unrelated local full-suite rerun.
- **Per user instruction: no browser, screenshots, devserver or visual self-verification. Visual acceptance belongs to the user.**

## Risk / Rollback

- UI routing only; underlying event data and map rendering are untouched.
- Revert this PR to restore sidebar placement; no migration or data rollback required.
- Existing All/News/Alerts queries/count formulas and controls remain separate.

## Related

- Feature: `docs/features/global-events/`
- Related PRs: #205, #207, #208

## Checklist

- [x] New isolated codex branch; shared checkout untouched
- [x] Conventional commit and feature docs
- [x] No new reader, store architecture, filters, scoring or data contracts
- [x] Visual verification explicitly delegated to user
