### PR TITLE
feat: add transport hub point display modes

### DIFF
--- a/docs/features/transport-hub-display/README.md
+++ b/docs/features/transport-hub-display/README.md
@@ -1,0 +1,34 @@
+# 交通場站顯示模式
+
+> **Slug**：`transport-hub-display`
+> **狀態**：`dev`
+> **最後更新**：2026-09-05
+> **相關 PR**：無
+
+## 一句話說明
+
+高鐵站、台鐵站、港口與機場可在原本的實際範圍 Polygon 與遠距離易讀的 Mapbox 點位間切換；港口依原始 `port_class` 分類著色。
+
+五個場站圖層皆預設使用 Mapbox 點位；有真實面資料的圖層仍可手動切回 Polygon。
+
+## 圖層行為
+
+| Layer key | Polygon 模式 | 點位模式 | 原始資料處理 |
+|---|---|---|---|
+| `stationsTHSR` | 12 站體範圍 | 由同一批 Polygon 派生面心 | 不另造站點 |
+| `stationsTRA` | 32 個大站範圍，小站點保留 | 32 大站面心 + 212 小站（z<10 overview、z>=10 原 detail） | 不補齊不存在的站體面 |
+| `stationsMetro` | 不提供 | 原始站點（z<10 overview、z>=10 原 detail） | Polygon 選項停用並標示無面資料 |
+| `ports` | 277 個港區範圍 | 由同一批 Polygon 派生面心 | 依 `port_class` 著色，缺值/新類別回灰 |
+| `airports` | 16 個機場範圍 | 由同一批 Polygon 派生面心 | 不影響燈塔圖層 |
+
+## 關鍵檔案
+
+- 模式與港口分類：`src/data/transportHubTypes.ts`
+- 參數與 Toggle：`src/data/layerParamsSpec.ts`
+- Mapbox layer：`src/map/overlayRegistry.ts`
+- Polygon 派生點：`src/map/overlayManager.ts`
+- Manifest / Legend / Popup：`src/data/layerManifest.ts`、`src/components/LegendPanel.tsx`、`src/components/featureInfo/infraPanels.tsx`
+
+## 資料契約
+
+看 [handoff.md](./handoff.md)。本次僅使用已有靜態 GeoJSON，沒有新增 collector、DB 或假造範圍。

--- a/docs/features/transport-hub-display/backlog.md
+++ b/docs/features/transport-hub-display/backlog.md
@@ -1,0 +1,11 @@
+# Backlog — 交通場站顯示模式
+
+## Release gate
+
+- [x] 完成本地 browser 驗收：五個圖層的控制面板、Polygon/點位切換、港口分色與 popup；console 無 error/warning。
+- [x] commit / PR 已獲授權，建立後以 PR 頁面為證據。
+- [ ] deploy / production browser 尚未獲授權，不在本次範圍。
+
+## Conditional
+
+- [ ] 只有取得可驗證的捷運站體實際範圍時，才開啟捷運 Polygon 模式。

--- a/docs/features/transport-hub-display/changelog.md
+++ b/docs/features/transport-hub-display/changelog.md
@@ -1,0 +1,12 @@
+# Changelog — 交通場站顯示模式
+
+## 2026-09-05 — 本地開發
+
+- 依最終驗收決策，高鐵、台鐵、捷運、港口與機場的顯示模式全部改為預設 Mapbox 點位。
+- 視覺複核後補上台鐵 212 個小站的 z<10 overview，遠距離不再只顯示 32 個大站；第二類漁港由鮮綠改為低飽和鼠尾草綠。
+- 高鐵、台鐵、港口、機場新增 Polygon / Mapbox 點位切換，保留原 Polygon 顯示。
+- 捷運新增相同模式控制，但因現有資料無站體面，Polygon 選項明確停用；z10 以下新增 overview 點，z10 以上保留原 detail layers。
+- 港口依 9 種現有 `port_class` 著色，Legend 與 popup 共用同一色彩 SSOT；未知分類回灰。
+- 新增 Polygon/MultiPolygon 派生點 transform、模式可見性守門與契約測試。
+- 本地 browser 驗收通過：全台遠距離點位、原 Polygon 切回、港口 9 類分色 / Legend / popup，以及捷運無面資料 disabled 狀態；console 無 error/warning。
+- 本次已獲授權建立 commit / PR；未 deploy。

--- a/docs/features/transport-hub-display/handoff.md
+++ b/docs/features/transport-hub-display/handoff.md
@@ -1,0 +1,26 @@
+# Handoff — 交通場站顯示模式
+
+## 下游資料契約
+
+| Asset | Geometry | 硬依賴欄位 | 目前範圍 |
+|---|---|---|---|
+| `public/geo/station_polygons.geojson` | Polygon | `system_id`, `name` | THSR 12、TRA 32 |
+| `public/geo/station_points.geojson` | Point | `system_id`, `name`, `color` | TRA 212、捷運/輕軌 291 |
+| `public/geo/port_polygons.geojson` | Polygon | `name`, `port_class`, `county`, `source` | 277 |
+| `public/geo/airports.geojson` | Polygon / MultiPolygon | `name` | 16 |
+
+## 語意邊界
+
+- 點位模式是顯示用派生 geometry：Polygon 取主面的面心，feature properties 原樣保留，不回寫靜態 asset。
+- MultiPolygon 取面積最大的部件，避免代表點落在分離面之間。
+- 非 Polygon geometry 不會被轉換或補值。
+- 捷運只有 Point，所以 UI 不把 buffer 或推定範圍稱為「實際範圍」。
+- 港口著色直接反映原始 `port_class`；未知分類使用灰色，不歸入既有類別。
+
+## 上游改動時的下游動作
+
+| 上游改動 | 下游動作 |
+|---|---|
+| `port_class` 新增或更名 | 同步 `PORT_CLASSES`、Legend、資料守門測試 |
+| 補入捷運真實站體 Polygon | 先驗證 lineage/覆蓋率，再開啟 Polygon 選項 |
+| 站體 geometry 改為 Point | 不可透過 centroid transform 猜測，需重定顯示契約 |

--- a/src/components/LegendPanel.tsx
+++ b/src/components/LegendPanel.tsx
@@ -31,6 +31,7 @@ import { ECO_NETWORK_ZONE_TYPES } from "../data/ecoNetworkZoneTypes";
 import {
   MARITIME_BOUNDARY_TYPES, MARITIME_BOUNDARY_SOURCE_NOTE,
 } from "../data/maritimeBoundaryTypes";
+import { PORT_CLASSES, PORT_CLASS_FALLBACK } from "../data/transportHubTypes";
 import { TEMPERATURE_GRID_BANDS } from "../data/temperatureGridTypes";
 import { CWA_INTENSITY_BANDS } from "../data/earthquakeReplayTypes";
 import { resolveMicroSensorMode, MICRO_SENSOR_NO_DATA_COLOR } from "../data/microSensorTypes";
@@ -352,6 +353,7 @@ export const LEGEND_REGISTRY: LegendEntry[] = [
   { id: "ships", render: () => <ShipsLegend /> },
   { id: "flights", render: () => <FlightsLegend /> },
   { id: "rail", render: ({ railSystems }) => <RailLegend railSystems={railSystems} /> },
+  { id: "ports", render: () => <PortsLegend /> },
   { id: "newsEvents", render: () => <NewsEventsLegend /> },
   { id: "plaActivity", render: () => <PlaActivityLegend /> },
   { id: "vesselWatch", render: () => <VesselWatchLegend /> },
@@ -849,6 +851,27 @@ function FireCatRows({ cats, square }: { cats: { color: string; label: string }[
           <span style={{ fontSize: FONT_SIZE.xs, color: t.textMuted }}>{c.label}</span>
         </div>
       ))}
+    </div>
+  );
+}
+
+function PortsLegend() {
+  const t = useLegendTheme();
+  return (
+    <div>
+      <div style={{ fontSize: FONT_SIZE.xs, color: t.textDim, letterSpacing: 1, marginBottom: 4 }}>
+        港口分類 PORT CLASS
+      </div>
+      <FireCatRows
+        square
+        cats={[
+          ...PORT_CLASSES.map((entry) => ({ color: entry.color, label: entry.label })),
+          { color: PORT_CLASS_FALLBACK.color, label: PORT_CLASS_FALLBACK.label },
+        ]}
+      />
+      <div style={{ fontSize: FONT_SIZE.xs, color: t.textDim, marginTop: 4, lineHeight: 1.3 }}>
+        顏色依原始 port_class；缺值不當作任一既有分級
+      </div>
     </div>
   );
 }

--- a/src/components/featureInfo/infraPanels.tsx
+++ b/src/components/featureInfo/infraPanels.tsx
@@ -7,6 +7,7 @@ import { TimeseriesSparkline, type SparklinePoint } from "../TimeseriesSparkline
 import { fetchAirportHourlyPax } from "../../data/airportPaxLoader";
 import { ixpRegionColor, anfrOperatorColor, ripeAtlasNodeColor } from "../../data/telecomTypes";
 import { OOKLA_GRID_META } from "../../data/telecomTypes";
+import { portClassColor } from "../../data/transportHubTypes";
 
 /** 超商品牌對應色 */
 const BRAND_COLORS: Record<string, string> = {
@@ -32,16 +33,6 @@ const TOILET_GRADE_COLOR: Record<string, string> = {
   優等級: "#ab47bc",
   普通級: "#ffb300",
   不合格: "#e53935",
-};
-
-/** 港口分類對應色 */
-const PORT_CLASS_COLORS: Record<string, string> = {
-  "國際商港": "#42a5f5",
-  "國內商港": "#64b5f6",
-  "第一類漁港": "#26c6da",
-  "第二類漁港": "#4dd0e1",
-  "工業專用港": "#ffa726",
-  "軍港": "#78909c",
 };
 
 /** CCTV source 對應色 / 標籤 */
@@ -449,7 +440,7 @@ export function LighthousePanel({ props }: { props: Record<string, unknown> }) {
 export function PortPanel({ props }: { props: Record<string, unknown> }) {
   const t = useFeatureTheme();
   const portClass = String(props.port_class ?? "");
-  const accentColor = PORT_CLASS_COLORS[portClass] ?? "#88bbff";
+  const accentColor = portClassColor(portClass);
 
   return (
     <>

--- a/src/components/sidebar/__tests__/layerConsistency.test.ts
+++ b/src/components/sidebar/__tests__/layerConsistency.test.ts
@@ -119,7 +119,7 @@ const NO_PARAMS_LEDGER = new Set([
 const NO_LEGEND_LEDGER = new Set([
   // 交通：車站/場站/線形皆單色（鐵道車種分色在 rail，已接 RailLegend）
   "stationsTHSR", "stationsTRA", "stationsMetro",
-  "ports", "lighthouses", "airports", "highways", "provincialRoads",
+  "lighthouses", "airports", "highways", "provincialRoads",
   "etcGantry", "serviceArea", "serviceAreaPolygon", "taxiStand", "windPlan",
   "busStationsCity", "busStationsIntercity", "bikeStations", "cyclingRoutes",
   "weatherStations",

--- a/src/data/__tests__/__fixtures__/layer-golden.json
+++ b/src/data/__tests__/__fixtures__/layer-golden.json
@@ -660,6 +660,20 @@
     },
     {
       "layers": [
+        "port-centroids-point-core",
+        "port-centroids-point-glow"
+      ],
+      "type": "port"
+    },
+    {
+      "layers": [
+        "airport-centroids-point-core",
+        "airport-centroids-point-glow"
+      ],
+      "type": "airport"
+    },
+    {
+      "layers": [
         "port-polygons-fill",
         "port-polygons-line",
         "port-polygons-glow-1",
@@ -710,6 +724,29 @@
         "taxi-stand-glow"
       ],
       "type": "taxiStand"
+    },
+    {
+      "layers": [
+        "station-polygon-centroids-thsr-point-core",
+        "station-polygon-centroids-thsr-point-glow",
+        "station-polygon-centroids-tra-point-core",
+        "station-polygon-centroids-tra-point-glow"
+      ],
+      "type": "railStation"
+    },
+    {
+      "layers": [
+        "station-points-tra-overview-point-core",
+        "station-points-tra-overview-point-glow"
+      ],
+      "type": "railStation"
+    },
+    {
+      "layers": [
+        "station-points-metro-overview-point-core",
+        "station-points-metro-overview-point-glow"
+      ],
+      "type": "railStation"
     },
     {
       "layers": [
@@ -1665,6 +1702,13 @@
     },
     {
       "layers": [
+        "station-polygons-tra-poly-fill",
+        "station-polygons-tra-poly-line"
+      ],
+      "type": "railStation"
+    },
+    {
+      "layers": [
         "station-polygons-thsr-poly-fill",
         "station-polygons-thsr-poly-line"
       ],
@@ -2446,7 +2490,14 @@
       "layers": [
         {
           "filter": null,
-          "layout": null,
+          "layout": {
+            "dark": {
+              "visibility": "none"
+            },
+            "light": {
+              "visibility": "none"
+            }
+          },
           "minzoom": null,
           "paint": {
             "dark": {
@@ -2467,7 +2518,14 @@
         },
         {
           "filter": null,
-          "layout": null,
+          "layout": {
+            "dark": {
+              "visibility": "none"
+            },
+            "light": {
+              "visibility": "none"
+            }
+          },
           "minzoom": null,
           "paint": {
             "dark": {
@@ -2488,7 +2546,14 @@
         },
         {
           "filter": null,
-          "layout": null,
+          "layout": {
+            "dark": {
+              "visibility": "none"
+            },
+            "light": {
+              "visibility": "none"
+            }
+          },
           "minzoom": null,
           "paint": {
             "dark": {
@@ -2505,7 +2570,14 @@
         },
         {
           "filter": null,
-          "layout": null,
+          "layout": {
+            "dark": {
+              "visibility": "none"
+            },
+            "light": {
+              "visibility": "none"
+            }
+          },
           "minzoom": null,
           "paint": {
             "dark": {
@@ -2536,13 +2608,178 @@
           "get",
           "system_id"
         ],
+        "thsr"
+      ],
+      "id": "stationsTHSR",
+      "layers": [
+        {
+          "filter": null,
+          "layout": {
+            "dark": {
+              "visibility": "visible"
+            },
+            "light": {
+              "visibility": "visible"
+            }
+          },
+          "minzoom": null,
+          "paint": {
+            "dark": {
+              "circle-blur": 0.8,
+              "circle-color": "#ff8c00",
+              "circle-opacity": 0.28,
+              "circle-radius": [
+                "interpolate",
+                [
+                  "linear"
+                ],
+                [
+                  "zoom"
+                ],
+                5,
+                7,
+                9,
+                11,
+                13,
+                16
+              ]
+            },
+            "light": {
+              "circle-blur": 0.8,
+              "circle-color": "#ff8c00",
+              "circle-opacity": 0.28,
+              "circle-radius": [
+                "interpolate",
+                [
+                  "linear"
+                ],
+                [
+                  "zoom"
+                ],
+                5,
+                7,
+                9,
+                11,
+                13,
+                16
+              ]
+            }
+          },
+          "suffix": "thsr-point-glow",
+          "type": "circle"
+        },
+        {
+          "filter": null,
+          "layout": {
+            "dark": {
+              "visibility": "visible"
+            },
+            "light": {
+              "visibility": "visible"
+            }
+          },
+          "minzoom": null,
+          "paint": {
+            "dark": {
+              "circle-color": "#ff8c00",
+              "circle-opacity": 0.92,
+              "circle-radius": [
+                "interpolate",
+                [
+                  "linear"
+                ],
+                [
+                  "zoom"
+                ],
+                5,
+                3.5,
+                9,
+                5.5,
+                13,
+                8
+              ],
+              "circle-stroke-color": "#0b1118",
+              "circle-stroke-opacity": 0.9,
+              "circle-stroke-width": [
+                "interpolate",
+                [
+                  "linear"
+                ],
+                [
+                  "zoom"
+                ],
+                5,
+                0.8,
+                12,
+                1.4
+              ]
+            },
+            "light": {
+              "circle-color": "#ff8c00",
+              "circle-opacity": 0.92,
+              "circle-radius": [
+                "interpolate",
+                [
+                  "linear"
+                ],
+                [
+                  "zoom"
+                ],
+                5,
+                3.5,
+                9,
+                5.5,
+                13,
+                8
+              ],
+              "circle-stroke-color": "#ffffff",
+              "circle-stroke-opacity": 0.9,
+              "circle-stroke-width": [
+                "interpolate",
+                [
+                  "linear"
+                ],
+                [
+                  "zoom"
+                ],
+                5,
+                0.8,
+                12,
+                1.4
+              ]
+            }
+          },
+          "suffix": "thsr-point-core",
+          "type": "circle"
+        }
+      ],
+      "pmtiles": null,
+      "rebuildOnParamChange": null,
+      "sourceId": "station-polygon-centroids",
+      "sourceUrl": "./geo/station_polygons.geojson"
+    },
+    {
+      "dynamicData": null,
+      "filter": [
+        "==",
+        [
+          "get",
+          "system_id"
+        ],
         "tra"
       ],
       "id": "stationsTRA",
       "layers": [
         {
           "filter": null,
-          "layout": null,
+          "layout": {
+            "dark": {
+              "visibility": "none"
+            },
+            "light": {
+              "visibility": "none"
+            }
+          },
           "minzoom": null,
           "paint": {
             "dark": {
@@ -2563,7 +2800,14 @@
         },
         {
           "filter": null,
-          "layout": null,
+          "layout": {
+            "dark": {
+              "visibility": "none"
+            },
+            "light": {
+              "visibility": "none"
+            }
+          },
           "minzoom": null,
           "paint": {
             "dark": {
@@ -2584,7 +2828,14 @@
         },
         {
           "filter": null,
-          "layout": null,
+          "layout": {
+            "dark": {
+              "visibility": "none"
+            },
+            "light": {
+              "visibility": "none"
+            }
+          },
           "minzoom": null,
           "paint": {
             "dark": {
@@ -2601,7 +2852,14 @@
         },
         {
           "filter": null,
-          "layout": null,
+          "layout": {
+            "dark": {
+              "visibility": "none"
+            },
+            "light": {
+              "visibility": "none"
+            }
+          },
           "minzoom": null,
           "paint": {
             "dark": {
@@ -2636,6 +2894,306 @@
       ],
       "id": "stationsTRA",
       "layers": [
+        {
+          "filter": null,
+          "layout": {
+            "dark": {
+              "visibility": "visible"
+            },
+            "light": {
+              "visibility": "visible"
+            }
+          },
+          "minzoom": null,
+          "paint": {
+            "dark": {
+              "circle-blur": 0.8,
+              "circle-color": "#b8a080",
+              "circle-opacity": 0.28,
+              "circle-radius": [
+                "interpolate",
+                [
+                  "linear"
+                ],
+                [
+                  "zoom"
+                ],
+                5,
+                7,
+                9,
+                11,
+                13,
+                16
+              ]
+            },
+            "light": {
+              "circle-blur": 0.8,
+              "circle-color": "#b8a080",
+              "circle-opacity": 0.28,
+              "circle-radius": [
+                "interpolate",
+                [
+                  "linear"
+                ],
+                [
+                  "zoom"
+                ],
+                5,
+                7,
+                9,
+                11,
+                13,
+                16
+              ]
+            }
+          },
+          "suffix": "tra-point-glow",
+          "type": "circle"
+        },
+        {
+          "filter": null,
+          "layout": {
+            "dark": {
+              "visibility": "visible"
+            },
+            "light": {
+              "visibility": "visible"
+            }
+          },
+          "minzoom": null,
+          "paint": {
+            "dark": {
+              "circle-color": "#b8a080",
+              "circle-opacity": 0.92,
+              "circle-radius": [
+                "interpolate",
+                [
+                  "linear"
+                ],
+                [
+                  "zoom"
+                ],
+                5,
+                3.5,
+                9,
+                5.5,
+                13,
+                8
+              ],
+              "circle-stroke-color": "#0b1118",
+              "circle-stroke-opacity": 0.9,
+              "circle-stroke-width": [
+                "interpolate",
+                [
+                  "linear"
+                ],
+                [
+                  "zoom"
+                ],
+                5,
+                0.8,
+                12,
+                1.4
+              ]
+            },
+            "light": {
+              "circle-color": "#b8a080",
+              "circle-opacity": 0.92,
+              "circle-radius": [
+                "interpolate",
+                [
+                  "linear"
+                ],
+                [
+                  "zoom"
+                ],
+                5,
+                3.5,
+                9,
+                5.5,
+                13,
+                8
+              ],
+              "circle-stroke-color": "#ffffff",
+              "circle-stroke-opacity": 0.9,
+              "circle-stroke-width": [
+                "interpolate",
+                [
+                  "linear"
+                ],
+                [
+                  "zoom"
+                ],
+                5,
+                0.8,
+                12,
+                1.4
+              ]
+            }
+          },
+          "suffix": "tra-point-core",
+          "type": "circle"
+        }
+      ],
+      "pmtiles": null,
+      "rebuildOnParamChange": null,
+      "sourceId": "station-polygon-centroids",
+      "sourceUrl": "./geo/station_polygons.geojson"
+    },
+    {
+      "dynamicData": null,
+      "filter": [
+        "==",
+        [
+          "get",
+          "system_id"
+        ],
+        "tra"
+      ],
+      "id": "stationsTRA",
+      "layers": [
+        {
+          "filter": null,
+          "layout": {
+            "dark": {
+              "visibility": "visible"
+            },
+            "light": {
+              "visibility": "visible"
+            }
+          },
+          "maxzoom": 10,
+          "minzoom": null,
+          "paint": {
+            "dark": {
+              "circle-blur": 0.8,
+              "circle-color": "#b8a080",
+              "circle-opacity": 0.28,
+              "circle-radius": [
+                "interpolate",
+                [
+                  "linear"
+                ],
+                [
+                  "zoom"
+                ],
+                5,
+                7,
+                9,
+                11,
+                13,
+                16
+              ]
+            },
+            "light": {
+              "circle-blur": 0.8,
+              "circle-color": "#b8a080",
+              "circle-opacity": 0.28,
+              "circle-radius": [
+                "interpolate",
+                [
+                  "linear"
+                ],
+                [
+                  "zoom"
+                ],
+                5,
+                7,
+                9,
+                11,
+                13,
+                16
+              ]
+            }
+          },
+          "suffix": "tra-overview-point-glow",
+          "type": "circle"
+        },
+        {
+          "filter": null,
+          "layout": {
+            "dark": {
+              "visibility": "visible"
+            },
+            "light": {
+              "visibility": "visible"
+            }
+          },
+          "maxzoom": 10,
+          "minzoom": null,
+          "paint": {
+            "dark": {
+              "circle-color": "#b8a080",
+              "circle-opacity": 0.92,
+              "circle-radius": [
+                "interpolate",
+                [
+                  "linear"
+                ],
+                [
+                  "zoom"
+                ],
+                5,
+                3.5,
+                9,
+                5.5,
+                13,
+                8
+              ],
+              "circle-stroke-color": "#0b1118",
+              "circle-stroke-opacity": 0.9,
+              "circle-stroke-width": [
+                "interpolate",
+                [
+                  "linear"
+                ],
+                [
+                  "zoom"
+                ],
+                5,
+                0.8,
+                12,
+                1.4
+              ]
+            },
+            "light": {
+              "circle-color": "#b8a080",
+              "circle-opacity": 0.92,
+              "circle-radius": [
+                "interpolate",
+                [
+                  "linear"
+                ],
+                [
+                  "zoom"
+                ],
+                5,
+                3.5,
+                9,
+                5.5,
+                13,
+                8
+              ],
+              "circle-stroke-color": "#ffffff",
+              "circle-stroke-opacity": 0.9,
+              "circle-stroke-width": [
+                "interpolate",
+                [
+                  "linear"
+                ],
+                [
+                  "zoom"
+                ],
+                5,
+                0.8,
+                12,
+                1.4
+              ]
+            }
+          },
+          "suffix": "tra-overview-point-core",
+          "type": "circle"
+        },
         {
           "filter": null,
           "layout": null,
@@ -2733,6 +3291,160 @@
       ],
       "id": "stationsMetro",
       "layers": [
+        {
+          "filter": null,
+          "layout": {
+            "dark": {
+              "visibility": "visible"
+            },
+            "light": {
+              "visibility": "visible"
+            }
+          },
+          "maxzoom": 10,
+          "minzoom": null,
+          "paint": {
+            "dark": {
+              "circle-blur": 0.8,
+              "circle-color": [
+                "get",
+                "color"
+              ],
+              "circle-opacity": 0.28,
+              "circle-radius": [
+                "interpolate",
+                [
+                  "linear"
+                ],
+                [
+                  "zoom"
+                ],
+                5,
+                7,
+                9,
+                11,
+                13,
+                16
+              ]
+            },
+            "light": {
+              "circle-blur": 0.8,
+              "circle-color": [
+                "get",
+                "color"
+              ],
+              "circle-opacity": 0.28,
+              "circle-radius": [
+                "interpolate",
+                [
+                  "linear"
+                ],
+                [
+                  "zoom"
+                ],
+                5,
+                7,
+                9,
+                11,
+                13,
+                16
+              ]
+            }
+          },
+          "suffix": "metro-overview-point-glow",
+          "type": "circle"
+        },
+        {
+          "filter": null,
+          "layout": {
+            "dark": {
+              "visibility": "visible"
+            },
+            "light": {
+              "visibility": "visible"
+            }
+          },
+          "maxzoom": 10,
+          "minzoom": null,
+          "paint": {
+            "dark": {
+              "circle-color": [
+                "get",
+                "color"
+              ],
+              "circle-opacity": 0.92,
+              "circle-radius": [
+                "interpolate",
+                [
+                  "linear"
+                ],
+                [
+                  "zoom"
+                ],
+                5,
+                3.5,
+                9,
+                5.5,
+                13,
+                8
+              ],
+              "circle-stroke-color": "#0b1118",
+              "circle-stroke-opacity": 0.9,
+              "circle-stroke-width": [
+                "interpolate",
+                [
+                  "linear"
+                ],
+                [
+                  "zoom"
+                ],
+                5,
+                0.8,
+                12,
+                1.4
+              ]
+            },
+            "light": {
+              "circle-color": [
+                "get",
+                "color"
+              ],
+              "circle-opacity": 0.92,
+              "circle-radius": [
+                "interpolate",
+                [
+                  "linear"
+                ],
+                [
+                  "zoom"
+                ],
+                5,
+                3.5,
+                9,
+                5.5,
+                13,
+                8
+              ],
+              "circle-stroke-color": "#ffffff",
+              "circle-stroke-opacity": 0.9,
+              "circle-stroke-width": [
+                "interpolate",
+                [
+                  "linear"
+                ],
+                [
+                  "zoom"
+                ],
+                5,
+                0.8,
+                12,
+                1.4
+              ]
+            }
+          },
+          "suffix": "metro-overview-point-core",
+          "type": "circle"
+        },
         {
           "filter": null,
           "layout": null,
@@ -2851,18 +3563,75 @@
       "layers": [
         {
           "filter": null,
-          "layout": null,
+          "layout": {
+            "dark": {
+              "visibility": "none"
+            },
+            "light": {
+              "visibility": "none"
+            }
+          },
           "minzoom": null,
           "paint": {
             "dark": {
               "line-blur": 8,
-              "line-color": "#88bbff",
+              "line-color": [
+                "match",
+                [
+                  "get",
+                  "port_class"
+                ],
+                "國際商港",
+                "#3b82f6",
+                "國內商港",
+                "#14b8a6",
+                "客運港",
+                "#8b5cf6",
+                "渡輪/觀光碼頭",
+                "#a855f7",
+                "離島渡輪港",
+                "#d946ef",
+                "第一類漁港",
+                "#f59e0b",
+                "第二類漁港",
+                "#5f8f78",
+                "廢止漁港",
+                "#64748b",
+                "對岸港口",
+                "#ef4444",
+                "#94a3b8"
+              ],
               "line-opacity": 0.04,
               "line-width": 12
             },
             "light": {
               "line-blur": 8,
-              "line-color": "#3a7bd5",
+              "line-color": [
+                "match",
+                [
+                  "get",
+                  "port_class"
+                ],
+                "國際商港",
+                "#3b82f6",
+                "國內商港",
+                "#14b8a6",
+                "客運港",
+                "#8b5cf6",
+                "渡輪/觀光碼頭",
+                "#a855f7",
+                "離島渡輪港",
+                "#d946ef",
+                "第一類漁港",
+                "#f59e0b",
+                "第二類漁港",
+                "#5f8f78",
+                "廢止漁港",
+                "#64748b",
+                "對岸港口",
+                "#ef4444",
+                "#94a3b8"
+              ],
               "line-opacity": 0.1,
               "line-width": 12
             }
@@ -2872,18 +3641,75 @@
         },
         {
           "filter": null,
-          "layout": null,
+          "layout": {
+            "dark": {
+              "visibility": "none"
+            },
+            "light": {
+              "visibility": "none"
+            }
+          },
           "minzoom": null,
           "paint": {
             "dark": {
               "line-blur": 3,
-              "line-color": "#88bbff",
+              "line-color": [
+                "match",
+                [
+                  "get",
+                  "port_class"
+                ],
+                "國際商港",
+                "#3b82f6",
+                "國內商港",
+                "#14b8a6",
+                "客運港",
+                "#8b5cf6",
+                "渡輪/觀光碼頭",
+                "#a855f7",
+                "離島渡輪港",
+                "#d946ef",
+                "第一類漁港",
+                "#f59e0b",
+                "第二類漁港",
+                "#5f8f78",
+                "廢止漁港",
+                "#64748b",
+                "對岸港口",
+                "#ef4444",
+                "#94a3b8"
+              ],
               "line-opacity": 0.1,
               "line-width": 5
             },
             "light": {
               "line-blur": 3,
-              "line-color": "#3a7bd5",
+              "line-color": [
+                "match",
+                [
+                  "get",
+                  "port_class"
+                ],
+                "國際商港",
+                "#3b82f6",
+                "國內商港",
+                "#14b8a6",
+                "客運港",
+                "#8b5cf6",
+                "渡輪/觀光碼頭",
+                "#a855f7",
+                "離島渡輪港",
+                "#d946ef",
+                "第一類漁港",
+                "#f59e0b",
+                "第二類漁港",
+                "#5f8f78",
+                "廢止漁港",
+                "#64748b",
+                "對岸港口",
+                "#ef4444",
+                "#94a3b8"
+              ],
               "line-opacity": 0.2,
               "line-width": 5
             }
@@ -2893,16 +3719,73 @@
         },
         {
           "filter": null,
-          "layout": null,
+          "layout": {
+            "dark": {
+              "visibility": "none"
+            },
+            "light": {
+              "visibility": "none"
+            }
+          },
           "minzoom": null,
           "paint": {
             "dark": {
-              "fill-color": "#ffffff",
-              "fill-opacity": 0.06
+              "fill-color": [
+                "match",
+                [
+                  "get",
+                  "port_class"
+                ],
+                "國際商港",
+                "#3b82f6",
+                "國內商港",
+                "#14b8a6",
+                "客運港",
+                "#8b5cf6",
+                "渡輪/觀光碼頭",
+                "#a855f7",
+                "離島渡輪港",
+                "#d946ef",
+                "第一類漁港",
+                "#f59e0b",
+                "第二類漁港",
+                "#5f8f78",
+                "廢止漁港",
+                "#64748b",
+                "對岸港口",
+                "#ef4444",
+                "#94a3b8"
+              ],
+              "fill-opacity": 0.16
             },
             "light": {
-              "fill-color": "#4a90d9",
-              "fill-opacity": 0.1
+              "fill-color": [
+                "match",
+                [
+                  "get",
+                  "port_class"
+                ],
+                "國際商港",
+                "#3b82f6",
+                "國內商港",
+                "#14b8a6",
+                "客運港",
+                "#8b5cf6",
+                "渡輪/觀光碼頭",
+                "#a855f7",
+                "離島渡輪港",
+                "#d946ef",
+                "第一類漁港",
+                "#f59e0b",
+                "第二類漁港",
+                "#5f8f78",
+                "廢止漁港",
+                "#64748b",
+                "對岸港口",
+                "#ef4444",
+                "#94a3b8"
+              ],
+              "fill-opacity": 0.22
             }
           },
           "suffix": "fill",
@@ -2910,16 +3793,73 @@
         },
         {
           "filter": null,
-          "layout": null,
+          "layout": {
+            "dark": {
+              "visibility": "none"
+            },
+            "light": {
+              "visibility": "none"
+            }
+          },
           "minzoom": null,
           "paint": {
             "dark": {
-              "line-color": "#ffffff",
+              "line-color": [
+                "match",
+                [
+                  "get",
+                  "port_class"
+                ],
+                "國際商港",
+                "#3b82f6",
+                "國內商港",
+                "#14b8a6",
+                "客運港",
+                "#8b5cf6",
+                "渡輪/觀光碼頭",
+                "#a855f7",
+                "離島渡輪港",
+                "#d946ef",
+                "第一類漁港",
+                "#f59e0b",
+                "第二類漁港",
+                "#5f8f78",
+                "廢止漁港",
+                "#64748b",
+                "對岸港口",
+                "#ef4444",
+                "#94a3b8"
+              ],
               "line-opacity": 0.25,
               "line-width": 1
             },
             "light": {
-              "line-color": "#4a90d9",
+              "line-color": [
+                "match",
+                [
+                  "get",
+                  "port_class"
+                ],
+                "國際商港",
+                "#3b82f6",
+                "國內商港",
+                "#14b8a6",
+                "客運港",
+                "#8b5cf6",
+                "渡輪/觀光碼頭",
+                "#a855f7",
+                "離島渡輪港",
+                "#d946ef",
+                "第一類漁港",
+                "#f59e0b",
+                "第二類漁港",
+                "#5f8f78",
+                "廢止漁港",
+                "#64748b",
+                "對岸港口",
+                "#ef4444",
+                "#94a3b8"
+              ],
               "line-opacity": 0.4,
               "line-width": 1.5
             }
@@ -2929,11 +3869,259 @@
         }
       ],
       "pmtiles": null,
-      "rebuildOnParamChange": [
-        "glow-2",
-        "glow-1"
-      ],
+      "rebuildOnParamChange": null,
       "sourceId": "port-polygons",
+      "sourceUrl": "./geo/port_polygons.geojson"
+    },
+    {
+      "dynamicData": null,
+      "filter": null,
+      "id": "ports",
+      "layers": [
+        {
+          "filter": null,
+          "layout": {
+            "dark": {
+              "visibility": "visible"
+            },
+            "light": {
+              "visibility": "visible"
+            }
+          },
+          "minzoom": null,
+          "paint": {
+            "dark": {
+              "circle-blur": 0.8,
+              "circle-color": [
+                "match",
+                [
+                  "get",
+                  "port_class"
+                ],
+                "國際商港",
+                "#3b82f6",
+                "國內商港",
+                "#14b8a6",
+                "客運港",
+                "#8b5cf6",
+                "渡輪/觀光碼頭",
+                "#a855f7",
+                "離島渡輪港",
+                "#d946ef",
+                "第一類漁港",
+                "#f59e0b",
+                "第二類漁港",
+                "#5f8f78",
+                "廢止漁港",
+                "#64748b",
+                "對岸港口",
+                "#ef4444",
+                "#94a3b8"
+              ],
+              "circle-opacity": 0.28,
+              "circle-radius": [
+                "interpolate",
+                [
+                  "linear"
+                ],
+                [
+                  "zoom"
+                ],
+                5,
+                7,
+                9,
+                11,
+                13,
+                16
+              ]
+            },
+            "light": {
+              "circle-blur": 0.8,
+              "circle-color": [
+                "match",
+                [
+                  "get",
+                  "port_class"
+                ],
+                "國際商港",
+                "#3b82f6",
+                "國內商港",
+                "#14b8a6",
+                "客運港",
+                "#8b5cf6",
+                "渡輪/觀光碼頭",
+                "#a855f7",
+                "離島渡輪港",
+                "#d946ef",
+                "第一類漁港",
+                "#f59e0b",
+                "第二類漁港",
+                "#5f8f78",
+                "廢止漁港",
+                "#64748b",
+                "對岸港口",
+                "#ef4444",
+                "#94a3b8"
+              ],
+              "circle-opacity": 0.28,
+              "circle-radius": [
+                "interpolate",
+                [
+                  "linear"
+                ],
+                [
+                  "zoom"
+                ],
+                5,
+                7,
+                9,
+                11,
+                13,
+                16
+              ]
+            }
+          },
+          "suffix": "point-glow",
+          "type": "circle"
+        },
+        {
+          "filter": null,
+          "layout": {
+            "dark": {
+              "visibility": "visible"
+            },
+            "light": {
+              "visibility": "visible"
+            }
+          },
+          "minzoom": null,
+          "paint": {
+            "dark": {
+              "circle-color": [
+                "match",
+                [
+                  "get",
+                  "port_class"
+                ],
+                "國際商港",
+                "#3b82f6",
+                "國內商港",
+                "#14b8a6",
+                "客運港",
+                "#8b5cf6",
+                "渡輪/觀光碼頭",
+                "#a855f7",
+                "離島渡輪港",
+                "#d946ef",
+                "第一類漁港",
+                "#f59e0b",
+                "第二類漁港",
+                "#5f8f78",
+                "廢止漁港",
+                "#64748b",
+                "對岸港口",
+                "#ef4444",
+                "#94a3b8"
+              ],
+              "circle-opacity": 0.92,
+              "circle-radius": [
+                "interpolate",
+                [
+                  "linear"
+                ],
+                [
+                  "zoom"
+                ],
+                5,
+                3.5,
+                9,
+                5.5,
+                13,
+                8
+              ],
+              "circle-stroke-color": "#0b1118",
+              "circle-stroke-opacity": 0.9,
+              "circle-stroke-width": [
+                "interpolate",
+                [
+                  "linear"
+                ],
+                [
+                  "zoom"
+                ],
+                5,
+                0.8,
+                12,
+                1.4
+              ]
+            },
+            "light": {
+              "circle-color": [
+                "match",
+                [
+                  "get",
+                  "port_class"
+                ],
+                "國際商港",
+                "#3b82f6",
+                "國內商港",
+                "#14b8a6",
+                "客運港",
+                "#8b5cf6",
+                "渡輪/觀光碼頭",
+                "#a855f7",
+                "離島渡輪港",
+                "#d946ef",
+                "第一類漁港",
+                "#f59e0b",
+                "第二類漁港",
+                "#5f8f78",
+                "廢止漁港",
+                "#64748b",
+                "對岸港口",
+                "#ef4444",
+                "#94a3b8"
+              ],
+              "circle-opacity": 0.92,
+              "circle-radius": [
+                "interpolate",
+                [
+                  "linear"
+                ],
+                [
+                  "zoom"
+                ],
+                5,
+                3.5,
+                9,
+                5.5,
+                13,
+                8
+              ],
+              "circle-stroke-color": "#ffffff",
+              "circle-stroke-opacity": 0.9,
+              "circle-stroke-width": [
+                "interpolate",
+                [
+                  "linear"
+                ],
+                [
+                  "zoom"
+                ],
+                5,
+                0.8,
+                12,
+                1.4
+              ]
+            }
+          },
+          "suffix": "point-core",
+          "type": "circle"
+        }
+      ],
+      "pmtiles": null,
+      "rebuildOnParamChange": null,
+      "sourceId": "port-centroids",
       "sourceUrl": "./geo/port_polygons.geojson"
     },
     {
@@ -4013,19 +5201,26 @@
       "layers": [
         {
           "filter": null,
-          "layout": null,
+          "layout": {
+            "dark": {
+              "visibility": "none"
+            },
+            "light": {
+              "visibility": "none"
+            }
+          },
           "minzoom": null,
           "paint": {
             "dark": {
               "line-blur": 15,
               "line-color": "#ffffff",
-              "line-opacity": 0.048,
+              "line-opacity": 0.0432,
               "line-width": 30
             },
             "light": {
               "line-blur": 15,
               "line-color": "#daa520",
-              "line-opacity": 0.12,
+              "line-opacity": 0.10800000000000001,
               "line-width": 30
             }
           },
@@ -4034,19 +5229,26 @@
         },
         {
           "filter": null,
-          "layout": null,
+          "layout": {
+            "dark": {
+              "visibility": "none"
+            },
+            "light": {
+              "visibility": "none"
+            }
+          },
           "minzoom": null,
           "paint": {
             "dark": {
               "line-blur": 5,
               "line-color": "#ffffff",
-              "line-opacity": 0.12,
+              "line-opacity": 0.10800000000000001,
               "line-width": 10
             },
             "light": {
               "line-blur": 5,
               "line-color": "#daa520",
-              "line-opacity": 0.24,
+              "line-opacity": 0.21600000000000003,
               "line-width": 10
             }
           },
@@ -4055,16 +5257,23 @@
         },
         {
           "filter": null,
-          "layout": null,
+          "layout": {
+            "dark": {
+              "visibility": "none"
+            },
+            "light": {
+              "visibility": "none"
+            }
+          },
           "minzoom": null,
           "paint": {
             "dark": {
               "fill-color": "#ffffff",
-              "fill-opacity": 0.12
+              "fill-opacity": 0.108
             },
             "light": {
               "fill-color": "#c89520",
-              "fill-opacity": 0.18
+              "fill-opacity": 0.162
             }
           },
           "suffix": "fill",
@@ -4072,17 +5281,24 @@
         },
         {
           "filter": null,
-          "layout": null,
+          "layout": {
+            "dark": {
+              "visibility": "none"
+            },
+            "light": {
+              "visibility": "none"
+            }
+          },
           "minzoom": null,
           "paint": {
             "dark": {
               "line-color": "#ffffff",
-              "line-opacity": 0.36,
+              "line-opacity": 0.45,
               "line-width": 1.5
             },
             "light": {
               "line-color": "#c89520",
-              "line-opacity": 0.36,
+              "line-opacity": 0.63,
               "line-width": 2
             }
           },
@@ -4093,6 +5309,157 @@
       "pmtiles": null,
       "rebuildOnParamChange": null,
       "sourceId": "airport-boundaries",
+      "sourceUrl": "./geo/airports.geojson"
+    },
+    {
+      "dynamicData": null,
+      "filter": null,
+      "id": "airports",
+      "layers": [
+        {
+          "filter": null,
+          "layout": {
+            "dark": {
+              "visibility": "visible"
+            },
+            "light": {
+              "visibility": "visible"
+            }
+          },
+          "minzoom": null,
+          "paint": {
+            "dark": {
+              "circle-blur": 0.8,
+              "circle-color": "#daa520",
+              "circle-opacity": 0.25200000000000006,
+              "circle-radius": [
+                "interpolate",
+                [
+                  "linear"
+                ],
+                [
+                  "zoom"
+                ],
+                5,
+                7,
+                9,
+                11,
+                13,
+                16
+              ]
+            },
+            "light": {
+              "circle-blur": 0.8,
+              "circle-color": "#daa520",
+              "circle-opacity": 0.25200000000000006,
+              "circle-radius": [
+                "interpolate",
+                [
+                  "linear"
+                ],
+                [
+                  "zoom"
+                ],
+                5,
+                7,
+                9,
+                11,
+                13,
+                16
+              ]
+            }
+          },
+          "suffix": "point-glow",
+          "type": "circle"
+        },
+        {
+          "filter": null,
+          "layout": {
+            "dark": {
+              "visibility": "visible"
+            },
+            "light": {
+              "visibility": "visible"
+            }
+          },
+          "minzoom": null,
+          "paint": {
+            "dark": {
+              "circle-color": "#daa520",
+              "circle-opacity": 0.8280000000000001,
+              "circle-radius": [
+                "interpolate",
+                [
+                  "linear"
+                ],
+                [
+                  "zoom"
+                ],
+                5,
+                3.5,
+                9,
+                5.5,
+                13,
+                8
+              ],
+              "circle-stroke-color": "#0b1118",
+              "circle-stroke-opacity": 0.81,
+              "circle-stroke-width": [
+                "interpolate",
+                [
+                  "linear"
+                ],
+                [
+                  "zoom"
+                ],
+                5,
+                0.8,
+                12,
+                1.4
+              ]
+            },
+            "light": {
+              "circle-color": "#daa520",
+              "circle-opacity": 0.8280000000000001,
+              "circle-radius": [
+                "interpolate",
+                [
+                  "linear"
+                ],
+                [
+                  "zoom"
+                ],
+                5,
+                3.5,
+                9,
+                5.5,
+                13,
+                8
+              ],
+              "circle-stroke-color": "#ffffff",
+              "circle-stroke-opacity": 0.81,
+              "circle-stroke-width": [
+                "interpolate",
+                [
+                  "linear"
+                ],
+                [
+                  "zoom"
+                ],
+                5,
+                0.8,
+                12,
+                1.4
+              ]
+            }
+          },
+          "suffix": "point-core",
+          "type": "circle"
+        }
+      ],
+      "pmtiles": null,
+      "rebuildOnParamChange": null,
+      "sourceId": "airport-centroids",
       "sourceUrl": "./geo/airports.geojson"
     },
     {
@@ -48723,11 +50090,33 @@
     ],
     "airports": [
       {
-        "label": "APT 0.12",
-        "max": 0.3,
-        "min": 0,
-        "step": 0.01,
-        "value": 0.12
+        "label": "透明度 0.90",
+        "max": 1,
+        "min": 0.1,
+        "step": 0.05,
+        "value": 0.9
+      },
+      {
+        "label": "顯示",
+        "options": [
+          {
+            "label": "實際範圍",
+            "value": "polygon"
+          },
+          {
+            "label": "Mapbox 點位",
+            "value": "point"
+          }
+        ],
+        "type": "select",
+        "value": "point"
+      },
+      {
+        "label": "大小 1.0",
+        "max": 3,
+        "min": 0.3,
+        "step": 0.1,
+        "value": 1
       },
       {
         "label": "Glow 0.8",
@@ -54827,6 +56216,28 @@
         "value": 1
       },
       {
+        "label": "顯示",
+        "options": [
+          {
+            "label": "實際範圍",
+            "value": "polygon"
+          },
+          {
+            "label": "Mapbox 點位",
+            "value": "point"
+          }
+        ],
+        "type": "select",
+        "value": "point"
+      },
+      {
+        "label": "大小 1.0",
+        "max": 3,
+        "min": 0.3,
+        "step": 0.1,
+        "value": 1
+      },
+      {
         "label": "Glow 1.0",
         "max": 3,
         "min": 0,
@@ -56340,6 +57751,22 @@
         "value": 1
       },
       {
+        "label": "顯示",
+        "options": [
+          {
+            "disabled": true,
+            "label": "實際範圍（無面資料）",
+            "value": "polygon"
+          },
+          {
+            "label": "Mapbox 點位",
+            "value": "point"
+          }
+        ],
+        "type": "select",
+        "value": "point"
+      },
+      {
         "label": "Stn 1.0",
         "max": 3,
         "min": 0.3,
@@ -56368,6 +57795,21 @@
         "value": 1
       },
       {
+        "label": "顯示",
+        "options": [
+          {
+            "label": "實際範圍",
+            "value": "polygon"
+          },
+          {
+            "label": "Mapbox 點位",
+            "value": "point"
+          }
+        ],
+        "type": "select",
+        "value": "point"
+      },
+      {
         "label": "Stn 1.0",
         "max": 3,
         "min": 0.3,
@@ -56394,6 +57836,21 @@
         "min": 0.1,
         "step": 0.05,
         "value": 1
+      },
+      {
+        "label": "顯示",
+        "options": [
+          {
+            "label": "實際範圍",
+            "value": "polygon"
+          },
+          {
+            "label": "Mapbox 點位",
+            "value": "point"
+          }
+        ],
+        "type": "select",
+        "value": "point"
       },
       {
         "label": "Stn 1.0",

--- a/src/data/layerManifest.ts
+++ b/src/data/layerManifest.ts
@@ -8670,10 +8670,9 @@ export const LAYER_MANIFEST = {
   // 只有 `ships` 是真的 `setFeatureInfo({ layerType: "ship" })`（批 4 的
   // `extractNonGisFeatureTypes` 已涵蓋）。照「Three.js 一定有 popup」推會四層全填錯。
   //
-  // ⚠️ **`stationsTHSR` 是本段唯一的「有 registry entry 卻沒有 popup」**：
-  // `GIS_LAYERS` 的 `railStation` 只收 `station-points-{tra,metro}-pt-*`，
-  // 高鐵那組是 `station-polygons-thsr-poly-*`、一個都不在裡面。三個車站層長得極像，
-  // 只有逐 layer id 反查才看得出來（同批 2 基礎建設的單複數陷阱，只是這次差在「有沒有」）。
+  // `stationsTHSR` 與 `stationsTRA` 的站體面及派生面心、`stationsMetro` 的原始點
+  // 全部共用 `railStation` popup。點層在 GIS_LAYERS 前段，站體面放末段，
+  // 避免面範圍搖先同區的細節點位。
   //
   // dataClass：A 8 ／ B 1（busStationsCity 是 PMTiles）／ D 9。
   // 9 個 D 沒有一個是「自繪 = 沒資料」：航空 4 層自建 PmTilesSource（同批 5 slopeVector /
@@ -8693,11 +8692,14 @@ export const LAYER_MANIFEST = {
       datasets: [{ datasetId: "ports", confidence: "MED" }],
     },
     dataClass: "A",
-    source: { kind: "geojson", sourceId: "port-polygons", url: "./geo/port_polygons.geojson" },
-    legend: null,
+    source: [
+      { kind: "geojson", sourceId: "port-polygons", url: "./geo/port_polygons.geojson" },
+      { kind: "geojson", sourceId: "port-centroids", url: "./geo/port_polygons.geojson" },
+    ],
+    legend: "ports",
     popup: "port",
-    params: { count: 4, kinds: ["slider", "slider", "toggle", "slider"] },
-    description: "商港／工業港範圍面（雙層 glow ＋ fill ＋ 邊框，可切 3D 光柱）",
+    params: { count: 6, kinds: ["slider", "select", "slider", "slider", "toggle", "slider"] },
+    description: "港口實際範圍／代表點切換，依 port_class 分級上色，可另開 3D 光柱",
     topics: ["交通", "港口", "樞紐"],
   },
 
@@ -8713,11 +8715,14 @@ export const LAYER_MANIFEST = {
       datasets: [{ datasetId: "airport", confidence: "HIGH" }],
     },
     dataClass: "A",
-    source: { kind: "geojson", sourceId: "airport-boundaries", url: "./geo/airports.geojson" },
+    source: [
+      { kind: "geojson", sourceId: "airport-boundaries", url: "./geo/airports.geojson" },
+      { kind: "geojson", sourceId: "airport-centroids", url: "./geo/airports.geojson" },
+    ],
     legend: null,
     popup: "airport",
-    params: { count: 4, kinds: ["slider", "slider", "toggle", "slider"] },
-    description: "機場範圍面（雙層 glow ＋ fill ＋ 邊框，可切 3D 光柱）",
+    params: { count: 6, kinds: ["slider", "select", "slider", "slider", "toggle", "slider"] },
+    description: "機場實際範圍／代表點切換，可另開 3D 光柱",
     topics: ["交通", "航空", "樞紐"],
   },
 
@@ -8855,15 +8860,16 @@ export const LAYER_MANIFEST = {
       datasets: [{ datasetId: "rail_stations", confidence: "MED" }],
     },
     dataClass: "A",
-    source: { kind: "geojson", sourceId: "station-polygons", url: "./geo/station_polygons.geojson" },
+    source: [
+      { kind: "geojson", sourceId: "station-polygons", url: "./geo/station_polygons.geojson" },
+      { kind: "geojson", sourceId: "station-polygon-centroids", url: "./geo/station_polygons.geojson" },
+    ],
     legend: null,
-    // W2 popup 補強：本層 4 個 layer id 全是 `station-polygons-thsr-poly-*`，
-    // 與 GIS_LAYERS 既有兩筆 railStation（`station-points-tra-pt-*` /
-    // `station-points-metro-pt-*`）是不同 layer id，故另立第三筆條目收站體面。
-    // station_points.geojson 零筆 thsr，站體面是高鐵唯一的可點載體。
+    // station_points.geojson 零筆 thsr：範圍模式用原站體面，點位模式由
+    // overlay hydration 自同一面資料派生面心，兩者都保留同一份 popup properties。
     popup: "railStation",
-    params: { count: 4, kinds: ["slider", "slider", "toggle", "slider"] },
-    description: "高鐵站體範圍面（雙層 glow ＋ fill ＋ 邊框，可切 3D 光柱）",
+    params: { count: 5, kinds: ["slider", "select", "slider", "toggle", "slider"] },
+    description: "高鐵站體實際範圍／代表點切換，可另開 3D 光柱",
     topics: ["交通", "軌道", "場站"],
   },
 
@@ -8879,18 +8885,19 @@ export const LAYER_MANIFEST = {
       datasets: [{ datasetId: "rail_stations", confidence: "MED" }],
     },
     dataClass: "A",
-    // 拍板②的第五個「同 key 多 config」（前四個 propertyValueGrid×3 / waterRivers×2 /
+    // 「同 key 多 config」：原站體面＋面心派生點＋原小站點。
     // waterReservoirs×2 已搬）。⚠️ 順序 = OVERLAY_REGISTRY 出現序：面在前、點在後，
     // 決定疊放，測試逐位對齊。兩筆 kind 同質（都是 geojson）→ dataClass 直接是 A。
-    // popup 只由第二筆（點）貢獻：面那組的 layer id 不在 GIS_LAYERS，同 stationsTHSR。
+    // 三組都接 railStation popup；點層優先、面層置後。
     source: [
       { kind: "geojson", sourceId: "station-polygons", url: "./geo/station_polygons.geojson" },
+      { kind: "geojson", sourceId: "station-polygon-centroids", url: "./geo/station_polygons.geojson" },
       { kind: "geojson", sourceId: "station-points", url: "./geo/station_points.geojson" },
     ],
     legend: null,
     popup: "railStation",
-    params: { count: 4, kinds: ["slider", "slider", "toggle", "slider"] },
-    description: "台鐵站：大站畫站體面、小站畫點（同一個 toggle 兩份資料）",
+    params: { count: 5, kinds: ["slider", "select", "slider", "toggle", "slider"] },
+    description: "台鐵站：原模式以大站範圍面＋小站點呈現，可切為全點位模式",
     topics: ["交通", "軌道", "場站"],
   },
 
@@ -8911,8 +8918,8 @@ export const LAYER_MANIFEST = {
     // 與 stationsTRA **共用同一個 layerType**（各自的 GIS_LAYERS 條目 → 同一個 railStation
     // panel）。批 4 的「兩個 key 一個 layer」是共用 layer id，這裡是兩組 layer id 共用 type。
     popup: "railStation",
-    params: { count: 4, kinds: ["slider", "slider", "toggle", "slider"] },
-    description: "捷運站點（三層 glow ＋ 命中範圍圈，可切 3D 光柱）",
+    params: { count: 5, kinds: ["slider", "select", "slider", "toggle", "slider"] },
+    description: "捷運站點（上游無站體面，實際範圍選項會明示停用），可另開 3D 光柱",
     topics: ["交通", "軌道", "場站"],
   },
 

--- a/src/data/layerParamsSpec.ts
+++ b/src/data/layerParamsSpec.ts
@@ -100,6 +100,7 @@ import { ANIMAL_WELFARE_POINT_TYPE_OPTIONS } from "./animalWelfarePointsTypes";
 import { OOKLA_GLOBAL_ZOOMS, OOKLA_PALETTES } from "./telecomTypes";
 import { assertMultiSelectBitmaskCapacity } from "./multiSelectMapbox";
 import { OFFICIAL_NOISE_PERIODS, SOUND_CAMERA_PRECISIONS } from "./noiseTypes";
+import { TRANSPORT_HUB_DISPLAY_MODES } from "./transportHubTypes";
 
 /** select 的選項；形狀與 `SelectConfig["options"]` 相同（disabled 由控件端消費） */
 export interface ParamSelectOption {
@@ -639,6 +640,28 @@ function stationScaleSlider(): SliderParamSpec {
     kind: "slider", name: "stationScale", labelPrefix: "Stn", digits: 1,
     default: 1, min: 0.3, max: 3, step: 0.1,
     sharedGroup: "stationScale",
+  };
+}
+
+function hubDisplayModeSelect(
+  name: string,
+  defaultMode: "polygon" | "point" = "point",
+  polygonUnavailable = false,
+): SelectIndexParamSpec {
+  return {
+    kind: "select",
+    name,
+    label: "顯示",
+    default: defaultMode,
+    options: TRANSPORT_HUB_DISPLAY_MODES.map((mode) => ({
+      label: polygonUnavailable && mode.value === "polygon"
+        ? "實際範圍（無面資料）"
+        : mode.label,
+      value: mode.value,
+      ...(polygonUnavailable && mode.value === "polygon" ? { disabled: true } : {}),
+    })),
+    out: `${name}Idx`,
+    encode: TRANSPORT_HUB_DISPLAY_MODES.map((mode) => mode.value),
   };
 }
 
@@ -2801,18 +2824,21 @@ export const LAYER_PARAMS_SPEC = {
   // 三個系統的站點大小共用一支 slider（跨 case 共用同一個 useState 的等價表達）
   stationsTHSR: [
     opacitySlider("thsrOpacity", 1),
+    hubDisplayModeSelect("thsrDisplayMode"),
     stationScaleSlider(),
     { kind: "toggle", name: "thsrPillarVisible", label: "Pillar", default: true, out: null },
     pillarHeightSlider("thsrPillarHeight", 0.6),
   ],
   stationsTRA: [
     opacitySlider("traOpacity", 1),
+    hubDisplayModeSelect("traDisplayMode"),
     stationScaleSlider(),
     { kind: "toggle", name: "traPillarVisible", label: "Pillar", default: true, out: null },
     pillarHeightSlider("traPillarHeight", 0.5),
   ],
   stationsMetro: [
     opacitySlider("metroOpacity", 1),
+    hubDisplayModeSelect("metroDisplayMode", "point", true),
     stationScaleSlider(),
     // ⚠️ 唯一**兩條通道都走**的月台柱開關：overlayParams 的 key 是 `metroPillar3d`
     //    （與參數名不同名），Three.js 那側另外吃 ref。
@@ -2824,15 +2850,16 @@ export const LAYER_PARAMS_SPEC = {
   ],
   ports: [
     opacitySlider("portOpacity", 1),
+    hubDisplayModeSelect("portDisplayMode"),
+    scaleSlider("portScale", 1),
     { kind: "slider", name: "portGlow", labelPrefix: "Glow", digits: 1, default: 1, min: 0, max: 3, step: 0.1 },
     { kind: "toggle", name: "portPillarVisible", label: "Pillar", default: false, out: null },
     pillarHeightSlider("portPillarHeight", 0.3),
   ],
   airports: [
-    {
-      kind: "slider", name: "airportOpacity", labelPrefix: "APT", digits: 2,
-      default: 0.12, min: 0, max: 0.3, step: 0.01,
-    },
+    opacitySlider("airportOpacity", 0.9),
+    hubDisplayModeSelect("airportDisplayMode"),
+    scaleSlider("airportScale", 1),
     {
       kind: "slider", name: "airportGlow", labelPrefix: "Glow", digits: 1,
       default: 0.8, min: 0, max: 2, step: 0.1,

--- a/src/data/transportHubTypes.test.ts
+++ b/src/data/transportHubTypes.test.ts
@@ -1,0 +1,36 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import {
+  PORT_CLASSES,
+  PORT_CLASS_COLOR_EXPRESSION,
+  PORT_CLASS_FALLBACK,
+  portClassColor,
+} from "./transportHubTypes";
+
+describe("transport hub port classes", () => {
+  it("每個已知 port_class 都有唯一色，地圖 expression 與 popup 共用同值", () => {
+    expect(new Set(PORT_CLASSES.map((entry) => entry.value)).size).toBe(PORT_CLASSES.length);
+    expect(new Set(PORT_CLASSES.map((entry) => entry.color)).size).toBe(PORT_CLASSES.length);
+    for (const entry of PORT_CLASSES) {
+      expect(portClassColor(entry.value)).toBe(entry.color);
+      expect(PORT_CLASS_COLOR_EXPRESSION).toContain(entry.value);
+      expect(PORT_CLASS_COLOR_EXPRESSION).toContain(entry.color);
+    }
+  });
+
+  it("缺值與未來新類別回灰色，不誤分到既有等級", () => {
+    expect(portClassColor(null)).toBe(PORT_CLASS_FALLBACK.color);
+    expect(portClassColor("未來新分類")).toBe(PORT_CLASS_FALLBACK.color);
+    expect(PORT_CLASS_COLOR_EXPRESSION[PORT_CLASS_COLOR_EXPRESSION.length - 1]).toBe(PORT_CLASS_FALLBACK.color);
+  });
+
+  it("目前港口 GeoJSON 的所有 port_class 都已明確配色", () => {
+    const asset = JSON.parse(readFileSync(
+      new URL("../../public/geo/port_polygons.geojson", import.meta.url),
+      "utf8",
+    )) as GeoJSON.FeatureCollection;
+    const actual = [...new Set(asset.features.map((feature) => feature.properties?.port_class))].sort();
+    const covered = PORT_CLASSES.map((entry) => entry.value).sort();
+    expect(actual).toEqual(covered);
+  });
+});

--- a/src/data/transportHubTypes.ts
+++ b/src/data/transportHubTypes.ts
@@ -1,0 +1,42 @@
+/**
+ * 台灣交通樞紐的顯示模式與港口分類色。
+ *
+ * 港口色階直接對齊 `public/geo/port_polygons.geojson` 的 `port_class`；
+ * 地圖、圖例與 popup 共用這份定義，避免同一類別在三處變成不同顏色。
+ */
+
+export const TRANSPORT_HUB_DISPLAY_MODES = [
+  { value: "polygon", label: "實際範圍" },
+  { value: "point", label: "Mapbox 點位" },
+] as const;
+
+export const PORT_CLASS_FALLBACK = {
+  value: "other",
+  label: "其他／未分類",
+  color: "#94a3b8",
+} as const;
+
+export const PORT_CLASSES = [
+  { value: "國際商港", label: "國際商港", color: "#3b82f6" },
+  { value: "國內商港", label: "國內商港", color: "#14b8a6" },
+  { value: "客運港", label: "客運港", color: "#8b5cf6" },
+  { value: "渡輪/觀光碼頭", label: "渡輪／觀光碼頭", color: "#a855f7" },
+  { value: "離島渡輪港", label: "離島渡輪港", color: "#d946ef" },
+  { value: "第一類漁港", label: "第一類漁港", color: "#f59e0b" },
+  { value: "第二類漁港", label: "第二類漁港", color: "#5f8f78" },
+  { value: "廢止漁港", label: "廢止漁港", color: "#64748b" },
+  { value: "對岸港口", label: "對岸港口", color: "#ef4444" },
+] as const;
+
+export function portClassColor(value: unknown): string {
+  const raw = String(value ?? "");
+  return PORT_CLASSES.find((entry) => entry.value === raw)?.color ?? PORT_CLASS_FALLBACK.color;
+}
+
+/** Mapbox `match` expression：缺值／新類別一律是灰色，不假裝成現有分級。 */
+export const PORT_CLASS_COLOR_EXPRESSION: unknown[] = [
+  "match",
+  ["get", "port_class"],
+  ...PORT_CLASSES.flatMap((entry) => [entry.value, entry.color]),
+  PORT_CLASS_FALLBACK.color,
+];

--- a/src/map/MapView.tsx
+++ b/src/map/MapView.tsx
@@ -325,9 +325,9 @@ export function MapView({ preset, styleUrl, pureBlack = false, flights, renderMo
       for (const config of OVERLAY_REGISTRY) {
         const v = isOverlayVisible(config, vis, overlayParamsRef.current);
         if (v) void hydrateOverlayIfNeeded(map, config);
-        setOverlayVisible(map, config, v);
+        setOverlayVisible(map, config, v, isDarkThemeRef.current, overlayParamsRef.current);
       }
-      updateAllOverlayThemes(map, OVERLAY_REGISTRY, isDarkThemeRef.current, overlayParamsRef.current);
+      updateAllOverlayThemes(map, OVERLAY_REGISTRY, isDarkThemeRef.current, overlayParamsRef.current, vis);
       onMapReadyRef.current?.(map);
     });
 
@@ -419,7 +419,7 @@ export function MapView({ preset, styleUrl, pureBlack = false, flights, renderMo
     const map = mapRef.current;
     if (!map || !readyRef.current) return;
     const vis = layerVisibilityStore.getAll();
-    updateAllOverlayThemes(map, OVERLAY_REGISTRY, isDarkTheme, overlayParams);
+    updateAllOverlayThemes(map, OVERLAY_REGISTRY, isDarkTheme, overlayParams, vis);
     // OVERLAY_REGISTRY 之外的專屬圖層：params 變動也要 re-apply
     updateAllAgricultureLayers(map, vis, overlayParams);
     // 等時圈：透明度 / 縣市下拉變動 → 更新
@@ -445,7 +445,7 @@ export function MapView({ preset, styleUrl, pureBlack = false, flights, renderMo
       for (const config of OVERLAY_REGISTRY) {
         const v = isOverlayVisible(config, vis, overlayParamsRef.current);
         if (v) void hydrateOverlayIfNeeded(map, config);
-        setOverlayVisible(map, config, v);
+        setOverlayVisible(map, config, v, isDarkThemeRef.current, overlayParamsRef.current);
       }
       // OVERLAY_REGISTRY 之外的專屬圖層
       updateAllAgricultureLayers(map, vis, overlayParamsRef.current);

--- a/src/map/__tests__/overlayManager.test.ts
+++ b/src/map/__tests__/overlayManager.test.ts
@@ -10,6 +10,8 @@ import {
   addOverlay,
   hydrateOverlayIfNeeded,
   resetOverlayHydration,
+  polygonFeaturesToCentroids,
+  setOverlayVisible,
   updateOverlayTheme,
   geojsonSourceOptions,
   applyLayerOpacity,
@@ -132,6 +134,55 @@ describe("geojsonSourceOptions", () => {
   });
 });
 
+describe("polygonFeaturesToCentroids", () => {
+  it("把 polygon 轉成保留 properties 的代表點，非面幾何不假造", () => {
+    const data: GeoJSON.FeatureCollection = {
+      type: "FeatureCollection",
+      features: [
+        {
+          type: "Feature",
+          id: "hub-1",
+          properties: { name: "A" },
+          geometry: { type: "Polygon", coordinates: [[[0, 0], [4, 0], [4, 2], [0, 2], [0, 0]]] },
+        },
+        {
+          type: "Feature",
+          properties: { name: "skip" },
+          geometry: { type: "Point", coordinates: [9, 9] },
+        },
+      ],
+    };
+
+    expect(polygonFeaturesToCentroids(data)).toEqual({
+      type: "FeatureCollection",
+      features: [{
+        type: "Feature",
+        id: "hub-1",
+        properties: { name: "A" },
+        geometry: { type: "Point", coordinates: [2, 1] },
+      }],
+    });
+  });
+
+  it("MultiPolygon 取最大部件，不把代表點放在兩塊面之間", () => {
+    const data: GeoJSON.FeatureCollection = {
+      type: "FeatureCollection",
+      features: [{
+        type: "Feature",
+        properties: {},
+        geometry: {
+          type: "MultiPolygon",
+          coordinates: [
+            [[[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]]],
+            [[[10, 10], [14, 10], [14, 14], [10, 14], [10, 10]]],
+          ],
+        },
+      }],
+    };
+    expect(polygonFeaturesToCentroids(data).features[0]?.geometry.coordinates).toEqual([12, 12]);
+  });
+});
+
 // ── mock map 整合測試：diff 式更新 ──
 
 interface Call { method: string; args: unknown[] }
@@ -214,6 +265,90 @@ describe("updateOverlayTheme (diff-based)", () => {
       .filter((c) => c.method === "setPaintProperty")
       .map((c) => c.args[1]);
     expect(keys).toContain("line-color");
+  });
+});
+
+describe("setOverlayVisible", () => {
+  it("圖層重開時仍尊重模式 layout，不會同時露出 polygon 與 point", () => {
+    const modeConfig: OverlayConfig = {
+      ...config,
+      layers: [{
+        suffix: "core",
+        type: "line",
+        layout: (_isDark, p) => ({ visibility: (p?.modeIdx ?? 0) === 1 ? "visible" : "none" }),
+        paint: () => ({}),
+      }],
+    } as OverlayConfig;
+    const { map, calls } = createMockMap();
+    addOverlay(map, modeConfig, true, { modeIdx: 0 });
+    calls.length = 0;
+
+    setOverlayVisible(map, modeConfig, true, true, { modeIdx: 0 });
+    setOverlayVisible(map, modeConfig, true, true, { modeIdx: 1 });
+
+    expect(calls.filter((call) => call.method === "setLayoutProperty").map((call) => call.args))
+      .toEqual([
+        ["water-rivers-core", "visibility", "none"],
+        ["water-rivers-core", "visibility", "visible"],
+      ]);
+  });
+
+  it("母圖層關閉時，params 更新不會讓 mode layout 穿透開關", () => {
+    const modeConfig: OverlayConfig = {
+      ...config,
+      layers: [{
+        suffix: "core",
+        type: "line",
+        layout: (_isDark, p) => ({ visibility: (p?.modeIdx ?? 0) === 1 ? "visible" : "none" }),
+        paint: () => ({}),
+      }],
+    } as OverlayConfig;
+    const { map, calls } = createMockMap();
+    addOverlay(map, modeConfig, true, { modeIdx: 0 });
+    calls.length = 0;
+
+    updateOverlayTheme(map, modeConfig, true, { modeIdx: 1 }, false);
+
+    expect(calls.filter((call) => call.method === "setLayoutProperty").map((call) => call.args))
+      .toEqual([["water-rivers-core", "visibility", "none"]]);
+  });
+});
+
+describe("交通場站派生點位接線", () => {
+  const expected = [
+    ["stationsTHSR", "station-polygon-centroids"],
+    ["stationsTRA", "station-polygon-centroids"],
+    ["ports", "port-centroids"],
+    ["airports", "airport-centroids"],
+  ] as const;
+
+  it.each(expected)("%s 的點位模式只由原 Polygon 心點派生", (id, sourceId) => {
+    const entry = OVERLAY_REGISTRY.find((config) => config.id === id && config.sourceId === sourceId);
+    expect(entry).toBeDefined();
+    expect(entry?.geojsonTransform).toBe("centroid");
+    expect(entry?.sourceUrl).toMatch(/\.geojson$/);
+    expect(entry?.layers.every((layer) => layer.type === "circle")).toBe(true);
+  });
+
+  it("捷運保留原 detail layers，並在 z10 以下提供全台 overview 點", () => {
+    const metro = OVERLAY_REGISTRY.filter((config) => config.id === "stationsMetro");
+    const overview = metro.find((config) => config.layers.some((layer) => layer.suffix === "metro-overview-point-core"));
+    const detail = metro.find((config) => config.layers.some((layer) => layer.suffix === "metro-pt-fill"));
+    expect(overview?.sourceId).toBe("station-points");
+    expect(overview?.layers
+      .filter((layer) => layer.suffix.startsWith("metro-overview-"))
+      .every((layer) => layer.maxzoom === 10 && layer.minzoom == null)).toBe(true);
+    expect(detail?.layers.some((layer) => layer.minzoom === 10)).toBe(true);
+  });
+
+  it("台鐵小站在 z10 以下有 overview，z10 以上保留原 detail layers", () => {
+    const tra = OVERLAY_REGISTRY.find(
+      (config) => config.id === "stationsTRA" && config.sourceId === "station-points",
+    );
+    const overview = tra?.layers.filter((layer) => layer.suffix.startsWith("tra-overview-"));
+    expect(overview).toHaveLength(2);
+    expect(overview?.every((layer) => layer.maxzoom === 10 && layer.minzoom == null)).toBe(true);
+    expect(tra?.layers.some((layer) => layer.suffix === "tra-pt-fill" && layer.minzoom === 10)).toBe(true);
   });
 });
 

--- a/src/map/gisClickRegistry.ts
+++ b/src/map/gisClickRegistry.ts
@@ -186,6 +186,8 @@ export const GIS_LAYERS: { layers: string[]; type: FeatureInfo["layerType"] }[] 
   { layers: ["jp-admin-municipality-fill"], type: "jpAdminBoundaries" },
   { layers: ["jp-admin-prefecture-fill"], type: "jpAdminPrefecture" },
   { layers: ["typhoon-tracks-current-ring", "typhoon-tracks-current-dot", "typhoon-tracks-points"], type: "typhoonTrack" },
+  { layers: ["port-centroids-point-core", "port-centroids-point-glow"], type: "port" },
+  { layers: ["airport-centroids-point-core", "airport-centroids-point-glow"], type: "airport" },
   { layers: ["port-polygons-fill", "port-polygons-line", "port-polygons-glow-1", "port-polygons-glow-2"], type: "port" },
   { layers: ["airport-boundaries-fill", "airport-boundaries-line", "airport-boundaries-glow-1", "airport-boundaries-glow-2"], type: "airport" },
   { layers: ["cctv-circle", "cctv-glow"], type: "cctv" },
@@ -193,6 +195,15 @@ export const GIS_LAYERS: { layers: string[]; type: FeatureInfo["layerType"] }[] 
   { layers: ["service-area-circle", "service-area-glow"], type: "serviceArea" },
   { layers: ["service-area-polygon-fill", "service-area-polygon-line"], type: "serviceAreaPolygon" },
   { layers: ["taxi-stand-circle", "taxi-stand-glow"], type: "taxiStand" },
+  {
+    layers: [
+      "station-polygon-centroids-thsr-point-core", "station-polygon-centroids-thsr-point-glow",
+      "station-polygon-centroids-tra-point-core", "station-polygon-centroids-tra-point-glow",
+    ],
+    type: "railStation",
+  },
+  { layers: ["station-points-tra-overview-point-core", "station-points-tra-overview-point-glow"], type: "railStation" },
+  { layers: ["station-points-metro-overview-point-core", "station-points-metro-overview-point-glow"], type: "railStation" },
   { layers: ["station-points-tra-pt-fill", "station-points-tra-pt-glow-1", "station-points-tra-pt-glow-2"], type: "railStation" },
   { layers: ["station-points-metro-pt-fill", "station-points-metro-pt-glow-1", "station-points-metro-pt-glow-2"], type: "railStation" },
   { layers: ["active-faults-fill", "active-faults-line", "active-faults-glow"], type: "activeFault" },
@@ -383,9 +394,10 @@ export const GIS_LAYERS: { layers: string[]; type: FeatureInfo["layerType"] }[] 
   // 🗑️ 清運點位 73,060 點：全站密度最高的點層，且 click 用 ±5px bbox 命中
   //    → 排在其他點層之後，免得在市區把消防栓 / 行道樹 / POI 的點擊整片吃掉。
   { layers: ["waste-stops-static-waste-stops-fill"], type: "wasteStopsStatic" },
-  // 🚄 高鐵站體面（12 面，station_points 零筆 thsr → 全台唯一點不到的車站族）。
-  //    唯一的載體是面，依「面層不可搶點層」放在所有點層之後；站體範圍內的消防栓 /
-  //    行道樹 / 停車場等點層因此仍優先命中。與 station-points-* 共用 railStation panel。
+  // 台鐵大站站體面；小站點層已在前段，所以面層放這裡不會搖先 popup。
+  { layers: ["station-polygons-tra-poly-fill", "station-polygons-tra-poly-line"], type: "railStation" },
+  // 🚄 高鐵站體面（12 面）。點位模式的派生面心已在前段；這裡保留原面 popup，
+  //    依「面層不可搶點層」放在所有點層之後。與 station-points-* 共用 railStation panel。
   { layers: ["station-polygons-thsr-poly-fill", "station-polygons-thsr-poly-line"], type: "railStation" },
   // 💧 水資源 線 / 面 5 層 —— 線層在前（±5px bbox 已夠命中細線，不必收 glow），
   //    面層依覆蓋面積由小到大排後，保護區流域級最大故置末。

--- a/src/map/overlayManager.ts
+++ b/src/map/overlayManager.ts
@@ -246,6 +246,7 @@ export function updateOverlayTheme(
   config: OverlayConfig,
   isDark: boolean,
   params?: Record<string, number>,
+  overlayVisible = true,
 ) {
   if (!map.getSource(config.sourceId)) return;
 
@@ -315,7 +316,8 @@ export function updateOverlayTheme(
       if (config.rebuildOnParamChange.includes(spec.suffix)) continue;
       applyPaintDiff(map, cache, layerId(config, spec.suffix), applyLayerOpacity(config, spec.paint(isDark, params), params));
       if (typeof spec.layout === "function") {
-        applyLayoutDiff(map, layerId(config, spec.suffix), spec.layout(isDark, params));
+        const layout = spec.layout(isDark, params);
+        applyLayoutDiff(map, layerId(config, spec.suffix), overlayVisible ? layout : { ...layout, visibility: "none" });
       }
     }
     return;
@@ -325,7 +327,8 @@ export function updateOverlayTheme(
   for (const spec of config.layers) {
     applyPaintDiff(map, cache, layerId(config, spec.suffix), applyLayerOpacity(config, spec.paint(isDark, params), params));
     if (typeof spec.layout === "function") {
-      applyLayoutDiff(map, layerId(config, spec.suffix), spec.layout(isDark, params));
+      const layout = spec.layout(isDark, params);
+      applyLayoutDiff(map, layerId(config, spec.suffix), overlayVisible ? layout : { ...layout, visibility: "none" });
     }
   }
 }
@@ -385,6 +388,76 @@ function applyPaintDiff(
 // key 用 sourceId（不是 config.id），自然處理「多個 overlay 共用同一 sourceUrl」。
 const hydratedSources = new Set<string>();
 
+function ringCentroid(ring: GeoJSON.Position[]): [number, number] | null {
+  if (ring.length < 3) return null;
+  let area2 = 0;
+  let xSum = 0;
+  let ySum = 0;
+  for (let i = 0; i < ring.length; i += 1) {
+    const a = ring[i]!;
+    const b = ring[(i + 1) % ring.length]!;
+    const ax = Number(a[0]);
+    const ay = Number(a[1]);
+    const bx = Number(b[0]);
+    const by = Number(b[1]);
+    if (![ax, ay, bx, by].every(Number.isFinite)) continue;
+    const cross = ax * by - bx * ay;
+    area2 += cross;
+    xSum += (ax + bx) * cross;
+    ySum += (ay + by) * cross;
+  }
+  if (Math.abs(area2) > 1e-12) return [xSum / (3 * area2), ySum / (3 * area2)];
+
+  const valid = ring
+    .map((position) => [Number(position[0]), Number(position[1])] as const)
+    .filter(([x, y]) => Number.isFinite(x) && Number.isFinite(y));
+  if (valid.length === 0) return null;
+  return [
+    valid.reduce((sum, [x]) => sum + x, 0) / valid.length,
+    valid.reduce((sum, [, y]) => sum + y, 0) / valid.length,
+  ];
+}
+
+function ringArea2(ring: GeoJSON.Position[]): number {
+  let area2 = 0;
+  for (let i = 0; i < ring.length; i += 1) {
+    const a = ring[i]!;
+    const b = ring[(i + 1) % ring.length]!;
+    area2 += Number(a[0]) * Number(b[1]) - Number(b[0]) * Number(a[1]);
+  }
+  return Number.isFinite(area2) ? Math.abs(area2) : 0;
+}
+
+/**
+ * Polygon / MultiPolygon 的主外環面心。MultiPolygon 取面積最大的部件，
+ * 避免機場離島或碎面把點位拉到幾何之間的空白區。
+ */
+function polygonCentroid(geometry: GeoJSON.Polygon | GeoJSON.MultiPolygon): [number, number] | null {
+  const polygons = geometry.type === "Polygon" ? [geometry.coordinates] : geometry.coordinates;
+  const largest = polygons
+    .map((polygon) => ({ ring: polygon[0] ?? [], area: ringArea2(polygon[0] ?? []) }))
+    .sort((a, b) => b.area - a.area)[0];
+  return largest ? ringCentroid(largest.ring) : null;
+}
+
+/** 保留 feature id / properties，只轉換可驗證的面幾何；其他類型不猜測也不補零。 */
+export function polygonFeaturesToCentroids(data: GeoJSON.FeatureCollection): GeoJSON.FeatureCollection<GeoJSON.Point> {
+  const features: GeoJSON.Feature<GeoJSON.Point>[] = [];
+  for (const feature of data.features) {
+    const geometry = feature.geometry;
+    if (!geometry || (geometry.type !== "Polygon" && geometry.type !== "MultiPolygon")) continue;
+    const coordinates = polygonCentroid(geometry);
+    if (!coordinates) continue;
+    features.push({
+      type: "Feature",
+      ...(feature.id !== undefined ? { id: feature.id } : {}),
+      geometry: { type: "Point", coordinates },
+      properties: feature.properties,
+    });
+  }
+  return { type: "FeatureCollection", features };
+}
+
 /**
  * 若 config 是靜態 GeoJSON 且尚未 hydrate → fetch sourceUrl + setData。
  * dynamicData / pmtiles 配置直接 no-op（pmtiles 由 Mapbox 自動 lazy load tile，
@@ -407,7 +480,10 @@ export async function hydrateOverlayIfNeeded(
   try {
     const res = await fetch(config.sourceUrl);
     if (!res.ok) throw new Error(`HTTP ${res.status}`);
-    const json = (await res.json()) as GeoJSON.FeatureCollection;
+    const raw = (await res.json()) as GeoJSON.FeatureCollection;
+    const json = config.geojsonTransform === "centroid"
+      ? polygonFeaturesToCentroids(raw)
+      : raw;
     const src = map.getSource(config.sourceId);
     if (src && "setData" in src) {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -432,11 +508,17 @@ export function setOverlayVisible(
   map: OverlayMap,
   config: OverlayConfig,
   visible: boolean,
+  isDark = false,
+  params?: Record<string, number>,
 ) {
-  const v = visible ? "visible" : "none";
   for (const spec of config.layers) {
     const id = layerId(config, spec.suffix);
     if (map.getLayer(id)) {
+      const resolvedLayout = typeof spec.layout === "function"
+        ? spec.layout(isDark, params)
+        : spec.layout;
+      const modeAllows = resolvedLayout?.visibility !== "none";
+      const v = visible && modeAllows ? "visible" : "none";
       map.setLayoutProperty(id, "visibility", v);
     }
   }
@@ -454,7 +536,7 @@ export function addAllOverlays(
   for (const config of registry) {
     addOverlay(map, config, isDark, params, opts);
     if (!isOverlayVisible(config, visibility, params)) {
-      setOverlayVisible(map, config, false);
+      setOverlayVisible(map, config, false, isDark, params);
     }
   }
 }
@@ -465,8 +547,15 @@ export function updateAllOverlayThemes(
   registry: OverlayConfig[],
   isDark: boolean,
   params?: Record<string, number>,
+  visibility?: LayerVisibility,
 ) {
   for (const config of registry) {
-    updateOverlayTheme(map, config, isDark, params);
+    updateOverlayTheme(
+      map,
+      config,
+      isDark,
+      params,
+      visibility ? isOverlayVisible(config, visibility, params) : true,
+    );
   }
 }

--- a/src/map/overlayRegistry.ts
+++ b/src/map/overlayRegistry.ts
@@ -127,6 +127,7 @@ import {
   officialNoisePeriodFilter,
   soundCameraFilter,
 } from "../data/noiseTypes";
+import { PORT_CLASS_COLOR_EXPRESSION } from "../data/transportHubTypes";
 
 function companyCapitalGridOverlay(scale: CompanyGridScale): OverlayConfig {
   const scaleIdx = Number(scale.value);
@@ -248,6 +249,57 @@ function unionClassFilter(p?: Record<string, number>): unknown[] {
 }
 
 const BASE_RADIUS = 5;
+
+function hubModeLayout(param: string, mode: "polygon" | "point") {
+  const expected = mode === "point" ? 1 : 0;
+  return (_isDark: boolean, params?: Record<string, number>) => ({
+    visibility: (params?.[param] ?? 0) === expected ? "visible" : "none",
+  });
+}
+
+function hubPointLayers(
+  suffixPrefix: string,
+  modeParam: string,
+  color: unknown,
+  scaleParam: string,
+  opacityParam?: string,
+): OverlayConfig["layers"] {
+  const opacity = (params?: Record<string, number>) => opacityParam
+    ? Math.max(0, Math.min(1, params?.[opacityParam] ?? 1))
+    : 1;
+  return [
+    {
+      suffix: `${suffixPrefix}point-glow`,
+      type: "circle",
+      layout: hubModeLayout(modeParam, "point"),
+      paint: (_isDark, params) => {
+        const scale = params?.[scaleParam] ?? 1;
+        return {
+          "circle-radius": ["interpolate", ["linear"], ["zoom"], 5, 7 * scale, 9, 11 * scale, 13, 16 * scale],
+          "circle-color": color,
+          "circle-blur": 0.8,
+          "circle-opacity": 0.28 * opacity(params),
+        };
+      },
+    },
+    {
+      suffix: `${suffixPrefix}point-core`,
+      type: "circle",
+      layout: hubModeLayout(modeParam, "point"),
+      paint: (isDark, params) => {
+        const scale = params?.[scaleParam] ?? 1;
+        return {
+          "circle-radius": ["interpolate", ["linear"], ["zoom"], 5, 3.5 * scale, 9, 5.5 * scale, 13, 8 * scale],
+          "circle-color": color,
+          "circle-opacity": 0.92 * opacity(params),
+          "circle-stroke-color": isDark ? "#0b1118" : "#ffffff",
+          "circle-stroke-width": ["interpolate", ["linear"], ["zoom"], 5, 0.8, 12, 1.4],
+          "circle-stroke-opacity": 0.9 * opacity(params),
+        };
+      },
+    },
+  ];
+}
 
 // ── 🐷 畜牧 Livestock helpers ──
 const FARM_SOURCE = "./agriculture/livestock_farms.geojson";
@@ -676,6 +728,7 @@ export const OVERLAY_REGISTRY: OverlayConfig[] = [
       {
         suffix: "thsr-poly-glow-2",
         type: "line",
+        layout: hubModeLayout("thsrDisplayModeIdx", "polygon"),
         paint: (isDark) => ({
           "line-color": isDark ? "#ff8c00" : "#cc7000",
           "line-width": 15,
@@ -686,6 +739,7 @@ export const OVERLAY_REGISTRY: OverlayConfig[] = [
       {
         suffix: "thsr-poly-glow-1",
         type: "line",
+        layout: hubModeLayout("thsrDisplayModeIdx", "polygon"),
         paint: (isDark) => ({
           "line-color": isDark ? "#ff8c00" : "#cc7000",
           "line-width": 6,
@@ -696,6 +750,7 @@ export const OVERLAY_REGISTRY: OverlayConfig[] = [
       {
         suffix: "thsr-poly-fill",
         type: "fill",
+        layout: hubModeLayout("thsrDisplayModeIdx", "polygon"),
         paint: (isDark) => ({
           "fill-color": isDark ? "#ff8c00" : "#e8a040",
           "fill-opacity": isDark ? 0.08 : 0.12,
@@ -704,6 +759,7 @@ export const OVERLAY_REGISTRY: OverlayConfig[] = [
       {
         suffix: "thsr-poly-line",
         type: "line",
+        layout: hubModeLayout("thsrDisplayModeIdx", "polygon"),
         paint: (isDark) => ({
           "line-color": isDark ? "#ff8c00" : "#e8a040",
           "line-width": isDark ? 1 : 1.5,
@@ -711,6 +767,17 @@ export const OVERLAY_REGISTRY: OverlayConfig[] = [
         }),
       },
     ],
+  },
+
+  // 高鐵只有站體面；點位模式在 lazy hydration 後從原面心派生，properties 原樣保留。
+  {
+    id: "stationsTHSR",
+    opacityParam: "thsrOpacity",
+    sourceUrl: "./geo/station_polygons.geojson",
+    sourceId: "station-polygon-centroids",
+    geojsonTransform: "centroid",
+    filter: ["==", ["get", "system_id"], "thsr"],
+    layers: hubPointLayers("thsr-", "thsrDisplayModeIdx", "#ff8c00", "stationScale"),
   },
 
   // ── TRA Station Polygon (台鐵大站) ──
@@ -724,6 +791,7 @@ export const OVERLAY_REGISTRY: OverlayConfig[] = [
       {
         suffix: "tra-poly-glow-2",
         type: "line",
+        layout: hubModeLayout("traDisplayModeIdx", "polygon"),
         paint: (isDark) => ({
           "line-color": isDark ? "#ffffff" : "#d4c4a8",
           "line-width": 15,
@@ -734,6 +802,7 @@ export const OVERLAY_REGISTRY: OverlayConfig[] = [
       {
         suffix: "tra-poly-glow-1",
         type: "line",
+        layout: hubModeLayout("traDisplayModeIdx", "polygon"),
         paint: (isDark) => ({
           "line-color": isDark ? "#ffffff" : "#d4c4a8",
           "line-width": 6,
@@ -744,6 +813,7 @@ export const OVERLAY_REGISTRY: OverlayConfig[] = [
       {
         suffix: "tra-poly-fill",
         type: "fill",
+        layout: hubModeLayout("traDisplayModeIdx", "polygon"),
         paint: (isDark) => ({
           "fill-color": isDark ? "#ffffff" : "#e8dcc8",
           "fill-opacity": isDark ? 0.08 : 0.12,
@@ -752,6 +822,7 @@ export const OVERLAY_REGISTRY: OverlayConfig[] = [
       {
         suffix: "tra-poly-line",
         type: "line",
+        layout: hubModeLayout("traDisplayModeIdx", "polygon"),
         paint: (isDark) => ({
           "line-color": isDark ? "#ffffff" : "#e8dcc8",
           "line-width": isDark ? 1 : 1.5,
@@ -761,7 +832,21 @@ export const OVERLAY_REGISTRY: OverlayConfig[] = [
     ],
   },
 
+  // 台鐵大站面的代表點；小站繼續由 station_points 承載，點位模式才能完整覆蓋。
+  {
+    id: "stationsTRA",
+    opacityParam: "traOpacity",
+    sourceUrl: "./geo/station_polygons.geojson",
+    sourceId: "station-polygon-centroids",
+    geojsonTransform: "centroid",
+    filter: ["==", ["get", "system_id"], "tra"],
+    layers: hubPointLayers("tra-", "traDisplayModeIdx", "#b8a080", "stationScale"),
+  },
+
   // ── TRA Station Points (台鐵小站) ──
+  // z<10 使用 overview 點補齊全 212 個小站；大站同時由上方
+  // station-polygon-centroids 顯示，因此全台視角不再只剩 32 個大站。
+  // z>=10 交還原 detail layers，保留既有近距樣式。
   {
     id: "stationsTRA",
     opacityParam: "traOpacity",
@@ -770,6 +855,12 @@ export const OVERLAY_REGISTRY: OverlayConfig[] = [
     filter: ["==", ["get", "system_id"], "tra"],
     rebuildOnParamChange: ["tra-pt-glow-2", "tra-pt-glow-1", "tra-pt-fill"],
     layers: [
+      ...hubPointLayers(
+        "tra-overview-",
+        "traDisplayModeIdx",
+        "#b8a080",
+        "stationScale",
+      ).map((layer) => ({ ...layer, maxzoom: 10 })),
       {
         suffix: "tra-pt-glow-2",
         type: "circle",
@@ -818,6 +909,8 @@ export const OVERLAY_REGISTRY: OverlayConfig[] = [
   },
 
   // ── Metro Station Points (捷運/輕軌站) ──
+  // z<10 使用 overview 點，讓全台視角仍看得到系統分佈；
+  // z>=10 無縫交給原本的 detail layers，保留既有細節與 3D 光柱邏輯。
   {
     id: "stationsMetro",
     opacityParam: "metroOpacity",
@@ -826,6 +919,12 @@ export const OVERLAY_REGISTRY: OverlayConfig[] = [
     filter: ["in", ["get", "system_id"], ["literal", ["trtc", "krtc", "klrt", "tmrt"]]],
     rebuildOnParamChange: ["metro-pt-range", "metro-pt-glow-2", "metro-pt-glow-1", "metro-pt-fill"],
     layers: [
+      ...hubPointLayers(
+        "metro-overview-",
+        "metroDisplayModeIdx",
+        ["get", "color"],
+        "stationScale",
+      ).map((layer) => ({ ...layer, maxzoom: 10 })),
       {
         suffix: "metro-pt-range",
         type: "circle",
@@ -897,15 +996,15 @@ export const OVERLAY_REGISTRY: OverlayConfig[] = [
     opacityParam: "portOpacity",
     sourceUrl: "./geo/port_polygons.geojson",
     sourceId: "port-polygons",
-    rebuildOnParamChange: ["glow-2", "glow-1"],
     layers: [
       {
         suffix: "glow-2",
         type: "line",
+        layout: hubModeLayout("portDisplayModeIdx", "polygon"),
         paint: (isDark, params) => {
           const g = params?.portGlow ?? 1;
           return {
-            "line-color": isDark ? "#88bbff" : "#3a7bd5",
+            "line-color": PORT_CLASS_COLOR_EXPRESSION,
             "line-width": 12 * g,
             "line-blur": 8 * g,
             "line-opacity": g * (isDark ? 0.04 : 0.10),
@@ -915,10 +1014,11 @@ export const OVERLAY_REGISTRY: OverlayConfig[] = [
       {
         suffix: "glow-1",
         type: "line",
+        layout: hubModeLayout("portDisplayModeIdx", "polygon"),
         paint: (isDark, params) => {
           const g = params?.portGlow ?? 1;
           return {
-            "line-color": isDark ? "#88bbff" : "#3a7bd5",
+            "line-color": PORT_CLASS_COLOR_EXPRESSION,
             "line-width": 5 * g,
             "line-blur": 3 * g,
             "line-opacity": g * (isDark ? 0.10 : 0.20),
@@ -928,21 +1028,32 @@ export const OVERLAY_REGISTRY: OverlayConfig[] = [
       {
         suffix: "fill",
         type: "fill",
+        layout: hubModeLayout("portDisplayModeIdx", "polygon"),
         paint: (isDark) => ({
-          "fill-color": isDark ? "#ffffff" : "#4a90d9",
-          "fill-opacity": isDark ? 0.06 : 0.10,
+          "fill-color": PORT_CLASS_COLOR_EXPRESSION,
+          "fill-opacity": isDark ? 0.16 : 0.22,
         }),
       },
       {
         suffix: "line",
         type: "line",
+        layout: hubModeLayout("portDisplayModeIdx", "polygon"),
         paint: (isDark) => ({
-          "line-color": isDark ? "#ffffff" : "#4a90d9",
+          "line-color": PORT_CLASS_COLOR_EXPRESSION,
           "line-width": isDark ? 1 : 1.5,
           "line-opacity": isDark ? 0.25 : 0.40,
         }),
       },
     ],
+  },
+
+  {
+    id: "ports",
+    opacityParam: "portOpacity",
+    sourceUrl: "./geo/port_polygons.geojson",
+    sourceId: "port-centroids",
+    geojsonTransform: "centroid",
+    layers: hubPointLayers("", "portDisplayModeIdx", PORT_CLASS_COLOR_EXPRESSION, "portScale"),
   },
 
   // ── Lighthouses ──
@@ -1351,53 +1462,66 @@ export const OVERLAY_REGISTRY: OverlayConfig[] = [
       {
         suffix: "glow-2",
         type: "line",
+        layout: hubModeLayout("airportDisplayModeIdx", "polygon"),
         paint: (isDark, params) => {
           const glow = params?.airportGlow ?? 0.8;
+          const opacity = params?.airportOpacity ?? 0.9;
           return {
             "line-color": isDark ? "#ffffff" : "#daa520",
             "line-width": 30,
             "line-blur": 15,
-            "line-opacity": glow * (isDark ? 0.06 : 0.15),
+            "line-opacity": glow * opacity * (isDark ? 0.06 : 0.15),
           };
         },
       },
       {
         suffix: "glow-1",
         type: "line",
+        layout: hubModeLayout("airportDisplayModeIdx", "polygon"),
         paint: (isDark, params) => {
           const glow = params?.airportGlow ?? 0.8;
+          const opacity = params?.airportOpacity ?? 0.9;
           return {
             "line-color": isDark ? "#ffffff" : "#daa520",
             "line-width": 10,
             "line-blur": 5,
-            "line-opacity": glow * (isDark ? 0.15 : 0.3),
+            "line-opacity": glow * opacity * (isDark ? 0.15 : 0.3),
           };
         },
       },
       {
         suffix: "fill",
         type: "fill",
+        layout: hubModeLayout("airportDisplayModeIdx", "polygon"),
         paint: (isDark, params) => {
-          const opacity = params?.airportOpacity ?? 0.12;
+          const opacity = params?.airportOpacity ?? 0.9;
           return {
             "fill-color": isDark ? "#ffffff" : "#c89520",
-            "fill-opacity": isDark ? opacity : opacity * 1.5,
+            "fill-opacity": opacity * (isDark ? 0.12 : 0.18),
           };
         },
       },
       {
         suffix: "line",
         type: "line",
+        layout: hubModeLayout("airportDisplayModeIdx", "polygon"),
         paint: (isDark, params) => {
-          const opacity = params?.airportOpacity ?? 0.12;
+          const opacity = params?.airportOpacity ?? 0.9;
           return {
             "line-color": isDark ? "#ffffff" : "#c89520",
             "line-width": isDark ? 1.5 : 2,
-            "line-opacity": Math.min(opacity * 3, isDark ? 0.5 : 0.7),
+            "line-opacity": opacity * (isDark ? 0.5 : 0.7),
           };
         },
       },
     ],
+  },
+  {
+    id: "airports",
+    sourceUrl: "./geo/airports.geojson",
+    sourceId: "airport-centroids",
+    geojsonTransform: "centroid",
+    layers: hubPointLayers("", "airportDisplayModeIdx", "#daa520", "airportScale", "airportOpacity"),
   },
   // ── CCTV (道路 CCTV 攝影機，~6,129 點) ──
   // source 分色：freeway 橙 / highway 黃 / city 青

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -652,6 +652,11 @@ export interface OverlayConfig {
   opacityParam?: string;
   sourceUrl: string;
   sourceId: string;
+  /**
+   * 靜態 GeoJSON 載入後的輕量幾何轉換。`centroid` 只把 Polygon /
+   * MultiPolygon 轉成代表點並保留原 properties，供同一場站的範圍／點位模式共用。
+   */
+  geojsonTransform?: "centroid";
   layers: OverlayLayerSpec[];
   rebuildOnParamChange?: string[];
   filter?: unknown[];


### PR DESCRIPTION
## Summary\n- Default THSR, TRA, Metro, ports, and airports to Mapbox point mode while preserving polygon mode where real footprints exist\n- Add low-zoom TRA and Metro overview points, plus centroid-derived point sources for polygon-only hubs\n- Color ports by raw port_class with shared map, legend, and popup semantics; mute second-class fishing ports\n\n## Data semantics\n- Metro polygon option is disabled because no authoritative footprint asset exists\n- Unknown or missing port classes remain neutral gray\n- No collector, database, or static source asset changes\n\n## Validation\n- npm test: 111 test files passed; 1107 tests passed, 3 skipped\n- npm run build: passed\n- Local browser: point/polygon toggles, TRA low-zoom station coverage, port legend/popup/color, console clean