### PR TITLE
feat(embed): support agriculture layer

### DIFF
--- a/docs/features/embeddable-map/README.md
+++ b/docs/features/embeddable-map/README.md
@@ -171,12 +171,16 @@ aws s3 sync public/embed-rail/ "s3://$S3_BUCKET/deploy-assets/embed-rail/" --reg
 
 | 類別 | 數量 | 來源 | 說明 |
 |---|---|---|---|
-| 靜態 | **145** | `overlayRegistry` 扣掉 dynamicData 與 gated | 自動派生，新增圖層不必改程式 |
+| 靜態 | **145 + factory 例外** | `overlayRegistry` 扣掉 dynamicData 與 gated，再加逐案審核的靜態 factory | registry 自動派生；factory 必須明列靜態 CDN 契約 |
 | 動態但已 CDN 化 | **7** | `/static-rpc/*.json` | 風機/光電/離岸風場/地熱/充電站/離島電網/北市再生 |
 | 歷史快照 | **1** | `/embed-snapshots/<layer>/<date>.geojson` | `plaActivity`（共機），需帶 `date=` |
 
 🔒 **35 個 owner-gated 圖層一律排除**，且不只是「不顯示」——實測 URL 硬塞 gated key 時，
 對應的資料檔**連一個 byte 都不會下載**（source 根本不建立）。
+
+**Factory 例外**：`agriculture`（FTW Fields 2025）在主站由 Mapbox 專用 factory 建立，
+embed 另以 `factoryOverlayConfigs.ts` 描述同一份靜態 PMTiles 與樣式，再交給 MapLibre adapter。
+它不查 Supabase；田區為衛星影像 AI 判讀結果，並非法定農地分區。
 
 **回放層（EM-16，2026-08-09 上線）**：`ships` / `flights` / `rail` 三層 Three.js 回放，
 只在網址真的帶了這些 key + `date=` 時才 `import()` three（純靜態嵌入完全不下載）。
@@ -190,6 +194,7 @@ aws s3 sync public/embed-rail/ "s3://$S3_BUCKET/deploy-assets/embed-rail/" --reg
 | `src/lib/urlState.ts` | 網址 ↔ 狀態（`parseUrlState` / `buildUrl`）；版本閘門 + 靜默降級 |
 | `src/embed/EmbedApp.tsx` | 嵌入版主體（MapLibre）。不呼叫 `useTransportParams`、不掛 Three.js |
 | `src/embed/embedWhitelist.ts` | 三層白名單派生 |
+| `src/embed/factoryOverlayConfigs.ts` | 主站 custom factory 的 embed 靜態例外（目前為 FTW 農田） |
 | `src/embed/maplibreAdapters.ts` | PMTiles protocol（兩引擎唯一的**實質**差異） |
 | `src/embed/basemapStyle.ts` | Protomaps style；底圖位置可由 `VITE_EMBED_BASEMAP_URL` 覆寫 |
 | `src/embed/dynamicCdnLayers.ts` | CDN 例外清單 + 通用 `rowsToGeoJSON` |

--- a/src/embed/__tests__/embedWhitelist.test.ts
+++ b/src/embed/__tests__/embedWhitelist.test.ts
@@ -16,6 +16,7 @@ import { SNAPSHOT_KEYS, snapshotUrl } from "../snapshotLayers";
 import { REPLAY_KEYS, REPLAY_LAYERS, replaySnapshotUrl, isReplayLayer } from "../replayLayers";
 import { GATED_LAYERS, LAYER_COLORS } from "../../components/sidebar/layerCatalog";
 import { EMBED_ALLOWED, EMBED_ALLOWED_CONFIGS, buildEmbedVisibility, configsFor } from "../embedWhitelist";
+import { EMBED_FACTORY_OVERLAY_CONFIGS } from "../factoryOverlayConfigs";
 import type { LayerVisibility } from "../../types";
 
 describe("EMBED_ALLOWED 白名單", () => {
@@ -73,6 +74,9 @@ describe("EMBED_ALLOWED 白名單", () => {
       ...OVERLAY_REGISTRY
         .filter((o) => (!o.dynamicData || o.id in EMBED_CDN_LAYERS) && !GATED_LAYERS.has(o.id))
         .map((o) => o.id),
+      ...EMBED_FACTORY_OVERLAY_CONFIGS
+        .filter((o) => !o.dynamicData && !GATED_LAYERS.has(o.id))
+        .map((o) => o.id),
       // EM-15：快照圖層不在 registry（主站是專屬 hook 畫的）
       ...SNAPSHOT_KEYS,
       // EM-16：回放圖層不在 registry（主站是 Three.js CustomLayer 畫的）
@@ -115,6 +119,24 @@ describe("EMBED_ALLOWED 白名單", () => {
     const missing = EMBED_ALLOWED_CONFIGS.filter((o) => !o.sourceUrl).map((o) => o.id);
     expect(missing).toEqual([]);
   });
+
+  it("🔒 custom factory 例外不得是動態圖層", () => {
+    const dynamic = EMBED_FACTORY_OVERLAY_CONFIGS.filter((o) => o.dynamicData).map((o) => o.id);
+    expect(dynamic).toEqual([]);
+  });
+
+  it("custom factory 的 FTW 農田使用靜態 PMTiles，且不碰動態資料", () => {
+    expect(EMBED_ALLOWED.has("agriculture")).toBe(true);
+    const [config] = configsFor(["agriculture"]);
+    expect(config).toMatchObject({
+      id: "agriculture",
+      sourceUrl: "./agriculture/ftw_fields_2025.pmtiles",
+      sourceId: "agri-ftw-fields",
+      pmtiles: { sourceLayer: "fields", minzoom: 5, maxzoom: 14 },
+    });
+    expect(config?.dynamicData).not.toBe(true);
+    expect(config?.layers.map((layer) => layer.suffix)).toEqual(["fill", "outline"]);
+  });
 });
 
 describe("buildEmbedVisibility", () => {
@@ -127,6 +149,12 @@ describe("buildEmbedVisibility", () => {
     const v = buildEmbedVisibility(["aquaculturePonds"]);
     expect(v.aquaculturePonds).toBe(true);
     expect(Object.entries(v).filter(([, on]) => on).map(([k]) => k)).toEqual(["aquaculturePonds"]);
+  });
+
+  it("可單獨開啟 custom factory 的農田圖層", () => {
+    const v = buildEmbedVisibility(["agriculture"]);
+    expect(v.agriculture).toBe(true);
+    expect(Object.entries(v).filter(([, on]) => on).map(([k]) => k)).toEqual(["agriculture"]);
   });
 
   it("🔒 即使被硬塞 gated key 也不會開啟（第二道防線）", () => {

--- a/src/embed/embedWhitelist.ts
+++ b/src/embed/embedWhitelist.ts
@@ -1,11 +1,13 @@
 /**
  * `/embed` 可用圖層白名單（EM-06）
  *
- * **自動派生，不手動維護** —— 新增圖層時不必回來改這裡，規則本身保證安全：
+ * registry 圖層自動派生；不在 registry 的 custom factory 必須逐案登記靜態 config。
+ * 兩條路徑都共用下列安全規則：
  *
  * 1. `dynamicData !== true` → 只收純靜態檔（GeoJSON / PMTiles）。動態圖層走 Supabase RPC，
  *    嵌在別人文章裡等於把 DB egress 交給別人的流量決定（見 embeddable-map.md §6-2）。
  * 2. 排除 `GATED_LAYERS` → owner-only 私人圖層不得經由嵌入洩漏。
+ * 3. custom factory 例外只能描述 CDN 靜態資產，仍由 MapLibre adapter 載入。
  *
  * 要開放某個動態圖層時，是「逐案評估 egress 後加例外」，不是放寬這裡的規則。
  */
@@ -14,6 +16,7 @@ import { GATED_LAYERS } from "../components/sidebar/layerCatalog";
 import { EMBED_CDN_LAYERS } from "./dynamicCdnLayers";
 import { SNAPSHOT_KEYS } from "./snapshotLayers";
 import { REPLAY_KEYS } from "./replayLayers";
+import { EMBED_FACTORY_OVERLAY_CONFIGS } from "./factoryOverlayConfigs";
 import type { OverlayConfig, LayerVisibility } from "../types";
 
 /**
@@ -24,9 +27,12 @@ function hasCdnSnapshot(id: keyof LayerVisibility): boolean {
   return id in EMBED_CDN_LAYERS;
 }
 
-export const EMBED_ALLOWED_CONFIGS: OverlayConfig[] = OVERLAY_REGISTRY.filter(
-  (o) => (!o.dynamicData || hasCdnSnapshot(o.id)) && !GATED_LAYERS.has(o.id),
-);
+export const EMBED_ALLOWED_CONFIGS: OverlayConfig[] = [
+  ...OVERLAY_REGISTRY.filter(
+    (o) => (!o.dynamicData || hasCdnSnapshot(o.id)) && !GATED_LAYERS.has(o.id),
+  ),
+  ...EMBED_FACTORY_OVERLAY_CONFIGS.filter((o) => !o.dynamicData && !GATED_LAYERS.has(o.id)),
+];
 
 export const EMBED_ALLOWED: ReadonlySet<string> = new Set([
   ...EMBED_ALLOWED_CONFIGS.map((o) => o.id),
@@ -42,6 +48,7 @@ export const EMBED_ALLOWED: ReadonlySet<string> = new Set([
 export function buildEmbedVisibility(keys: readonly (keyof LayerVisibility)[] = []): LayerVisibility {
   const out = {} as LayerVisibility;
   for (const config of OVERLAY_REGISTRY) out[config.id] = false;
+  for (const config of EMBED_FACTORY_OVERLAY_CONFIGS) out[config.id] = false;
   for (const k of SNAPSHOT_KEYS) out[k] = false;
   for (const k of REPLAY_KEYS) out[k] = false;
   for (const k of keys) {

--- a/src/embed/factoryOverlayConfigs.ts
+++ b/src/embed/factoryOverlayConfigs.ts
@@ -1,0 +1,60 @@
+/**
+ * 主站以 custom factory 建立、但適合在 `/embed` 安全載入的靜態圖層。
+ *
+ * 這些 config 必須符合 embed 的兩個邊界：只讀 CDN 靜態資產、不得是 owner-gated。
+ * PMTiles source 仍由 EmbedApp 注入 MapLibre adapter，不可直接呼叫綁定 mapbox-gl 的
+ * factory。視覺參數需與對應 factory 保持一致，相關測試會釘住 source 與 layer 契約。
+ */
+import type { OverlayConfig } from "../types";
+
+/** 與 `agricultureLayerFactory.ensureAgricultureLayers` 的 FTW 田區樣式對齊。 */
+const agriculture: OverlayConfig = {
+  id: "agriculture",
+  sourceUrl: "./agriculture/ftw_fields_2025.pmtiles",
+  sourceId: "agri-ftw-fields",
+  opacityParam: "agricultureOpacity",
+  pmtiles: { sourceLayer: "fields", minzoom: 5, maxzoom: 14 },
+  attribution: "Fields of The World (CC BY 4.0)",
+  layers: [
+    {
+      suffix: "fill",
+      type: "fill",
+      minzoom: 5,
+      paint: (_isDark, params) => ({
+        "fill-color": "#2e7d32",
+        "fill-opacity": [
+          "interpolate", ["linear"],
+          ["coalesce", ["get", "confidence_mean"], 0.5],
+          0.5, 0.18,
+          0.6, 0.42,
+        ],
+        "fill-outline-color": "rgba(46, 125, 50, 0.6)",
+        "fill-translate": [0, -(params?.agricultureZ ?? 0)],
+        "fill-translate-anchor": "viewport",
+      }),
+    },
+    {
+      suffix: "outline",
+      type: "line",
+      minzoom: 10,
+      layout: (_isDark, params) => ({
+        visibility: (params?.agricultureShowOutline ?? 1) > 0 ? "visible" : "none",
+      }),
+      paint: (_isDark, params) => {
+        const width = params?.agricultureOutlineWidth ?? 1;
+        return {
+          "line-color": "#1b5e20",
+          "line-width": [
+            "interpolate", ["linear"], ["zoom"],
+            10, 0.2 * width,
+            13, 0.6 * width,
+            16, 1.2 * width,
+          ],
+          "line-opacity": 0.55,
+        };
+      },
+    },
+  ],
+};
+
+export const EMBED_FACTORY_OVERLAY_CONFIGS: readonly OverlayConfig[] = [agriculture];


### PR DESCRIPTION
## Summary
- expose the existing FTW Fields 2025 agriculture PMTiles in the MapLibre embed whitelist
- keep the custom factory path static and owner-gated safe
- document the factory exception and add whitelist coverage

## Verification
- npm test -- --run: 109 test files passed, 1091 tests passed, 3 skipped
- npx tsc -b
- npm run build
- production asset HEAD: 200, Accept-Ranges: bytes, 107138689 bytes

## Release
The production PMTiles asset already exists at /agriculture/ftw_fields_2025.pmtiles. Merging to master triggers the normal Zeabur deployment.